### PR TITLE
feat(memory): add status API endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "prisma generate && next build",
     "start": "next start",
     "test": "npm run test:memory",
-    "test:memory": "node --import tsx --test src/__tests__/memory/budget.test.ts src/__tests__/memory/conflict.test.ts src/__tests__/memory/dedup.test.ts src/__tests__/memory/hindsight-provider.test.ts src/__tests__/memory/promotion.test.ts src/__tests__/memory/backfill.test.ts src/__tests__/memory/recall-orchestrator.test.ts src/__tests__/memory/settings.test.ts src/__tests__/memory/scheduler.test.ts",
+    "test:memory": "node --import tsx --test src/__tests__/memory/api-status.test.ts src/__tests__/memory/budget.test.ts src/__tests__/memory/conflict.test.ts src/__tests__/memory/dedup.test.ts src/__tests__/memory/hindsight-provider.test.ts src/__tests__/memory/promotion.test.ts src/__tests__/memory/backfill.test.ts src/__tests__/memory/recall-orchestrator.test.ts src/__tests__/memory/settings.test.ts src/__tests__/memory/scheduler.test.ts",
     "test:scheduler": "node --import tsx --test src/__tests__/memory/scheduler.test.ts",
     "lint": "eslint",
     "db:migrate": "prisma migrate dev",

--- a/src/__tests__/memory/api-status.test.ts
+++ b/src/__tests__/memory/api-status.test.ts
@@ -28,6 +28,7 @@ test("memory status includes normalized public recall settings", () => {
       maxInjectedMemories: 3.8,
       maxInjectedTokens: -1,
       conflictThreshold: 5,
+      summaryFirst: false,
     },
   });
 
@@ -36,15 +37,39 @@ test("memory status includes normalized public recall settings", () => {
   assert.equal(snapshot.settings.conflictThreshold, 1);
   assert.equal(snapshot.settings.autoRecallEnabled, true);
   assert.equal(snapshot.settings.conflictStrategy, "surface");
+  assert.equal(snapshot.settings.summaryFirst, false);
+});
+
+test("memory status respects provider auto-recall capability gates", () => {
+  const snapshot = getMemoryStatusSnapshot({
+    providers: [
+      {
+        descriptor: {
+          id: "manual-only",
+          sourceType: "external",
+          defaultConfig: {
+            enabled: true,
+            priorityWeight: 1,
+            allowAutoRecall: true,
+          },
+          capabilities: {
+            search: true,
+            getById: true,
+            score: false,
+            autoRecall: false,
+          },
+        },
+      },
+    ],
+  });
+
+  assert.equal(snapshot.providers[0]?.allowAutoRecall, false);
 });
 
 test("memory status does not expose secret-like fields", () => {
   const serialized = JSON.stringify(getMemoryStatusSnapshot()).toLowerCase();
 
-  assert.equal(serialized.includes("apikey"), false);
-  assert.equal(serialized.includes("api_key"), false);
-  assert.equal(serialized.includes("apikey"), false);
-  assert.equal(serialized.includes("authorization"), false);
-  assert.equal(serialized.includes("secret"), false);
-  assert.equal(serialized.includes("password"), false);
+  for (const forbidden of ["apikey", "api_key", "bearer", "keyhash", "secret", "password"]) {
+    assert.equal(serialized.includes(forbidden), false, `unexpected ${forbidden} in status`);
+  }
 });

