### PR TITLE
Define normalized memory result schema

### DIFF
--- a/src/lib/memory/index.ts
+++ b/src/lib/memory/index.ts
@@ -1,0 +1,15 @@
+export type {
+  MemoryCurationLevel,
+  MemoryProviderMetadata,
+  MemoryResult,
+  MemoryResultInput,
+  MemoryScore,
+  MemorySourceType,
+} from "./types";
+
+export {
+  DEFAULT_MEMORY_CHARS_PER_TOKEN,
+  defineMemoryResult,
+  estimateMemoryTokens,
+  normalizeMemoryScore,
+} from "./types";

--- a/src/lib/memory/index.ts
+++ b/src/lib/memory/index.ts
@@ -11,5 +11,6 @@ export {
   DEFAULT_MEMORY_CHARS_PER_TOKEN,
   defineMemoryResult,
   estimateMemoryTokens,
+  normalizeMemoryTokenEstimate,
   normalizeMemoryScore,
 } from "./types";

--- a/src/lib/memory/types.ts
+++ b/src/lib/memory/types.ts
@@ -61,10 +61,7 @@ export interface MemoryResult {
   metadata?: MemoryProviderMetadata;
 }
 
-export interface MemoryResultInput
-  extends Omit<MemoryResult, "tokenEstimate"> {
-  tokenEstimate?: number;
-}
+export type MemoryResultInput = MemoryResult;
 
 export const DEFAULT_MEMORY_CHARS_PER_TOKEN = 4;
 
@@ -84,7 +81,22 @@ export function estimateMemoryTokens(
     return 0;
   }
 
-  return Math.ceil(text.length / charsPerToken);
+  const safeCharsPerToken =
+    Number.isFinite(charsPerToken) && charsPerToken > 0
+      ? charsPerToken
+      : DEFAULT_MEMORY_CHARS_PER_TOKEN;
+
+  return Math.ceil(text.length / safeCharsPerToken);
+}
+
+export function normalizeMemoryTokenEstimate(
+  tokenEstimate: number | undefined,
+): number | undefined {
+  if (tokenEstimate === undefined || !Number.isFinite(tokenEstimate)) {
+    return undefined;
+  }
+
+  return Math.max(0, Math.ceil(tokenEstimate));
 }
 
 export function defineMemoryResult(input: MemoryResultInput): MemoryResult {
@@ -103,6 +115,7 @@ export function defineMemoryResult(input: MemoryResultInput): MemoryResult {
         ? undefined
         : normalizeMemoryScore(input.recencyScore),
     tokenEstimate:
-      input.tokenEstimate ?? estimateMemoryTokens(input.summary ?? input.content),
+      normalizeMemoryTokenEstimate(input.tokenEstimate) ??
+      estimateMemoryTokens(input.summary || input.content),
   };
 }

--- a/src/lib/memory/types.ts
+++ b/src/lib/memory/types.ts
@@ -1,0 +1,108 @@
+export type MemorySourceType =
+  | "noosphere"
+  | "hindsight"
+  | "external"
+  | "procedural"
+  | (string & {});
+
+export type MemoryCurationLevel = "ephemeral" | "reviewed" | "curated";
+
+export type MemoryScore = number;
+
+export type MemoryProviderMetadata = Record<string, unknown>;
+
+export interface MemoryResult {
+  /** Provider-local stable identifier for this memory result. */
+  id: string;
+
+  /** Provider identifier, for example "noosphere" or "hindsight". */
+  provider: string;
+
+  /** Broad provider/source category used by provider-agnostic policy code. */
+  sourceType: MemorySourceType;
+
+  /** Optional human-readable label. */
+  title?: string;
+
+  /** Normalized memory body. Providers should avoid putting metadata here. */
+  content: string;
+
+  /** Short form preferred for low-budget recall injection. */
+  summary?: string;
+
+  /** Query relevance, normalized to 0.0–1.0 when available. */
+  relevanceScore?: MemoryScore;
+
+  /** Provider confidence, normalized to 0.0–1.0 when available. */
+  confidenceScore?: MemoryScore;
+
+  /** Freshness signal, normalized to 0.0–1.0 when available. */
+  recencyScore?: MemoryScore;
+
+  /** How durable or reviewed the memory is. */
+  curationLevel?: MemoryCurationLevel;
+
+  /** ISO-8601 creation timestamp if the provider exposes one. */
+  createdAt?: string;
+
+  /** ISO-8601 update timestamp if the provider exposes one. */
+  updatedAt?: string;
+
+  /** Estimated prompt tokens for summary/content selection. */
+  tokenEstimate?: number;
+
+  /** Provider-agnostic canonical reference for dedupe, provenance, or linking. */
+  canonicalRef?: string;
+
+  /** Provider-agnostic tags or labels. */
+  tags?: string[];
+
+  /** Provider-specific fields must remain isolated here. */
+  metadata?: MemoryProviderMetadata;
+}
+
+export interface MemoryResultInput
+  extends Omit<MemoryResult, "tokenEstimate"> {
+  tokenEstimate?: number;
+}
+
+export const DEFAULT_MEMORY_CHARS_PER_TOKEN = 4;
+
+export function normalizeMemoryScore(score: number): MemoryScore {
+  if (Number.isNaN(score)) {
+    return 0;
+  }
+
+  return Math.max(0, Math.min(1, score));
+}
+
+export function estimateMemoryTokens(
+  text: string,
+  charsPerToken = DEFAULT_MEMORY_CHARS_PER_TOKEN,
+): number {
+  if (text.length === 0) {
+    return 0;
+  }
+
+  return Math.ceil(text.length / charsPerToken);
+}
+
+export function defineMemoryResult(input: MemoryResultInput): MemoryResult {
+  return {
+    ...input,
+    relevanceScore:
+      input.relevanceScore === undefined
+        ? undefined
+        : normalizeMemoryScore(input.relevanceScore),
+    confidenceScore:
+      input.confidenceScore === undefined
+        ? undefined
+        : normalizeMemoryScore(input.confidenceScore),
+    recencyScore:
+      input.recencyScore === undefined
+        ? undefined
+        : normalizeMemoryScore(input.recencyScore),
+    tokenEstimate:
+      input.tokenEstimate ?? estimateMemoryTokens(input.summary ?? input.content),
+  };
+}


### PR DESCRIPTION
## Summary
- Add a provider-agnostic `MemoryResult` schema for Noosphere, Hindsight, external, and future procedural providers
- Add shared score, curation, source, metadata, and token-estimation conventions under `src/lib/memory`
- Export normalization helpers for future provider adapters and recall orchestration

## Validation
- `npx eslint src/lib/memory/types.ts src/lib/memory/index.ts`
- `npx tsc --noEmit --skipLibCheck src/lib/memory/types.ts src/lib/memory/index.ts`
- Full `npx tsc --noEmit` currently fails on pre-existing project-wide Prisma/type errors outside this PR

Closes #6
Part of #5

## Summary by Sourcery

Introduce a shared, provider-agnostic memory result schema and helpers for normalizing scores and token estimates.

New Features:
- Add a unified MemoryResult type with standard fields for content, scoring, curation, timestamps, tags, and provider metadata across memory providers.
- Expose normalization and token-estimation helpers for memory results via a new src/lib/memory module.

Enhancements:
- Export memory types and utilities through a central index to support future provider adapters and orchestration logic.