### PR TITLE
Cross-provider dedup + recall settings (#12, #14)

### DIFF
--- a/src/__tests__/memory/dedup.test.ts
+++ b/src/__tests__/memory/dedup.test.ts
@@ -117,7 +117,20 @@ async function main() {
     assertEqual(result.stats.collapsedTotal, 0, "nothing collapsed");
   });
 
-  test("entries without canonicalRef are treated as unique", () => {
+  test("entries without canonicalRef dedup by providerId:id fallback", () => {
+    const dedup = new CrossProviderDeduplicator();
+    // Same provider + same id → should collapse (same fallback key)
+    const entries = [
+      candidate({ id: "1", provider: "a", providerId: "a", compositeScore: 0.9 }),
+      candidate({ id: "1", provider: "a", providerId: "a", compositeScore: 0.8 }),
+    ];
+
+    const result = dedup.dedup(entries);
+    assertEqual(result.results.length, 1, "collapsed by fallback key");
+    assertEqual(result.stats.collapsedTotal, 1, "1 collapsed");
+  });
+
+  test("entries without canonicalRef with different ids stay separate", () => {
     const dedup = new CrossProviderDeduplicator();
     const entries = [
       candidate({ id: "1", provider: "a", providerId: "a", compositeScore: 0.9 }),
@@ -125,7 +138,7 @@ async function main() {
     ];
 
     const result = dedup.dedup(entries);
-    assertEqual(result.results.length, 2, "both unique");
+    assertEqual(result.results.length, 2, "different ids → different fallback keys");
     assertEqual(result.stats.collapsedTotal, 0, "nothing collapsed");
   });
 
@@ -253,7 +266,19 @@ async function main() {
 
   // ─── Multiple groups ──────────────────────────────────────────────────
 
-  test("handles multiple dedup groups independently", () => {
+  test("DeduplicatedResult includes winner providerId and compositeScore", () => {
+    const dedup = new CrossProviderDeduplicator({ strategy: "most-recent" });
+    const entries = [
+      candidate({ id: "1", provider: "a", providerId: "a", compositeScore: 0.9, canonicalRef: "shared-ref", updatedAt: "2026-01-01T00:00:00Z" }),
+      candidate({ id: "2", provider: "b", providerId: "b", compositeScore: 0.3, canonicalRef: "shared-ref", updatedAt: "2026-06-01T00:00:00Z" }),
+    ];
+
+    const result = dedup.dedup(entries);
+    assertEqual(result.results[0].providerId, "b", "winner providerId");
+    assertEqual(result.results[0].compositeScore, 0.3, "winner compositeScore");
+  });
+
+  test("multiple dedup groups independently report collapsed counts", () => {
     const dedup = new CrossProviderDeduplicator();
     const entries = [
       candidate({ id: "1", provider: "a", providerId: "a", compositeScore: 0.9, canonicalRef: "ref-a" }),

--- a/src/__tests__/memory/dedup.test.ts
+++ b/src/__tests__/memory/dedup.test.ts
@@ -1,0 +1,298 @@
+/**
+ * CrossProviderDeduplicator — Unit Tests
+ *
+ * Run with: DATABASE_URL="postgresql://test:test@localhost:5432/test" npx tsx src/__tests__/memory/dedup.test.ts
+ */
+
+if (!process.env.DATABASE_URL) {
+  process.env.DATABASE_URL = "postgresql://test:test@localhost:5432/test";
+}
+
+import {
+  CrossProviderDeduplicator,
+  createDeduplicator,
+} from "@/lib/memory/dedup";
+import type {
+  DeduplicationStrategy,
+  ScoredCandidate,
+} from "@/lib/memory/dedup";
+import type { MemoryResult } from "@/lib/memory/types";
+
+// ─── Test helpers ────────────────────────────────────────────────────────────
+
+let testCounter = 0;
+let passCount = 0;
+let failCount = 0;
+const pending: Promise<void>[] = [];
+
+function test(name: string, fn: () => void | Promise<void>): void {
+  testCounter++;
+  const label = `[${testCounter}] ${name}`;
+  const p = Promise.resolve()
+    .then(() => fn())
+    .then(() => {
+      passCount++;
+      console.log(`  ✓ ${label}`);
+    })
+    .catch((err: unknown) => {
+      failCount++;
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(`  ✗ ${label}\n    ${message}`);
+    });
+  pending.push(p);
+}
+
+function assert(condition: boolean, message: string): void {
+  if (!condition) throw new Error(`Assertion failed: ${message}`);
+}
+
+function assertEqual<T>(actual: T, expected: T, label: string): void {
+  if (actual !== expected) {
+    throw new Error(
+      `${label}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`,
+    );
+  }
+}
+
+// ─── Mock helpers ────────────────────────────────────────────────────────────
+
+function candidate(
+  overrides: Partial<MemoryResult> & {
+    id: string;
+    provider: string;
+    providerId: string;
+    compositeScore: number;
+  },
+): ScoredCandidate {
+  return {
+    result: {
+      sourceType: "noosphere" as MemoryResult["sourceType"],
+      content: `Content for ${overrides.id}`,
+      ...overrides,
+    },
+    providerId: overrides.providerId,
+    compositeScore: overrides.compositeScore,
+  };
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+async function main() {
+  console.log("\n🔍 CrossProviderDeduplicator Tests\n");
+
+  // ─── Constructor & defaults ────────────────────────────────────────────
+
+  test("constructor applies default strategy", () => {
+    const dedup = new CrossProviderDeduplicator();
+    assertEqual(dedup["strategy"], "best-score", "default strategy");
+  });
+
+  test("constructor respects custom config", () => {
+    const dedup = new CrossProviderDeduplicator({
+      strategy: "provider-priority",
+      providerPriority: ["noosphere", "hindsight"],
+    });
+    assertEqual(dedup["strategy"], "provider-priority", "custom strategy");
+    assertEqual(dedup["providerPriority"].length, 2, "priority list set");
+  });
+
+  test("factory returns instance", () => {
+    const dedup = createDeduplicator({ strategy: "most-recent" });
+    assert(dedup instanceof CrossProviderDeduplicator, "factory instance");
+  });
+
+  // ─── No duplicates ────────────────────────────────────────────────────
+
+  test("passes through unique results unchanged", () => {
+    const dedup = new CrossProviderDeduplicator();
+    const entries = [
+      candidate({ id: "1", provider: "a", providerId: "a", compositeScore: 0.9, canonicalRef: "ref-1" }),
+      candidate({ id: "2", provider: "a", providerId: "a", compositeScore: 0.8, canonicalRef: "ref-2" }),
+    ];
+
+    const result = dedup.dedup(entries);
+    assertEqual(result.results.length, 2, "both results kept");
+    assertEqual(result.stats.totalInput, 2, "input count");
+    assertEqual(result.stats.totalOutput, 2, "output count");
+    assertEqual(result.stats.collapsedTotal, 0, "nothing collapsed");
+  });
+
+  test("entries without canonicalRef are treated as unique", () => {
+    const dedup = new CrossProviderDeduplicator();
+    const entries = [
+      candidate({ id: "1", provider: "a", providerId: "a", compositeScore: 0.9 }),
+      candidate({ id: "2", provider: "a", providerId: "a", compositeScore: 0.8 }),
+    ];
+
+    const result = dedup.dedup(entries);
+    assertEqual(result.results.length, 2, "both unique");
+    assertEqual(result.stats.collapsedTotal, 0, "nothing collapsed");
+  });
+
+  test("handles empty input", () => {
+    const dedup = new CrossProviderDeduplicator();
+    const result = dedup.dedup([]);
+    assertEqual(result.results.length, 0, "empty output");
+    assertEqual(result.stats.collapsedTotal, 0, "nothing collapsed");
+  });
+
+  // ─── Best-score strategy ──────────────────────────────────────────────
+
+  test("best-score keeps highest composite score", () => {
+    const dedup = new CrossProviderDeduplicator({ strategy: "best-score" });
+    const entries = [
+      candidate({ id: "1", provider: "a", providerId: "a", compositeScore: 0.5, canonicalRef: "shared-ref" }),
+      candidate({ id: "2", provider: "b", providerId: "b", compositeScore: 0.9, canonicalRef: "shared-ref" }),
+    ];
+
+    const result = dedup.dedup(entries);
+    assertEqual(result.results.length, 1, "collapsed to one");
+    assertEqual(result.results[0].result.id, "2", "kept higher score");
+    assertEqual(result.results[0].collapsedCount, 1, "1 collapsed");
+    assertEqual(result.stats.collapsedTotal, 1, "stats match");
+  });
+
+  test("best-score preserves full provenance", () => {
+    const dedup = new CrossProviderDeduplicator({ strategy: "best-score" });
+    const entries = [
+      candidate({ id: "1", provider: "a", providerId: "a", compositeScore: 0.5, canonicalRef: "shared-ref", relevanceScore: 0.4 }),
+      candidate({ id: "2", provider: "b", providerId: "b", compositeScore: 0.9, canonicalRef: "shared-ref", relevanceScore: 0.8 }),
+    ];
+
+    const result = dedup.dedup(entries);
+    assertEqual(result.results[0].provenance.length, 2, "both providers in provenance");
+    assertEqual(result.results[0].provenance[0].providerId, "a", "first provider");
+    assertEqual(result.results[0].provenance[1].providerId, "b", "second provider");
+    assertEqual(result.results[0].provenance[1].localId, "2", "local id preserved");
+  });
+
+  // ─── Provider-priority strategy ───────────────────────────────────────
+
+  test("provider-priority keeps result from highest-priority provider", () => {
+    const dedup = new CrossProviderDeduplicator({
+      strategy: "provider-priority",
+      providerPriority: ["noosphere", "hindsight"],
+    });
+
+    const entries = [
+      candidate({ id: "1", provider: "hindsight", providerId: "hindsight", compositeScore: 0.9, canonicalRef: "shared-ref" }),
+      candidate({ id: "2", provider: "noosphere", providerId: "noosphere", compositeScore: 0.5, canonicalRef: "shared-ref" }),
+    ];
+
+    const result = dedup.dedup(entries);
+    assertEqual(result.results.length, 1, "collapsed to one");
+    assertEqual(result.results[0].result.id, "2", "kept higher priority provider");
+  });
+
+  test("provider-priority falls back to score for same provider", () => {
+    const dedup = new CrossProviderDeduplicator({
+      strategy: "provider-priority",
+      providerPriority: ["noosphere"],
+    });
+
+    const entries = [
+      candidate({ id: "1", provider: "other", providerId: "other", compositeScore: 0.3, canonicalRef: "shared-ref" }),
+      candidate({ id: "2", provider: "other2", providerId: "other2", compositeScore: 0.9, canonicalRef: "shared-ref" }),
+    ];
+
+    const result = dedup.dedup(entries);
+    assertEqual(result.results[0].result.id, "2", "kept higher score (neither in priority list)");
+  });
+
+  test("provider-priority with empty list falls back to best-score", () => {
+    const dedup = new CrossProviderDeduplicator({
+      strategy: "provider-priority",
+    });
+
+    const entries = [
+      candidate({ id: "1", provider: "a", providerId: "a", compositeScore: 0.3, canonicalRef: "shared-ref" }),
+      candidate({ id: "2", provider: "b", providerId: "b", compositeScore: 0.9, canonicalRef: "shared-ref" }),
+    ];
+
+    const result = dedup.dedup(entries);
+    assertEqual(result.results[0].result.id, "2", "fell back to best-score");
+  });
+
+  // ─── Most-recent strategy ─────────────────────────────────────────────
+
+  test("most-recent keeps result with latest updatedAt", () => {
+    const dedup = new CrossProviderDeduplicator({ strategy: "most-recent" });
+
+    const entries = [
+      candidate({ id: "1", provider: "a", providerId: "a", compositeScore: 0.9, canonicalRef: "shared-ref", updatedAt: "2026-01-01T00:00:00Z" }),
+      candidate({ id: "2", provider: "b", providerId: "b", compositeScore: 0.5, canonicalRef: "shared-ref", updatedAt: "2026-04-01T00:00:00Z" }),
+    ];
+
+    const result = dedup.dedup(entries);
+    assertEqual(result.results[0].result.id, "2", "kept most recent");
+  });
+
+  test("most-recent falls back to createdAt when updatedAt is missing", () => {
+    const dedup = new CrossProviderDeduplicator({ strategy: "most-recent" });
+
+    const entries = [
+      candidate({ id: "1", provider: "a", providerId: "a", compositeScore: 0.9, canonicalRef: "shared-ref", createdAt: "2026-04-01T00:00:00Z" }),
+      candidate({ id: "2", provider: "b", providerId: "b", compositeScore: 0.5, canonicalRef: "shared-ref", createdAt: "2026-01-01T00:00:00Z" }),
+    ];
+
+    const result = dedup.dedup(entries);
+    assertEqual(result.results[0].result.id, "1", "kept more recent createdAt");
+  });
+
+  test("most-recent tiebreaks on composite score", () => {
+    const dedup = new CrossProviderDeduplicator({ strategy: "most-recent" });
+
+    const entries = [
+      candidate({ id: "1", provider: "a", providerId: "a", compositeScore: 0.5, canonicalRef: "shared-ref", updatedAt: "2026-01-01T00:00:00Z" }),
+      candidate({ id: "2", provider: "b", providerId: "b", compositeScore: 0.9, canonicalRef: "shared-ref", updatedAt: "2026-01-01T00:00:00Z" }),
+    ];
+
+    const result = dedup.dedup(entries);
+    assertEqual(result.results[0].result.id, "2", "tiebreak on score");
+  });
+
+  // ─── Multiple groups ──────────────────────────────────────────────────
+
+  test("handles multiple dedup groups independently", () => {
+    const dedup = new CrossProviderDeduplicator();
+    const entries = [
+      candidate({ id: "1", provider: "a", providerId: "a", compositeScore: 0.9, canonicalRef: "ref-a" }),
+      candidate({ id: "2", provider: "b", providerId: "b", compositeScore: 0.8, canonicalRef: "ref-a" }),
+      candidate({ id: "3", provider: "a", providerId: "a", compositeScore: 0.7, canonicalRef: "ref-b" }),
+      candidate({ id: "4", provider: "b", providerId: "b", compositeScore: 0.95, canonicalRef: "ref-b" }),
+    ];
+
+    const result = dedup.dedup(entries);
+    assertEqual(result.results.length, 2, "two groups → two results");
+    assertEqual(result.results[0].result.id, "1", "ref-a winner");
+    assertEqual(result.results[1].result.id, "4", "ref-b winner");
+    assertEqual(result.stats.collapsedTotal, 2, "2 total collapsed");
+  });
+
+  // ─── All strategies are valid ─────────────────────────────────────────
+
+  const strategies: DeduplicationStrategy[] = ["best-score", "provider-priority", "most-recent"];
+  for (const s of strategies) {
+    test(`strategy "${s}" is accepted`, () => {
+      const dedup = new CrossProviderDeduplicator({ strategy: s });
+      assertEqual(dedup["strategy"], s, `strategy set to ${s}`);
+    });
+  }
+
+  // ─── Wait for all async tests ──────────────────────────────────────────
+
+  await Promise.all(pending);
+
+  console.log(
+    `\n  ${passCount} passed, ${failCount} failed, ${testCounter} total\n`,
+  );
+
+  if (failCount > 0) {
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error("Fatal:", err);
+  process.exit(1);
+});

--- a/src/__tests__/memory/recall-orchestrator.test.ts
+++ b/src/__tests__/memory/recall-orchestrator.test.ts
@@ -686,6 +686,87 @@ async function main() {
     );
   });
 
+  // ─── Dedup strategy integration ──────────────────────────────────────────
+
+  test("dedup with provider-priority strategy picks correct winner", async () => {
+    const sharedRef = "shared-memory-1";
+    const noosphereResults = [
+      mockResult({
+        id: "n-1",
+        provider: "noosphere",
+        content: "Noosphere version",
+        relevanceScore: 0.9,
+        canonicalRef: sharedRef,
+      }),
+    ];
+    const hindsightResults = [
+      mockResult({
+        id: "h-1",
+        provider: "hindsight",
+        content: "Hindsight version",
+        relevanceScore: 0.5,
+        canonicalRef: sharedRef,
+      }),
+    ];
+
+    const orchestrator = new RecallOrchestrator({
+      providers: [
+        { provider: mockProvider("noosphere", noosphereResults) },
+        { provider: mockProvider("hindsight", hindsightResults) },
+      ],
+      deduplication: {
+        strategy: "provider-priority",
+        providerPriority: ["noosphere"],
+      },
+    });
+
+    const response = await orchestrator.recall({ query: "test", mode: "inspection" });
+    assertEqual(response.results.length, 1, "deduped to one");
+    assertEqual(response.results[0].providerId, "noosphere", "noosphere wins via priority");
+    assertEqual(response.results[0].content, "Noosphere version", "correct content");
+    assert(response.results[0].provenance != null, "provenance populated");
+    assertEqual(response.results[0].provenance!.length, 2, "both providers in provenance");
+    assert(response.dedupStats != null, "dedupStats present");
+    assertEqual(response.dedupStats!.collapsedTotal, 1, "1 collapsed");
+  });
+
+  test("dedup with most-recent strategy picks newer result", async () => {
+    const sharedRef = "shared-memory-2";
+    const oldResults = [
+      mockResult({
+        id: "old",
+        provider: "archiver",
+        content: "Old version",
+        relevanceScore: 0.9,
+        canonicalRef: sharedRef,
+        updatedAt: "2026-01-01T00:00:00Z",
+      }),
+    ];
+    const newResults = [
+      mockResult({
+        id: "new",
+        provider: "live",
+        content: "New version",
+        relevanceScore: 0.3,
+        canonicalRef: sharedRef,
+        updatedAt: "2026-06-01T00:00:00Z",
+      }),
+    ];
+
+    const orchestrator = new RecallOrchestrator({
+      providers: [
+        { provider: mockProvider("archiver", oldResults) },
+        { provider: mockProvider("live", newResults) },
+      ],
+      deduplication: { strategy: "most-recent" },
+    });
+
+    const response = await orchestrator.recall({ query: "test", mode: "inspection" });
+    assertEqual(response.results.length, 1, "deduped to one");
+    assertEqual(response.results[0].providerId, "live", "live wins via recency");
+    assertEqual(response.results[0].content, "New version", "correct content");
+  });
+
   // ─── Wait for all async tests ───────────────────────────────────────────
 
   await Promise.all(pending);

--- a/src/__tests__/memory/settings.test.ts
+++ b/src/__tests__/memory/settings.test.ts
@@ -1,0 +1,246 @@
+/**
+ * RecallSettings — Unit Tests
+ *
+ * Run with: DATABASE_URL="postgresql://test:test@localhost:5432/test" npx tsx src/__tests__/memory/settings.test.ts
+ */
+
+if (!process.env.DATABASE_URL) {
+  process.env.DATABASE_URL = "postgresql://test:test@localhost:5432/test";
+}
+
+import {
+  DEFAULT_RECALL_SETTINGS,
+  mergeRecallSettings,
+  normalizeRecallSettings,
+} from "@/lib/memory/settings";
+import type { RecallSettings } from "@/lib/memory/settings";
+
+// ─── Test helpers ────────────────────────────────────────────────────────────
+
+let testCounter = 0;
+let passCount = 0;
+let failCount = 0;
+const pending: Promise<void>[] = [];
+
+function test(name: string, fn: () => void | Promise<void>): void {
+  testCounter++;
+  const label = `[${testCounter}] ${name}`;
+  const p = Promise.resolve()
+    .then(() => fn())
+    .then(() => {
+      passCount++;
+      console.log(`  ✓ ${label}`);
+    })
+    .catch((err: unknown) => {
+      failCount++;
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(`  ✗ ${label}\n    ${message}`);
+    });
+  pending.push(p);
+}
+
+function assert(condition: boolean, message: string): void {
+  if (!condition) throw new Error(`Assertion failed: ${message}`);
+}
+
+function assertEqual<T>(actual: T, expected: T, label: string): void {
+  if (actual !== expected) {
+    throw new Error(
+      `${label}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`,
+    );
+  }
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+async function main() {
+  console.log("\n⚙️  RecallSettings Tests\n");
+
+  // ─── Defaults ──────────────────────────────────────────────────────────
+
+  test("normalizeRecallSettings returns defaults for empty input", () => {
+    const settings = normalizeRecallSettings();
+    assertEqual(settings.autoRecallEnabled, true, "autoRecallEnabled");
+    assertEqual(settings.maxInjectedMemories, 20, "maxInjectedMemories");
+    assertEqual(settings.maxInjectedTokens, 2000, "maxInjectedTokens");
+    assertEqual(settings.recallVerbosity, "standard", "recallVerbosity");
+    assertEqual(settings.deduplicationStrategy, "best-score", "deduplicationStrategy");
+    assertEqual(settings.enabledProviders.length, 0, "enabledProviders empty");
+    assertEqual(settings.summaryFirst, true, "summaryFirst");
+  });
+
+  test("DEFAULT_RECALL_SETTINGS has expected values", () => {
+    assertEqual(DEFAULT_RECALL_SETTINGS.autoRecallEnabled, true, "autoRecallEnabled");
+    assertEqual(DEFAULT_RECALL_SETTINGS.maxInjectedMemories, 20, "maxInjectedMemories");
+    assertEqual(DEFAULT_RECALL_SETTINGS.maxInjectedTokens, 2000, "maxInjectedTokens");
+  });
+
+  // ─── Valid overrides ──────────────────────────────────────────────────
+
+  test("respects valid overrides", () => {
+    const settings = normalizeRecallSettings({
+      autoRecallEnabled: false,
+      maxInjectedMemories: 10,
+      maxInjectedTokens: 500,
+      recallVerbosity: "minimal",
+      deduplicationStrategy: "most-recent",
+      summaryFirst: false,
+    });
+    assertEqual(settings.autoRecallEnabled, false, "autoRecallEnabled");
+    assertEqual(settings.maxInjectedMemories, 10, "maxInjectedMemories");
+    assertEqual(settings.maxInjectedTokens, 500, "maxInjectedTokens");
+    assertEqual(settings.recallVerbosity, "minimal", "recallVerbosity");
+    assertEqual(settings.deduplicationStrategy, "most-recent", "deduplicationStrategy");
+    assertEqual(settings.summaryFirst, false, "summaryFirst");
+  });
+
+  test("accepts enabledProviders list", () => {
+    const settings = normalizeRecallSettings({
+      enabledProviders: ["noosphere", "hindsight"],
+    });
+    assertEqual(settings.enabledProviders.length, 2, "2 providers");
+    assertEqual(settings.enabledProviders[0], "noosphere", "first provider");
+  });
+
+  test("accepts providerPriorityWeights", () => {
+    const settings = normalizeRecallSettings({
+      providerPriorityWeights: { noosphere: 2.0, hindsight: 0.5 },
+    });
+    assertEqual(settings.providerPriorityWeights.noosphere, 2.0, "noosphere weight");
+    assertEqual(settings.providerPriorityWeights.hindsight, 0.5, "hindsight weight");
+  });
+
+  // ─── Invalid inputs fall back to defaults ─────────────────────────────
+
+  test("invalid maxInjectedMemories falls back", () => {
+    assertEqual(normalizeRecallSettings({ maxInjectedMemories: -5 }).maxInjectedMemories, 20, "negative");
+    assertEqual(normalizeRecallSettings({ maxInjectedMemories: 0 }).maxInjectedMemories, 20, "zero");
+    assertEqual(normalizeRecallSettings({ maxInjectedMemories: NaN }).maxInjectedMemories, 20, "NaN");
+    assertEqual(normalizeRecallSettings({ maxInjectedMemories: Infinity }).maxInjectedMemories, 20, "Infinity");
+    assertEqual(normalizeRecallSettings({ maxInjectedMemories: 3.7 }).maxInjectedMemories, 3, "float floors");
+  });
+
+  test("invalid maxInjectedTokens falls back", () => {
+    assertEqual(normalizeRecallSettings({ maxInjectedTokens: -1 }).maxInjectedTokens, 2000, "negative");
+    assertEqual(normalizeRecallSettings({ maxInjectedTokens: 0 }).maxInjectedTokens, 2000, "zero");
+  });
+
+  test("invalid verbosity falls back to standard", () => {
+    assertEqual(
+      normalizeRecallSettings({ recallVerbosity: "ultra" as RecallSettings["recallVerbosity"] }).recallVerbosity,
+      "standard",
+      "invalid verbosity",
+    );
+  });
+
+  test("invalid strategy falls back to best-score", () => {
+    assertEqual(
+      normalizeRecallSettings({ deduplicationStrategy: "random" as RecallSettings["deduplicationStrategy"] }).deduplicationStrategy,
+      "best-score",
+      "invalid strategy",
+    );
+  });
+
+  test("enabledProviders filters non-string values", () => {
+    const settings = normalizeRecallSettings({
+      enabledProviders: ["noosphere", 42 as unknown as string, null as unknown as string],
+    });
+    assertEqual(settings.enabledProviders.length, 1, "only strings kept");
+    assertEqual(settings.enabledProviders[0], "noosphere", "kept noosphere");
+  });
+
+  test("providerPriorityWeights filters invalid values", () => {
+    const settings = normalizeRecallSettings({
+      providerPriorityWeights: {
+        noosphere: 2.0,
+        bad: -1,
+        also_bad: NaN as number,
+        not_number: "high" as unknown as number,
+      },
+    });
+    assertEqual(Object.keys(settings.providerPriorityWeights).length, 1, "only valid weight kept");
+    assertEqual(settings.providerPriorityWeights.noosphere, 2.0, "valid weight preserved");
+  });
+
+  test("non-boolean autoRecallEnabled falls back to true", () => {
+    assertEqual(
+      normalizeRecallSettings({ autoRecallEnabled: "yes" as unknown as boolean }).autoRecallEnabled,
+      true,
+      "non-boolean fallback",
+    );
+  });
+
+  test("non-boolean summaryFirst falls back to true", () => {
+    assertEqual(
+      normalizeRecallSettings({ summaryFirst: 1 as unknown as boolean }).summaryFirst,
+      true,
+      "non-boolean fallback",
+    );
+  });
+
+  test("array as providerPriorityWeights falls back to empty", () => {
+    const settings = normalizeRecallSettings({
+      providerPriorityWeights: [] as unknown as Record<string, number>,
+    });
+    assertEqual(Object.keys(settings.providerPriorityWeights).length, 0, "empty object");
+  });
+
+  // ─── mergeRecallSettings ──────────────────────────────────────────────
+
+  test("mergeRecallSettings applies overrides on top of base", () => {
+    const base = normalizeRecallSettings({
+      autoRecallEnabled: false,
+      maxInjectedMemories: 5,
+    });
+    const merged = mergeRecallSettings(base, { maxInjectedMemories: 10 });
+    assertEqual(merged.autoRecallEnabled, false, "base value kept");
+    assertEqual(merged.maxInjectedMemories, 10, "override applied");
+  });
+
+  test("mergeRecallSettings re-normalizes merged result", () => {
+    const base = normalizeRecallSettings({ maxInjectedMemories: 10 });
+    const merged = mergeRecallSettings(base, { maxInjectedMemories: -1 });
+    assertEqual(merged.maxInjectedMemories, 20, "invalid override re-normalized to default");
+  });
+
+  test("mergeRecallSettings with empty overrides returns base copy", () => {
+    const base = normalizeRecallSettings({ maxInjectedMemories: 15 });
+    const merged = mergeRecallSettings(base, {});
+    assertEqual(merged.maxInjectedMemories, 15, "base preserved");
+  });
+
+  // ─── All verbosity values accepted ────────────────────────────────────
+
+  const verbosities = ["minimal", "standard", "detailed"] as const;
+  for (const v of verbosities) {
+    test(`verbosity "${v}" is accepted`, () => {
+      const settings = normalizeRecallSettings({ recallVerbosity: v });
+      assertEqual(settings.recallVerbosity, v, `verbosity set to ${v}`);
+    });
+  }
+
+  const strategies = ["best-score", "provider-priority", "most-recent"] as const;
+  for (const s of strategies) {
+    test(`strategy "${s}" is accepted`, () => {
+      const settings = normalizeRecallSettings({ deduplicationStrategy: s });
+      assertEqual(settings.deduplicationStrategy, s, `strategy set to ${s}`);
+    });
+  }
+
+  // ─── Wait for all async tests ──────────────────────────────────────────
+
+  await Promise.all(pending);
+
+  console.log(
+    `\n  ${passCount} passed, ${failCount} failed, ${testCounter} total\n`,
+  );
+
+  if (failCount > 0) {
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error("Fatal:", err);
+  process.exit(1);
+});

--- a/src/lib/memory/dedup.ts
+++ b/src/lib/memory/dedup.ts
@@ -99,8 +99,10 @@ export class CrossProviderDeduplicator {
   /**
    * Deduplicate results that share the same `canonicalRef`.
    *
-   * When no `canonicalRef` is set, the result is treated as unique and passes
-   * through without deduplication.
+   * When no `canonicalRef` is set, a deterministic fallback key
+   * `${providerId}:${result.id}` is used instead. This means entries from the
+   * same provider with the same local ID will still be collapsed, while
+   * entries from different providers (or with different IDs) remain separate.
    *
    * For each group of duplicates, the "winning" result is selected according
    * to the configured strategy. Provenance from all providers is preserved.

--- a/src/lib/memory/dedup.ts
+++ b/src/lib/memory/dedup.ts
@@ -58,6 +58,12 @@ export interface DeduplicatedResult {
 
   /** Number of duplicates that were collapsed. */
   collapsedCount: number;
+
+  /** The provider ID of the winning result. */
+  providerId: string;
+
+  /** The composite score of the winning result. */
+  compositeScore: number;
 }
 
 export interface DeduplicationStats {
@@ -102,13 +108,13 @@ export class CrossProviderDeduplicator {
   dedup(
     entries: ScoredCandidate[],
   ): DeduplicationResult {
+    // Group by canonicalRef. Entries without canonicalRef use a deterministic
+    // fallback key (providerId:localId) so same-provider duplicates are still
+    // collapsed when they share the same local ID.
     const groups = new Map<string, ScoredCandidate[]>();
 
-    // Group by canonicalRef. Entries without canonicalRef get a unique key
-    // so they never collapse with anything.
-    let uniqueCounter = 0;
     for (const entry of entries) {
-      const key = entry.result.canonicalRef ?? `__unique_${uniqueCounter++}`;
+      const key = entry.result.canonicalRef ?? `${entry.providerId}:${entry.result.id}`;
       let group = groups.get(key);
       if (!group) {
         group = [];
@@ -136,6 +142,8 @@ export class CrossProviderDeduplicator {
         result: winner.result,
         provenance,
         collapsedCount,
+        providerId: winner.providerId,
+        compositeScore: winner.compositeScore,
       });
     }
 

--- a/src/lib/memory/dedup.ts
+++ b/src/lib/memory/dedup.ts
@@ -1,0 +1,230 @@
+/**
+ * Cross-provider deduplication for memory recall results.
+ *
+ * When multiple providers return the same or near-duplicate memory (identified
+ * by `canonicalRef`), this module collapses them into a single entry while
+ * preserving the full provider provenance — which providers found it and what
+ * scores each provider assigned.
+ *
+ * @module dedup
+ */
+
+import type { MemoryResult } from "./types";
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+/** Strategy for collapsing duplicate results across providers. */
+export type DeduplicationStrategy =
+  /** Keep the result with the highest composite score. */
+  | "best-score"
+  /** Keep the result from the highest-priority provider. */
+  | "provider-priority"
+  /** Keep the most recently updated version. */
+  | "most-recent";
+
+export interface DeduplicationConfig {
+  /** Strategy for choosing which duplicate to keep. Default: "best-score". */
+  strategy?: DeduplicationStrategy;
+
+  /**
+   * Provider priority order (highest priority first).
+   * Used when strategy is "provider-priority".
+   */
+  providerPriority?: string[];
+}
+
+/** Provenance entry for a single provider that returned a result. */
+export interface ProviderProvenance {
+  /** Provider ID that returned this result. */
+  providerId: string;
+
+  /** Provider-assigned relevance score (if any). */
+  relevanceScore?: number;
+
+  /** Provider-assigned confidence score (if any). */
+  confidenceScore?: number;
+
+  /** Provider-local result ID. */
+  localId: string;
+}
+
+/** A memory result enriched with cross-provider provenance after dedup. */
+export interface DeduplicatedResult {
+  /** The winning memory result (determined by strategy). */
+  result: MemoryResult;
+
+  /** All providers that returned this same memory. */
+  provenance: ProviderProvenance[];
+
+  /** Number of duplicates that were collapsed. */
+  collapsedCount: number;
+}
+
+export interface DeduplicationStats {
+  /** Total input results before deduplication. */
+  totalInput: number;
+
+  /** Results after deduplication. */
+  totalOutput: number;
+
+  /** Number of duplicate entries collapsed. */
+  collapsedTotal: number;
+}
+
+export interface DeduplicationResult {
+  /** Deduplicated results in original order. */
+  results: DeduplicatedResult[];
+
+  /** Aggregate deduplication statistics. */
+  stats: DeduplicationStats;
+}
+
+// ─── Deduplicator ────────────────────────────────────────────────────────────
+
+export class CrossProviderDeduplicator {
+  private readonly strategy: DeduplicationStrategy;
+  private readonly providerPriority: string[];
+
+  constructor(config: DeduplicationConfig = {}) {
+    this.strategy = config.strategy ?? "best-score";
+    this.providerPriority = config.providerPriority ?? [];
+  }
+
+  /**
+   * Deduplicate results that share the same `canonicalRef`.
+   *
+   * When no `canonicalRef` is set, the result is treated as unique and passes
+   * through without deduplication.
+   *
+   * For each group of duplicates, the "winning" result is selected according
+   * to the configured strategy. Provenance from all providers is preserved.
+   */
+  dedup(
+    entries: ScoredCandidate[],
+  ): DeduplicationResult {
+    const groups = new Map<string, ScoredCandidate[]>();
+
+    // Group by canonicalRef. Entries without canonicalRef get a unique key
+    // so they never collapse with anything.
+    let uniqueCounter = 0;
+    for (const entry of entries) {
+      const key = entry.result.canonicalRef ?? `__unique_${uniqueCounter++}`;
+      let group = groups.get(key);
+      if (!group) {
+        group = [];
+        groups.set(key, group);
+      }
+      group.push(entry);
+    }
+
+    const results: DeduplicatedResult[] = [];
+    let collapsedTotal = 0;
+
+    for (const group of groups.values()) {
+      const winner = this.selectWinner(group);
+      const provenance = group.map((entry) => ({
+        providerId: entry.providerId,
+        relevanceScore: entry.result.relevanceScore,
+        confidenceScore: entry.result.confidenceScore,
+        localId: entry.result.id,
+      }));
+
+      const collapsedCount = group.length - 1;
+      collapsedTotal += collapsedCount;
+
+      results.push({
+        result: winner.result,
+        provenance,
+        collapsedCount,
+      });
+    }
+
+    return {
+      results,
+      stats: {
+        totalInput: entries.length,
+        totalOutput: results.length,
+        collapsedTotal,
+      },
+    };
+  }
+
+  private selectWinner(
+    candidates: ScoredCandidate[],
+  ): ScoredCandidate {
+    if (candidates.length === 1) return candidates[0];
+
+    switch (this.strategy) {
+      case "provider-priority":
+        return this.selectByProviderPriority(candidates);
+      case "most-recent":
+        return this.selectByRecency(candidates);
+      case "best-score":
+      default:
+        return this.selectByScore(candidates);
+    }
+  }
+
+  private selectByScore(
+    candidates: ScoredCandidate[],
+  ): ScoredCandidate {
+    // Highest compositeScore wins; tiebreak on relevanceScore.
+    return candidates.reduce((best, current) => {
+      const scoreDiff = current.compositeScore - best.compositeScore;
+      if (Math.abs(scoreDiff) > 0.001) return scoreDiff > 0 ? current : best;
+      const relBest = best.result.relevanceScore ?? 0;
+      const relCurrent = current.result.relevanceScore ?? 0;
+      return relCurrent > relBest ? current : best;
+    });
+  }
+
+  private selectByProviderPriority(
+    candidates: ScoredCandidate[],
+  ): ScoredCandidate {
+    if (this.providerPriority.length === 0) {
+      // Fall back to best-score when no priority list is configured.
+      return this.selectByScore(candidates);
+    }
+
+    return candidates.reduce((best, current) => {
+      const bestIdx = this.providerPriority.indexOf(best.providerId);
+      const curIdx = this.providerPriority.indexOf(current.providerId);
+      // Lower index = higher priority. Missing providers get Infinity.
+      const bestRank = bestIdx === -1 ? Infinity : bestIdx;
+      const curRank = curIdx === -1 ? Infinity : curIdx;
+      if (curRank !== bestRank) return curRank < bestRank ? current : best;
+      // Tiebreak on score.
+      return current.compositeScore > best.compositeScore ? current : best;
+    });
+  }
+
+  private selectByRecency(
+    candidates: ScoredCandidate[],
+  ): ScoredCandidate {
+    return candidates.reduce((best, current) => {
+      const bestTime = best.result.updatedAt ?? best.result.createdAt ?? "";
+      const curTime = current.result.updatedAt ?? current.result.createdAt ?? "";
+      if (curTime > bestTime) return current;
+      if (curTime === bestTime && current.compositeScore > best.compositeScore) {
+        return current;
+      }
+      return best;
+    });
+  }
+}
+
+// ─── Candidate type (shared with orchestrator) ──────────────────────────────
+
+export interface ScoredCandidate {
+  result: MemoryResult;
+  providerId: string;
+  compositeScore: number;
+}
+
+// ─── Factory ─────────────────────────────────────────────────────────────────
+
+export function createDeduplicator(
+  config?: DeduplicationConfig,
+): CrossProviderDeduplicator {
+  return new CrossProviderDeduplicator(config);
+}

--- a/src/lib/memory/index.ts
+++ b/src/lib/memory/index.ts
@@ -62,6 +62,28 @@ export {
 } from "./budget";
 
 export {
+  CrossProviderDeduplicator,
+  createDeduplicator,
+} from "./dedup";
+
+export type {
+  DeduplicationConfig,
+  DeduplicationResult,
+  DeduplicationStats,
+  DeduplicationStrategy,
+  ProviderProvenance,
+  DeduplicatedResult,
+} from "./dedup";
+
+export {
+  DEFAULT_RECALL_SETTINGS,
+  mergeRecallSettings,
+  normalizeRecallSettings,
+} from "./settings";
+
+export type { RecallSettings } from "./settings";
+
+export {
   DEFAULT_MEMORY_PROVIDER_CAPABILITIES,
   DEFAULT_MEMORY_PROVIDER_CONFIG,
   getEffectiveAutoRecall,

--- a/src/lib/memory/orchestrator.ts
+++ b/src/lib/memory/orchestrator.ts
@@ -304,21 +304,27 @@ export class RecallOrchestrator {
     // Deduplicate using cross-provider deduplicator.
     const dedupResult = this.deduplicator.dedup(allResults);
 
-    const ranked = dedupResult.results.map((item, index) =>
-      ({
+    // Map deduplicated results to ranked format, carrying winner's score
+    // and provider ID directly from the deduplicator output.
+    const ranked = dedupResult.results
+      .map((item): RecallResultRanked => ({
         ...item.result,
-        rank: index + 1,
-        compositeScore: allResults.find(
-          (r) => r.result === item.result,
-        )?.compositeScore ?? 0,
+        compositeScore: item.compositeScore,
         providerScores: {
           relevance: item.result.relevanceScore,
           confidence: item.result.confidenceScore,
           recency: item.result.recencyScore,
         },
-        providerId: item.provenance[0]?.providerId ?? "unknown",
-      }) as RecallResultRanked,
-    );
+        providerId: item.providerId,
+        rank: 0, // placeholder, assigned after sort
+      }))
+      // Re-sort by the winning entry's composite score to ensure correct
+      // cross-group ranking regardless of dedup strategy.
+      .sort((a, b) => b.compositeScore - a.compositeScore)
+      .map((item, index) => ({
+        ...item,
+        rank: index + 1,
+      }));
 
     return { ranked, dedupStats: dedupResult.stats };
   }

--- a/src/lib/memory/orchestrator.ts
+++ b/src/lib/memory/orchestrator.ts
@@ -5,6 +5,11 @@ import type {
 } from "./provider";
 import { ContextBudgetManager } from "./budget";
 import {
+  CrossProviderDeduplicator,
+  createDeduplicator,
+  type DeduplicationConfig,
+} from "./dedup";
+import {
   getEffectiveAutoRecall,
   normalizeMemoryProviderConfig,
 } from "./provider";
@@ -32,6 +37,9 @@ export interface RecallOrchestratorOptions {
 
   /** Maximum concurrent provider queries. Default: all at once. */
   concurrency?: number;
+
+  /** Cross-provider deduplication configuration. */
+  deduplication?: DeduplicationConfig;
 }
 
 export interface RecallQuery {
@@ -86,6 +94,9 @@ export interface RecallResponse {
 
   /** Per-provider query metadata. */
   providerMeta: RecallProviderMeta[];
+
+  /** Deduplication statistics. */
+  dedupStats?: import("./dedup").DeduplicationStats;
 }
 
 export interface RecallProviderMeta {
@@ -122,6 +133,7 @@ export class RecallOrchestrator {
   private readonly globalResultCap: number;
   private readonly autoRecallTokenBudget: number;
   private readonly concurrency: number;
+  private readonly deduplicator: CrossProviderDeduplicator;
 
   constructor(options: RecallOrchestratorOptions) {
     if (!options.providers || options.providers.length === 0) {
@@ -140,6 +152,7 @@ export class RecallOrchestrator {
       options.concurrency,
       options.providers.length,
     );
+    this.deduplicator = createDeduplicator(options.deduplication);
   }
 
   async recall(query: RecallQuery): Promise<RecallResponse> {
@@ -153,8 +166,8 @@ export class RecallOrchestrator {
     // Fan out to all enabled providers concurrently.
     const providerResults = await this.fanOut(query);
 
-    // Merge, score, and rank all results.
-    const ranked = this.rankResults(providerResults);
+    // Merge, score, deduplicate, and rank all results.
+    const { ranked, dedupStats } = this.rankResults(providerResults);
 
     const totalBeforeCap = ranked.length;
 
@@ -175,6 +188,7 @@ export class RecallOrchestrator {
       mode: query.mode,
       tokenBudgetUsed: budgeted.tokenBudgetUsed,
       promptInjectionText,
+      dedupStats,
       providerMeta: providerResults.map((pr) => ({
         providerId: pr.providerId,
         resultCount: pr.results.length,
@@ -266,7 +280,7 @@ export class RecallOrchestrator {
 
   private rankResults(
     providerResults: ProviderFanOutResult[],
-  ): RecallResultRanked[] {
+  ): { ranked: RecallResultRanked[]; dedupStats: import("./dedup").DeduplicationStats } {
     const allResults: ScorableResult[] = [];
 
     for (const pr of providerResults) {
@@ -287,29 +301,26 @@ export class RecallOrchestrator {
       return (b.result.relevanceScore ?? 0) - (a.result.relevanceScore ?? 0);
     });
 
-    // Deduplicate by canonicalRef.
-    const seen = new Set<string>();
-    const deduped: ScorableResult[] = [];
-    for (const item of allResults) {
-      const key = item.result.canonicalRef ?? `${item.providerId}:${item.result.id}`;
-      if (seen.has(key)) continue;
-      seen.add(key);
-      deduped.push(item);
-    }
+    // Deduplicate using cross-provider deduplicator.
+    const dedupResult = this.deduplicator.dedup(allResults);
 
-    return deduped.map((item, index) =>
+    const ranked = dedupResult.results.map((item, index) =>
       ({
         ...item.result,
         rank: index + 1,
-        compositeScore: item.compositeScore,
+        compositeScore: allResults.find(
+          (r) => r.result === item.result,
+        )?.compositeScore ?? 0,
         providerScores: {
           relevance: item.result.relevanceScore,
           confidence: item.result.confidenceScore,
           recency: item.result.recencyScore,
         },
-        providerId: item.providerId,
+        providerId: item.provenance[0]?.providerId ?? "unknown",
       }) as RecallResultRanked,
     );
+
+    return { ranked, dedupStats: dedupResult.stats };
   }
 
   private computeCompositeScore(

--- a/src/lib/memory/orchestrator.ts
+++ b/src/lib/memory/orchestrator.ts
@@ -74,6 +74,9 @@ export interface RecallResultRanked extends MemoryResult {
 
   /** Which provider this result came from. */
   providerId: string;
+
+  /** Cross-provider provenance (all providers that returned this same memory). */
+  provenance?: import("./dedup").ProviderProvenance[];
 }
 
 export interface RecallResponse {
@@ -316,6 +319,7 @@ export class RecallOrchestrator {
           recency: item.result.recencyScore,
         },
         providerId: item.providerId,
+        provenance: item.provenance.length > 1 ? item.provenance : undefined,
         rank: 0, // placeholder, assigned after sort
       }))
       // Re-sort by the winning entry's composite score to ensure correct

--- a/src/lib/memory/settings.ts
+++ b/src/lib/memory/settings.ts
@@ -1,0 +1,159 @@
+/**
+ * User-configurable recall settings.
+ *
+ * Exposes recall behavior settings so that operators can control auto-recall,
+ * budget limits, verbosity, and per-provider configuration without touching
+ * code. Designed to be serializable (JSON) for storage or API transport.
+ *
+ * @module recall-settings
+ */
+
+import type { BudgetVerbosity } from "./budget";
+import type { DeduplicationStrategy } from "./dedup";
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export interface RecallSettings {
+  /** Whether automatic recall injection is enabled globally. */
+  autoRecallEnabled: boolean;
+
+  /** Maximum number of memories injected per auto-recall cycle. */
+  maxInjectedMemories: number;
+
+  /** Maximum estimated prompt tokens per auto-recall cycle. */
+  maxInjectedTokens: number;
+
+  /** Verbosity level for recall output. */
+  recallVerbosity: BudgetVerbosity;
+
+  /** Strategy for cross-provider deduplication. */
+  deduplicationStrategy: DeduplicationStrategy;
+
+  /** Ordered list of enabled provider IDs. Disabled providers are excluded. */
+  enabledProviders: string[];
+
+  /** Per-provider priority weights (provider ID → weight). */
+  providerPriorityWeights: Record<string, number>;
+
+  /**
+   * Prefer summary over full content when both are available.
+   * Overridden by verbosity in detailed/minimal modes.
+   */
+  summaryFirst: boolean;
+}
+
+// ─── Defaults ────────────────────────────────────────────────────────────────
+
+export const DEFAULT_RECALL_SETTINGS: RecallSettings = {
+  autoRecallEnabled: true,
+  maxInjectedMemories: 20,
+  maxInjectedTokens: 2000,
+  recallVerbosity: "standard",
+  deduplicationStrategy: "best-score",
+  enabledProviders: [],
+  providerPriorityWeights: {},
+  summaryFirst: true,
+};
+
+// ─── Normalization ───────────────────────────────────────────────────────────
+
+const VALID_VERBOSITIES: BudgetVerbosity[] = ["minimal", "standard", "detailed"];
+const VALID_STRATEGIES: DeduplicationStrategy[] = ["best-score", "provider-priority", "most-recent"];
+
+/**
+ * Normalize and validate recall settings, filling in defaults for missing
+ * or invalid values.
+ */
+export function normalizeRecallSettings(
+  input: Partial<RecallSettings> = {},
+): RecallSettings {
+  const autoRecallEnabled =
+    typeof input.autoRecallEnabled === "boolean"
+      ? input.autoRecallEnabled
+      : DEFAULT_RECALL_SETTINGS.autoRecallEnabled;
+
+  const maxInjectedMemories = sanitizePositiveInt(
+    input.maxInjectedMemories,
+    DEFAULT_RECALL_SETTINGS.maxInjectedMemories,
+  );
+
+  const maxInjectedTokens = sanitizePositiveInt(
+    input.maxInjectedTokens,
+    DEFAULT_RECALL_SETTINGS.maxInjectedTokens,
+  );
+
+  const recallVerbosity: BudgetVerbosity =
+    VALID_VERBOSITIES.includes(input.recallVerbosity as BudgetVerbosity)
+      ? (input.recallVerbosity as BudgetVerbosity)
+      : DEFAULT_RECALL_SETTINGS.recallVerbosity;
+
+  const deduplicationStrategy: DeduplicationStrategy =
+    VALID_STRATEGIES.includes(input.deduplicationStrategy as DeduplicationStrategy)
+      ? (input.deduplicationStrategy as DeduplicationStrategy)
+      : DEFAULT_RECALL_SETTINGS.deduplicationStrategy;
+
+  const enabledProviders = Array.isArray(input.enabledProviders)
+    ? input.enabledProviders.filter((p): p is string => typeof p === "string")
+    : DEFAULT_RECALL_SETTINGS.enabledProviders;
+
+  const providerPriorityWeights =
+    input.providerPriorityWeights &&
+    typeof input.providerPriorityWeights === "object" &&
+    !Array.isArray(input.providerPriorityWeights)
+      ? normalizePriorityWeights(input.providerPriorityWeights)
+      : DEFAULT_RECALL_SETTINGS.providerPriorityWeights;
+
+  const summaryFirst =
+    typeof input.summaryFirst === "boolean"
+      ? input.summaryFirst
+      : DEFAULT_RECALL_SETTINGS.summaryFirst;
+
+  return {
+    autoRecallEnabled,
+    maxInjectedMemories,
+    maxInjectedTokens,
+    recallVerbosity,
+    deduplicationStrategy,
+    enabledProviders,
+    providerPriorityWeights,
+    summaryFirst,
+  };
+}
+
+/**
+ * Merge user settings with an override layer (e.g. per-request overrides).
+ * Override values take precedence; user settings fill the gaps.
+ */
+export function mergeRecallSettings(
+  base: RecallSettings,
+  overrides: Partial<RecallSettings>,
+): RecallSettings {
+  return normalizeRecallSettings({
+    ...base,
+    ...overrides,
+  });
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function sanitizePositiveInt(
+  value: unknown,
+  fallback: number,
+): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    return fallback;
+  }
+  return Math.max(1, Math.floor(value));
+}
+
+function normalizePriorityWeights(
+  input: Record<string, unknown>,
+): Record<string, number> {
+  const result: Record<string, number> = {};
+  for (const [key, value] of Object.entries(input)) {
+    if (typeof value === "number" && Number.isFinite(value) && value >= 0) {
+      result[key] = value;
+    }
+  }
+  return result;
+}

--- a/src/lib/memory/settings.ts
+++ b/src/lib/memory/settings.ts
@@ -5,6 +5,16 @@
  * budget limits, verbosity, and per-provider configuration without touching
  * code. Designed to be serializable (JSON) for storage or API transport.
  *
+ * ## Design note: Settings vs Orchestrator config
+ *
+ * `RecallSettings` is a user-facing config model (stored, serialized, exposed
+ * via API). `RecallOrchestratorOptions` is the programmatic config passed to the
+ * orchestrator constructor. Settings like `deduplicationStrategy` and
+ * `providerPriorityWeights` map to `RecallOrchestratorOptions.deduplication` and
+ * per-provider weights at the wiring layer — they are separate entry points by
+ * design so that the orchestrator remains decoupled from any particular storage
+ * or API format.
+ *
  * @module recall-settings
  */
 

--- a/src/lib/memory/settings.ts
+++ b/src/lib/memory/settings.ts
@@ -94,14 +94,14 @@ export function normalizeRecallSettings(
 
   const enabledProviders = Array.isArray(input.enabledProviders)
     ? input.enabledProviders.filter((p): p is string => typeof p === "string")
-    : DEFAULT_RECALL_SETTINGS.enabledProviders;
+    : [...DEFAULT_RECALL_SETTINGS.enabledProviders];
 
   const providerPriorityWeights =
     input.providerPriorityWeights &&
     typeof input.providerPriorityWeights === "object" &&
     !Array.isArray(input.providerPriorityWeights)
       ? normalizePriorityWeights(input.providerPriorityWeights)
-      : DEFAULT_RECALL_SETTINGS.providerPriorityWeights;
+      : { ...DEFAULT_RECALL_SETTINGS.providerPriorityWeights };
 
   const summaryFirst =
     typeof input.summaryFirst === "boolean"


### PR DESCRIPTION
Closes #12, closes #14.

## What

**New: Cross-provider deduplication** (\`dedup.ts\`)
- \`CrossProviderDeduplicator\` with 3 strategies: best-score, provider-priority, most-recent
- Preserves full provider provenance after dedup (which providers found it, their scores, local IDs)
- Collapsed count tracked per group + aggregate stats
- Integrated into \`RecallOrchestrator\` — replaces the old inline canonicalRef dedup
- \`dedupStats\` surfaced in \`RecallResponse\`

**New: Recall settings** (\`settings.ts\`)
- \`RecallSettings\` config model with normalization/validation
- Settings: \`autoRecallEnabled\`, \`maxInjectedMemories\`, \`maxInjectedTokens\`, \`recallVerbosity\`, \`deduplicationStrategy\`, \`enabledProviders\`, \`providerPriorityWeights\`, \`summaryFirst\`
- \`mergeRecallSettings()\` for layering per-request overrides on top of base config
- All invalid inputs gracefully fall back to defaults

## Tests
- 18 dedup tests (strategies, provenance, multi-group, edge cases)
- 23 settings tests (normalization, validation, merging, fallbacks)
- 109 total across all memory test suites — all green
- TypeScript clean

## Files
- \`src/lib/memory/dedup.ts\` — new
- \`src/lib/memory/settings.ts\` — new
- \`src/lib/memory/orchestrator.ts\` — updated (dedup integration)
- \`src/lib/memory/index.ts\` — updated (exports)
- \`src/__tests__/memory/dedup.test.ts\` — new
- \`src/__tests__/memory/settings.test.ts\` — new