--- a/src/__tests__/memory/api-status.test.ts
+++ b/src/__tests__/memory/api-status.test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { getMemoryStatusSnapshot } from "@/lib/memory/api/providers";
+
+test("memory status exposes safe provider metadata", () => {
+  const snapshot = getMemoryStatusSnapshot({
+    now: new Date("2026-04-29T08:00:00.000Z"),
+  });
+
+  assert.equal(snapshot.ok, true);
+  assert.equal(snapshot.timestamp, "2026-04-29T08:00:00.000Z");
+  assert.equal(snapshot.providers.length, 1);
+
+  const [provider] = snapshot.providers;
+  assert.equal(provider.id, "noosphere");
+  assert.equal(provider.sourceType, "noosphere");
+  assert.equal(provider.enabled, true);
+  assert.equal(provider.allowAutoRecall, true);
+  assert.equal(provider.capabilities.search, true);
+  assert.equal(provider.capabilities.getById, true);
+  assert.equal(provider.capabilities.autoRecall, true);
+});
+
+test("memory status includes normalized public recall settings", () => {
+  const snapshot = getMemoryStatusSnapshot({
+    settings: {
+      maxInjectedMemories: 3.8,
+      maxInjectedTokens: -1,
+      conflictThreshold: 5,
+    },
+  });
+
+  assert.equal(snapshot.settings.maxInjectedMemories, 3);
+  assert.equal(snapshot.settings.maxInjectedTokens, 2000);
+  assert.equal(snapshot.settings.conflictThreshold, 1);
+  assert.equal(snapshot.settings.autoRecallEnabled, true);
+  assert.equal(snapshot.settings.conflictStrategy, "surface");
+});
+
+test("memory status does not expose secret-like fields", () => {
+  const serialized = JSON.stringify(getMemoryStatusSnapshot()).toLowerCase();
+
+  assert.equal(serialized.includes("apikey"), false);
+  assert.equal(serialized.includes("api_key"), false);
+  assert.equal(serialized.includes("apikey"), false);
+  assert.equal(serialized.includes("authorization"), false);
+  assert.equal(serialized.includes("secret"), false);
+  assert.equal(serialized.includes("password"), false);
+});

--- a/src/app/api/memory/status/route.ts
+++ b/src/app/api/memory/status/route.ts
@@ -1,18 +1,17 @@
-import { NextResponse } from "next/server";
-import { requireApiKey } from "@/lib/api/keys";
+import { NextRequest, NextResponse } from "next/server";
+import { requirePermission } from "@/lib/api/auth";
 import { getMemoryStatusSnapshot } from "@/lib/memory/api/providers";
 
