### PR TITLE
Code Review: Full Codebase Audit

### DIFF
--- a/.github/CODE_REVIEW_REQUEST.md
+++ b/.github/CODE_REVIEW_REQUEST.md
@@ -1,0 +1,21 @@
+# Code Review Request
+
+**Purpose:** Full codebase review to identify bugs, security issues, code quality problems, and improvement opportunities.
+
+**Scope:** Entire repository
+
+**Focus Areas:**
+- Security vulnerabilities (SQL injection, XSS, auth bypass, exposed secrets)
+- Error handling gaps and edge cases
+- Performance bottlenecks (N+1 queries, missing indexes, inefficient algorithms)
+- Code that contradicts its comments/documentation
+- Logic errors in business logic
+- Missing input validation / sanitization
+- Race conditions or concurrency issues
+- Memory leaks or resource management issues
+- Dependency vulnerabilities
+- Anything that would make a production deployment risky
+
+**Priority:** High — this is a production system handling real user data and business workflows.
+
+**Contact:** @SweetSophia

--- a/src/app/api/answer/route.ts
+++ b/src/app/api/answer/route.ts
@@ -61,7 +61,12 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
   }
 
-  const { title, content, topicId, excerpt, tags, sourceQuery, confidence, status, authorName } = body;
+  const { title, content, topicId, excerpt, tags, sourceQuery, confidence, status, authorName: rawAuthorName } = body;
+  // Sanitize authorName from body to prevent HTML injection / name spoofing
+  const authorName = (rawAuthorName ?? "")
+    .replace(/<[^>]*>/g, "")
+    .trim()
+    .slice(0, 100) || session?.user?.name || "Unknown";
   const sessionUser = session?.user as ({ id?: string } | null) | undefined;
   const userId = sessionUser?.id ?? null;
 

