### PR TITLE
feat(memory): Recall Orchestrator core

### DIFF
--- a/src/__tests__/memory/recall-orchestrator.test.ts
+++ b/src/__tests__/memory/recall-orchestrator.test.ts
@@ -22,7 +22,6 @@ import {
   RecallOrchestrator,
   createRecallOrchestrator,
 } from "@/lib/memory/orchestrator";
-import type { RecallQuery } from "@/lib/memory/orchestrator";
 
 // ─── Test helpers ────────────────────────────────────────────────────────────
 
@@ -123,6 +122,21 @@ async function main() {
       providers: [{ provider: mockProvider("test") }],
     });
     assert(orchestrator instanceof RecallOrchestrator, "instance check");
+  });
+
+  test("constructor rejects duplicate provider IDs", () => {
+    let threw = false;
+    try {
+      new RecallOrchestrator({
+        providers: [
+          { provider: mockProvider("duplicate") },
+          { provider: mockProvider("duplicate") },
+        ],
+      });
+    } catch {
+      threw = true;
+    }
+    assert(threw, "should throw on duplicate provider IDs");
   });
 
   test("createRecallOrchestrator factory returns instance", () => {
@@ -237,6 +251,11 @@ async function main() {
           provider: mockProvider("disabled", []),
           config: { enabled: false },
         },
+        {
+          provider: mockProvider("second-enabled", [
+            mockResult({ id: "2", provider: "second-enabled", content: "hello" }),
+          ]),
+        },
       ],
     });
 
@@ -245,8 +264,20 @@ async function main() {
       mode: "inspection",
     });
 
-    assertEqual(response.providerMeta.length, 1, "only enabled provider");
+    assertEqual(response.providerMeta.length, 3, "all providers reported");
     assertEqual(response.providerMeta[0].providerId, "enabled", "enabled id");
+    assertEqual(response.providerMeta[1].providerId, "disabled", "disabled id");
+    assertEqual(response.providerMeta[1].enabled, false, "disabled provider marked disabled");
+    assertEqual(
+      response.providerMeta[1].skippedReason,
+      "disabled",
+      "disabled skip reason",
+    );
+    assertEqual(
+      response.providerMeta[2].providerId,
+      "second-enabled",
+      "provider metadata preserves registration order",
+    );
   });
 
   // ─── Auto-recall gating ─────────────────────────────────────────────────
@@ -274,8 +305,40 @@ async function main() {
     });
 
     assertEqual(response.results.length, 0, "no results from auto-blocked");
-    // Provider was skipped entirely — no meta entry.
-    assertEqual(response.providerMeta.length, 0, "provider was skipped");
+    assertEqual(response.providerMeta.length, 1, "provider skip reported");
+    assertEqual(response.providerMeta[0].enabled, false, "provider marked skipped");
+    assertEqual(
+      response.providerMeta[0].skippedReason,
+      "auto-recall-disabled",
+      "auto capability skip reason",
+    );
+  });
+
+  test("auto mode respects allowAutoRecall=false provider config", async () => {
+    const provider = mockProvider("config-no-auto", [
+      mockResult({ id: "1", provider: "config-no-auto", content: "hidden" }),
+    ]);
+
+    const orchestrator = new RecallOrchestrator({
+      providers: [
+        {
+          provider,
+          config: { allowAutoRecall: false },
+        },
+      ],
+    });
+
+    const response = await orchestrator.recall({
+      query: "test",
+      mode: "auto",
+    });
+
+    assertEqual(response.results.length, 0, "config blocks auto recall");
+    assertEqual(
+      response.providerMeta[0].skippedReason,
+      "auto-recall-disabled",
+      "config skip reason",
+    );
   });
 
   // ─── Error handling ─────────────────────────────────────────────────────
@@ -295,7 +358,41 @@ async function main() {
     });
 
     assertEqual(response.results.length, 0, "no results on error");
+    assertEqual(response.providerMeta[0].providerId, "failing", "failed provider id");
+    assertEqual(response.providerMeta[0].enabled, true, "failed provider still enabled");
     assertEqual(response.providerMeta[0].error, "DB connection lost", "error message");
+  });
+
+  test("respects provider query concurrency limit", async () => {
+    let active = 0;
+    let maxActive = 0;
+    const makeDelayedProvider = (id: string) =>
+      mockProvider(id, [], {
+        search: async () => {
+          active++;
+          maxActive = Math.max(maxActive, active);
+          await new Promise((resolve) => setTimeout(resolve, 10));
+          active--;
+          return [mockResult({ id, provider: id, content: id })];
+        },
+      });
+
+    const orchestrator = new RecallOrchestrator({
+      providers: [
+        { provider: makeDelayedProvider("p1") },
+        { provider: makeDelayedProvider("p2") },
+        { provider: makeDelayedProvider("p3") },
+      ],
+      concurrency: 1,
+    });
+
+    const response = await orchestrator.recall({
+      query: "test",
+      mode: "inspection",
+    });
+
+    assertEqual(response.results.length, 3, "all providers queried");
+    assertEqual(maxActive, 1, "only one provider active at a time");
   });
 
   // ─── Deduplication ──────────────────────────────────────────────────────
@@ -405,8 +502,40 @@ async function main() {
     });
 
     assert(response.results.length < 5, "truncated by budget");
-    assert(response.tokenBudgetUsed === 20, "budget reported");
+    const tokenBudgetUsed = response.tokenBudgetUsed;
+    if (tokenBudgetUsed === undefined) {
+      throw new Error("token usage reported");
+    }
+    assert(tokenBudgetUsed <= 20, "actual usage within budget");
     assert(response.promptInjectionText !== undefined, "has prompt text");
+  });
+
+  test("auto mode budgets full content before falling back to summary", async () => {
+    const results = [
+      mockResult({
+        id: "long",
+        provider: "noosphere",
+        content: "A".repeat(400),
+        summary: "short",
+        tokenEstimate: 2,
+        relevanceScore: 1,
+      }),
+    ];
+
+    const orchestrator = new RecallOrchestrator({
+      providers: [{ provider: mockProvider("noosphere", results) }],
+      autoRecallTokenBudget: 10,
+    });
+
+    const response = await orchestrator.recall({
+      query: "test",
+      mode: "auto",
+    });
+
+    assertEqual(response.results.length, 1, "summary fallback kept result");
+    assertEqual(response.results[0].content, "short", "summary used for output");
+    assertEqual(response.tokenBudgetUsed, 2, "actual summary token usage reported");
+    assert(!response.promptInjectionText?.includes("AAAA"), "long content omitted");
   });
 
   // ─── Prompt injection formatting ────────────────────────────────────────