-export async function GET(request: Request) {
-  const auth = await requireApiKey(request);
-  if (!auth.authorized) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+export async function GET(request: NextRequest) {
+  const auth = await requirePermission(request, ["WRITE"]);
+  if (!auth.success) {
+    return auth.response;
   }
 
   try {
     return NextResponse.json(getMemoryStatusSnapshot());
   } catch (error) {
-    const message = error instanceof Error ? error.message : "Unknown error";
-    console.error("[GET /api/memory/status]", message);
+    console.error("[GET /api/memory/status]", error);
     return NextResponse.json(
       {
         ok: false,

--- a/src/app/api/memory/status/route.ts
+++ b/src/app/api/memory/status/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from "next/server";
+import { requireApiKey } from "@/lib/api/keys";
+import { getMemoryStatusSnapshot } from "@/lib/memory/api/providers";
+
+export async function GET(request: Request) {
+  const auth = await requireApiKey(request);
+  if (!auth.authorized) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    return NextResponse.json(getMemoryStatusSnapshot());
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    console.error("[GET /api/memory/status]", message);
+    return NextResponse.json(
+      {
+        ok: false,
+        timestamp: new Date().toISOString(),
+        error: "Memory status unavailable",
+      },
+      { status: 503 },
+    );
+  }
+}

--- a/src/lib/memory/api/providers.ts
+++ b/src/lib/memory/api/providers.ts
@@ -1,28 +1,26 @@
 import {
-  DEFAULT_RECALL_SETTINGS,
   normalizeRecallSettings,
   type RecallSettings,
 } from "@/lib/memory/settings";
 import {
+  getEffectiveAutoRecall,
   normalizeMemoryProviderConfig,
+  type MemoryProviderCapabilities,
   type MemoryProviderConfig,
   type MemoryProviderDescriptor,
 } from "@/lib/memory/provider";
+import { NOOSPHERE_PROVIDER_DESCRIPTOR } from "@/lib/memory/noosphere-descriptor";
+import type { MemorySourceType } from "@/lib/memory/types";
 
 export interface MemoryProviderStatus {
   id: string;
   displayName?: string;
-  sourceType: string;
+  sourceType: MemorySourceType;
   enabled: boolean;
   allowAutoRecall: boolean;
   priorityWeight: number;
   maxResults?: number;
-  capabilities: {
-    search: boolean;
-    getById: boolean;
-    score: boolean;
-    autoRecall: boolean;
-  };
+  capabilities: MemoryProviderCapabilities;
 }
 
 export interface MemoryStatusSnapshot {
@@ -38,37 +36,17 @@ export interface MemoryStatusSnapshot {
     | "deduplicationStrategy"
     | "conflictStrategy"
     | "conflictThreshold"
+    | "summaryFirst"
   >;
 }
 
-interface MemoryProviderStatusSource {
+export interface MemoryProviderStatusSource {
   descriptor: MemoryProviderDescriptor;
   config?: Partial<MemoryProviderConfig>;
 }
 
-const DEFAULT_NOOSPHERE_DESCRIPTOR: MemoryProviderDescriptor = {
-  id: "noosphere",
-  displayName: "Noosphere",
-  sourceType: "noosphere",
-  defaultConfig: {
-    enabled: true,
-    priorityWeight: 1.25,
-    maxResults: 10,
-    allowAutoRecall: true,
-  },
-  capabilities: {
-    search: true,
-    getById: true,
-    score: true,
-    autoRecall: true,
-  },
-  metadata: {
-    contentType: "article",
-  },
-};
-
 export function getDefaultMemoryProviderStatusSources(): MemoryProviderStatusSource[] {
-  return [{ descriptor: DEFAULT_NOOSPHERE_DESCRIPTOR }];
+  return [{ descriptor: NOOSPHERE_PROVIDER_DESCRIPTOR }];
 }
 
 export function getMemoryStatusSnapshot(
@@ -79,10 +57,7 @@ export function getMemoryStatusSnapshot(
   } = {},
 ): MemoryStatusSnapshot {
   const providers = options.providers ?? getDefaultMemoryProviderStatusSources();
-  const settings = normalizeRecallSettings({
-    ...DEFAULT_RECALL_SETTINGS,
-    ...options.settings,
-  });
+  const settings = normalizeRecallSettings(options.settings);
 
   return {
     ok: true,
@@ -96,6 +71,7 @@ export function getMemoryStatusSnapshot(
       deduplicationStrategy: settings.deduplicationStrategy,
       conflictStrategy: settings.conflictStrategy,
       conflictThreshold: settings.conflictThreshold,
+      summaryFirst: settings.summaryFirst,
     },
   };
 }
@@ -112,7 +88,7 @@ function toProviderStatus(source: MemoryProviderStatusSource): MemoryProviderSta
     displayName: descriptor.displayName,
     sourceType: descriptor.sourceType,
     enabled: config.enabled,
-    allowAutoRecall: config.allowAutoRecall !== false,
+    allowAutoRecall: getEffectiveAutoRecall(descriptor.capabilities, config),
     priorityWeight: config.priorityWeight,
     maxResults: config.maxResults,
     capabilities: { ...descriptor.capabilities },

--- a/src/lib/memory/api/providers.ts
+++ b/src/lib/memory/api/providers.ts
@@ -1,0 +1,120 @@
+import {
+  DEFAULT_RECALL_SETTINGS,
+  normalizeRecallSettings,
+  type RecallSettings,
+} from "@/lib/memory/settings";
+import {
+  normalizeMemoryProviderConfig,
+  type MemoryProviderConfig,
+  type MemoryProviderDescriptor,
+} from "@/lib/memory/provider";
+
+export interface MemoryProviderStatus {
+  id: string;
+  displayName?: string;
+  sourceType: string;
+  enabled: boolean;
+  allowAutoRecall: boolean;
+  priorityWeight: number;
+  maxResults?: number;
+  capabilities: {
+    search: boolean;
+    getById: boolean;
+    score: boolean;
+    autoRecall: boolean;
+  };
+}
+
+export interface MemoryStatusSnapshot {
+  ok: boolean;
+  timestamp: string;
+  providers: MemoryProviderStatus[];
+  settings: Pick<
+    RecallSettings,
+    | "autoRecallEnabled"
+    | "maxInjectedMemories"
+    | "maxInjectedTokens"
+    | "recallVerbosity"
+    | "deduplicationStrategy"
+    | "conflictStrategy"
+    | "conflictThreshold"
+  >;
+}
+
+interface MemoryProviderStatusSource {
+  descriptor: MemoryProviderDescriptor;
+  config?: Partial<MemoryProviderConfig>;
+}
+
+const DEFAULT_NOOSPHERE_DESCRIPTOR: MemoryProviderDescriptor = {
+  id: "noosphere",
+  displayName: "Noosphere",
+  sourceType: "noosphere",
+  defaultConfig: {
+    enabled: true,
+    priorityWeight: 1.25,
+    maxResults: 10,
+    allowAutoRecall: true,
+  },
+  capabilities: {
+    search: true,
+    getById: true,
+    score: true,
+    autoRecall: true,
+  },
+  metadata: {
+    contentType: "article",
+  },
+};
+
+export function getDefaultMemoryProviderStatusSources(): MemoryProviderStatusSource[] {
+  return [{ descriptor: DEFAULT_NOOSPHERE_DESCRIPTOR }];
+}
+
+export function getMemoryStatusSnapshot(
+  options: {
+    now?: Date;
+    providers?: MemoryProviderStatusSource[];
+    settings?: Partial<RecallSettings>;
+  } = {},
+): MemoryStatusSnapshot {
+  const providers = options.providers ?? getDefaultMemoryProviderStatusSources();
+  const settings = normalizeRecallSettings({
+    ...DEFAULT_RECALL_SETTINGS,
+    ...options.settings,
+  });
+
+  return {
+    ok: true,
+    timestamp: (options.now ?? new Date()).toISOString(),
+    providers: providers.map(toProviderStatus),
+    settings: {
+      autoRecallEnabled: settings.autoRecallEnabled,
+      maxInjectedMemories: settings.maxInjectedMemories,
+      maxInjectedTokens: settings.maxInjectedTokens,
+      recallVerbosity: settings.recallVerbosity,
+      deduplicationStrategy: settings.deduplicationStrategy,
+      conflictStrategy: settings.conflictStrategy,
+      conflictThreshold: settings.conflictThreshold,
+    },
+  };
+}
+
+function toProviderStatus(source: MemoryProviderStatusSource): MemoryProviderStatus {
+  const descriptor = source.descriptor;
+  const config = normalizeMemoryProviderConfig({
+    ...descriptor.defaultConfig,
+    ...source.config,
+  });
+
+  return {
+    id: descriptor.id,
+    displayName: descriptor.displayName,
+    sourceType: descriptor.sourceType,
+    enabled: config.enabled,
+    allowAutoRecall: config.allowAutoRecall !== false,
+    priorityWeight: config.priorityWeight,
+    maxResults: config.maxResults,
+    capabilities: { ...descriptor.capabilities },
+  };
+}

--- a/src/lib/memory/noosphere-descriptor.ts
+++ b/src/lib/memory/noosphere-descriptor.ts
@@ -1,0 +1,31 @@
+import type { MemoryProviderDescriptor } from "./provider";
+
+export const NOOSPHERE_PROVIDER_ID = "noosphere";
+export const DEFAULT_NOOSPHERE_MAX_RESULTS = 10;
+
+/**
+ * DB-free descriptor for the built-in Noosphere article provider.
+ *
+ * Keep provider identity, defaults, and capabilities here so API status routes
+ * can report safe metadata without instantiating Prisma-backed providers.
+ */
+export const NOOSPHERE_PROVIDER_DESCRIPTOR: MemoryProviderDescriptor = {
+  id: NOOSPHERE_PROVIDER_ID,
+  displayName: "Noosphere",
+  sourceType: "noosphere",
+  defaultConfig: {
+    enabled: true,
+    priorityWeight: 1.25,
+    maxResults: DEFAULT_NOOSPHERE_MAX_RESULTS,
+    allowAutoRecall: true,
+  },
+  capabilities: {
+    search: true,
+    getById: true,
+    score: true,
+    autoRecall: true,
+  },
+  metadata: {
+    contentType: "article",
+  },
+};

--- a/src/lib/memory/noosphere.ts
+++ b/src/lib/memory/noosphere.ts
@@ -18,6 +18,11 @@ import {
   removeUndefined,
 } from "./types";
 import type { MemoryProviderMetadata, MemoryResult } from "./types";
+import {
+  DEFAULT_NOOSPHERE_MAX_RESULTS,
+  NOOSPHERE_PROVIDER_DESCRIPTOR,
+  NOOSPHERE_PROVIDER_ID,
+} from "./noosphere-descriptor";
 
 export interface NoosphereProviderSettings {
   /** Optional Prisma client override for scripts, tests, or alternate runtimes. */
@@ -55,8 +60,6 @@ type NoosphereArticle = Prisma.ArticleGetPayload<{
   };
 }>;
 
-const NOOSPHERE_PROVIDER_ID = "noosphere";
-const DEFAULT_NOOSPHERE_MAX_RESULTS = 10;
 const RECENCY_HALF_LIFE_DAYS = 90;
 
 export class NoosphereProvider implements MemoryProvider {
@@ -68,25 +71,13 @@ export class NoosphereProvider implements MemoryProvider {
     this.prisma = settings.prisma ?? defaultPrisma;
 
     this.descriptor = {
-      id: NOOSPHERE_PROVIDER_ID,
-      displayName: "Noosphere",
-      sourceType: "noosphere",
+      ...NOOSPHERE_PROVIDER_DESCRIPTOR,
       defaultConfig: {
-        enabled: true,
-        priorityWeight: 1.25,
-        maxResults: DEFAULT_NOOSPHERE_MAX_RESULTS,
-        allowAutoRecall: true,
+        ...NOOSPHERE_PROVIDER_DESCRIPTOR.defaultConfig,
         ...settings.providerConfig,
       },
-      capabilities: {
-        search: true,
-        getById: true,
-        score: true,
-        autoRecall: true,
-      },
-      metadata: {
-        contentType: "article",
-      },
+      capabilities: { ...NOOSPHERE_PROVIDER_DESCRIPTOR.capabilities },
+      metadata: { ...NOOSPHERE_PROVIDER_DESCRIPTOR.metadata },
     };
   }
 


### PR DESCRIPTION
## Summary
- add authenticated GET /api/memory/status
- expose safe memory provider metadata and normalized public recall settings
- add DB-free status helper tests and include them in test:memory

## Verification
- node --import tsx --test src/__tests__/memory/api-status.test.ts
- npm run test:memory
- npx tsc --noEmit
- git diff --check

## Notes
- status metadata is descriptor-based so this endpoint can be tested without DATABASE_URL and without instantiating Prisma-backed providers.

## Summary by Sourcery

Add an authenticated memory status API endpoint that exposes provider metadata and recall settings, along with supporting helpers and tests.

New Features:
- Expose a GET /api/memory/status endpoint that returns a normalized snapshot of memory provider status and recall settings.

Enhancements:
- Introduce a descriptor-based memory status snapshot helper to derive provider and settings metadata without requiring database-backed providers.

Build:
- Extend the test:memory npm script to include the new memory status API tests.

Tests:
- Add DB-free tests for the memory status snapshot helper and API endpoint.