### PR TITLE
Add Noosphere memory provider adapter

### DIFF
--- a/src/__tests__/memory/noosphere-provider.test.ts
+++ b/src/__tests__/memory/noosphere-provider.test.ts
@@ -4,30 +4,37 @@
  * Run with: npx tsx src/__tests__/memory/noosphere-provider.test.ts
  *
  * Tests cover:
- * 1. Pure function unit tests (mapConfidenceScore, mapCurationLevel, mapRecencyScore, normalizeRank, normalizeOffset)
- * 2. Constructor validation
- * 3. search() with mock Prisma (empty query, disabled config, successful search)
- * 4. getById() with mock Prisma (found, not found, disabled, canonical ref stripping)
- * 5. score() edge cases (non-noosphere results, missing fields, aggregate calculation)
- * 6. resolveSearchLimit priority chain
+ * 1. Constructor validation (descriptor, config overrides, factory)
+ * 2. search() edge cases (empty query, disabled config, no results)
+ * 3. getById() (found, not found, disabled, canonical ref stripping)
+ * 4. score() (non-noosphere guard, aggregate, recency decay)
+ * 5. Confidence and curation level mapping via getById
+ * 6. Descriptor metadata
  */
 
-// ─── Inline access to private-scoped helpers via re-export ──────────────────
-// The helper functions are module-scoped, so we test them through the provider's
-// public interface and verify the outputs on MemoryResult / MemoryProviderScore.
+// Provide a dummy DATABASE_URL so the default Prisma client import doesn't crash.
+// Tests inject their own mock Prisma, so this connection string is never used.
+if (!process.env.DATABASE_URL) {
+  process.env.DATABASE_URL = "postgresql://test:test@localhost:5432/test";
+}
 
 import type { PrismaClient } from "@prisma/client";
+import {
+  NoosphereProvider,
+  createNoosphereProvider,
+} from "@/lib/memory/noosphere";
 
 // ─── Test helpers ────────────────────────────────────────────────────────────
 
 let testCounter = 0;
 let passCount = 0;
 let failCount = 0;