--- a/src/__tests__/memory/recall-orchestrator.test.ts
+++ b/src/__tests__/memory/recall-orchestrator.test.ts
@@ -1,0 +1,576 @@
+/**
+ * RecallOrchestrator — Unit Tests
+ *
+ * Run with: DATABASE_URL="postgresql://test:test@localhost:5432/test" npx tsx src/__tests__/memory/recall-orchestrator.test.ts
+ *
+ * Tests cover:
+ * 1. Constructor validation (empty providers, defaults)
+ * 2. Fan-out (enabled/disabled providers, auto-recall gating, error handling)
+ * 3. Ranking (composite score, deduplication, ordering)
+ * 4. Token budget (auto mode truncation, summary fallback)
+ * 5. Prompt injection formatting (XML output, escaping)
+ * 6. Inspection mode (structured output, no budget truncation)
+ */
+
+if (!process.env.DATABASE_URL) {
+  process.env.DATABASE_URL = "postgresql://test:test@localhost:5432/test";
+}
+
+import type { MemoryProvider } from "@/lib/memory/provider";
+import type { MemoryResult } from "@/lib/memory/types";
+import {
+  RecallOrchestrator,
+  createRecallOrchestrator,
+} from "@/lib/memory/orchestrator";
+import type { RecallQuery } from "@/lib/memory/orchestrator";
+
+// ─── Test helpers ────────────────────────────────────────────────────────────
+
+let testCounter = 0;
+let passCount = 0;
+let failCount = 0;
+const pending: Promise<void>[] = [];
+
+function test(name: string, fn: () => void | Promise<void>): void {
+  testCounter++;
+  const label = `[${testCounter}] ${name}`;
+  const p = Promise.resolve()
+    .then(() => fn())
+    .then(() => {
+      passCount++;
+      console.log(`  ✓ ${label}`);
+    })
+    .catch((err: unknown) => {
+      failCount++;
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(`  ✗ ${label}\n    ${message}`);
+    });
+  pending.push(p);
+}
+
+function assert(condition: boolean, message: string): void {
+  if (!condition) throw new Error(`Assertion failed: ${message}`);
+}
+
+function assertEqual<T>(actual: T, expected: T, label: string): void {
+  if (actual !== expected) {
+    throw new Error(
+      `${label}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`,
+    );
+  }
+}
+
+// ─── Mock providers ──────────────────────────────────────────────────────────
+
+function mockProvider(
+  id: string,
+  results: MemoryResult[] = [],
+  overrides: Partial<MemoryProvider> = {},
+): MemoryProvider {
+  return {
+    descriptor: {
+      id,
+      displayName: id,
+      sourceType: id as MemoryResult["sourceType"],
+      defaultConfig: {
+        enabled: true,
+        priorityWeight: 1,
+        allowAutoRecall: true,
+      },
+      capabilities: {
+        search: true,
+        getById: true,
+        score: true,
+        autoRecall: true,
+      },
+    },
+    search: () => Promise.resolve(results),
+    getById: () => Promise.resolve(null),
+    score: () => ({}),
+    ...overrides,
+  } as MemoryProvider;
+}
+
+function mockResult(
+  overrides: Partial<MemoryResult> & { id: string; provider: string },
+): MemoryResult {
+  return {
+    sourceType: overrides.provider as MemoryResult["sourceType"],
+    content: `Content for ${overrides.id}`,
+    ...overrides,
+  };
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+async function main() {
+  console.log("\n🧠 RecallOrchestrator Tests\n");
+
+  // ─── Constructor ─────────────────────────────────────────────────────────
+
+  test("constructor throws with no providers", () => {
+    let threw = false;
+    try {
+      new RecallOrchestrator({ providers: [] });
+    } catch {
+      threw = true;
+    }
+    assert(threw, "should throw on empty providers");
+  });
+
+  test("constructor accepts valid providers", () => {
+    const orchestrator = new RecallOrchestrator({
+      providers: [{ provider: mockProvider("test") }],
+    });
+    assert(orchestrator instanceof RecallOrchestrator, "instance check");
+  });
+
+  test("createRecallOrchestrator factory returns instance", () => {
+    const orchestrator = createRecallOrchestrator({
+      providers: [{ provider: mockProvider("test") }],
+    });
+    assert(orchestrator instanceof RecallOrchestrator, "factory instance");
+  });
+
+  // ─── Basic recall (inspection mode) ─────────────────────────────────────
+
+  test("returns empty results for empty provider output", async () => {
+    const orchestrator = new RecallOrchestrator({
+      providers: [{ provider: mockProvider("empty") }],
+    });
+    const response = await orchestrator.recall({
+      query: "test query",
+      mode: "inspection",
+    });
+    assertEqual(response.results.length, 0, "empty results");
+    assertEqual(response.totalBeforeCap, 0, "total before cap");
+    assertEqual(response.mode, "inspection", "mode");
+    assertEqual(response.promptInjectionText, undefined, "no prompt text");
+  });
+
+  test("returns results from single provider", async () => {
+    const results = [
+      mockResult({
+        id: "1",
+        provider: "noosphere",
+        title: "Article A",
+        content: "Content A",
+        relevanceScore: 0.9,
+      }),
+      mockResult({
+        id: "2",
+        provider: "noosphere",
+        title: "Article B",
+        content: "Content B",
+        relevanceScore: 0.5,
+      }),
+    ];
+    const orchestrator = new RecallOrchestrator({
+      providers: [{ provider: mockProvider("noosphere", results) }],
+    });
+
+    const response = await orchestrator.recall({
+      query: "test",
+      mode: "inspection",
+    });
+
+    assertEqual(response.results.length, 2, "result count");
+    assertEqual(response.results[0].rank, 1, "first rank");
+    assertEqual(response.results[0].title, "Article A", "first title (highest relevance)");
+    assertEqual(response.results[0].providerId, "noosphere", "provider id");
+    assert(response.results[0].compositeScore > 0, "composite score > 0");
+  });
+
+  test("merges results from multiple providers", async () => {
+    const noosphereResults = [
+      mockResult({
+        id: "n1",
+        provider: "noosphere",
+        title: "Wiki Article",
+        content: "Wiki content",
+        relevanceScore: 0.8,
+      }),
+    ];
+    const hindsightResults = [
+      mockResult({
+        id: "h1",
+        provider: "hindsight",
+        title: "Memory",
+        content: "Hindsight content",
+        relevanceScore: 0.6,
+      }),
+    ];
+
+    const orchestrator = new RecallOrchestrator({
+      providers: [
+        { provider: mockProvider("noosphere", noosphereResults) },
+        { provider: mockProvider("hindsight", hindsightResults) },
+      ],
+    });
+
+    const response = await orchestrator.recall({
+      query: "test",
+      mode: "inspection",
+    });
+
+    assertEqual(response.results.length, 2, "merged count");
+    assertEqual(response.providerMeta.length, 2, "provider meta count");
+    // Higher relevance should rank first.
+    assertEqual(
+      response.results[0].providerId,
+      "noosphere",
+      "noosphere ranks higher",
+    );
+  });
+
+  // ─── Disabled providers ─────────────────────────────────────────────────
+
+  test("skips disabled providers", async () => {
+    const orchestrator = new RecallOrchestrator({
+      providers: [
+        {
+          provider: mockProvider("enabled", [
+            mockResult({ id: "1", provider: "enabled", content: "hi" }),
+          ]),
+        },
+        {
+          provider: mockProvider("disabled", []),
+          config: { enabled: false },
+        },
+      ],
+    });
+
+    const response = await orchestrator.recall({
+      query: "test",
+      mode: "inspection",
+    });
+
+    assertEqual(response.providerMeta.length, 1, "only enabled provider");
+    assertEqual(response.providerMeta[0].providerId, "enabled", "enabled id");
+  });
+
+  // ─── Auto-recall gating ─────────────────────────────────────────────────
+
+  test("auto mode skips providers with autoRecall=false", async () => {
+    const noAutoRecallProvider = mockProvider("no-auto", [], {
+      descriptor: {
+        ...mockProvider("no-auto").descriptor,
+        capabilities: {
+          search: true,
+          getById: true,
+          score: false,
+          autoRecall: false,
+        },
+      },
+    });
+
+    const orchestrator = new RecallOrchestrator({
+      providers: [{ provider: noAutoRecallProvider }],
+    });
+
+    const response = await orchestrator.recall({
+      query: "test",
+      mode: "auto",
+    });
+
+    assertEqual(response.results.length, 0, "no results from auto-blocked");
+    // Provider was skipped entirely — no meta entry.
+    assertEqual(response.providerMeta.length, 0, "provider was skipped");
+  });
+
+  // ─── Error handling ─────────────────────────────────────────────────────
+
+  test("gracefully handles provider errors", async () => {
+    const failingProvider = mockProvider("failing", [], {
+      search: () => Promise.reject(new Error("DB connection lost")),
+    });
+
+    const orchestrator = new RecallOrchestrator({
+      providers: [{ provider: failingProvider }],
+    });
+
+    const response = await orchestrator.recall({
+      query: "test",
+      mode: "inspection",
+    });
+
+    assertEqual(response.results.length, 0, "no results on error");
+    assertEqual(response.providerMeta[0].error, "DB connection lost", "error message");
+  });
+
+  // ─── Deduplication ──────────────────────────────────────────────────────
+
+  test("deduplicates results by canonicalRef", async () => {
+    const results = [
+      mockResult({
+        id: "1",
+        provider: "noosphere",
+        canonicalRef: "noosphere:article:shared",
+        content: "Version A",
+        relevanceScore: 0.9,
+      }),
+      mockResult({
+        id: "2",
+        provider: "noosphere",
+        canonicalRef: "noosphere:article:shared",
+        content: "Version B",
+        relevanceScore: 0.5,
+      }),
+    ];
+
+    const orchestrator = new RecallOrchestrator({
+      providers: [{ provider: mockProvider("noosphere", results) }],
+    });
+
+    const response = await orchestrator.recall({
+      query: "test",
+      mode: "inspection",
+    });
+
+    assertEqual(response.results.length, 1, "deduped to 1");
+    assertEqual(response.results[0].content, "Version A", "kept higher relevance");
+  });
+
+  // ─── Global result cap ─────────────────────────────────────────────────
+
+  test("respects global result cap", async () => {
+    const results = Array.from({ length: 10 }, (_, i) =>
+      mockResult({
+        id: `${i}`,
+        provider: "noosphere",
+        content: `Content ${i}`,
+        relevanceScore: 1 - i * 0.1,
+      }),
+    );
+
+    const orchestrator = new RecallOrchestrator({
+      providers: [{ provider: mockProvider("noosphere", results) }],
+      globalResultCap: 3,
+    });
+
+    const response = await orchestrator.recall({
+      query: "test",
+      mode: "inspection",
+    });
+
+    assertEqual(response.results.length, 3, "capped at 3");
+    assertEqual(response.totalBeforeCap, 10, "total before cap");
+  });
+
+  test("per-query resultCap overrides global", async () => {
+    const results = Array.from({ length: 5 }, (_, i) =>
+      mockResult({
+        id: `${i}`,
+        provider: "noosphere",
+        content: `Content ${i}`,
+        relevanceScore: 1 - i * 0.1,
+      }),
+    );
+
+    const orchestrator = new RecallOrchestrator({
+      providers: [{ provider: mockProvider("noosphere", results) }],
+      globalResultCap: 3,
+    });
+
+    const response = await orchestrator.recall({
+      query: "test",
+      mode: "inspection",
+      resultCap: 1,
+    });
+
+    assertEqual(response.results.length, 1, "query cap overrides global");
+  });
+
+  // ─── Token budget (auto mode) ───────────────────────────────────────────
+
+  test("auto mode truncates results to token budget", async () => {
+    // Each result is ~30 chars → ~8 tokens at 4 chars/token.
+    const results = Array.from({ length: 5 }, (_, i) =>
+      mockResult({
+        id: `${i}`,
+        provider: "noosphere",
+        content: `A`.repeat(40),
+        relevanceScore: 1 - i * 0.1,
+      }),
+    );
+
+    const orchestrator = new RecallOrchestrator({
+      providers: [{ provider: mockProvider("noosphere", results) }],
+      autoRecallTokenBudget: 20, // ~5 results worth → should fit ~2
+    });
+
+    const response = await orchestrator.recall({
+      query: "test",
+      mode: "auto",
+    });
+
+    assert(response.results.length < 5, "truncated by budget");
+    assert(response.tokenBudgetUsed === 20, "budget reported");
+    assert(response.promptInjectionText !== undefined, "has prompt text");
+  });
+
+  // ─── Prompt injection formatting ────────────────────────────────────────
+
+  test("auto mode generates prompt injection XML", async () => {
+    const results = [
+      mockResult({
+        id: "1",
+        provider: "noosphere",
+        title: "Test Article",
+        content: "Hello world",
+        canonicalRef: "noosphere:article:1",
+        relevanceScore: 0.9,
+      }),
+    ];
+
+    const orchestrator = new RecallOrchestrator({
+      providers: [{ provider: mockProvider("noosphere", results) }],
+    });
+
+    const response = await orchestrator.recall({
+      query: "test query",
+      mode: "auto",
+    });
+
+    const xml = response.promptInjectionText!;
+    assert(xml.includes('<recall query="test query">'), "recall open tag");
+    assert(xml.includes('<memory source="noosphere"'), "memory tag");
+    assert(xml.includes('title="Test Article"'), "title attr");
+    assert(xml.includes('ref="noosphere:article:1"'), "ref attr");
+    assert(xml.includes("Hello world"), "content");
+    assert(xml.includes("</recall>"), "recall close tag");
+  });
+
+  test("prompt injection escapes XML special characters", async () => {
+    const results = [
+      mockResult({
+        id: "1",
+        provider: "noosphere",
+        title: 'Test "quotes" & <brackets>',
+        content: "Value: 5 > 3 & 2 < 4",
+        relevanceScore: 0.9,
+      }),
+    ];
+
+    const orchestrator = new RecallOrchestrator({
+      providers: [{ provider: mockProvider("noosphere", results) }],
+    });
+
+    const response = await orchestrator.recall({
+      query: 'test "query"',
+      mode: "auto",
+    });
+
+    const xml = response.promptInjectionText!;
+    assert(!xml.includes('"query"'), "query quotes escaped");
+    assert(xml.includes("&quot;"), "quote escaped in attr");
+    assert(xml.includes("&amp;"), "ampersand escaped");
+    assert(xml.includes("&lt;"), "less-than escaped");
+    assert(xml.includes("&gt;"), "greater-than escaped");
+  });
+
+  test("auto mode returns empty string for no results", async () => {
+    const orchestrator = new RecallOrchestrator({
+      providers: [{ provider: mockProvider("empty") }],
+    });
+
+    const response = await orchestrator.recall({
+      query: "test",
+      mode: "auto",
+    });
+
+    assertEqual(response.promptInjectionText, "", "empty prompt text");
+  });
+
+  // ─── Provider duration tracking ─────────────────────────────────────────
+
+  test("tracks per-provider duration", async () => {
+    const slowProvider = mockProvider("slow", [], {
+      search: async () => {
+        await new Promise((r) => setTimeout(r, 10));
+        return [
+          mockResult({ id: "1", provider: "slow", content: "data" }),
+        ];
+      },
+    });
+
+    const orchestrator = new RecallOrchestrator({
+      providers: [{ provider: slowProvider }],
+    });
+
+    const response = await orchestrator.recall({
+      query: "test",
+      mode: "inspection",
+    });
+
+    assert(
+      response.providerMeta[0].durationMs >= 10,
+      "duration tracked (>= 10ms)",
+    );
+  });
+
+  // ─── Priority weight affects ranking ────────────────────────────────────
+
+  test("higher priority weight boosts ranking", async () => {
+    const lowResults = [
+      mockResult({
+        id: "low",
+        provider: "low-priority",
+        content: "low priority content",
+        relevanceScore: 0.9,
+      }),
+    ];
+    const highResults = [
+      mockResult({
+        id: "high",
+        provider: "high-priority",
+        content: "high priority content",
+        relevanceScore: 0.5,
+      }),
+    ];
+
+    const orchestrator = new RecallOrchestrator({
+      providers: [
+        {
+          provider: mockProvider("low-priority", lowResults),
+          config: { priorityWeight: 0.5 },
+        },
+        {
+          provider: mockProvider("high-priority", highResults),
+          config: { priorityWeight: 2.0 },
+        },
+      ],
+    });
+
+    const response = await orchestrator.recall({
+      query: "test",
+      mode: "inspection",
+    });
+
+    // High priority with weight 2.0 should outrank low priority with weight 0.5
+    // even though low has higher relevance (0.9 vs 0.5).
+    // Composite: low = 0.9*0.4*0.5 = 0.18, high = 0.5*0.4*2.0 = 0.4
+    assertEqual(
+      response.results[0].providerId,
+      "high-priority",
+      "high priority wins",
+    );
+  });
+
+  // ─── Wait for all async tests ───────────────────────────────────────────
+
+  await Promise.all(pending);
+
+  console.log(
+    `\n  ${passCount} passed, ${failCount} failed, ${testCounter} total\n`,
+  );
+
+  if (failCount > 0) {
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error("Fatal:", err);
+  process.exit(1);
+});

--- a/src/lib/memory/index.ts
+++ b/src/lib/memory/index.ts
@@ -35,6 +35,19 @@ export type {
 
 export { createHindsightProvider, HindsightProvider } from "./hindsight";
 export { createNoosphereProvider, NoosphereProvider } from "./noosphere";
+export {
+  RecallOrchestrator,
+  createRecallOrchestrator,
+} from "./orchestrator";
+export type {
+  RecallMode,
+  RecallOrchestratorOptions,
+  RecallOrchestratorProviderEntry,
+  RecallQuery,
+  RecallProviderMeta,
+  RecallResponse,
+  RecallResultRanked,
+} from "./orchestrator";
 
 export {
   DEFAULT_MEMORY_PROVIDER_CAPABILITIES,

--- a/src/lib/memory/orchestrator.ts
+++ b/src/lib/memory/orchestrator.ts
@@ -3,9 +3,11 @@ import type {
   MemoryProviderConfig,
   MemoryProviderSearchOptions,
 } from "./provider";
-import { normalizeMemoryProviderConfig } from "./provider";
 import {
-  defineMemoryResult,
+  getEffectiveAutoRecall,
+  normalizeMemoryProviderConfig,
+} from "./provider";
+import {
   estimateMemoryTokens,
   normalizeMemoryScore,
 } from "./types";
@@ -78,7 +80,7 @@ export interface RecallResponse {
   /** Effective mode used. */
   mode: RecallMode;
 
-  /** Effective token budget (auto mode). */
+  /** Estimated tokens consumed after budget enforcement (auto mode). */
   tokenBudgetUsed?: number;
 
   /** Formatted prompt injection text (auto mode only). */
@@ -94,6 +96,7 @@ export interface RecallProviderMeta {
   enabled: boolean;
   error?: string;
   durationMs: number;
+  skippedReason?: string;
 }
 
 // ─── Constants ───────────────────────────────────────────────────────────────
@@ -117,6 +120,7 @@ const CURATION_SCORE_MAP: Record<string, number> = {
 
 export class RecallOrchestrator {
   private readonly providers: RecallOrchestratorProviderEntry[];
+  private readonly providerWeights: Map<string, number>;
   private readonly globalResultCap: number;
   private readonly autoRecallTokenBudget: number;
   private readonly concurrency: number;
@@ -126,12 +130,18 @@ export class RecallOrchestrator {
       throw new Error("RecallOrchestrator requires at least one provider.");
     }
 
+    assertUniqueProviderIds(options.providers);
+
     this.providers = options.providers;
+    this.providerWeights = buildProviderWeightMap(options.providers);
     this.globalResultCap =
       options.globalResultCap ?? DEFAULT_GLOBAL_RESULT_CAP;
     this.autoRecallTokenBudget =
       options.autoRecallTokenBudget ?? DEFAULT_AUTO_RECALL_TOKEN_BUDGET;
-    this.concurrency = options.concurrency ?? options.providers.length;
+    this.concurrency = normalizePositiveInteger(
+      options.concurrency,
+      options.providers.length,
+    );
   }
 
   async recall(query: RecallQuery): Promise<RecallResponse> {
@@ -157,26 +167,27 @@ export class RecallOrchestrator {
     const budgeted =
       query.mode === "auto" && effectiveBudget !== undefined
         ? this.applyTokenBudget(capped, effectiveBudget)
-        : capped;
+        : { results: capped, tokenBudgetUsed: undefined };
 
     // Build prompt injection text for auto mode.
     const promptInjectionText =
       query.mode === "auto"
-        ? this.formatPromptInjection(budgeted, query.query)
+        ? this.formatPromptInjection(budgeted.results, query.query)
         : undefined;
 
     return {
-      results: budgeted,
+      results: budgeted.results,
       totalBeforeCap,
       mode: query.mode,
-      tokenBudgetUsed: effectiveBudget,
+      tokenBudgetUsed: budgeted.tokenBudgetUsed,
       promptInjectionText,
       providerMeta: providerResults.map((pr) => ({
         providerId: pr.providerId,
         resultCount: pr.results.length,
-        enabled: true,
+        enabled: pr.enabled,
         error: pr.error,
         durationMs: pr.durationMs,
+        skippedReason: pr.skippedReason,
       })),
     };
   }
@@ -186,74 +197,75 @@ export class RecallOrchestrator {
   private async fanOut(
     query: RecallQuery,
   ): Promise<ProviderFanOutResult[]> {
-    const entries = this.providers
-      .map((entry) => {
-        const config = normalizeMemoryProviderConfig({
-          ...entry.provider.descriptor.defaultConfig,
-          ...entry.config,
-        });
+    const skipped: ProviderFanOutResult[] = [];
+    const entries: RunnableProviderEntry[] = [];
 
-        if (!config.enabled) {
-          return null;
-        }
+    for (const [order, entry] of this.providers.entries()) {
+      const config = normalizeMemoryProviderConfig({
+        ...entry.provider.descriptor.defaultConfig,
+        ...entry.config,
+      });
+      const providerId = entry.provider.descriptor.id;
 
-        // Auto-recall gating: skip providers that can't auto-recall when in auto mode.
-        if (
-          query.mode === "auto" &&
-          !entry.provider.descriptor.capabilities.autoRecall
-        ) {
-          return null;
-        }
+      if (!config.enabled) {
+        skipped.push(buildSkippedProviderResult(providerId, order, "disabled"));
+        continue;
+      }
 
-        return { entry, config };
-      })
-      .filter((e): e is NonNullable<typeof e> => e !== null);
+      if (
+        query.mode === "auto" &&
+        !getEffectiveAutoRecall(entry.provider.descriptor.capabilities, config)
+      ) {
+        skipped.push(
+          buildSkippedProviderResult(providerId, order, "auto-recall-disabled"),
+        );
+        continue;
+      }
 
-    // Execute all queries concurrently (future: respect concurrency limit).
-    const results = await Promise.allSettled(
-      entries.map(async ({ entry, config }) => {
-        const start = performance.now();
+      entries.push({ entry, config, providerId, order });
+    }
 
-        try {
-          const searchOptions: MemoryProviderSearchOptions = {
-            limit: config.maxResults,
-            scope: query.scope,
-            autoRecall: query.mode === "auto",
-            config,
-            signal: query.signal,
-          };
-
-          const raw = await entry.provider.search(query.query, searchOptions);
-          const durationMs = Math.round(performance.now() - start);
-
-          return {
-            providerId: entry.provider.descriptor.id,
-            results: raw,
-            durationMs,
-          };
-        } catch (err) {
-          const durationMs = Math.round(performance.now() - start);
-          return {
-            providerId: entry.provider.descriptor.id,
-            results: [],
-            durationMs,
-            error:
-              err instanceof Error ? err.message : String(err),
-          };
-        }
-      }),
+    const queried = await runWithConcurrency(entries, this.concurrency, (entry) =>
+      this.queryProvider(entry, query),
     );
 
-    return results.map((r) =>
-      r.status === "fulfilled"
-        ? r.value
-        : {
-            providerId: "unknown",
-            results: [],
-            durationMs: 0,
-            error: r.reason?.message ?? String(r.reason),
-          },
-    );
+    return [...queried, ...skipped].sort((left, right) => left.order - right.order);
+  }
+
+  private async queryProvider(
+    { entry, config, providerId, order }: RunnableProviderEntry,
+    query: RecallQuery,
+  ): Promise<ProviderFanOutResult> {
+    const start = performance.now();
+
+    try {
+      const searchOptions: MemoryProviderSearchOptions = {
+        limit: config.maxResults,
+        scope: query.scope,
+        autoRecall: query.mode === "auto",
+        config,
+        signal: query.signal,
+      };
+
+      const raw = await entry.provider.search(query.query, searchOptions);
+
+      return {
+        providerId,
+        results: raw,
+        durationMs: elapsedMs(start),
+        enabled: true,
+        order,
+      };
+    } catch (err) {
+      return {
+        providerId,
+        results: [],
+        durationMs: elapsedMs(start),
+        enabled: true,
+        order,
+        error: err instanceof Error ? err.message : String(err),
+      };
+    }
   }
 
   // ─── Ranking ───────────────────────────────────────────────────────────
@@ -316,14 +328,7 @@ export class RecallOrchestrator {
     const curation =
       CURATION_SCORE_MAP[result.curationLevel ?? ""] ?? 0.5;
 
-    // Look up provider priority weight (respect config override).
-    const entry = this.providers.find(
-      (e) => e.provider.descriptor.id === providerId,
-    );
-    const defaultWeight = entry?.provider.descriptor.defaultConfig.priorityWeight ?? 1;
-    const overrideWeight = entry?.config?.priorityWeight;
-    const weight =
-      overrideWeight !== undefined ? overrideWeight : defaultWeight;
+    const weight = this.providerWeights.get(providerId) ?? 1;
 
     const raw =
       COMPOSITE_WEIGHTS.relevance * relevance +
@@ -340,12 +345,13 @@ export class RecallOrchestrator {
   private applyTokenBudget(
     results: RecallResultRanked[],
     budget: number,
-  ): RecallResultRanked[] {
+  ): { results: RecallResultRanked[]; tokenBudgetUsed: number } {
     const budgeted: RecallResultRanked[] = [];
     let remaining = budget;
+    let tokenBudgetUsed = 0;
 
     for (const result of results) {
-      const tokens = result.tokenEstimate ?? estimateMemoryTokens(result.content);
+      const tokens = estimateMemoryTokens(result.content);
 
       if (tokens > remaining) {
         // Try summary instead if it fits.
@@ -361,6 +367,7 @@ export class RecallOrchestrator {
             tokenEstimate: summaryTokens,
           });
           remaining -= summaryTokens;
+          tokenBudgetUsed += summaryTokens;
           continue;
         }
 
@@ -368,11 +375,15 @@ export class RecallOrchestrator {
         break;
       }
 
-      budgeted.push(result);
+      budgeted.push({
+        ...result,
+        tokenEstimate: tokens,
+      });
       remaining -= tokens;
+      tokenBudgetUsed += tokens;
     }
 
-    return budgeted;
+    return { results: budgeted, tokenBudgetUsed };
   }
 
   // ─── Prompt injection formatting ──────────────────────────────────────
@@ -414,7 +425,17 @@ interface ProviderFanOutResult {
   providerId: string;
   results: MemoryResult[];
   durationMs: number;
+  enabled: boolean;
+  order: number;
   error?: string;
+  skippedReason?: string;
+}
+
+interface RunnableProviderEntry {
+  entry: RecallOrchestratorProviderEntry;
+  config: MemoryProviderConfig;
+  providerId: string;
+  order: number;
 }
 
 interface ScorableResult {
@@ -436,6 +457,76 @@ function escapeXmlContent(value: string): string {
     .replace(/&/g, "&amp;")
     .replace(/</g, "&lt;")
     .replace(/>/g, "&gt;");
+}
+
+function assertUniqueProviderIds(
+  providers: RecallOrchestratorProviderEntry[],
+): void {
+  const seen = new Set<string>();
+  for (const entry of providers) {
+    const providerId = entry.provider.descriptor.id;
+    if (seen.has(providerId)) {
+      throw new Error(`Duplicate memory provider id: ${providerId}`);
+    }
+    seen.add(providerId);
+  }
+}
+
+function buildProviderWeightMap(
+  providers: RecallOrchestratorProviderEntry[],
+): Map<string, number> {
+  return new Map(
+    providers.map((entry) => {
+      const config = normalizeMemoryProviderConfig({
+        ...entry.provider.descriptor.defaultConfig,
+        ...entry.config,
+      });
+      return [entry.provider.descriptor.id, config.priorityWeight];
+    }),
+  );
+}
+
+function buildSkippedProviderResult(
+  providerId: string,
+  order: number,
+  skippedReason: string,
+): ProviderFanOutResult {
+  return {
+    providerId,
+    results: [],
+    durationMs: 0,
+    enabled: false,
+    order,
+    skippedReason,
+  };
+}
+
+async function runWithConcurrency<T, R>(
+  items: T[],
+  concurrency: number,
+  worker: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = [];
+  for (let index = 0; index < items.length; index += concurrency) {
+    const batch = items.slice(index, index + concurrency);
+    results.push(...(await Promise.all(batch.map(worker))));
+  }
+  return results;
+}
+
+function normalizePositiveInteger(
+  value: number | undefined,
+  fallback: number,
+): number {
+  if (value === undefined || !Number.isFinite(value) || value <= 0) {
+    return Math.max(1, Math.floor(fallback));
+  }
+
+  return Math.max(1, Math.floor(value));
+}
+
+function elapsedMs(start: number): number {
+  return Math.round(performance.now() - start);
 }
 
 // ─── Factory ─────────────────────────────────────────────────────────────────

--- a/src/lib/memory/orchestrator.ts
+++ b/src/lib/memory/orchestrator.ts
@@ -1,0 +1,447 @@
+import type {
+  MemoryProvider,
+  MemoryProviderConfig,
+  MemoryProviderSearchOptions,
+} from "./provider";
+import { normalizeMemoryProviderConfig } from "./provider";
+import {
+  defineMemoryResult,
+  estimateMemoryTokens,
+  normalizeMemoryScore,
+} from "./types";
+import type { MemoryResult, MemoryScore } from "./types";
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export type RecallMode = "auto" | "inspection";
+
+export interface RecallOrchestratorProviderEntry {
+  provider: MemoryProvider;
+  config?: Partial<MemoryProviderConfig>;
+}
+
+export interface RecallOrchestratorOptions {
+  /** Registered providers in priority order. */
+  providers: RecallOrchestratorProviderEntry[];
+
+  /** Global maximum number of results across all providers. */
+  globalResultCap?: number;
+
+  /** Token budget for auto-recall prompt injection output. */
+  autoRecallTokenBudget?: number;
+
+  /** Maximum concurrent provider queries. Default: all at once. */
+  concurrency?: number;
+}
+
+export interface RecallQuery {
+  /** The search query string. */
+  query: string;
+
+  /** Recall mode affects output format and budget behavior. */
+  mode: RecallMode;
+
+  /** Per-query token budget override (auto mode only). */
+  tokenBudget?: number;
+
+  /** Per-query result cap override. */
+  resultCap?: number;
+
+  /** Abort signal. */
+  signal?: AbortSignal;
+
+  /** Scope hint passed through to providers. */
+  scope?: string;
+}
+
+export interface RecallResultRanked extends MemoryResult {
+  /** Cross-provider rank (1 = best). */
+  rank: number;
+
+  /** Orchestrator-level composite score used for ranking. */
+  compositeScore: number;
+
+  /** Provider-local score breakdown. */
+  providerScores: Record<string, MemoryScore | undefined>;
+
+  /** Which provider this result came from. */
+  providerId: string;
+}
+
+export interface RecallResponse {
+  /** Ordered results (best first). */
+  results: RecallResultRanked[];
+
+  /** Total results before cap was applied. */
+  totalBeforeCap: number;
+
+  /** Effective mode used. */
+  mode: RecallMode;
+
+  /** Effective token budget (auto mode). */
+  tokenBudgetUsed?: number;
+
+  /** Formatted prompt injection text (auto mode only). */
+  promptInjectionText?: string;
+
+  /** Per-provider query metadata. */
+  providerMeta: RecallProviderMeta[];
+}
+
+export interface RecallProviderMeta {
+  providerId: string;
+  resultCount: number;
+  enabled: boolean;
+  error?: string;
+  durationMs: number;
+}
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+const DEFAULT_GLOBAL_RESULT_CAP = 20;
+const DEFAULT_AUTO_RECALL_TOKEN_BUDGET = 2000;
+const COMPOSITE_WEIGHTS = {
+  relevance: 0.4,
+  confidence: 0.25,
+  recency: 0.2,
+  curation: 0.15,
+} as const;
+
+const CURATION_SCORE_MAP: Record<string, number> = {
+  curated: 1.0,
+  reviewed: 0.7,
+  ephemeral: 0.3,
+};
+
+// ─── Orchestrator ────────────────────────────────────────────────────────────
+
+export class RecallOrchestrator {
+  private readonly providers: RecallOrchestratorProviderEntry[];
+  private readonly globalResultCap: number;
+  private readonly autoRecallTokenBudget: number;
+  private readonly concurrency: number;
+
+  constructor(options: RecallOrchestratorOptions) {
+    if (!options.providers || options.providers.length === 0) {
+      throw new Error("RecallOrchestrator requires at least one provider.");
+    }
+
+    this.providers = options.providers;
+    this.globalResultCap =
+      options.globalResultCap ?? DEFAULT_GLOBAL_RESULT_CAP;
+    this.autoRecallTokenBudget =
+      options.autoRecallTokenBudget ?? DEFAULT_AUTO_RECALL_TOKEN_BUDGET;
+    this.concurrency = options.concurrency ?? options.providers.length;
+  }
+
+  async recall(query: RecallQuery): Promise<RecallResponse> {
+    const effectiveCap =
+      query.resultCap ?? this.globalResultCap;
+    const effectiveBudget =
+      query.mode === "auto"
+        ? (query.tokenBudget ?? this.autoRecallTokenBudget)
+        : undefined;
+
+    // Fan out to all enabled providers concurrently.
+    const providerResults = await this.fanOut(query);
+
+    // Merge, score, and rank all results.
+    const ranked = this.rankResults(providerResults);
+
+    const totalBeforeCap = ranked.length;
+
+    // Apply global cap.
+    const capped = ranked.slice(0, effectiveCap);
+
+    // Estimate tokens for auto-recall budget.
+    const budgeted =
+      query.mode === "auto" && effectiveBudget !== undefined
+        ? this.applyTokenBudget(capped, effectiveBudget)
+        : capped;
+
+    // Build prompt injection text for auto mode.
+    const promptInjectionText =
+      query.mode === "auto"
+        ? this.formatPromptInjection(budgeted, query.query)
+        : undefined;
+
+    return {
+      results: budgeted,
+      totalBeforeCap,
+      mode: query.mode,
+      tokenBudgetUsed: effectiveBudget,
+      promptInjectionText,
+      providerMeta: providerResults.map((pr) => ({
+        providerId: pr.providerId,
+        resultCount: pr.results.length,
+        enabled: true,
+        error: pr.error,
+        durationMs: pr.durationMs,
+      })),
+    };
+  }
+
+  // ─── Fan-out ───────────────────────────────────────────────────────────
+
+  private async fanOut(
+    query: RecallQuery,
+  ): Promise<ProviderFanOutResult[]> {
+    const entries = this.providers
+      .map((entry) => {
+        const config = normalizeMemoryProviderConfig({
+          ...entry.provider.descriptor.defaultConfig,
+          ...entry.config,
+        });
+
+        if (!config.enabled) {
+          return null;
+        }
+
+        // Auto-recall gating: skip providers that can't auto-recall when in auto mode.
+        if (
+          query.mode === "auto" &&
+          !entry.provider.descriptor.capabilities.autoRecall
+        ) {
+          return null;
+        }
+
+        return { entry, config };
+      })
+      .filter((e): e is NonNullable<typeof e> => e !== null);
+
+    // Execute all queries concurrently (future: respect concurrency limit).
+    const results = await Promise.allSettled(
+      entries.map(async ({ entry, config }) => {
+        const start = performance.now();
+
+        try {
+          const searchOptions: MemoryProviderSearchOptions = {
+            limit: config.maxResults,
+            scope: query.scope,
+            autoRecall: query.mode === "auto",
+            config,
+            signal: query.signal,
+          };
+
+          const raw = await entry.provider.search(query.query, searchOptions);
+          const durationMs = Math.round(performance.now() - start);
+
+          return {
+            providerId: entry.provider.descriptor.id,
+            results: raw,
+            durationMs,
+          };
+        } catch (err) {
+          const durationMs = Math.round(performance.now() - start);
+          return {
+            providerId: entry.provider.descriptor.id,
+            results: [],
+            durationMs,
+            error:
+              err instanceof Error ? err.message : String(err),
+          };
+        }
+      }),
+    );
+
+    return results.map((r) =>
+      r.status === "fulfilled"
+        ? r.value
+        : {
+            providerId: "unknown",
+            results: [],
+            durationMs: 0,
+            error: r.reason?.message ?? String(r.reason),
+          },
+    );
+  }
+
+  // ─── Ranking ───────────────────────────────────────────────────────────
+
+  private rankResults(
+    providerResults: ProviderFanOutResult[],
+  ): RecallResultRanked[] {
+    const allResults: ScorableResult[] = [];
+
+    for (const pr of providerResults) {
+      for (const result of pr.results) {
+        const compositeScore = this.computeCompositeScore(result, pr.providerId);
+        allResults.push({
+          result,
+          providerId: pr.providerId,
+          compositeScore,
+        });
+      }
+    }
+
+    // Sort by composite score descending, then by relevance descending as tiebreaker.
+    allResults.sort((a, b) => {
+      const scoreDiff = b.compositeScore - a.compositeScore;
+      if (Math.abs(scoreDiff) > 0.001) return scoreDiff;
+      return (b.result.relevanceScore ?? 0) - (a.result.relevanceScore ?? 0);
+    });
+
+    // Deduplicate by canonicalRef.
+    const seen = new Set<string>();
+    const deduped: ScorableResult[] = [];
+    for (const item of allResults) {
+      const key = item.result.canonicalRef ?? `${item.providerId}:${item.result.id}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      deduped.push(item);
+    }
+
+    return deduped.map((item, index) =>
+      ({
+        ...item.result,
+        rank: index + 1,
+        compositeScore: item.compositeScore,
+        providerScores: {
+          relevance: item.result.relevanceScore,
+          confidence: item.result.confidenceScore,
+          recency: item.result.recencyScore,
+        },
+        providerId: item.providerId,
+      }) as RecallResultRanked,
+    );
+  }
+
+  private computeCompositeScore(
+    result: MemoryResult,
+    providerId: string,
+  ): number {
+    const relevance = result.relevanceScore ?? 0;
+    const confidence = result.confidenceScore ?? 0;
+    const recency = result.recencyScore ?? 0;
+    const curation =
+      CURATION_SCORE_MAP[result.curationLevel ?? ""] ?? 0.5;
+
+    // Look up provider priority weight (respect config override).
+    const entry = this.providers.find(
+      (e) => e.provider.descriptor.id === providerId,
+    );
+    const defaultWeight = entry?.provider.descriptor.defaultConfig.priorityWeight ?? 1;
+    const overrideWeight = entry?.config?.priorityWeight;
+    const weight =
+      overrideWeight !== undefined ? overrideWeight : defaultWeight;
+
+    const raw =
+      COMPOSITE_WEIGHTS.relevance * relevance +
+      COMPOSITE_WEIGHTS.confidence * confidence +
+      COMPOSITE_WEIGHTS.recency * recency +
+      COMPOSITE_WEIGHTS.curation * curation;
+
+    // Apply provider weight as a multiplier.
+    return normalizeMemoryScore(raw * weight);
+  }
+
+  // ─── Token budget ─────────────────────────────────────────────────────
+
+  private applyTokenBudget(
+    results: RecallResultRanked[],
+    budget: number,
+  ): RecallResultRanked[] {
+    const budgeted: RecallResultRanked[] = [];
+    let remaining = budget;
+
+    for (const result of results) {
+      const tokens = result.tokenEstimate ?? estimateMemoryTokens(result.content);
+
+      if (tokens > remaining) {
+        // Try summary instead if it fits.
+        const summaryTokens = result.summary
+          ? estimateMemoryTokens(result.summary)
+          : tokens;
+
+        if (summaryTokens <= remaining) {
+          // Use summary-only version.
+          budgeted.push({
+            ...result,
+            content: result.summary!,
+            tokenEstimate: summaryTokens,
+          });
+          remaining -= summaryTokens;
+          continue;
+        }
+
+        // Neither fits — stop.
+        break;
+      }
+
+      budgeted.push(result);
+      remaining -= tokens;
+    }
+
+    return budgeted;
+  }
+
+  // ─── Prompt injection formatting ──────────────────────────────────────
+
+  private formatPromptInjection(
+    results: RecallResultRanked[],
+    query: string,
+  ): string {
+    if (results.length === 0) {
+      return "";
+    }
+
+    const lines: string[] = [
+      `<recall query="${escapeXmlAttr(query)}">`,
+    ];
+
+    for (const result of results) {
+      const source = result.providerId;
+      const title = result.title ? ` title="${escapeXmlAttr(result.title)}"` : "";
+      const ref = result.canonicalRef
+        ? ` ref="${escapeXmlAttr(result.canonicalRef)}"`
+        : "";
+
+      lines.push(
+        `  <memory source="${escapeXmlAttr(source)}"${title}${ref}>`,
+        `    ${escapeXmlContent(result.content)}`,
+        `  </memory>`,
+      );
+    }
+
+    lines.push("</recall>");
+    return lines.join("\n");
+  }
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+interface ProviderFanOutResult {
+  providerId: string;
+  results: MemoryResult[];
+  durationMs: number;
+  error?: string;
+}
+
+interface ScorableResult {
+  result: MemoryResult;
+  providerId: string;
+  compositeScore: number;
+}
+
+function escapeXmlAttr(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+function escapeXmlContent(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+// ─── Factory ─────────────────────────────────────────────────────────────────
+
+export function createRecallOrchestrator(
+  options: RecallOrchestratorOptions,
+): RecallOrchestrator {
+  return new RecallOrchestrator(options);
+}


### PR DESCRIPTION
Closes #10

## What
Implements the central retrieval engine that queries enabled providers, normalizes results, and prepares them for downstream arbitration and budgeting.

## Deliverables
- ✅ Multi-provider query fanout (concurrent, error-isolated)
- ✅ Result normalization (cross-provider composite ranking)
- ✅ Ranking pipeline hooks (weighted blend of relevance/confidence/recency/curation × provider priority)
- ✅ Output modes: prompt injection XML (auto) vs structured inspection payload
- ✅ Deduplication by canonicalRef
- ✅ Token budget management with summary fallback
- ✅ Global + per-query result caps
- ✅ Auto-recall gating (respects provider capabilities)

## Tests
18 unit tests — constructor, fan-out, ranking, dedup, caps, token budget, XML formatting, escaping, priority weights.

Run: `DATABASE_URL="postgresql://test:test@localhost:5432/test" npx tsx src/__tests__/memory/recall-orchestrator.test.ts`

## Summary by Sourcery

Introduce a central RecallOrchestrator for memory retrieval across multiple providers, with ranking, deduplication, and prompt-injection-friendly output, and add comprehensive unit tests for its behavior.

New Features:
- Add a RecallOrchestrator service that fans out queries to multiple memory providers, merges their results, and exposes a typed recall API with auto and inspection modes.
- Support configurable global and per-query result caps, provider priority weighting, token-budget-aware truncation with summary fallback, and XML-formatted prompt injection output.

Tests:
- Add a dedicated recall-orchestrator.test.ts suite covering construction, multi-provider fan-out, ranking and deduplication, caps and token budgeting, XML formatting and escaping, error handling, duration tracking, and priority weighting behavior.