--- a/src/app/api/articles/route.ts
+++ b/src/app/api/articles/route.ts
@@ -70,7 +70,7 @@ export async function GET(request: NextRequest) {
             include: {
               topic: true,
               tags: { include: { tag: true } },
-              author: { select: { id: true, name: true, email: true } },
+              author: { select: { id: true, name: true } },
               relatedTo: {
                 include: {
                   target: { select: { id: true, title: true, slug: true, topic: true } },
@@ -89,7 +89,7 @@ export async function GET(request: NextRequest) {
           include: {
             topic: true,
             tags: { include: { tag: true } },
-            author: { select: { id: true, name: true, email: true } },
+            author: { select: { id: true, name: true } },
             relatedTo: {
               include: {
                 target: { select: { id: true, title: true, slug: true, topic: true } },

--- a/src/app/api/graph/route.ts
+++ b/src/app/api/graph/route.ts
@@ -1,5 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
+import { requireApiKey } from "@/lib/api/keys";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
 
 // GET /api/graph — Wiki knowledge graph
 //
@@ -18,6 +21,13 @@ import { prisma } from "@/lib/prisma";
 //   }
 
 export async function GET(request: NextRequest) {
+  // Auth: API key (any permission) or session
+  const apiAuth = await requireApiKey(request);
+  const session = await getServerSession(authOptions);
+  if (!apiAuth.authorized && !session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
   const { searchParams } = new URL(request.url);
   const topicSlug = searchParams.get("topic");
   const limit = Math.min(parseInt(searchParams.get("limit") ?? "100", 10), 500);

--- a/src/app/api/import/route.ts
+++ b/src/app/api/import/route.ts
@@ -9,6 +9,19 @@ import yaml from "js-yaml";
 // Disable Next.js body parsing for file uploads
 export const dynamic = "force-dynamic";
 
+// ── Validation helpers ───────────────────────────────────────────────────────
+
+const VALID_CONFIDENCE = new Set(["low", "medium", "high"]);
+const VALID_STATUS = new Set(["draft", "reviewed", "published"]);
+
+function validatedConfidence(v: string | undefined): string | null {
+  return v && VALID_CONFIDENCE.has(v) ? v : null;
+}
+
+function validatedStatus(v: string | undefined, fallback: string): string {
+  return v && VALID_STATUS.has(v) ? v : fallback;
+}
+
 interface ImportArticle {
   filename: string;
   title: string;
@@ -101,6 +114,12 @@ export async function POST(request: NextRequest) {
     zipBuffer = await fileEntry.arrayBuffer();
   } catch {
     return NextResponse.json({ error: "Failed to read uploaded zip file" }, { status: 400 });
+  }
+
+  // Enforce compressed size limit to mitigate zip-bomb DoS
+  const MAX_ZIP_SIZE = 50 * 1024 * 1024; // 50 MB
+  if (zipBuffer.byteLength > MAX_ZIP_SIZE) {
+    return NextResponse.json({ error: "Zip file exceeds 50 MB compressed size limit" }, { status: 400 });
   }
 
   // Parse zip
@@ -232,8 +251,8 @@ export async function POST(request: NextRequest) {
               title: article.title,
               content: article.content,
               excerpt: article.excerpt ?? article.content.slice(0, 160).replace(/[#*`_]/g, ""),
-              confidence: article.confidence ?? null,
-              status: article.status ?? existing.status,
+              confidence: validatedConfidence(article.confidence),
+              status: validatedStatus(article.status, existing.status),
               updatedAt: new Date(),
             },
           });
@@ -270,8 +289,8 @@ export async function POST(request: NextRequest) {
           topicId: topic.id,
           authorId: userId,
           authorName: userName,
-          confidence: article.confidence ?? null,
-          status: article.status ?? "published",
+          confidence: validatedConfidence(article.confidence),
+          status: validatedStatus(article.status, "published"),
           sourceUrl: article.sourceUrl ?? null,
           sourceType: article.sourceType ?? "import",
           tags: { create: tagConnections },

--- a/src/app/api/import/route.ts
+++ b/src/app/api/import/route.ts
@@ -142,8 +142,26 @@ export async function POST(request: NextRequest) {
   const toImport: ImportArticle[] = [];
   const zipFiles = Object.values(zip.files);
 
+  // Track uncompressed size to prevent zip-bomb decompression.
+  // JSZip's central directory exposes uncompressedSize after loadAsync()
+  // without requiring decompression — check before each entry is processed.
+  const MAX_UNCOMPRESSED = 200 * 1024 * 1024; // 200 MB total
+  let totalUncompressed = 0;
+
   for (const entry of zipFiles) {
     if (entry.dir || !entry.name.endsWith(".md") || entry.name.includes("README")) continue;
+
+    // Abort early if cumulative uncompressed size would exceed limit.
+    // _data is internal JSZip metadata populated from the central directory after
+    // loadAsync() — accessed via type assertion since it's not in public types.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const entrySize = (entry as any)._data?.uncompressedSize ?? 0;
+    if (totalUncompressed + entrySize > MAX_UNCOMPRESSED) {
+      return NextResponse.json(
+        { error: "Zip contents exceed 200 MB uncompressed size limit" },
+        { status: 400 }
+      );
+    }
 
     let content: string;
     try {
@@ -152,6 +170,9 @@ export async function POST(request: NextRequest) {
       toImport.push({ filename: entry.name, title: "", slug: "", topicSlug: "", content: "", tags: [], error: "Failed to read file" });
       continue;
     }
+
+    // Update cumulative size after successful decompression
+    totalUncompressed += entrySize;
 
     // Parse frontmatter (handles both \n and \r\n)
     const fmMatch = content.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n([\s\S]*)$/);

--- a/src/app/api/ingest/route.ts
+++ b/src/app/api/ingest/route.ts
@@ -133,6 +133,16 @@ export async function POST(request: NextRequest) {
   const createdArticles: { id: string; title: string; slug: string; topic: string }[] = [];
   let totalTagsApplied = 0;
 
+  // Validate content sizes before entering transaction — throws are not caught inside $transaction
+  for (const article of articles) {
+    if (new TextEncoder().encode(article.content).length > MAX_ARTICLE_CONTENT_SIZE) {
+      return NextResponse.json(
+        { error: `Article [${articles.indexOf(article)}] content exceeds ${MAX_ARTICLE_CONTENT_SIZE} bytes` },
+        { status: 400 }
+      );
+    }
+  }
+
   // Use a transaction to keep everything consistent
   const result = await prisma.$transaction(async (tx) => {
     for (const article of articles) {
@@ -145,14 +155,6 @@ export async function POST(request: NextRequest) {
         // Skip — don't overwrite in ingest. Agent should use PATCH for updates.
         // Log a warning but continue with other articles.
         continue;
-      }
-
-      // Content size guard
-      if (new TextEncoder().encode(article.content).length > MAX_ARTICLE_CONTENT_SIZE) {
-        throw Object.assign(
-          new Error(`Article [${articles.indexOf(article)}] content exceeds ${MAX_ARTICLE_CONTENT_SIZE} bytes`),
-          { status: 400 }
-        );
       }
 
       // Merge article tags + global tags, deduplicate

--- a/src/app/api/ingest/route.ts
+++ b/src/app/api/ingest/route.ts
@@ -5,6 +5,10 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { buildTagConnections } from "@/lib/wiki";
 
+// Security limits
+const MAX_ARTICLE_CONTENT_SIZE = 1024 * 1024; // 1 MB per article
+const MAX_AUTHOR_NAME_LENGTH = 100;
+
 // POST /api/ingest — Process a source into multiple wiki articles
 // Auth: API key (WRITE/ADMIN) or session (EDITOR/ADMIN)
 //
@@ -76,7 +80,12 @@ export async function POST(request: NextRequest) {
   }
 
   const { source, articles, tags: globalTags } = body;
-  const authorName = body.authorName || session?.user?.name || "Unknown";
+  // authorName from body is accepted but sanitized to prevent HTML injection / spoofing
+  const rawAuthorName = body.authorName ?? "";
+  const sanitizedAuthorName = rawAuthorName
+    .replace(/<[^>]*>/g, "") // strip any HTML tags
+    .trim()
+    .slice(0, MAX_AUTHOR_NAME_LENGTH) || session?.user?.name || "Unknown";
   const userId = session?.user ? (session.user as { id?: string }).id ?? null : null;
 
   // --- Validate ---
@@ -138,6 +147,14 @@ export async function POST(request: NextRequest) {
         continue;
       }
 
+      // Content size guard
+      if (new TextEncoder().encode(article.content).length > MAX_ARTICLE_CONTENT_SIZE) {
+        throw Object.assign(
+          new Error(`Article [${articles.indexOf(article)}] content exceeds ${MAX_ARTICLE_CONTENT_SIZE} bytes`),
+          { status: 400 }
+        );
+      }
+
       // Merge article tags + global tags, deduplicate
       const articleTags = [...(article.tags ?? []), ...(globalTags ?? [])];
       const uniqueTags = [...new Set(articleTags.map((t) => t.trim().toLowerCase()))].filter(Boolean);
@@ -174,7 +191,11 @@ export async function POST(request: NextRequest) {
           content: article.content,
           excerpt,
           authorId: userId,
-          authorName: article.authorName || authorName,
+          // article.authorName is accepted but sanitized — strip HTML, cap length
+          authorName: (article.authorName ?? "")
+            .replace(/<[^>]*>/g, "")
+            .trim()
+            .slice(0, MAX_AUTHOR_NAME_LENGTH) || sanitizedAuthorName,
           topicId: article.topicId,
           sourceUrl: article.sourceUrl || sourceUrl,
           sourceType: source.type,
@@ -216,7 +237,7 @@ export async function POST(request: NextRequest) {
         type: "ingest",
         title: `Ingested "${source.title}" — ${createdArticles.length} articles created`,
         sourceUrl,
-        authorName,
+        authorName: sanitizedAuthorName,
         details: {
           sourceTitle: source.title,
           sourceType: source.type,

--- a/src/app/api/lint/route.ts
+++ b/src/app/api/lint/route.ts
@@ -213,8 +213,8 @@ export async function POST(request: NextRequest) {
       const titlePlain = new RegExp(`\\b${a.title}\\b`, "i");
       const slugPlain = new RegExp(`\\b${a.slug}\\b`, "i");
       const isLinked =
-        /\[\[a.slug\]\]/i.test(a.content) ||
-        new RegExp(`/wiki/[^/]*/a.slug`).test(a.content);
+        new RegExp(`\\[\\[${a.slug}\\]\\]`, "i").test(b.content) ||
+        new RegExp(`/wiki/[^/]*/${a.slug}(?![a-z0-9-])`, "i").test(b.content);
 
       if (!isLinked && (titlePlain.test(b.content) || slugPlain.test(b.content))) {
         unlinkedMentions.push(b.title);

--- a/src/app/api/lint/route.ts
+++ b/src/app/api/lint/route.ts
@@ -209,9 +209,11 @@ export async function POST(request: NextRequest) {
     for (const b of articles) {
       if (b.id === a.id) continue;
 
-      // Does b's content mention a's title or slug without linking?
-      const titlePlain = new RegExp(`\\b${a.title}\\b`, "i");
-      const slugPlain = new RegExp(`\\b${a.slug}\\b`, "i");
+      // Escape regex special chars in user-controlled article metadata
+      // before building word-boundary patterns to prevent ReDoS.
+      const escapeRe = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      const titlePlain = new RegExp(`\\b${escapeRe(a.title)}\\b`, "i");
+      const slugPlain = new RegExp(`\\b${escapeRe(a.slug)}\\b`, "i");
       const isLinked =
         new RegExp(`\\[\\[${a.slug}\\]\\]`, "i").test(b.content) ||
         new RegExp(`/wiki/[^/]*/${a.slug}(?![a-z0-9-])`, "i").test(b.content);

--- a/src/app/api/log/route.ts
+++ b/src/app/api/log/route.ts
@@ -1,5 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
+import { requireApiKey } from "@/lib/api/keys";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
 
 // GET /api/log — Query the activity log
 //
@@ -15,6 +18,13 @@ import { prisma } from "@/lib/prisma";
 //   { entries: [{id, type, title, details, sourceUrl, authorName, createdAt}], total, limit, offset }
 
 export async function GET(request: NextRequest) {
+  // Auth: API key (any permission) or session
+  const apiAuth = await requireApiKey(request);
+  const session = await getServerSession(authOptions);
+  if (!apiAuth.authorized && !session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
   const { searchParams } = new URL(request.url);
 
   const type = searchParams.get("type");

--- a/src/app/wiki/[topicSlug]/[articleSlug]/page.tsx
+++ b/src/app/wiki/[topicSlug]/[articleSlug]/page.tsx
@@ -92,16 +92,24 @@ export default async function ArticlePage({ params }: Props) {
               Reviewed {new Date(article.lastReviewed).toLocaleDateString()}
             </span>
           )}
-          {article.sourceUrl && (
-            <a
-              href={article.sourceUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              style={{ fontSize: "0.8em" }}
-            >
-              📄 Source
-            </a>
-          )}
+          {article.sourceUrl && (() => {
+            // Validate protocol before rendering to prevent javascript: XSS
+            let safe = false;
+            try {
+              const parsed = new URL(article.sourceUrl);
+              safe = parsed.protocol === "https:" || parsed.protocol === "http:";
+            } catch { /* invalid URL */ }
+            return safe ? (
+              <a
+                href={article.sourceUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                style={{ fontSize: "0.8em" }}
+              >
+                📄 Source
+              </a>
+            ) : null;
+          })()}
         </div>
 
         {/* Related articles */}

--- a/src/app/wiki/admin/keys/actions.ts
+++ b/src/app/wiki/admin/keys/actions.ts
@@ -6,6 +6,7 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { generateApiKey } from "@/lib/api/keys";
+import { cookies } from "next/headers";
 
 async function requireAdmin() {
   const session = await getServerSession(authOptions);
@@ -42,8 +43,18 @@ export async function createApiKeyAction(formData: FormData) {
     },
   });
 
+  // Flash the raw key via HttpOnly cookie instead of URL query param
+  // so it never appears in server logs, browser history, or Referer headers
+  (await cookies()).set("api_key_flash", raw, {
+    httpOnly: true,
+    secure: true,
+    maxAge: 60,
+    path: "/wiki/admin/keys",
+    sameSite: "lax",
+  });
+
   revalidatePath("/wiki/admin/keys");
-  redirect(`/wiki/admin/keys?created=${encodeURIComponent(raw)}&name=${encodeURIComponent(name)}`);
+  redirect(`/wiki/admin/keys?flash=1&name=${encodeURIComponent(name)}`);
 }
 
 export async function revokeApiKeyAction(formData: FormData) {

--- a/src/app/wiki/admin/keys/page.tsx
+++ b/src/app/wiki/admin/keys/page.tsx
@@ -5,11 +5,12 @@ import { authOptions } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { CopyButton } from "@/components/wiki/CopyButton";
 import { createApiKeyAction, revokeApiKeyAction } from "./actions";
+import { cookies } from "next/headers";
 
 export const dynamic = "force-dynamic";
 
 interface Props {
-  searchParams: Promise<{ created?: string; name?: string }>;
+  searchParams: Promise<{ flash?: string; name?: string }>;
 }
 
 export default async function ApiKeysPage({ searchParams }: Props) {
@@ -22,6 +23,13 @@ export default async function ApiKeysPage({ searchParams }: Props) {
   }
 
   const params = await searchParams;
+  const cookieStore = await cookies();
+  const flashKey = cookieStore.get("api_key_flash")?.value ?? null;
+  // Clear the flash cookie now that we've read it
+  if (flashKey) {
+    cookieStore.delete("api_key_flash");
+  }
+
   const keys = await prisma.apiKey.findMany({
     orderBy: [{ revokedAt: "asc" }, { createdAt: "desc" }],
   });
@@ -41,12 +49,12 @@ export default async function ApiKeysPage({ searchParams }: Props) {
         </div>
       </div>
 
-      {params.created && (
+      {params.flash && flashKey && (
         <div className="alert alert-success">
           <strong>New key created for {params.name || "agent"}.</strong>
           <div className="secret-box-row">
-            <div className="secret-box">{params.created}</div>
-            <CopyButton text={params.created} label="Copy key" copiedLabel="Key copied" />
+            <div className="secret-box">{flashKey}</div>
+            <CopyButton text={flashKey} label="Copy key" copiedLabel="Key copied" />
           </div>
           <p className="secret-hint">Save it now. The raw key is only shown once.</p>
         </div>

--- a/src/app/wiki/admin/keys/page.tsx
+++ b/src/app/wiki/admin/keys/page.tsx
@@ -25,10 +25,9 @@ export default async function ApiKeysPage({ searchParams }: Props) {
   const params = await searchParams;
   const cookieStore = await cookies();
   const flashKey = cookieStore.get("api_key_flash")?.value ?? null;
-  // Clear the flash cookie now that we've read it
-  if (flashKey) {
-    cookieStore.delete("api_key_flash");
-  }
+  // Note: cookie deletion in Server Components is not supported in Next.js 15+.
+  // The cookie expires naturally after maxAge=60 (set in createApiKeyAction).
+  // The "only shown once" guarantee relies on the short maxAge, not explicit deletion.
 
   const keys = await prisma.apiKey.findMany({
     orderBy: [{ revokedAt: "asc" }, { createdAt: "desc" }],


### PR DESCRIPTION
## Code Review Request

This PR triggers a full codebase review of the **Noosphere** project (agent-authored wiki).

### What to Review
- All source code in the repository
- Security vulnerabilities (injection, auth bypass, exposed secrets)
- Error handling gaps
- Logic errors in business logic
- Performance issues
- Dependency vulnerabilities
- Production deployment risks

### Context
- Stack: Next.js 16 + Prisma 7 + PostgreSQL 16 (Docker) + NextAuth.js
- Wiki knowledge base for engineering and project documentation

### Priority
🔴 HIGH — production system

---

*Opened automatically via Cylena*

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR is a security-focused audit of the Noosphere codebase, addressing several real vulnerabilities and hardening multiple API routes. The changes close authorization gaps on `/api/graph` and `/api/log`, fix a `javascript:` XSS vector in article pages, move raw API key delivery out of URLs into a short-lived HttpOnly cookie, add zip-bomb protection to the import endpoint, sanitize agent-supplied `authorName` fields across three routes, fix a ReDoS vulnerability in the lint route, and remove `email` from public article responses.

Key changes:
- **Auth added** to `/api/graph` and `/api/log` (previously unauthenticated)
- **XSS fix**: `sourceUrl` protocol validated (`http:`/`https:` only) before rendering in article pages
- **API key flash**: raw key moved from URL query param → short-lived HttpOnly cookie to avoid log/history exposure
- **Zip-bomb hardening**: both compressed (50 MB) and uncompressed (200 MB) size limits enforced in `/api/import`
- **Author name sanitization**: HTML tags stripped and length capped on `authorName` in `/api/answer`, `/api/ingest`, and `/api/import`
- **ReDoS fix**: article titles and slugs are now regex-escaped before use in word-boundary patterns in `/api/lint`
- **Email not leaked**: `email` field removed from author projections in article list responses

Two issues require fixes before merge: the content-size guard in `ingest/route.ts` throws inside a Prisma transaction without a catch handler (returning 500 instead of 400), and the same route skips the `confidence`/`status` enum validation that was added to the `import` and `answer` routes in this same PR.

<h3>Confidence Score: 3/5</h3>

Not safe to merge as-is: the content size guard in `ingest/route.ts` unconditionally returns a 500 on oversized content, and the route also persists unvalidated `confidence`/`status` enum values.

The PR closes a significant number of real security issues cleanly. However two concrete bugs were introduced in `ingest/route.ts` within this PR: a throw inside an uncaught transaction that degrades the API (500 instead of 400), and missing enum validation that allows arbitrary strings to be persisted for `confidence`/`status` — the exact fix the PR applies to the other two routes. Both are straightforward to fix but affect a write endpoint on a production system.

`src/app/api/ingest/route.ts` — content size guard and missing enum validation both need to be fixed before merge.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/app/api/ingest/route.ts | Adds author name sanitization and a 1 MB content size guard — but the size guard throws inside the Prisma transaction with no outer catch, returning 500 instead of 400; also skips enum validation for `confidence`/`status` that every other route now enforces. |
| src/app/api/lint/route.ts | Fixes ReDoS by escaping regex metacharacters in article titles/slugs; fixes the original bug where `isLinked` checked `a.content` instead of `b.content`. Two issues remain: stale-severity ternary is a no-op (both branches return "low"), and `escapeRe` is re-declared inside the O(n²) loop. |
| src/app/api/import/route.ts | Adds uncompressed-size tracking via JSZip internal `_data` to guard against zip-bombs, plus `validatedConfidence`/`validatedStatus` helpers to reject invalid enum values — solid fixes, though the `_data` access relies on an undocumented JSZip property. |
| src/app/wiki/[topicSlug]/[articleSlug]/page.tsx | Validates `sourceUrl` protocol (`http:`/`https:` only) before rendering the anchor element, correctly closing a `javascript:` XSS vector in article metadata. |
| src/app/wiki/admin/keys/actions.ts | Moves raw API key delivery from URL query param to a short-lived HttpOnly cookie, eliminating exposure in server logs, browser history, and Referer headers. |
| src/app/api/articles/route.ts | Removes `email` from the author select projection in article list responses, preventing accidental email disclosure to API consumers. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    REQ([Incoming Request]) --> AUTH{Auth check\nAPI key or session?}
    AUTH -->|Neither| UNAUTH[401 Unauthorized]
    AUTH -->|API key| PERM{Permission\nlevel?}
    AUTH -->|Session| ROLE{User role?}

    PERM -->|READ only on write route| FORBIDDEN[403 Forbidden]
    PERM -->|WRITE or ADMIN| VALIDATE
    ROLE -->|VIEWER on write route| FORBIDDEN
    ROLE -->|EDITOR or ADMIN| VALIDATE

    VALIDATE[Validate input\ntitle, slug, content, topicId] --> SIZE{Content\n≤ 1 MB?}
    SIZE -->|No — ingest throws inside tx\nreturns 500 not 400| ERR500[⚠️ 500 Error\nbug in ingest route]
    SIZE -->|Yes| ENUM{confidence/status\nvalid enums?}

    ENUM -->|Validated in answer + import\nNOT validated in ingest| DB[(Write to DB)]
    ENUM -->|Invalid in answer/import| E400[400 Bad Request]

    DB --> LOG[Write ActivityLog]
    LOG --> RESP[201 Created]

    style ERR500 fill:#f88,stroke:#c00
    style FORBIDDEN fill:#fcc
    style UNAUTH fill:#fcc
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/app/api/log/route.ts`, line 17 ([link](https://github.com/sweetsophia/noosphere/blob/9ce5f377c5e9440df25e9b2e505a085c982866ef/src/app/api/log/route.ts#L17)) 

   <a href="#"><img alt="P0" src="https://greptile-static-assets.s3.amazonaws.com/badges/p0.svg?v=7" align="top"></a> <a href="#"><img alt="security" src="https://greptile-static-assets.s3.amazonaws.com/badges/Security.svg?v=1" align="top"></a> **Activity log exposed without authentication**

   `GET /api/log` has no authentication or authorization check at all — any unauthenticated HTTP client can query the complete activity log, which includes author names, article IDs, source URLs, ingest details, and tag counts.

   Compare this to every other sensitive route in the project (ingest, export, lint, sync) which all check either an API key or session before responding.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/app/api/log/route.ts
   Line: 17

   Comment:
   **Activity log exposed without authentication**

   `GET /api/log` has no authentication or authorization check at all — any unauthenticated HTTP client can query the complete activity log, which includes author names, article IDs, source URLs, ingest details, and tag counts.

   Compare this to every other sensitive route in the project (ingest, export, lint, sync) which all check either an API key or session before responding.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `src/app/wiki/admin/keys/actions.ts`, line 46 ([link](https://github.com/sweetsophia/noosphere/blob/9ce5f377c5e9440df25e9b2e505a085c982866ef/src/app/wiki/admin/keys/actions.ts#L46)) 

   <a href="#"><img alt="P0" src="https://greptile-static-assets.s3.amazonaws.com/badges/p0.svg?v=7" align="top"></a> <a href="#"><img alt="security" src="https://greptile-static-assets.s3.amazonaws.com/badges/Security.svg?v=1" align="top"></a> **Raw API key placed in URL query parameter**

   The newly-created raw key is appended to the redirect URL as a query parameter. This means the secret value is recorded in server access logs (URLs are logged verbatim by most web servers and reverse proxies), in browser history, and can leak through HTTP `Referer` headers if the admin navigates to an external link while the key is visible.

   The one-time display pattern is correct in concept, but the secret must travel through a mechanism that never touches the URL. Options: store the key in a short-lived server-side record keyed by a random opaque token and redirect to that token, or use a server-side session flash cookie. The raw key should never appear in any URL.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/app/wiki/admin/keys/actions.ts
   Line: 46

   Comment:
   **Raw API key placed in URL query parameter**

   The newly-created raw key is appended to the redirect URL as a query parameter. This means the secret value is recorded in server access logs (URLs are logged verbatim by most web servers and reverse proxies), in browser history, and can leak through HTTP `Referer` headers if the admin navigates to an external link while the key is visible.

   The one-time display pattern is correct in concept, but the secret must travel through a mechanism that never touches the URL. Options: store the key in a short-lived server-side record keyed by a random opaque token and redirect to that token, or use a server-side session flash cookie. The raw key should never appear in any URL.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

3. `src/app/wiki/[topicSlug]/[articleSlug]/page.tsx`, line 96-103 ([link](https://github.com/sweetsophia/noosphere/blob/9ce5f377c5e9440df25e9b2e505a085c982866ef/src/app/wiki/[topicSlug]/[articleSlug]/page.tsx#L96-L103)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> <a href="#"><img alt="security" src="https://greptile-static-assets.s3.amazonaws.com/badges/Security.svg?v=1" align="top"></a> **Stored XSS via unvalidated `sourceUrl`**

   `article.sourceUrl` is stored directly from user-controlled input (via `POST /api/articles`, `POST /api/ingest`, or `POST /api/answer` where `sourceUrl: sourceQuery || null`) and rendered here as a raw `href` with no protocol validation. A `javascript:` URL stored in this field will execute JavaScript in the viewer's context when the "📄 Source" link is clicked.

   The `rel="noopener noreferrer"` attribute guards against the *target* page accessing the opener, but it does **not** prevent `javascript:` URI execution in the current tab.

   Add a protocol allowlist check before rendering the link:

   

   Alternatively, strip/validate `sourceUrl` at write time in the API routes.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/app/wiki/[topicSlug]/[articleSlug]/page.tsx
   Line: 96-103

   Comment:
   **Stored XSS via unvalidated `sourceUrl`**

   `article.sourceUrl` is stored directly from user-controlled input (via `POST /api/articles`, `POST /api/ingest`, or `POST /api/answer` where `sourceUrl: sourceQuery || null`) and rendered here as a raw `href` with no protocol validation. A `javascript:` URL stored in this field will execute JavaScript in the viewer's context when the "📄 Source" link is clicked.

   The `rel="noopener noreferrer"` attribute guards against the *target* page accessing the opener, but it does **not** prevent `javascript:` URI execution in the current tab.

   Add a protocol allowlist check before rendering the link:

   

   Alternatively, strip/validate `sourceUrl` at write time in the API routes.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

4. `src/app/api/lint/route.ts`, line 215-218 ([link](https://github.com/sweetsophia/noosphere/blob/9ce5f377c5e9440df25e9b2e505a085c982866ef/src/app/api/lint/route.ts#L215-L218)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Broken `isLinked` check — always tests the wrong article and the wrong string**

   Two compounding bugs here:

   1. **String literals instead of interpolation** — `a.slug` inside the regex string is the four-character literal `"a.slug"`, not the article's actual slug value. The template literal is missing, so `${a.slug}` is never substituted.
   2. **Tests `a.content` instead of `b.content`** — the check is supposed to determine whether article *b* mentions article *a*, but it tests `a.content` (the source article itself) instead of `b.content` (the article being scanned for mentions).

   The combined effect is that `isLinked` is always `false` for every article pair, causing every detected mention to be flagged as unlinked even when a proper wikilink exists.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/app/api/lint/route.ts
   Line: 215-218

   Comment:
   **Broken `isLinked` check — always tests the wrong article and the wrong string**

   Two compounding bugs here:

   1. **String literals instead of interpolation** — `a.slug` inside the regex string is the four-character literal `"a.slug"`, not the article's actual slug value. The template literal is missing, so `${a.slug}` is never substituted.
   2. **Tests `a.content` instead of `b.content`** — the check is supposed to determine whether article *b* mentions article *a*, but it tests `a.content` (the source article itself) instead of `b.content` (the article being scanned for mentions).

   The combined effect is that `isLinked` is always `false` for every article pair, causing every detected mention to be flagged as unlinked even when a proper wikilink exists.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

5. `src/app/api/import/route.ts`, line 99-112 ([link](https://github.com/sweetsophia/noosphere/blob/9ce5f377c5e9440df25e9b2e505a085c982866ef/src/app/api/import/route.ts#L99-L112)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **No upload size limit — zip bomb risk**

   The zip file is read entirely into memory (`fileEntry.arrayBuffer()`) and then decompressed (`JSZip.loadAsync`) without any size check. A user with WRITE permission could upload a zip bomb to exhaust server memory and crash the Node.js process.

   Add both a raw-bytes limit before decompression and track cumulative uncompressed size while parsing:

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/app/api/import/route.ts
   Line: 99-112

   Comment:
   **No upload size limit — zip bomb risk**

   The zip file is read entirely into memory (`fileEntry.arrayBuffer()`) and then decompressed (`JSZip.loadAsync`) without any size check. A user with WRITE permission could upload a zip bomb to exhaust server memory and crash the Node.js process.

   Add both a raw-bytes limit before decompression and track cumulative uncompressed size while parsing:

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

6. `src/app/api/import/route.ts`, line 224-246 ([link](https://github.com/sweetsophia/noosphere/blob/9ce5f377c5e9440df25e9b2e505a085c982866ef/src/app/api/import/route.ts#L224-L246)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`status` and `confidence` not validated against allowlists on import**

   When overwriting an existing article, `status` and `confidence` are taken directly from YAML frontmatter without checking them against the allowed values (`draft/reviewed/published` and `low/medium/high`). An arbitrary string can be stored in the database, bypassing the validation that exists in `POST /api/articles` and `PATCH /api/articles/[id]`.

   The same gap applies to new articles created via import (lines 264–286). Add allowlist checks before writing, falling back to the existing value on overwrite or the default on create.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/app/api/import/route.ts
   Line: 224-246

   Comment:
   **`status` and `confidence` not validated against allowlists on import**

   When overwriting an existing article, `status` and `confidence` are taken directly from YAML frontmatter without checking them against the allowed values (`draft/reviewed/published` and `low/medium/high`). An arbitrary string can be stored in the database, bypassing the validation that exists in `POST /api/articles` and `PATCH /api/articles/[id]`.

   The same gap applies to new articles created via import (lines 264–286). Add allowlist checks before writing, falling back to the existing value on overwrite or the default on create.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

7. `src/app/api/graph/route.ts`, line 20 ([link](https://github.com/sweetsophia/noosphere/blob/9ce5f377c5e9440df25e9b2e505a085c982866ef/src/app/api/graph/route.ts#L20)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`GET /api/graph` is unauthenticated**

   This endpoint returns article titles, excerpts, and the full tag/cross-reference structure for the entire wiki without any authentication check. Every other data-reading API route either requires an API key or session, or is explicitly left open (like `/api/health`). If article content is intended to be non-public, this is an information-disclosure gap.

   At minimum, add a `READ`-level API key or session check consistent with `GET /api/articles`.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/app/api/graph/route.ts
   Line: 20

   Comment:
   **`GET /api/graph` is unauthenticated**

   This endpoint returns article titles, excerpts, and the full tag/cross-reference structure for the entire wiki without any authentication check. Every other data-reading API route either requires an API key or session, or is explicitly left open (like `/api/health`). If article content is intended to be non-public, this is an information-disclosure gap.

   At minimum, add a `READ`-level API key or session check consistent with `GET /api/articles`.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/app/api/ingest/route.ts
Line: 150-156

Comment:
**Content size guard throws a 500, not a 400**

The `throw` inside the `$transaction` callback is not caught by any `try/catch` in the outer function. When this error is thrown, the transaction rejects and the unhandled rejection propagates up to Next.js, which returns a generic **500** response — not the intended 400. The `.status: 400` property attached to the Error object is never read by anything.

Fix: move the size check *before* the transaction begins, so it can return a proper `400` response:

```typescript
// Before the $transaction call:
for (const article of articles) {
  if (new TextEncoder().encode(article.content).length > MAX_ARTICLE_CONTENT_SIZE) {
    return NextResponse.json(
      { error: `Article [${articles.indexOf(article)}] content exceeds ${MAX_ARTICLE_CONTENT_SIZE} bytes` },
      { status: 400 }
    );
  }
}

const result = await prisma.$transaction(async (tx) => { ... });
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/app/api/ingest/route.ts
Line: 200-203

Comment:
**`confidence` and `status` stored without enum validation**

The `import` route (updated in this same PR) uses `validatedConfidence()` and `validatedStatus()` helpers to reject arbitrary values, and `answer/route.ts` returns a 400 on unknown values. The `ingest` route stores these fields directly from the request body without any validation — allowing values like `confidence: "very-high"` or `status: "active"` to be persisted to the database.

```typescript
confidence: article.confidence || null,
status: article.status || "published",
```

Apply the same helpers used in the import route:

```suggestion
              confidence: validatedConfidence(article.confidence ?? undefined),
              status: validatedStatus(article.status ?? undefined, "published"),
```

You'll need to import (or move) `validatedConfidence` and `validatedStatus` into a shared helper so both routes can use them.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/app/api/lint/route.ts
Line: 155-157

Comment:
**Both branches of the stale severity ternary return `"low"` — dead code**

```typescript
severity: daysSince > staleDays * 2 ? "low" : "low",
```

The conditional is a no-op; every stale article gets severity `"low"` regardless of how stale it is. This looks like a copy-paste error where the first branch was meant to be a higher severity (e.g., `"medium"` or `"high"`). As written, the severity scale is meaningless for stale articles.

```suggestion
        severity: daysSince > staleDays * 2 ? "medium" : "low",
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/app/api/lint/route.ts
Line: 214

Comment:
**`escapeRe` helper re-declared on every loop iteration in an O(n²) loop**

`escapeRe` is a pure, stateless function. Declaring it inside the inner `for (const b of articles)` loop creates a new function object for every pair `(a, b)` — that's `n²` allocations for a wiki with `n` articles. Move it to module scope (or at least outside both loops).

```suggestion
  const escapeRe = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
  for (const a of articles) {
    const unlinkedMentions: string[] = [];
    for (const b of articles) {
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix: PII leak, author spoofing, content ..."](https://github.com/sweetsophia/noosphere/commit/bc9c16002fe2bacf2d60f1fb03db0e33ad3dec52) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28516839)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->