+const pending: Promise<void>[] = [];
 
 function test(name: string, fn: () => void | Promise<void>): void {
   testCounter++;
   const label = `[${testCounter}] ${name}`;
-  Promise.resolve()
+  const p = Promise.resolve()
     .then(() => fn())
     .then(() => {
       passCount++;
@@ -38,6 +45,7 @@ function test(name: string, fn: () => void | Promise<void>): void {
       const message = err instanceof Error ? err.message : String(err);
       console.error(`  ✗ ${label}\n    ${message}`);
     });
+  pending.push(p);
 }
 
 function assert(condition: boolean, message: string): void {
@@ -46,68 +54,121 @@ function assert(condition: boolean, message: string): void {
 
 function assertEqual<T>(actual: T, expected: T, label: string): void {
   if (actual !== expected) {
-    throw new Error(`${label}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+    throw new Error(
+      `${label}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`,
+    );
   }
 }
 
-function assertApprox(actual: number, expected: number, tolerance: number, label: string): void {
+function assertApprox(
+  actual: number,
+  expected: number,
+  tolerance: number,
+  label: string,
+): void {
   if (Math.abs(actual - expected) > tolerance) {
-    throw new Error(`${label}: expected ~${expected} (±${tolerance}), got ${actual}`);
+    throw new Error(
+      `${label}: expected ~${expected} (±${tolerance}), got ${actual}`,
+    );
   }
 }
 
 // ─── Mock Prisma ─────────────────────────────────────────────────────────────
 
-function createMockPrisma(overrides: Record<string, unknown> = {}): PrismaClient {
+function createMockPrisma(
+  overrides: Record<string, unknown> = {},
+): PrismaClient {
   return {
     article: {
-      findFirst: (() => Promise.resolve(null)) as unknown as PrismaClient["article"]["findFirst"],
-      findMany: (() => Promise.resolve([])) as unknown as PrismaClient["article"]["findMany"],
+      findFirst: (() =>
+        Promise.resolve(null)) as unknown as PrismaClient["article"]["findFirst"],
+      findMany: (() =>
+        Promise.resolve(
+          [],
+        )) as unknown as PrismaClient["article"]["findMany"],
     },
-    $queryRaw: (() => Promise.resolve([])) as unknown as PrismaClient["$queryRaw"],
+    $queryRaw: (() =>
+      Promise.resolve([])) as unknown as PrismaClient["$queryRaw"],
     ...overrides,
   } as unknown as PrismaClient;
 }
 
-// ─── Import the provider (dynamic to allow tsx execution) ───────────────────
+// ─── Shared mock article factory ────────────────────────────────────────────
+
+function mockArticle(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "test-id",
+    title: "Test Article",
+    slug: "test-article",
+    content: "Test content body",
+    excerpt: "Test excerpt",
+    status: "published",
+    confidence: "high",
+    sourceUrl: null,
+    sourceType: null,
+    createdAt: new Date("2026-01-01"),
+    updatedAt: new Date("2026-04-01"),
+    lastReviewed: null,
+    authorId: null,
+    authorName: null,
+    topicId: "topic-1",
+    topic: { id: "topic-1", slug: "engineering", name: "Engineering" },
+    tags: [],
+    ...overrides,
+  };
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
 
 async function main() {
-  // Dynamic import so tsx can resolve TypeScript + path aliases.
-  // We import the module and destructure what we need.
-  const { NoosphereProvider, createNoosphereProvider } = await import(
-    "@/lib/memory/noosphere"
-  );
-
   console.log("\n🔍 NoosphereProvider Tests\n");
 
-  // ─── Constructor ───────────────────────────────────────────────────────────
+  // ─── Constructor ─────────────────────────────────────────────────────────
 
   test("constructor uses default Prisma when none provided", () => {
-    // Just verify it doesn't throw and has the right descriptor.
-    // (Can't call search without a real DB.)
     const provider = new NoosphereProvider();
     assertEqual(provider.descriptor.id, "noosphere", "provider id");
     assertEqual(provider.descriptor.sourceType, "noosphere", "source type");
-    assertEqual(provider.descriptor.capabilities.search, true, "search cap");
-    assertEqual(provider.descriptor.capabilities.getById, true, "getById cap");
+    assertEqual(
+      provider.descriptor.capabilities.search,
+      true,
+      "search cap",
+    );
+    assertEqual(
+      provider.descriptor.capabilities.getById,
+      true,
+      "getById cap",
+    );
     assertEqual(provider.descriptor.capabilities.score, true, "score cap");
-    assertEqual(provider.descriptor.capabilities.autoRecall, true, "autoRecall cap");
+    assertEqual(
+      provider.descriptor.capabilities.autoRecall,
+      true,
+      "autoRecall cap",
+    );
   });
 
   test("constructor applies providerConfig overrides", () => {
     const provider = new NoosphereProvider({
       providerConfig: { priorityWeight: 2.5, maxResults: 5 },
     });
-    assertEqual(provider.descriptor.defaultConfig.priorityWeight, 2.5, "priorityWeight override");
-    assertEqual(provider.descriptor.defaultConfig.maxResults, 5, "maxResults override");
+    assertEqual(
+      provider.descriptor.defaultConfig.priorityWeight,
+      2.5,
+      "priorityWeight override",
+    );
+    assertEqual(
+      provider.descriptor.defaultConfig.maxResults,
+      5,
+      "maxResults override",
+    );
   });
 
-  test("createNoosphereProvider factory returns NoosphereProvider instance", () => {
+  test("createNoosphereProvider factory returns instance", () => {
     const provider = createNoosphereProvider();
     assert(provider instanceof NoosphereProvider, "instance check");
   });
 
-  // ─── search() ──────────────────────────────────────────────────────────────
+  // ─── search() ───────────────────────────────────────────────────────────
 
   test("search returns empty array for empty query", async () => {
     const provider = new NoosphereProvider({
@@ -138,14 +199,12 @@ async function main() {
     assertEqual(results.length, 0, "no results");
   });
 
-  // ─── getById() ─────────────────────────────────────────────────────────────
+  // ─── getById() ──────────────────────────────────────────────────────────
 
   test("getById returns null when article not found", async () => {
     const provider = new NoosphereProvider({
       prisma: createMockPrisma({
-        article: {
-          findFirst: () => Promise.resolve(null),
-        },
+        article: { findFirst: () => Promise.resolve(null) },
       }),
     });
     const result = await provider.getById("nonexistent-id");
@@ -164,33 +223,14 @@ async function main() {
   });
 
   test("getById strips noosphere:article: prefix from id", async () => {
-    const mockArticle = {
-      id: "abc123",
-      title: "Test Article",
-      slug: "test-article",
-      content: "Test content",
-      excerpt: "Test excerpt",
-      status: "published",
-      confidence: "high",
-      sourceUrl: null,
-      sourceType: null,
-      createdAt: new Date("2026-01-01"),
-      updatedAt: new Date("2026-04-01"),
-      lastReviewed: null,
-      authorId: null,
-      authorName: null,
-      topicId: "topic1",
-      topic: { id: "topic1", slug: "engineering", name: "Engineering" },
-      tags: [],
-    };
-
     let capturedId: string | undefined;
     const provider = new NoosphereProvider({
       prisma: createMockPrisma({
         article: {
-          findFirst: (args: { where: { id: string } }) => {
-            capturedId = args.where.id;
-            return Promise.resolve(mockArticle);
+          findFirst: (args: Record<string, unknown>) => {
+            const where = args.where as { id: string };
+            capturedId = where.id;
+            return Promise.resolve(mockArticle({ id: "abc123" }));
           },
         },
       }),
@@ -202,13 +242,45 @@ async function main() {
     assertEqual(result!.provider, "noosphere", "provider field");
     assertEqual(result!.sourceType, "noosphere", "sourceType field");
     assertEqual(result!.title, "Test Article", "title");
-    assertEqual(result!.content, "Test content", "content");
+    assertEqual(result!.content, "Test content body", "content");
     assertEqual(result!.summary, "Test excerpt", "summary");
-    assertEqual(result!.curationLevel, "curated", "curation level for published");
-    assertEqual(result!.canonicalRef, "noosphere:article:abc123", "canonical ref");
+    assertEqual(
+      result!.curationLevel,
+      "curated",
+      "curation level for published",
+    );
+    assertEqual(
+      result!.canonicalRef,
+      "noosphere:article:abc123",
+      "canonical ref",
+    );
   });
 
-  // ─── score() ───────────────────────────────────────────────────────────────
+  test("getById maps confidence and recency from article fields", async () => {
+    const provider = new NoosphereProvider({
+      prisma: createMockPrisma({
+        article: {
+          findFirst: () =>
+            Promise.resolve(
+              mockArticle({
+                confidence: "high",
+                updatedAt: new Date("2026-04-25"),
+              }),
+            ),
+        },
+      }),
+    });
+    const result = await provider.getById("test");
+    assert(result !== null, "result exists");
+    assertEqual(result!.confidenceScore, 1, "high confidence → 1");
+    // recencyScore depends on current time vs updatedAt, so just verify it's high.
+    assert(
+      result!.recencyScore !== undefined && result!.recencyScore! > 0.9,
+      "recent article → recency > 0.9",
+    );
+  });
+
+  // ─── score() ────────────────────────────────────────────────────────────
 
   test("score returns empty object for non-noosphere results", () => {
     const provider = new NoosphereProvider({ prisma: createMockPrisma() });
@@ -233,7 +305,6 @@ async function main() {
       updatedAt: new Date("2026-04-01").toISOString(),
     });
     assert(score.aggregateScore !== undefined, "aggregate should exist");
-    // Average of 0.8 (relevance) + 1.0 (confidence) + recency (should be < 1.0)
     assert(score.aggregateScore! > 0, "aggregate > 0");
     assert(score.aggregateScore! <= 1, "aggregate <= 1");
     assert(score.reasons !== undefined, "reasons should exist");
@@ -248,14 +319,18 @@ async function main() {
       sourceType: "noosphere",
       content: "test",
     });
-    assertEqual(score.aggregateScore, undefined, "no aggregate without signals");
+    assertEqual(
+      score.aggregateScore,
+      undefined,
+      "no aggregate without signals",
+    );
   });
 
-  test("score recency decays over time", () => {
+  test("score recency decays with 90-day half-life", () => {
     const provider = new NoosphereProvider({ prisma: createMockPrisma() });
     const now = new Date("2026-04-25");
 
-    // Fresh article (0 days old)
+    // Fresh article (0 days old) → recency 1
     const fresh = provider.score(
       {
         id: "1",
@@ -268,8 +343,10 @@ async function main() {
     );
     assertEqual(fresh.recencyScore, 1, "fresh article score");
 
-    // 90 days old = half-life should give ~0.5
-    const ninetyDaysAgo = new Date(now.getTime() - 90 * 24 * 60 * 60 * 1000);
+    // 90 days old → half-life ≈ 0.5
+    const ninetyDaysAgo = new Date(
+      now.getTime() - 90 * 24 * 60 * 60 * 1000,
+    );
     const old = provider.score(
       {
         id: "2",
@@ -283,8 +360,10 @@ async function main() {
     assert(old.recencyScore !== undefined, "old recency should exist");
     assertApprox(old.recencyScore!, 0.5, 0.01, "90-day half-life");
 
-    // Very old article (365 days)
-    const yearAgo = new Date(now.getTime() - 365 * 24 * 60 * 60 * 1000);
+    // 365 days old → very decayed
+    const yearAgo = new Date(
+      now.getTime() - 365 * 24 * 60 * 60 * 1000,
+    );
     const ancient = provider.score(
       {
         id: "3",
@@ -295,126 +374,101 @@ async function main() {
       },
       { now },
     );
-    assert(ancient.recencyScore !== undefined, "ancient recency should exist");
-    assert(ancient.recencyScore! < 0.1, "365-day should be < 0.1");
+    assert(ancient.recencyScore !== undefined, "ancient recency exists");
+    assert(ancient.recencyScore! < 0.1, "365-day < 0.1");
   });
 
-  // ─── mapConfidenceScore (tested via score/getById) ─────────────────────────
+  // ─── Confidence mapping via getById ─────────────────────────────────────
 
-  test("confidence mapping: high=1, medium=0.66, low=0.33, null=undefined", () => {
-    const provider = new NoosphereProvider({ prisma: createMockPrisma() });
-
-    // Test via score — the confidenceScore on the result comes from mapConfidenceScore.
-    // We test the output of getById which calls toMemoryResult → mapConfidenceScore.
-    const mockArticleFactory = (confidence: string | null) => ({
-      id: "test",
-      title: "Test",
-      slug: "test",
-      content: "content",
-      excerpt: null,
-      status: "published",
-      confidence,
-      sourceUrl: null,
-      sourceType: null,
-      createdAt: new Date("2026-01-01"),
-      updatedAt: new Date("2026-01-01"),
-      lastReviewed: null,
-      authorId: null,
-      authorName: null,
-      topicId: "t1",
-      topic: { id: "t1", slug: "test", name: "Test" },
-      tags: [],
-    });
-
-    // We can test mapConfidenceScore indirectly by checking score output on results
-    // that have confidenceScore set. But since score() just reads the result's
-    // confidenceScore, let's test the mapping directly via getById mock.
-    const expectations: [string | null, number | undefined][] = [
+  test("confidence: high=1, medium=0.66, low=0.33, null=undefined", async () => {
+    const cases: [string | null, number | undefined][] = [
       ["high", 1],
       ["medium", 0.66],
       ["low", 0.33],
       [null, undefined],
     ];
 
-    for (const [confidence, expected] of expectations) {
+    for (const [confidence, expected] of cases) {
       const provider = new NoosphereProvider({
         prisma: createMockPrisma({
           article: {
-            findFirst: () => Promise.resolve(mockArticleFactory(confidence)),
+            findFirst: () =>
+              Promise.resolve(mockArticle({ confidence })),
           },
         }),
       });
-      provider.getById("test").then((result) => {
-        if (!result) throw new Error("result is null");
-        if (expected === undefined) {
-          assertEqual(result.confidenceScore, undefined, `confidence=${confidence}`);
-        } else {
-          assertApprox(result.confidenceScore!, expected, 0.01, `confidence=${confidence}`);
-        }
-      });
+      const result = await provider.getById("test");
+      assert(result !== null, `result exists for confidence=${confidence}`);
+      if (expected === undefined) {
+        assertEqual(
+          result!.confidenceScore,
+          undefined,
+          `confidence=${confidence}`,
+        );
+      } else {
+        assertApprox(
+          result!.confidenceScore!,
+          expected,
+          0.01,
+          `confidence=${confidence}`,
+        );
+      }
     }
   });
 
-  // ─── mapCurationLevel (tested via getById) ─────────────────────────────────
+  // ─── Curation level mapping via getById ─────────────────────────────────
 
-  test("curation level mapping: published=curated, reviewed=reviewed, draft=ephemeral", async () => {
-    const mockArticleFactory = (status: string) => ({
-      id: "test",
-      title: "Test",
-      slug: "test",
-      content: "content",
-      excerpt: null,
-      status,
-      confidence: null,
-      sourceUrl: null,
-      sourceType: null,
-      createdAt: new Date("2026-01-01"),
-      updatedAt: new Date("2026-01-01"),
-      lastReviewed: null,
-      authorId: null,
-      authorName: null,
-      topicId: "t1",
-      topic: { id: "t1", slug: "test", name: "Test" },
-      tags: [],
-    });
-
-    const expectations: [string, string][] = [
+  test("curation: published=curated, reviewed=reviewed, draft=ephemeral", async () => {
+    const cases: [string, string][] = [
       ["published", "curated"],
       ["reviewed", "reviewed"],
       ["draft", "ephemeral"],
     ];
 
-    for (const [status, expected] of expectations) {
+    for (const [status, expected] of cases) {
       const provider = new NoosphereProvider({
         prisma: createMockPrisma({
           article: {
-            findFirst: () => Promise.resolve(mockArticleFactory(status)),
+            findFirst: () => Promise.resolve(mockArticle({ status })),
           },
         }),
       });
       const result = await provider.getById("test");
-      assertEqual(result?.curationLevel, expected as "curated" | "reviewed" | "ephemeral", `status=${status}`);
+      assertEqual(
+        result?.curationLevel,
+        expected as "curated" | "reviewed" | "ephemeral",
+        `status=${status}`,
+      );
     }
   });
 
-  // ─── descriptor metadata ───────────────────────────────────────────────────
+  // ─── Descriptor metadata ───────────────────────────────────────────────
 
   test("descriptor has correct default priority weight", () => {
     const provider = new NoosphereProvider();
-    assertEqual(provider.descriptor.defaultConfig.priorityWeight, 1.25, "default priority");
+    assertEqual(
+      provider.descriptor.defaultConfig.priorityWeight,
+      1.25,
+      "default priority",
+    );
   });
 
   test("descriptor metadata includes contentType article", () => {
     const provider = new NoosphereProvider();
-    assertEqual(provider.descriptor.metadata?.contentType, "article", "contentType");
+    assertEqual(
+      provider.descriptor.metadata?.contentType,
+      "article",
+      "contentType",
+    );
   });
 
-  // ─── Wait for async tests to complete ──────────────────────────────────────
+  // ─── Wait for all async tests ───────────────────────────────────────────
 
-  // Small delay to let all async test assertions settle.
-  await new Promise((resolve) => setTimeout(resolve, 200));
+  await Promise.all(pending);
 
-  console.log(`\n  ${passCount} passed, ${failCount} failed, ${testCounter} total\n`);
+  console.log(
+    `\n  ${passCount} passed, ${failCount} failed, ${testCounter} total\n`,
+  );
 
   if (failCount > 0) {
     process.exit(1);

--- a/src/__tests__/memory/noosphere-provider.test.ts
+++ b/src/__tests__/memory/noosphere-provider.test.ts
@@ -1,0 +1,427 @@
+/**
+ * NoosphereProvider — Unit Tests
+ *
+ * Run with: npx tsx src/__tests__/memory/noosphere-provider.test.ts
+ *
+ * Tests cover:
+ * 1. Pure function unit tests (mapConfidenceScore, mapCurationLevel, mapRecencyScore, normalizeRank, normalizeOffset)
+ * 2. Constructor validation
+ * 3. search() with mock Prisma (empty query, disabled config, successful search)
+ * 4. getById() with mock Prisma (found, not found, disabled, canonical ref stripping)
+ * 5. score() edge cases (non-noosphere results, missing fields, aggregate calculation)
+ * 6. resolveSearchLimit priority chain
+ */
+
+// ─── Inline access to private-scoped helpers via re-export ──────────────────
+// The helper functions are module-scoped, so we test them through the provider's
+// public interface and verify the outputs on MemoryResult / MemoryProviderScore.
+
+import type { PrismaClient } from "@prisma/client";
+
+// ─── Test helpers ────────────────────────────────────────────────────────────
+
+let testCounter = 0;
+let passCount = 0;
+let failCount = 0;
+
+function test(name: string, fn: () => void | Promise<void>): void {
+  testCounter++;
+  const label = `[${testCounter}] ${name}`;
+  Promise.resolve()
+    .then(() => fn())
+    .then(() => {
+      passCount++;
+      console.log(`  ✓ ${label}`);
+    })
+    .catch((err: unknown) => {
+      failCount++;
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(`  ✗ ${label}\n    ${message}`);
+    });
+}
+
+function assert(condition: boolean, message: string): void {
+  if (!condition) throw new Error(`Assertion failed: ${message}`);
+}
+
+function assertEqual<T>(actual: T, expected: T, label: string): void {
+  if (actual !== expected) {
+    throw new Error(`${label}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+  }
+}
+
+function assertApprox(actual: number, expected: number, tolerance: number, label: string): void {
+  if (Math.abs(actual - expected) > tolerance) {
+    throw new Error(`${label}: expected ~${expected} (±${tolerance}), got ${actual}`);
+  }
+}
+
+// ─── Mock Prisma ─────────────────────────────────────────────────────────────
+
+function createMockPrisma(overrides: Record<string, unknown> = {}): PrismaClient {
+  return {
+    article: {
+      findFirst: (() => Promise.resolve(null)) as unknown as PrismaClient["article"]["findFirst"],
+      findMany: (() => Promise.resolve([])) as unknown as PrismaClient["article"]["findMany"],
+    },
+    $queryRaw: (() => Promise.resolve([])) as unknown as PrismaClient["$queryRaw"],
+    ...overrides,
+  } as unknown as PrismaClient;
+}
+
+// ─── Import the provider (dynamic to allow tsx execution) ───────────────────
+
+async function main() {
+  // Dynamic import so tsx can resolve TypeScript + path aliases.
+  // We import the module and destructure what we need.
+  const { NoosphereProvider, createNoosphereProvider } = await import(
+    "@/lib/memory/noosphere"
+  );
+
+  console.log("\n🔍 NoosphereProvider Tests\n");
+
+  // ─── Constructor ───────────────────────────────────────────────────────────
+
+  test("constructor uses default Prisma when none provided", () => {
+    // Just verify it doesn't throw and has the right descriptor.
+    // (Can't call search without a real DB.)
+    const provider = new NoosphereProvider();
+    assertEqual(provider.descriptor.id, "noosphere", "provider id");
+    assertEqual(provider.descriptor.sourceType, "noosphere", "source type");
+    assertEqual(provider.descriptor.capabilities.search, true, "search cap");
+    assertEqual(provider.descriptor.capabilities.getById, true, "getById cap");
+    assertEqual(provider.descriptor.capabilities.score, true, "score cap");
+    assertEqual(provider.descriptor.capabilities.autoRecall, true, "autoRecall cap");
+  });
+
+  test("constructor applies providerConfig overrides", () => {
+    const provider = new NoosphereProvider({
+      providerConfig: { priorityWeight: 2.5, maxResults: 5 },
+    });
+    assertEqual(provider.descriptor.defaultConfig.priorityWeight, 2.5, "priorityWeight override");
+    assertEqual(provider.descriptor.defaultConfig.maxResults, 5, "maxResults override");
+  });
+
+  test("createNoosphereProvider factory returns NoosphereProvider instance", () => {
+    const provider = createNoosphereProvider();
+    assert(provider instanceof NoosphereProvider, "instance check");
+  });
+
+  // ─── search() ──────────────────────────────────────────────────────────────
+
+  test("search returns empty array for empty query", async () => {
+    const provider = new NoosphereProvider({
+      prisma: createMockPrisma(),
+    });
+    const results = await provider.search("  ");
+    assertEqual(results.length, 0, "empty query results");
+  });
+
+  test("search returns empty array when disabled", async () => {
+    const provider = new NoosphereProvider({
+      prisma: createMockPrisma(),
+      providerConfig: { enabled: false },
+    });
+    const results = await provider.search("test", {
+      config: { enabled: false },
+    });
+    assertEqual(results.length, 0, "disabled results");
+  });
+
+  test("search returns empty array when raw query yields no results", async () => {
+    const provider = new NoosphereProvider({
+      prisma: createMockPrisma({
+        $queryRaw: () => Promise.resolve([]),
+      }),
+    });
+    const results = await provider.search("nonexistent topic");
+    assertEqual(results.length, 0, "no results");
+  });
+
+  // ─── getById() ─────────────────────────────────────────────────────────────
+
+  test("getById returns null when article not found", async () => {
+    const provider = new NoosphereProvider({
+      prisma: createMockPrisma({
+        article: {
+          findFirst: () => Promise.resolve(null),
+        },
+      }),
+    });
+    const result = await provider.getById("nonexistent-id");
+    assertEqual(result, null, "not found");
+  });
+
+  test("getById returns null when disabled", async () => {
+    const provider = new NoosphereProvider({
+      prisma: createMockPrisma(),
+      providerConfig: { enabled: false },
+    });
+    const result = await provider.getById("some-id", {
+      config: { enabled: false },
+    });
+    assertEqual(result, null, "disabled getById");
+  });
+
+  test("getById strips noosphere:article: prefix from id", async () => {
+    const mockArticle = {
+      id: "abc123",
+      title: "Test Article",
+      slug: "test-article",
+      content: "Test content",
+      excerpt: "Test excerpt",
+      status: "published",
+      confidence: "high",
+      sourceUrl: null,
+      sourceType: null,
+      createdAt: new Date("2026-01-01"),
+      updatedAt: new Date("2026-04-01"),
+      lastReviewed: null,
+      authorId: null,
+      authorName: null,
+      topicId: "topic1",
+      topic: { id: "topic1", slug: "engineering", name: "Engineering" },
+      tags: [],
+    };
+
+    let capturedId: string | undefined;
+    const provider = new NoosphereProvider({
+      prisma: createMockPrisma({
+        article: {
+          findFirst: (args: { where: { id: string } }) => {
+            capturedId = args.where.id;
+            return Promise.resolve(mockArticle);
+          },
+        },
+      }),
+    });
+
+    const result = await provider.getById("noosphere:article:abc123");
+    assertEqual(capturedId, "abc123", "stripped prefix");
+    assert(result !== null, "result should not be null");
+    assertEqual(result!.provider, "noosphere", "provider field");
+    assertEqual(result!.sourceType, "noosphere", "sourceType field");
+    assertEqual(result!.title, "Test Article", "title");
+    assertEqual(result!.content, "Test content", "content");
+    assertEqual(result!.summary, "Test excerpt", "summary");
+    assertEqual(result!.curationLevel, "curated", "curation level for published");
+    assertEqual(result!.canonicalRef, "noosphere:article:abc123", "canonical ref");
+  });
+
+  // ─── score() ───────────────────────────────────────────────────────────────
+
+  test("score returns empty object for non-noosphere results", () => {
+    const provider = new NoosphereProvider({ prisma: createMockPrisma() });
+    const score = provider.score({
+      id: "1",
+      provider: "hindsight",
+      sourceType: "hindsight",
+      content: "test",
+    });
+    assertEqual(Object.keys(score).length, 0, "no keys for non-noosphere");
+  });
+
+  test("score computes aggregate from available signals", () => {
+    const provider = new NoosphereProvider({ prisma: createMockPrisma() });
+    const score = provider.score({
+      id: "1",
+      provider: "noosphere",
+      sourceType: "noosphere",
+      content: "test",
+      relevanceScore: 0.8,
+      confidenceScore: 1.0,
+      updatedAt: new Date("2026-04-01").toISOString(),
+    });
+    assert(score.aggregateScore !== undefined, "aggregate should exist");
+    // Average of 0.8 (relevance) + 1.0 (confidence) + recency (should be < 1.0)
+    assert(score.aggregateScore! > 0, "aggregate > 0");
+    assert(score.aggregateScore! <= 1, "aggregate <= 1");
+    assert(score.reasons !== undefined, "reasons should exist");
+    assert(score.reasons!.length > 0, "reasons should not be empty");
+  });
+
+  test("score returns undefined aggregate when no signals present", () => {
+    const provider = new NoosphereProvider({ prisma: createMockPrisma() });
+    const score = provider.score({
+      id: "1",
+      provider: "noosphere",
+      sourceType: "noosphere",
+      content: "test",
+    });
+    assertEqual(score.aggregateScore, undefined, "no aggregate without signals");
+  });
+
+  test("score recency decays over time", () => {
+    const provider = new NoosphereProvider({ prisma: createMockPrisma() });
+    const now = new Date("2026-04-25");
+
+    // Fresh article (0 days old)
+    const fresh = provider.score(
+      {
+        id: "1",
+        provider: "noosphere",
+        sourceType: "noosphere",
+        content: "test",
+        updatedAt: now.toISOString(),
+      },
+      { now },
+    );
+    assertEqual(fresh.recencyScore, 1, "fresh article score");
+
+    // 90 days old = half-life should give ~0.5
+    const ninetyDaysAgo = new Date(now.getTime() - 90 * 24 * 60 * 60 * 1000);
+    const old = provider.score(
+      {
+        id: "2",
+        provider: "noosphere",
+        sourceType: "noosphere",
+        content: "test",
+        updatedAt: ninetyDaysAgo.toISOString(),
+      },
+      { now },
+    );
+    assert(old.recencyScore !== undefined, "old recency should exist");
+    assertApprox(old.recencyScore!, 0.5, 0.01, "90-day half-life");
+
+    // Very old article (365 days)
+    const yearAgo = new Date(now.getTime() - 365 * 24 * 60 * 60 * 1000);
+    const ancient = provider.score(
+      {
+        id: "3",
+        provider: "noosphere",
+        sourceType: "noosphere",
+        content: "test",
+        updatedAt: yearAgo.toISOString(),
+      },
+      { now },
+    );
+    assert(ancient.recencyScore !== undefined, "ancient recency should exist");
+    assert(ancient.recencyScore! < 0.1, "365-day should be < 0.1");
+  });
+
+  // ─── mapConfidenceScore (tested via score/getById) ─────────────────────────
+
+  test("confidence mapping: high=1, medium=0.66, low=0.33, null=undefined", () => {
+    const provider = new NoosphereProvider({ prisma: createMockPrisma() });
+
+    // Test via score — the confidenceScore on the result comes from mapConfidenceScore.
+    // We test the output of getById which calls toMemoryResult → mapConfidenceScore.
+    const mockArticleFactory = (confidence: string | null) => ({
+      id: "test",
+      title: "Test",
+      slug: "test",
+      content: "content",
+      excerpt: null,
+      status: "published",
+      confidence,
+      sourceUrl: null,
+      sourceType: null,
+      createdAt: new Date("2026-01-01"),
+      updatedAt: new Date("2026-01-01"),
+      lastReviewed: null,
+      authorId: null,
+      authorName: null,
+      topicId: "t1",
+      topic: { id: "t1", slug: "test", name: "Test" },
+      tags: [],
+    });
+
+    // We can test mapConfidenceScore indirectly by checking score output on results
+    // that have confidenceScore set. But since score() just reads the result's
+    // confidenceScore, let's test the mapping directly via getById mock.
+    const expectations: [string | null, number | undefined][] = [
+      ["high", 1],
+      ["medium", 0.66],
+      ["low", 0.33],
+      [null, undefined],
+    ];
+
+    for (const [confidence, expected] of expectations) {
+      const provider = new NoosphereProvider({
+        prisma: createMockPrisma({
+          article: {
+            findFirst: () => Promise.resolve(mockArticleFactory(confidence)),
+          },
+        }),
+      });
+      provider.getById("test").then((result) => {
+        if (!result) throw new Error("result is null");
+        if (expected === undefined) {
+          assertEqual(result.confidenceScore, undefined, `confidence=${confidence}`);
+        } else {
+          assertApprox(result.confidenceScore!, expected, 0.01, `confidence=${confidence}`);
+        }
+      });
+    }
+  });
+
+  // ─── mapCurationLevel (tested via getById) ─────────────────────────────────
+
+  test("curation level mapping: published=curated, reviewed=reviewed, draft=ephemeral", async () => {
+    const mockArticleFactory = (status: string) => ({
+      id: "test",
+      title: "Test",
+      slug: "test",
+      content: "content",
+      excerpt: null,
+      status,
+      confidence: null,
+      sourceUrl: null,
+      sourceType: null,
+      createdAt: new Date("2026-01-01"),
+      updatedAt: new Date("2026-01-01"),
+      lastReviewed: null,
+      authorId: null,
+      authorName: null,
+      topicId: "t1",
+      topic: { id: "t1", slug: "test", name: "Test" },
+      tags: [],
+    });
+
+    const expectations: [string, string][] = [
+      ["published", "curated"],
+      ["reviewed", "reviewed"],
+      ["draft", "ephemeral"],
+    ];
+
+    for (const [status, expected] of expectations) {
+      const provider = new NoosphereProvider({
+        prisma: createMockPrisma({
+          article: {
+            findFirst: () => Promise.resolve(mockArticleFactory(status)),
+          },
+        }),
+      });
+      const result = await provider.getById("test");
+      assertEqual(result?.curationLevel, expected as "curated" | "reviewed" | "ephemeral", `status=${status}`);
+    }
+  });
+
+  // ─── descriptor metadata ───────────────────────────────────────────────────
+
+  test("descriptor has correct default priority weight", () => {
+    const provider = new NoosphereProvider();
+    assertEqual(provider.descriptor.defaultConfig.priorityWeight, 1.25, "default priority");
+  });
+
+  test("descriptor metadata includes contentType article", () => {
+    const provider = new NoosphereProvider();
+    assertEqual(provider.descriptor.metadata?.contentType, "article", "contentType");
+  });
+
+  // ─── Wait for async tests to complete ──────────────────────────────────────
+
+  // Small delay to let all async test assertions settle.
+  await new Promise((resolve) => setTimeout(resolve, 200));
+
+  console.log(`\n  ${passCount} passed, ${failCount} failed, ${testCounter} total\n`);
+
+  if (failCount > 0) {
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error("Fatal:", err);
+  process.exit(1);
+});

--- a/src/lib/memory/hindsight.ts
+++ b/src/lib/memory/hindsight.ts
@@ -5,7 +5,7 @@ import type {
   MemoryProviderGetOptions,
   MemoryProviderSearchOptions,
 } from "./provider";
-import { defineMemoryResult } from "./types";
+import { defineMemoryResult, removeUndefined } from "./types";
 import type { MemoryProviderMetadata, MemoryResult } from "./types";
 
 export type HindsightMemoryType = "world" | "experience" | "observation";
@@ -352,10 +352,4 @@ function parseHindsightErrorBody(body: string): string | undefined {
   }
 
   return undefined;
-}
-
-function removeUndefined<T extends Record<string, unknown>>(value: T): Partial<T> {
-  return Object.fromEntries(
-    Object.entries(value).filter(([, entry]) => entry !== undefined),
-  ) as Partial<T>;
 }

--- a/src/lib/memory/index.ts
+++ b/src/lib/memory/index.ts
@@ -49,4 +49,5 @@ export {
   estimateMemoryTokens,
   normalizeMemoryTokenEstimate,
   normalizeMemoryScore,
+  removeUndefined,
 } from "./types";

--- a/src/lib/memory/index.ts
+++ b/src/lib/memory/index.ts
@@ -9,6 +9,11 @@ export type {
 } from "./hindsight";
 
 export type {
+  NoosphereProviderSettings,
+  NoosphereSearchOptionsMetadata,
+} from "./noosphere";
+
+export type {
   MemoryProvider,
   MemoryProviderCapabilities,
   MemoryProviderConfig,
@@ -29,6 +34,7 @@ export type {
 } from "./types";
 
 export { createHindsightProvider, HindsightProvider } from "./hindsight";
+export { createNoosphereProvider, NoosphereProvider } from "./noosphere";
 
 export {
   DEFAULT_MEMORY_PROVIDER_CAPABILITIES,

--- a/src/lib/memory/noosphere.ts
+++ b/src/lib/memory/noosphere.ts
@@ -198,6 +198,19 @@ export class NoosphereProvider implements MemoryProvider {
     const scoredValues = [relevanceScore, confidenceScore, recencyScore].filter(
       (score): score is number => score !== undefined,
     );
+    const reasons = [
+      "Noosphere articles are curated durable knowledge.",
+      confidenceScore === undefined
+        ? "Article has no explicit confidence label."
+        : "Confidence score mapped from article confidence label.",
+      "Recency score decays from the article updated timestamp.",
+    ];
+
+    if (scoredValues.length > 0) {
+      reasons.push(
+        "Aggregate score averages available relevance, confidence, and recency signals.",
+      );
+    }
 
     return {
       relevanceScore,
@@ -210,14 +223,7 @@ export class NoosphereProvider implements MemoryProvider {
               scoredValues.reduce((sum, score) => sum + score, 0) /
                 scoredValues.length,
             ),
-      reasons: [
-        "Noosphere articles are curated durable knowledge.",
-        confidenceScore === undefined
-          ? "Article has no explicit confidence label."
-          : "Confidence score mapped from article confidence label.",
-        "Recency score decays from the article updated timestamp.",
-        "Aggregate score averages available relevance, confidence, and recency signals.",
-      ],
+      reasons,
     };
   }
 
@@ -266,8 +272,8 @@ export class NoosphereProvider implements MemoryProvider {
       OFFSET ${options.offset}
     `);
 
-    const maxRank = Math.max(
-      ...rows.map((row) => normalizeRank(row.rank)),
+    const maxRank = rows.reduce(
+      (max, row) => Math.max(max, normalizeRank(row.rank)),
       0,
     );
 
@@ -311,7 +317,7 @@ export class NoosphereProvider implements MemoryProvider {
         topicName: article.topic.name,
         wikiPath: `/wiki/${article.topic.slug}/${article.slug}`,
         sourceUrl: article.sourceUrl ?? undefined,
-        sourceType: article.sourceType ?? undefined,
+        articleSourceType: article.sourceType ?? undefined,
         status: article.status,
         confidence: article.confidence ?? undefined,
         lastReviewed: article.lastReviewed?.toISOString(),
@@ -389,25 +395,28 @@ function resolveSearchLimit(
   config: MemoryProviderConfig,
 ): number | undefined {
   if (optionLimit !== undefined) {
-    return normalizeOptionalLimit(optionLimit);
+    return normalizeExplicitLimit(optionLimit) ?? DEFAULT_NOOSPHERE_MAX_RESULTS;
   }
 
   if (
     configOverride &&
     Object.prototype.hasOwnProperty.call(configOverride, "maxResults")
   ) {
-    return normalizeOptionalLimit(configOverride.maxResults);
+    return configOverride.maxResults === undefined
+      ? undefined
+      : normalizeExplicitLimit(configOverride.maxResults) ??
+          DEFAULT_NOOSPHERE_MAX_RESULTS;
   }
 
   return config.maxResults ?? DEFAULT_NOOSPHERE_MAX_RESULTS;
 }
 
-function normalizeOptionalLimit(limit: number | undefined): number | undefined {
-  if (limit === undefined || !Number.isFinite(limit) || limit <= 0) {
+function normalizeExplicitLimit(limit: number): number | undefined {
+  if (!Number.isFinite(limit) || limit < 0) {
     return undefined;
   }
 
-  return Math.max(1, Math.floor(limit));
+  return Math.floor(limit);
 }
 
 function normalizeOffset(offset: number | undefined): number {

--- a/src/lib/memory/noosphere.ts
+++ b/src/lib/memory/noosphere.ts
@@ -52,7 +52,6 @@ type NoosphereArticle = Prisma.ArticleGetPayload<{
 
 const NOOSPHERE_PROVIDER_ID = "noosphere";
 const DEFAULT_NOOSPHERE_MAX_RESULTS = 10;
-const DEFAULT_RELEVANCE_SCORE = 1;
 const RECENCY_HALF_LIFE_DAYS = 90;
 
 export class NoosphereProvider implements MemoryProvider {
@@ -103,7 +102,7 @@ export class NoosphereProvider implements MemoryProvider {
       return [];
     }
 
-    const limit = normalizeLimit(options.limit ?? config.maxResults);
+    const limit = resolveSearchLimit(options.limit, options.config, config);
     const metadata = (options.metadata ?? {}) as NoosphereSearchOptionsMetadata;
     const rows = await this.searchArticleRows(normalizedQuery, {
       limit,
@@ -135,7 +134,6 @@ export class NoosphereProvider implements MemoryProvider {
       },
     });
 
-    const rowById = new Map(rows.map((row) => [row.id, row]));
     const articleById = new Map(articles.map((article) => [article.id, article]));
 
     return rows.flatMap((row) => {
@@ -145,10 +143,6 @@ export class NoosphereProvider implements MemoryProvider {
       }
 
       return [this.toMemoryResult(article, row.relevanceScore)];
-    }).sort((left, right) => {
-      const leftRank = rowById.get(left.id)?.rank ?? 0;
-      const rightRank = rowById.get(right.id)?.rank ?? 0;
-      return rightRank - leftRank;
     });
   }
 
@@ -156,7 +150,13 @@ export class NoosphereProvider implements MemoryProvider {
     id: string,
     options: MemoryProviderGetOptions = {},
   ): Promise<MemoryResult | null> {
-    void options;
+    const config = normalizeMemoryProviderConfig({
+      ...this.descriptor.defaultConfig,
+      ...options.config,
+    });
+    if (!config.enabled) {
+      return null;
+    }
 
     const articleId = parseNoosphereArticleId(id);
     const article = await this.prisma.article.findFirst({
@@ -185,7 +185,7 @@ export class NoosphereProvider implements MemoryProvider {
       return {};
     }
 
-    const relevanceScore = result.relevanceScore ?? DEFAULT_RELEVANCE_SCORE;
+    const relevanceScore = result.relevanceScore;
     const confidenceScore = result.confidenceScore;
     const recencyScore = result.updatedAt
       ? mapRecencyScore(new Date(result.updatedAt), context.now)
@@ -223,11 +223,13 @@ export class NoosphereProvider implements MemoryProvider {
       tagSlug?: string;
       status?: string;
       confidence?: string;
-      limit: number;
+      limit?: number;
       offset: number;
     },
   ): Promise<{ id: string; rank: number; relevanceScore: number }[]> {
     const filters = buildNoosphereSearchFilters(options);
+    const limitClause =
+      options.limit === undefined ? Prisma.empty : Prisma.sql`LIMIT ${options.limit}`;
 
     const rows = await this.prisma.$queryRaw<
       { id: string; rank: number | string }[]
@@ -255,7 +257,7 @@ export class NoosphereProvider implements MemoryProvider {
       FROM searchable
       WHERE document @@ websearch_to_tsquery('simple', ${query})
       ORDER BY rank DESC, "updatedAt" DESC
-      LIMIT ${options.limit}
+      ${limitClause}
       OFFSET ${options.offset}
     `);
 
@@ -270,7 +272,7 @@ export class NoosphereProvider implements MemoryProvider {
         id: row.id,
         rank,
         relevanceScore:
-          maxRank === 0 ? DEFAULT_RELEVANCE_SCORE : rank / maxRank,
+          maxRank === 0 ? 0 : rank / maxRank,
       };
     });
   }
@@ -396,7 +398,9 @@ function mapRecencyScore(
   }
 
   const ageDays = ageMs / (1000 * 60 * 60 * 24);
-  return normalizeMemoryScore(Math.exp(-ageDays / RECENCY_HALF_LIFE_DAYS));
+  return normalizeMemoryScore(
+    Math.exp((-ageDays * Math.LN2) / RECENCY_HALF_LIFE_DAYS),
+  );
 }
 
 function parseNoosphereArticleId(id: string): string {
@@ -405,12 +409,32 @@ function parseNoosphereArticleId(id: string): string {
 }
 
 function normalizeRank(rank: number | string): number {
-  return typeof rank === "number" ? rank : Number(rank);
+  const normalizedRank = typeof rank === "number" ? rank : Number(rank);
+  return Number.isFinite(normalizedRank) ? Math.max(0, normalizedRank) : 0;
 }
 
-function normalizeLimit(limit: number | undefined): number {
+function resolveSearchLimit(
+  optionLimit: number | undefined,
+  configOverride: Partial<MemoryProviderConfig> | undefined,
+  config: MemoryProviderConfig,
+): number | undefined {
+  if (optionLimit !== undefined) {
+    return normalizeOptionalLimit(optionLimit);
+  }
+
+  if (
+    configOverride &&
+    Object.prototype.hasOwnProperty.call(configOverride, "maxResults")
+  ) {
+    return normalizeOptionalLimit(configOverride.maxResults);
+  }
+
+  return config.maxResults ?? DEFAULT_NOOSPHERE_MAX_RESULTS;
+}
+
+function normalizeOptionalLimit(limit: number | undefined): number | undefined {
   if (limit === undefined || !Number.isFinite(limit) || limit <= 0) {
-    return DEFAULT_NOOSPHERE_MAX_RESULTS;
+    return undefined;
   }
 
   return Math.max(1, Math.floor(limit));

--- a/src/lib/memory/noosphere.ts
+++ b/src/lib/memory/noosphere.ts
@@ -109,7 +109,7 @@ export class NoosphereProvider implements MemoryProvider {
 
     const limit = resolveSearchLimit(options.limit, options.config, config);
     const metadata = (options.metadata ?? {}) as NoosphereSearchOptionsMetadata;
-    const rows = await this.searchArticleRows(normalizedQuery, {
+    const articles = await this.searchArticles(normalizedQuery, {
       limit,
       offset: normalizeOffset(metadata.offset),
       topicSlug: metadata.topicSlug ?? options.scope,
@@ -118,37 +118,7 @@ export class NoosphereProvider implements MemoryProvider {
       confidence: metadata.confidence,
     });
 
-    if (rows.length === 0) {
-      return [];
-    }
-
-    const articles = await this.prisma.article.findMany({
-      where: {
-        id: {
-          in: rows.map((row) => row.id),
-        },
-        deletedAt: null,
-      },
-      include: {
-        topic: true,
-        tags: {
-          include: {
-            tag: true,
-          },
-        },
-      },
-    });
-
-    const articleById = new Map(articles.map((article) => [article.id, article]));
-
-    return rows.flatMap((row) => {
-      const article = articleById.get(row.id);
-      if (!article) {
-        return [];
-      }
-
-      return [this.toMemoryResult(article, row.relevanceScore)];
-    });
+    return articles;
   }
 
   async getById(
@@ -227,7 +197,14 @@ export class NoosphereProvider implements MemoryProvider {
     };
   }
 
-  private async searchArticleRows(
+  /**
+   * Single-query search: returns fully-hydrated MemoryResult[] directly from the
+   * database, eliminating the previous two-query pattern (rank IDs → findMany).
+   *
+   * The CTE computes full-text rank, then joins back to Article+Topic+Tag rows
+   * so we get both the relevance score and article data in one round-trip.
+   */
+  private async searchArticles(
     query: string,
     options: {
       topicSlug?: string;
@@ -237,54 +214,200 @@ export class NoosphereProvider implements MemoryProvider {
       limit?: number;
       offset: number;
     },
-  ): Promise<{ id: string; rank: number; relevanceScore: number }[]> {
+  ): Promise<MemoryResult[]> {
     const filters = buildSearchFilters(options);
     const limitClause =
       options.limit === undefined ? Prisma.empty : Prisma.sql`LIMIT ${options.limit}`;
 
+    // Raw query returns flat rows — we'll aggregate tags in JS.
     const rows = await this.prisma.$queryRaw<
-      { id: string; rank: number | string }[]
+      {
+        id: string;
+        rank: number | string;
+        title: string;
+        slug: string;
+        content: string;
+        excerpt: string | null;
+        status: string;
+        confidence: string | null;
+        sourceUrl: string | null;
+        sourceType: string | null;
+        createdAt: Date;
+        updatedAt: Date;
+        lastReviewed: Date | null;
+        authorId: string | null;
+        authorName: string | null;
+        topicId: string;
+        topicSlug: string;
+        topicName: string;
+        tagName: string | null;
+      }[]
     >(Prisma.sql`
-      WITH searchable AS (
+      WITH ranked AS (
         SELECT
           a.id,
           a."updatedAt",
-          (
+          ts_rank(
             setweight(to_tsvector('simple', coalesce(a.title, '')), 'A') ||
             setweight(to_tsvector('simple', coalesce(a.excerpt, '')), 'B') ||
             setweight(to_tsvector('simple', coalesce(a.content, '')), 'C') ||
-            setweight(to_tsvector('simple', coalesce(string_agg(tg.name, ' '), '')), 'B')
-          ) AS document
+            setweight(to_tsvector('simple', coalesce(string_agg(tg.name, ' '), '')), 'B'),
+            websearch_to_tsquery('simple', ${query})
+          ) AS rank
         FROM "Article" a
         INNER JOIN "Topic" tpc ON tpc.id = a."topicId"
         LEFT JOIN "ArticleTag" at ON at."articleId" = a.id
         LEFT JOIN "Tag" tg ON tg.id = at."tagId"
         WHERE ${Prisma.join(filters, " AND ")}
         GROUP BY a.id, a.title, a.excerpt, a.content, a."updatedAt"
+        HAVING ts_rank(
+          setweight(to_tsvector('simple', coalesce(a.title, '')), 'A') ||
+          setweight(to_tsvector('simple', coalesce(a.excerpt, '')), 'B') ||
+          setweight(to_tsvector('simple', coalesce(a.content, '')), 'C') ||
+          setweight(to_tsvector('simple', coalesce(string_agg(tg.name, ' '), '')), 'B'),
+          websearch_to_tsquery('simple', ${query})
+        ) > 0
+        ORDER BY rank DESC, a."updatedAt" DESC
+        ${limitClause}
+        OFFSET ${options.offset}
       )
       SELECT
-        id,
-        ts_rank(document, websearch_to_tsquery('simple', ${query})) AS rank
-      FROM searchable
-      WHERE document @@ websearch_to_tsquery('simple', ${query})
-      ORDER BY rank DESC, "updatedAt" DESC
-      ${limitClause}
-      OFFSET ${options.offset}
+        r.id, r.rank,
+        a.title, a.slug, a.content, a.excerpt, a.status, a.confidence,
+        a."sourceUrl", a."sourceType",
+        a."createdAt", a."updatedAt", a."lastReviewed",
+        a."authorId", a."authorName",
+        tpc.id AS "topicId", tpc.slug AS "topicSlug", tpc.name AS "topicName",
+        tg.name AS "tagName"
+      FROM ranked r
+      INNER JOIN "Article" a ON a.id = r.id
+      INNER JOIN "Topic" tpc ON tpc.id = a."topicId"
+      LEFT JOIN "ArticleTag" at2 ON at2."articleId" = a.id
+      LEFT JOIN "Tag" tg ON tg.id = at2."tagId"
+      ORDER BY r.rank DESC, a."updatedAt" DESC
     `);
 
+    if (rows.length === 0) {
+      return [];
+    }
+
+    // Compute max rank for relative relevance scoring.
     const maxRank = rows.reduce(
       (max, row) => Math.max(max, normalizeRank(row.rank)),
       0,
     );
 
-    return rows.map((row) => {
-      const rank = normalizeRank(row.rank);
-      return {
-        id: row.id,
-        rank,
-        relevanceScore:
-          maxRank === 0 ? 0 : rank / maxRank,
-      };
+    // Aggregate flat rows (one per tag) into article groups.
+    const articleMap = new Map<
+      string,
+      {
+        row: (typeof rows)[number];
+        tags: string[];
+      }
+    >();
+
+    for (const row of rows) {
+      const existing = articleMap.get(row.id);
+      if (existing) {
+        if (row.tagName) {
+          existing.tags.push(row.tagName);
+        }
+      } else {
+        articleMap.set(row.id, {
+          row,
+          tags: row.tagName ? [row.tagName] : [],
+        });
+      }
+    }
+
+    // Preserve rank-descending order from the query.
+    const seenIds = new Set<string>();
+    const results: MemoryResult[] = [];
+
+    for (const row of rows) {
+      if (seenIds.has(row.id)) continue;
+      seenIds.add(row.id);
+
+      const entry = articleMap.get(row.id)!;
+      const rank = normalizeRank(entry.row.rank);
+      const relevanceScore = maxRank === 0 ? 0 : rank / maxRank;
+
+      results.push(
+        this.toMemoryResultFromRow(entry.row, entry.tags, relevanceScore),
+      );
+    }
+
+    return results;
+  }
+
+  /**
+   * Build a MemoryResult from a raw SQL row (single-query path).
+   * Avoids the Prisma include/hydration overhead of toMemoryResult().
+   */
+  private toMemoryResultFromRow(
+    row: {
+      id: string;
+      title: string;
+      slug: string;
+      content: string;
+      excerpt: string | null;
+      status: string;
+      confidence: string | null;
+      sourceUrl: string | null;
+      sourceType: string | null;
+      createdAt: Date | string;
+      updatedAt: Date | string;
+      lastReviewed: Date | string | null;
+      authorId: string | null;
+      authorName: string | null;
+      topicId: string;
+      topicSlug: string;
+      topicName: string;
+    },
+    tags: string[],
+    relevanceScore?: number,
+  ): MemoryResult {
+    const updatedAt =
+      row.updatedAt instanceof Date ? row.updatedAt : new Date(row.updatedAt);
+    const createdAt =
+      row.createdAt instanceof Date ? row.createdAt : new Date(row.createdAt);
+    const lastReviewed =
+      row.lastReviewed == null
+        ? undefined
+        : row.lastReviewed instanceof Date
+          ? row.lastReviewed
+          : new Date(row.lastReviewed);
+
+    return defineMemoryResult({
+      id: row.id,
+      provider: NOOSPHERE_PROVIDER_ID,
+      sourceType: "noosphere",
+      title: row.title,
+      content: row.content,
+      summary: row.excerpt ?? undefined,
+      relevanceScore,
+      confidenceScore: mapConfidenceScore(row.confidence),
+      recencyScore: mapRecencyScore(updatedAt),
+      curationLevel: mapCurationLevel(row.status),
+      createdAt: createdAt.toISOString(),
+      updatedAt: updatedAt.toISOString(),
+      canonicalRef: `noosphere:article:${row.id}`,
+      tags,
+      metadata: removeUndefined({
+        articleId: row.id,
+        articleSlug: row.slug,
+        topicId: row.topicId,
+        topicSlug: row.topicSlug,
+        topicName: row.topicName,
+        wikiPath: `/wiki/${row.topicSlug}/${row.slug}`,
+        sourceUrl: row.sourceUrl ?? undefined,
+        articleSourceType: row.sourceType ?? undefined,
+        status: row.status,
+        confidence: row.confidence ?? undefined,
+        lastReviewed: lastReviewed?.toISOString(),
+        authorId: row.authorId ?? undefined,
+        authorName: row.authorName ?? undefined,
+      }),
     });
   }
 
@@ -394,18 +517,22 @@ function resolveSearchLimit(
   configOverride: Partial<MemoryProviderConfig> | undefined,
   config: MemoryProviderConfig,
 ): number | undefined {
+  // Priority: explicit option > config override > default config > hardcoded default.
   if (optionLimit !== undefined) {
     return normalizeExplicitLimit(optionLimit) ?? DEFAULT_NOOSPHERE_MAX_RESULTS;
   }
 
+  const overrideMax = configOverride?.maxResults;
+  if (overrideMax !== undefined) {
+    return normalizeExplicitLimit(overrideMax) ?? DEFAULT_NOOSPHERE_MAX_RESULTS;
+  }
+
+  // If the override explicitly set maxResults to undefined (unset), use no cap.
   if (
     configOverride &&
     Object.prototype.hasOwnProperty.call(configOverride, "maxResults")
   ) {
-    return configOverride.maxResults === undefined
-      ? undefined
-      : normalizeExplicitLimit(configOverride.maxResults) ??
-          DEFAULT_NOOSPHERE_MAX_RESULTS;
+    return undefined;
   }
 
   return config.maxResults ?? DEFAULT_NOOSPHERE_MAX_RESULTS;

--- a/src/lib/memory/noosphere.ts
+++ b/src/lib/memory/noosphere.ts
@@ -12,7 +12,11 @@ import type {
   MemoryProviderSearchOptions,
 } from "./provider";
 import { normalizeMemoryProviderConfig } from "./provider";
-import { defineMemoryResult, normalizeMemoryScore } from "./types";
+import {
+  defineMemoryResult,
+  normalizeMemoryScore,
+  removeUndefined,
+} from "./types";
 import type { MemoryProviderMetadata, MemoryResult } from "./types";
 
 export interface NoosphereProviderSettings {
@@ -412,10 +416,4 @@ function normalizeOffset(offset: number | undefined): number {
   }
 
   return Math.floor(offset);
-}
-
-function removeUndefined<T extends Record<string, unknown>>(value: T): Partial<T> {
-  return Object.fromEntries(
-    Object.entries(value).filter(([, entry]) => entry !== undefined),
-  ) as Partial<T>;
 }

--- a/src/lib/memory/noosphere.ts
+++ b/src/lib/memory/noosphere.ts
@@ -1,5 +1,6 @@
 import { Prisma, type PrismaClient } from "@prisma/client";
 import { prisma as defaultPrisma } from "@/lib/prisma";
+import { buildSearchFilters } from "@/lib/wiki";
 
 import type {
   MemoryProvider,
@@ -227,7 +228,7 @@ export class NoosphereProvider implements MemoryProvider {
       offset: number;
     },
   ): Promise<{ id: string; rank: number; relevanceScore: number }[]> {
-    const filters = buildNoosphereSearchFilters(options);
+    const filters = buildSearchFilters(options);
     const limitClause =
       options.limit === undefined ? Prisma.empty : Prisma.sql`LIMIT ${options.limit}`;
 
@@ -321,41 +322,6 @@ export function createNoosphereProvider(
   settings: NoosphereProviderSettings = {},
 ): NoosphereProvider {
   return new NoosphereProvider(settings);
-}
-
-function buildNoosphereSearchFilters(options: {
-  topicSlug?: string;
-  tagSlug?: string;
-  status?: string;
-  confidence?: string;
-}): Prisma.Sql[] {
-  const clauses: Prisma.Sql[] = [Prisma.sql`a."deletedAt" IS NULL`];
-
-  if (options.topicSlug) {
-    clauses.push(Prisma.sql`tpc.slug = ${options.topicSlug}`);
-  }
-
-  if (options.tagSlug) {
-    clauses.push(
-      Prisma.sql`EXISTS (
-        SELECT 1
-        FROM "ArticleTag" at_filter
-        INNER JOIN "Tag" tag_filter ON tag_filter.id = at_filter."tagId"
-        WHERE at_filter."articleId" = a.id
-          AND tag_filter.slug = ${options.tagSlug}
-      )`,
-    );
-  }
-
-  if (options.status) {
-    clauses.push(Prisma.sql`a.status = ${options.status}`);
-  }
-
-  if (options.confidence) {
-    clauses.push(Prisma.sql`a.confidence = ${options.confidence}`);
-  }
-
-  return clauses;
 }
 
 function mapConfidenceScore(confidence: string | null): number | undefined {

--- a/src/lib/memory/noosphere.ts
+++ b/src/lib/memory/noosphere.ts
@@ -1,0 +1,431 @@
+import { Prisma, type PrismaClient } from "@prisma/client";
+import { prisma as defaultPrisma } from "@/lib/prisma";
+
+import type {
+  MemoryProvider,
+  MemoryProviderConfig,
+  MemoryProviderDescriptor,
+  MemoryProviderGetOptions,
+  MemoryProviderScore,
+  MemoryProviderScoreContext,
+  MemoryProviderSearchOptions,
+} from "./provider";
+import { normalizeMemoryProviderConfig } from "./provider";
+import { defineMemoryResult, normalizeMemoryScore } from "./types";
+import type { MemoryProviderMetadata, MemoryResult } from "./types";
+
+export interface NoosphereProviderSettings {
+  /** Optional Prisma client override for scripts, tests, or alternate runtimes. */
+  prisma?: PrismaClient;
+
+  /** Base provider config consumed by orchestrators. */
+  providerConfig?: Partial<MemoryProviderConfig>;
+}
+
+export interface NoosphereSearchOptionsMetadata extends MemoryProviderMetadata {
+  /** Restrict search to a topic slug. Defaults to options.scope when present. */
+  topicSlug?: string;
+
+  /** Restrict search to articles with this tag slug. */
+  tagSlug?: string;
+
+  /** Restrict search to a lifecycle status, for example "published". */
+  status?: string;
+
+  /** Restrict search to a confidence label, for example "high". */
+  confidence?: string;
+
+  /** Offset used by inspection/API callers that page through provider results. */
+  offset?: number;
+}
+
+type NoosphereArticle = Prisma.ArticleGetPayload<{
+  include: {
+    topic: true;
+    tags: {
+      include: {
+        tag: true;
+      };
+    };
+  };
+}>;
+
+const NOOSPHERE_PROVIDER_ID = "noosphere";
+const DEFAULT_NOOSPHERE_MAX_RESULTS = 10;
+const DEFAULT_RELEVANCE_SCORE = 1;
+const RECENCY_HALF_LIFE_DAYS = 90;
+
+export class NoosphereProvider implements MemoryProvider {
+  readonly descriptor: MemoryProviderDescriptor;
+
+  private readonly prisma: PrismaClient;
+
+  constructor(settings: NoosphereProviderSettings = {}) {
+    this.prisma = settings.prisma ?? defaultPrisma;
+
+    this.descriptor = {
+      id: NOOSPHERE_PROVIDER_ID,
+      displayName: "Noosphere",
+      sourceType: "noosphere",
+      defaultConfig: {
+        enabled: true,
+        priorityWeight: 1.25,
+        maxResults: DEFAULT_NOOSPHERE_MAX_RESULTS,
+        allowAutoRecall: true,
+        ...settings.providerConfig,
+      },
+      capabilities: {
+        search: true,
+        getById: true,
+        score: true,
+        autoRecall: true,
+      },
+      metadata: {
+        contentType: "article",
+      },
+    };
+  }
+
+  async search(
+    query: string,
+    options: MemoryProviderSearchOptions = {},
+  ): Promise<MemoryResult[]> {
+    const normalizedQuery = query.trim();
+    if (!normalizedQuery) {
+      return [];
+    }
+
+    const config = normalizeMemoryProviderConfig({
+      ...this.descriptor.defaultConfig,
+      ...options.config,
+    });
+    if (!config.enabled) {
+      return [];
+    }
+
+    const limit = normalizeLimit(options.limit ?? config.maxResults);
+    const metadata = (options.metadata ?? {}) as NoosphereSearchOptionsMetadata;
+    const rows = await this.searchArticleRows(normalizedQuery, {
+      limit,
+      offset: normalizeOffset(metadata.offset),
+      topicSlug: metadata.topicSlug ?? options.scope,
+      tagSlug: metadata.tagSlug,
+      status: metadata.status,
+      confidence: metadata.confidence,
+    });
+
+    if (rows.length === 0) {
+      return [];
+    }
+
+    const articles = await this.prisma.article.findMany({
+      where: {
+        id: {
+          in: rows.map((row) => row.id),
+        },
+        deletedAt: null,
+      },
+      include: {
+        topic: true,
+        tags: {
+          include: {
+            tag: true,
+          },
+        },
+      },
+    });
+
+    const rowById = new Map(rows.map((row) => [row.id, row]));
+    const articleById = new Map(articles.map((article) => [article.id, article]));
+
+    return rows.flatMap((row) => {
+      const article = articleById.get(row.id);
+      if (!article) {
+        return [];
+      }
+
+      return [this.toMemoryResult(article, row.relevanceScore)];
+    }).sort((left, right) => {
+      const leftRank = rowById.get(left.id)?.rank ?? 0;
+      const rightRank = rowById.get(right.id)?.rank ?? 0;
+      return rightRank - leftRank;
+    });
+  }
+
+  async getById(
+    id: string,
+    options: MemoryProviderGetOptions = {},
+  ): Promise<MemoryResult | null> {
+    void options;
+
+    const articleId = parseNoosphereArticleId(id);
+    const article = await this.prisma.article.findFirst({
+      where: {
+        id: articleId,
+        deletedAt: null,
+      },
+      include: {
+        topic: true,
+        tags: {
+          include: {
+            tag: true,
+          },
+        },
+      },
+    });
+
+    return article ? this.toMemoryResult(article) : null;
+  }
+
+  score(
+    result: MemoryResult,
+    context: MemoryProviderScoreContext = {},
+  ): MemoryProviderScore {
+    if (result.provider !== NOOSPHERE_PROVIDER_ID) {
+      return {};
+    }
+
+    const relevanceScore = result.relevanceScore ?? DEFAULT_RELEVANCE_SCORE;
+    const confidenceScore = result.confidenceScore;
+    const recencyScore = result.updatedAt
+      ? mapRecencyScore(new Date(result.updatedAt), context.now)
+      : result.recencyScore;
+    const scoredValues = [relevanceScore, confidenceScore, recencyScore].filter(
+      (score): score is number => score !== undefined,
+    );
+
+    return {
+      relevanceScore,
+      confidenceScore,
+      recencyScore,
+      aggregateScore:
+        scoredValues.length === 0
+          ? undefined
+          : normalizeMemoryScore(
+              scoredValues.reduce((sum, score) => sum + score, 0) /
+                scoredValues.length,
+            ),
+      reasons: [
+        "Noosphere articles are curated durable knowledge.",
+        confidenceScore === undefined
+          ? "Article has no explicit confidence label."
+          : "Confidence score mapped from article confidence label.",
+        "Recency score decays from the article updated timestamp.",
+        "Aggregate score averages available relevance, confidence, and recency signals.",
+      ],
+    };
+  }
+
+  private async searchArticleRows(
+    query: string,
+    options: {
+      topicSlug?: string;
+      tagSlug?: string;
+      status?: string;
+      confidence?: string;
+      limit: number;
+      offset: number;
+    },
+  ): Promise<{ id: string; rank: number; relevanceScore: number }[]> {
+    const filters = buildNoosphereSearchFilters(options);
+
+    const rows = await this.prisma.$queryRaw<
+      { id: string; rank: number | string }[]
+    >(Prisma.sql`
+      WITH searchable AS (
+        SELECT
+          a.id,
+          a."updatedAt",
+          (
+            setweight(to_tsvector('simple', coalesce(a.title, '')), 'A') ||
+            setweight(to_tsvector('simple', coalesce(a.excerpt, '')), 'B') ||
+            setweight(to_tsvector('simple', coalesce(a.content, '')), 'C') ||
+            setweight(to_tsvector('simple', coalesce(string_agg(tg.name, ' '), '')), 'B')
+          ) AS document
+        FROM "Article" a
+        INNER JOIN "Topic" tpc ON tpc.id = a."topicId"
+        LEFT JOIN "ArticleTag" at ON at."articleId" = a.id
+        LEFT JOIN "Tag" tg ON tg.id = at."tagId"
+        WHERE ${Prisma.join(filters, " AND ")}
+        GROUP BY a.id, a.title, a.excerpt, a.content, a."updatedAt"
+      )
+      SELECT
+        id,
+        ts_rank(document, websearch_to_tsquery('simple', ${query})) AS rank
+      FROM searchable
+      WHERE document @@ websearch_to_tsquery('simple', ${query})
+      ORDER BY rank DESC, "updatedAt" DESC
+      LIMIT ${options.limit}
+      OFFSET ${options.offset}
+    `);
+
+    const maxRank = Math.max(
+      ...rows.map((row) => normalizeRank(row.rank)),
+      0,
+    );
+
+    return rows.map((row) => {
+      const rank = normalizeRank(row.rank);
+      return {
+        id: row.id,
+        rank,
+        relevanceScore:
+          maxRank === 0 ? DEFAULT_RELEVANCE_SCORE : rank / maxRank,
+      };
+    });
+  }
+
+  private toMemoryResult(
+    article: NoosphereArticle,
+    relevanceScore?: number,
+  ): MemoryResult {
+    const tags = article.tags.map(({ tag }) => tag.name);
+
+    return defineMemoryResult({
+      id: article.id,
+      provider: NOOSPHERE_PROVIDER_ID,
+      sourceType: "noosphere",
+      title: article.title,
+      content: article.content,
+      summary: article.excerpt ?? undefined,
+      relevanceScore,
+      confidenceScore: mapConfidenceScore(article.confidence),
+      recencyScore: mapRecencyScore(article.updatedAt),
+      curationLevel: mapCurationLevel(article.status),
+      createdAt: article.createdAt.toISOString(),
+      updatedAt: article.updatedAt.toISOString(),
+      canonicalRef: `noosphere:article:${article.id}`,
+      tags,
+      metadata: removeUndefined({
+        articleId: article.id,
+        articleSlug: article.slug,
+        topicId: article.topic.id,
+        topicSlug: article.topic.slug,
+        topicName: article.topic.name,
+        wikiPath: `/wiki/${article.topic.slug}/${article.slug}`,
+        sourceUrl: article.sourceUrl ?? undefined,
+        sourceType: article.sourceType ?? undefined,
+        status: article.status,
+        confidence: article.confidence ?? undefined,
+        lastReviewed: article.lastReviewed?.toISOString(),
+        authorId: article.authorId ?? undefined,
+        authorName: article.authorName ?? undefined,
+      }),
+    });
+  }
+}
+
+export function createNoosphereProvider(
+  settings: NoosphereProviderSettings = {},
+): NoosphereProvider {
+  return new NoosphereProvider(settings);
+}
+
+function buildNoosphereSearchFilters(options: {
+  topicSlug?: string;
+  tagSlug?: string;
+  status?: string;
+  confidence?: string;
+}): Prisma.Sql[] {
+  const clauses: Prisma.Sql[] = [Prisma.sql`a."deletedAt" IS NULL`];
+
+  if (options.topicSlug) {
+    clauses.push(Prisma.sql`tpc.slug = ${options.topicSlug}`);
+  }
+
+  if (options.tagSlug) {
+    clauses.push(
+      Prisma.sql`EXISTS (
+        SELECT 1
+        FROM "ArticleTag" at_filter
+        INNER JOIN "Tag" tag_filter ON tag_filter.id = at_filter."tagId"
+        WHERE at_filter."articleId" = a.id
+          AND tag_filter.slug = ${options.tagSlug}
+      )`,
+    );
+  }
+
+  if (options.status) {
+    clauses.push(Prisma.sql`a.status = ${options.status}`);
+  }
+
+  if (options.confidence) {
+    clauses.push(Prisma.sql`a.confidence = ${options.confidence}`);
+  }
+
+  return clauses;
+}
+
+function mapConfidenceScore(confidence: string | null): number | undefined {
+  switch (confidence) {
+    case "high":
+      return 1;
+    case "medium":
+      return 0.66;
+    case "low":
+      return 0.33;
+    default:
+      return undefined;
+  }
+}
+
+function mapCurationLevel(status: string): MemoryResult["curationLevel"] {
+  switch (status) {
+    case "published":
+      return "curated";
+    case "reviewed":
+      return "reviewed";
+    case "draft":
+      return "ephemeral";
+    default:
+      return "reviewed";
+  }
+}
+
+function mapRecencyScore(
+  updatedAt: Date | null | undefined,
+  now = new Date(),
+): number | undefined {
+  if (!updatedAt) {
+    return undefined;
+  }
+
+  const ageMs = now.getTime() - updatedAt.getTime();
+  if (ageMs <= 0) {
+    return 1;
+  }
+
+  const ageDays = ageMs / (1000 * 60 * 60 * 24);
+  return normalizeMemoryScore(Math.exp(-ageDays / RECENCY_HALF_LIFE_DAYS));
+}
+
+function parseNoosphereArticleId(id: string): string {
+  const prefix = "noosphere:article:";
+  return id.startsWith(prefix) ? id.slice(prefix.length) : id;
+}
+
+function normalizeRank(rank: number | string): number {
+  return typeof rank === "number" ? rank : Number(rank);
+}
+
+function normalizeLimit(limit: number | undefined): number {
+  if (limit === undefined || !Number.isFinite(limit) || limit <= 0) {
+    return DEFAULT_NOOSPHERE_MAX_RESULTS;
+  }
+
+  return Math.max(1, Math.floor(limit));
+}
+
+function normalizeOffset(offset: number | undefined): number {
+  if (offset === undefined || !Number.isFinite(offset) || offset < 0) {
+    return 0;
+  }
+
+  return Math.floor(offset);
+}
+
+function removeUndefined<T extends Record<string, unknown>>(value: T): Partial<T> {
+  return Object.fromEntries(
+    Object.entries(value).filter(([, entry]) => entry !== undefined),
+  ) as Partial<T>;
+}

--- a/src/lib/memory/types.ts
+++ b/src/lib/memory/types.ts
@@ -119,3 +119,11 @@ export function defineMemoryResult(input: MemoryResultInput): MemoryResult {
       estimateMemoryTokens(input.summary || input.content),
   };
 }
+
+export function removeUndefined<T extends Record<string, unknown>>(
+  value: T,
+): Partial<T> {
+  return Object.fromEntries(
+    Object.entries(value).filter(([, entry]) => entry !== undefined),
+  ) as Partial<T>;
+}

--- a/src/lib/wiki.ts
+++ b/src/lib/wiki.ts
@@ -40,7 +40,7 @@ export async function buildTagConnections(tagNames: string[]) {
   );
 }
 
-interface SearchArticlesOptions {
+export interface SearchArticlesOptions {
   topicSlug?: string;
   tagSlug?: string;
   status?: string;
@@ -49,7 +49,7 @@ interface SearchArticlesOptions {
   offset?: number;
 }
 
-function buildSearchFilters(options: SearchArticlesOptions) {
+export function buildSearchFilters(options: SearchArticlesOptions) {
   const clauses: Prisma.Sql[] = [Prisma.sql`a."deletedAt" IS NULL`];
 
   if (options.topicSlug) {


### PR DESCRIPTION
## Summary
- Add a Noosphere memory provider implementing the universal `MemoryProvider` contract.
- Map wiki articles, topics, tags, lifecycle status, confidence, and provenance into normalized `MemoryResult` objects.
- Export the Noosphere provider class, factory, and metadata option types from the memory module.

## Verification
- `npm run lint` (passes with existing warnings)
- `npx tsc --noEmit`

Closes #9

## Summary by Sourcery

Add a Noosphere-backed memory provider integrating wiki articles into the universal memory system.

New Features:
- Introduce a Noosphere memory provider implementation exposing search, fetch-by-id, and scoring capabilities over wiki articles.

Enhancements:
- Export the Noosphere memory provider factory, class, and related metadata option types from the memory module for external use.