### PR TITLE
Add tokenEstimate to RecallResultRanked type

### DIFF
--- a/src/lib/memory/orchestrator.ts
+++ b/src/lib/memory/orchestrator.ts
@@ -66,9 +66,6 @@ export interface RecallResultRanked extends MemoryResult {
 
   /** Which provider this result came from. */
   providerId: string;
-
-  /** Estimated prompt tokens after budget enforcement (auto mode). */
-  tokenEstimate?: number;
 }
 
 export interface RecallResponse {
@@ -489,6 +486,8 @@ function applyRecallBudget(
   const budgeted = budget.apply(results);
 
   return {
+    // Overwrites the inherited MemoryResult.tokenEstimate with the
+    // budget-adjusted estimate from ContextBudgetManager.
     results: budgeted.results.map((entry) => ({
       ...entry.result,
       tokenEstimate: entry.tokenEstimate,

--- a/src/lib/memory/orchestrator.ts
+++ b/src/lib/memory/orchestrator.ts
@@ -66,6 +66,9 @@ export interface RecallResultRanked extends MemoryResult {
 
   /** Which provider this result came from. */
   providerId: string;
+
+  /** Estimated prompt tokens after budget enforcement (auto mode). */
+  tokenEstimate?: number;
 }
 
 export interface RecallResponse {


### PR DESCRIPTION
Follow-up cleanup from #27.

The `applyRecallBudget` helper in the orchestrator adds `tokenEstimate` to each ranked result, but `RecallResultRanked` didn't declare it — the field was structurally present at runtime but not in the type. This adds `tokenEstimate?: number` to the interface so the type matches reality.

No functional changes, all existing tests pass.

## Summary by Sourcery

Enhancements:
- Declare an optional tokenEstimate field on RecallResultRanked to reflect the estimated prompt tokens after budget enforcement.