### PR TITLE
feat(memory): add recall API endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "prisma generate && next build",
     "start": "next start",
     "test": "npm run test:memory",
-    "test:memory": "node --import tsx --test src/__tests__/memory/api-status.test.ts src/__tests__/memory/budget.test.ts src/__tests__/memory/conflict.test.ts src/__tests__/memory/dedup.test.ts src/__tests__/memory/hindsight-provider.test.ts src/__tests__/memory/promotion.test.ts src/__tests__/memory/backfill.test.ts src/__tests__/memory/recall-orchestrator.test.ts src/__tests__/memory/settings.test.ts src/__tests__/memory/scheduler.test.ts",
+    "test:memory": "node --import tsx --test src/__tests__/memory/api-recall.test.ts src/__tests__/memory/api-status.test.ts src/__tests__/memory/budget.test.ts src/__tests__/memory/conflict.test.ts src/__tests__/memory/dedup.test.ts src/__tests__/memory/hindsight-provider.test.ts src/__tests__/memory/promotion.test.ts src/__tests__/memory/backfill.test.ts src/__tests__/memory/recall-orchestrator.test.ts src/__tests__/memory/settings.test.ts src/__tests__/memory/scheduler.test.ts",
     "test:scheduler": "node --import tsx --test src/__tests__/memory/scheduler.test.ts",
     "lint": "eslint",
     "db:migrate": "prisma migrate dev",

--- a/src/__tests__/memory/api-recall.test.ts
+++ b/src/__tests__/memory/api-recall.test.ts
@@ -1,0 +1,248 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  executeMemoryRecallRequest,
+  validateMemoryRecallRequest,
+} from "@/lib/memory/api/recall";
+import type { MemoryProvider } from "@/lib/memory/provider";
+import type { MemoryResult } from "@/lib/memory/types";
+
+function mockProvider(
+  id: string,
+  results: MemoryResult[] = [],
+  overrides: Partial<MemoryProvider> = {},
+): MemoryProvider {
+  return {
+    descriptor: {
+      id,
+      displayName: id,
+      sourceType: id as MemoryResult["sourceType"],
+      defaultConfig: {
+        enabled: true,
+        priorityWeight: 1,
+        allowAutoRecall: true,
+      },
+      capabilities: {
+        search: true,
+        getById: true,
+        score: true,
+        autoRecall: true,
+      },
+    },
+    search: () => Promise.resolve(results),
+    getById: () => Promise.resolve(null),
+    score: () => ({}),
+    ...overrides,
+  } as MemoryProvider;
+}
+
+function mockResult(
+  overrides: Partial<MemoryResult> & { id: string; provider: string },
+): MemoryResult {
+  return {
+    sourceType: overrides.provider as MemoryResult["sourceType"],
+    content: `Content for ${overrides.id}`,
+    relevanceScore: 0.8,
+    confidenceScore: 0.8,
+    ...overrides,
+  };
+}
+
+test("memory recall validation rejects missing or empty query", () => {
+  assert.deepEqual(validateMemoryRecallRequest({}), {
+    ok: false,
+    status: 400,
+    error: "query is required",
+  });
+  assert.deepEqual(validateMemoryRecallRequest({ query: "   " }), {
+    ok: false,
+    status: 400,
+    error: "query is required",
+  });
+});
+
+test("memory recall validation normalizes caps and defaults", () => {
+  const result = validateMemoryRecallRequest({
+    query: "  serianis memory  ",
+    resultCap: 999,
+    tokenBudget: 99999,
+  });
+
+  assert.equal(result.ok, true);
+  if (!result.ok) return;
+  assert.equal(result.request.query, "serianis memory");
+  assert.equal(result.request.mode, "inspection");
+  assert.equal(result.request.resultCap, 10);
+  assert.equal(result.request.tokenBudget, 2000);
+});
+
+test("memory recall inspection mode returns results without prompt text", async () => {
+  const response = await executeMemoryRecallRequest(
+    { query: "deployment", mode: "inspection", resultCap: 5 },
+    {
+      providers: [
+        {
+          provider: mockProvider("noosphere", [
+            mockResult({
+              id: "article-1",
+              provider: "noosphere",
+              title: "Deployment Notes",
+              content: "Use the documented deployment workflow.",
+            }),
+          ]),
+        },
+      ],
+    },
+  );
+
+  assert.equal(response.status, 200);
+  assert.ok("results" in response.body);
+  if (!("results" in response.body)) return;
+  assert.equal(response.body.mode, "inspection");
+  assert.equal(response.body.results.length, 1);
+  assert.equal(response.body.results[0]?.providerId, "noosphere");
+  assert.equal(response.body.promptInjectionText, undefined);
+});
+
+test("memory recall auto mode returns bounded prompt text", async () => {
+  const response = await executeMemoryRecallRequest(
+    { query: "serianis", mode: "auto", resultCap: 1, tokenBudget: 50 },
+    {
+      providers: [
+        {
+          provider: mockProvider("noosphere", [
+            mockResult({
+              id: "article-1",
+              provider: "noosphere",
+              title: "Serianis",
+              content: "Serianis deployment memory.",
+              tokenEstimate: 20,
+            }),
+          ]),
+        },
+      ],
+    },
+  );
+
+  assert.equal(response.status, 200);
+  assert.ok("promptInjectionText" in response.body);
+  if (!("promptInjectionText" in response.body)) return;
+  assert.equal(response.body.mode, "auto");
+  assert.equal(response.body.results.length, 1);
+  assert.ok((response.body.tokenBudgetUsed ?? 0) > 0);
+  assert.ok((response.body.tokenBudgetUsed ?? 0) <= 50);
+  assert.match(response.body.promptInjectionText ?? "", /^<recall query="serianis">/);
+  assert.match(response.body.promptInjectionText ?? "", /<memory source="noosphere"/);
+});
+
+
+test("memory recall auto mode defaults to noosphere provider only", async () => {
+  const response = await executeMemoryRecallRequest(
+    { query: "memory", mode: "auto" },
+    {
+      providers: [
+        {
+          provider: mockProvider("noosphere", [
+            mockResult({ id: "n1", provider: "noosphere", content: "Noosphere" }),
+          ]),
+        },
+        {
+          provider: mockProvider("hindsight", [
+            mockResult({ id: "h1", provider: "hindsight", content: "Hindsight" }),
+          ]),
+        },
+      ],
+    },
+  );
+
+  assert.equal(response.status, 200);
+  assert.ok("results" in response.body);
+  if (!("results" in response.body)) return;
+  assert.equal(response.body.results.length, 1);
+  assert.equal(response.body.results[0]?.providerId, "noosphere");
+  assert.deepEqual(response.body.providerMeta.map((meta) => meta.providerId), ["noosphere"]);
+});
+
+test("memory recall filters providers at route layer", async () => {
+  const response = await executeMemoryRecallRequest(
+    { query: "memory", providers: ["secondary"] },
+    {
+      providers: [
+        {
+          provider: mockProvider("noosphere", [
+            mockResult({ id: "n1", provider: "noosphere", content: "Noosphere" }),
+          ]),
+        },
+        {
+          provider: mockProvider("secondary", [
+            mockResult({ id: "s1", provider: "secondary", content: "Secondary" }),
+          ]),
+        },
+      ],
+    },
+  );
+
+  assert.equal(response.status, 200);
+  assert.ok("results" in response.body);
+  if (!("results" in response.body)) return;
+  assert.equal(response.body.results.length, 1);
+  assert.equal(response.body.results[0]?.providerId, "secondary");
+  assert.deepEqual(response.body.providerMeta.map((meta) => meta.providerId), ["secondary"]);
+});
+
+test("memory recall rejects unknown provider filters", async () => {
+  const response = await executeMemoryRecallRequest(
+    { query: "memory", providers: ["missing"] },
+    { providers: [{ provider: mockProvider("noosphere") }] },
+  );
+
+  assert.equal(response.status, 400);
+  assert.deepEqual(response.body, { error: "Unknown provider ID: missing" });
+});
+
+test("memory recall preserves provider errors as metadata", async () => {
+  const response = await executeMemoryRecallRequest(
+    { query: "memory", mode: "inspection" },
+    {
+      providers: [
+        {
+          provider: mockProvider("broken", [], {
+            search: () => Promise.reject(new Error("provider unavailable")),
+          }),
+        },
+      ],
+    },
+  );
+
+  assert.equal(response.status, 200);
+  assert.ok("results" in response.body);
+  if (!("results" in response.body)) return;
+  assert.equal(response.body.results.length, 0);
+  assert.equal(response.body.providerMeta[0]?.providerId, "broken");
+  assert.equal(response.body.providerMeta[0]?.error, "provider unavailable");
+});
+
+test("memory recall timeout fails open with provider metadata", async () => {
+  const response = await executeMemoryRecallRequest(
+    { query: "slow", mode: "auto" },
+    {
+      timeoutMs: 1,
+      providers: [
+        {
+          provider: mockProvider("noosphere", [], {
+            search: () => new Promise((resolve) => setTimeout(() => resolve([]), 50)),
+          }),
+        },
+      ],
+    },
+  );
+
+  assert.equal(response.status, 200);
+  assert.ok("results" in response.body);
+  if (!("results" in response.body)) return;
+  assert.equal(response.body.results.length, 0);
+  assert.equal(response.body.mode, "auto");
+  assert.equal(response.body.promptInjectionText, "");
+  assert.equal(response.body.providerMeta[0]?.error, "Memory recall timed out");
+});

--- a/src/__tests__/memory/api-recall.test.ts
+++ b/src/__tests__/memory/api-recall.test.ts
@@ -77,6 +77,20 @@ test("memory recall validation normalizes caps and defaults", () => {
   assert.equal(result.request.tokenBudget, 2000);
 });
 
+test("memory recall validation rejects non-string provider elements", () => {
+  assert.deepEqual(
+    validateMemoryRecallRequest({ query: "memory", providers: ["noosphere", 123 as unknown] }),
+    { ok: false, status: 400, error: "providers must be an array of provider ID strings" },
+  );
+});
+
+test("memory recall validation rejects empty providers array", () => {
+  assert.deepEqual(
+    validateMemoryRecallRequest({ query: "memory", providers: [] }),
+    { ok: false, status: 400, error: "providers must contain at least one non-empty provider ID" },
+  );
+});
+
 test("memory recall inspection mode returns results without prompt text", async () => {
   const response = await executeMemoryRecallRequest(
     { query: "deployment", mode: "inspection", resultCap: 5 },

--- a/src/app/api/memory/recall/route.ts
+++ b/src/app/api/memory/recall/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from "next/server";
+import { Permissions } from "@prisma/client";
+import { requirePermission } from "@/lib/api/auth";
+import { executeMemoryRecallRequest } from "@/lib/memory/api/recall";
+
+export async function POST(request: NextRequest) {
+  const auth = await requirePermission(request, [Permissions.READ]);
+  if (!auth.success) {
+    return auth.response;
+  }
+
+  try {
+    const result = await executeMemoryRecallRequest(await request.json());
+    return NextResponse.json(result.body, { status: result.status });
+  } catch (error) {
+    console.error("[POST /api/memory/recall]", error);
+    return NextResponse.json(
+      { error: "Memory recall unavailable" },
+      { status: 503 },
+    );
+  }
+}

--- a/src/app/api/memory/recall/route.ts
+++ b/src/app/api/memory/recall/route.ts
@@ -9,8 +9,18 @@ export async function POST(request: NextRequest) {
     return auth.response;
   }
 
+  let body: unknown;
   try {
-    const result = await executeMemoryRecallRequest(await request.json());
+    body = await request.json();
+  } catch (error) {
+    return NextResponse.json(
+      { error: "Invalid JSON body" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const result = await executeMemoryRecallRequest(body);
     return NextResponse.json(result.body, { status: result.status });
   } catch (error) {
     console.error("[POST /api/memory/recall]", error);

--- a/src/lib/memory/api/recall.ts
+++ b/src/lib/memory/api/recall.ts
@@ -111,12 +111,19 @@ export function validateMemoryRecallRequest(input: unknown): MemoryRecallValidat
     if (!Array.isArray(body.providers)) {
       return { ok: false, status: 400, error: "providers must be an array of provider IDs" };
     }
-    providers = [...new Set(body.providers.map((provider) => {
-      if (typeof provider !== "string") {
-        return "";
-      }
-      return provider.trim();
-    }).filter(Boolean))];
+    if (body.providers.some((provider: unknown) => typeof provider !== "string")) {
+      return { ok: false, status: 400, error: "providers must be an array of provider ID strings" };
+    }
+    providers = [
+      ...new Set(
+        (body.providers as string[])
+          .map((provider) => provider.trim())
+          .filter(Boolean),
+      ),
+    ];
+    if (providers.length === 0) {
+      return { ok: false, status: 400, error: "providers must contain at least one non-empty provider ID" };
+    }
   }
 
   return {
@@ -160,7 +167,7 @@ export async function executeMemoryRecallRequest(
   const timeoutMs = clampPositiveInteger(
     options.timeoutMs,
     MEMORY_RECALL_LIMITS.timeoutMs,
-    MEMORY_RECALL_LIMITS.timeoutMs,
+    Number.MAX_SAFE_INTEGER,
   );
   const controller = new AbortController();
 

--- a/src/lib/memory/api/recall.ts
+++ b/src/lib/memory/api/recall.ts
@@ -169,13 +169,21 @@ export async function executeMemoryRecallRequest(
     MEMORY_RECALL_LIMITS.timeoutMs,
     Number.MAX_SAFE_INTEGER,
   );
+  const effectiveResultCap = Math.min(
+    settings.maxInjectedMemories,
+    MEMORY_RECALL_LIMITS.maxResultCap,
+  );
+  const effectiveTokenBudget = Math.min(
+    settings.maxInjectedTokens,
+    MEMORY_RECALL_LIMITS.maxTokenBudget,
+  );
   const controller = new AbortController();
 
   try {
     const orchestrator = createRecallOrchestrator({
       providers: providers.entries,
-      globalResultCap: Math.min(settings.maxInjectedMemories, MEMORY_RECALL_LIMITS.maxResultCap),
-      autoRecallTokenBudget: Math.min(settings.maxInjectedTokens, MEMORY_RECALL_LIMITS.maxTokenBudget),
+      globalResultCap: effectiveResultCap,
+      autoRecallTokenBudget: effectiveTokenBudget,
       deduplication: {
         strategy: settings.deduplicationStrategy,
         providerPriority: settings.enabledProviders,
@@ -187,8 +195,8 @@ export async function executeMemoryRecallRequest(
       orchestrator.recall({
         query: validation.request.query,
         mode: validation.request.mode,
-        resultCap: Math.min(validation.request.resultCap, Math.min(settings.maxInjectedMemories, MEMORY_RECALL_LIMITS.maxResultCap)),
-        tokenBudget: Math.min(validation.request.tokenBudget, Math.min(settings.maxInjectedTokens, MEMORY_RECALL_LIMITS.maxTokenBudget)),
+        resultCap: Math.min(validation.request.resultCap, effectiveResultCap),
+        tokenBudget: Math.min(validation.request.tokenBudget, effectiveTokenBudget),
         scope: validation.request.scope,
         signal: controller.signal,
       }),

--- a/src/lib/memory/api/recall.ts
+++ b/src/lib/memory/api/recall.ts
@@ -1,0 +1,300 @@
+import {
+  createRecallOrchestrator,
+  type RecallMode,
+  type RecallOrchestratorProviderEntry,
+  type RecallProviderMeta,
+  type RecallResponse,
+  type RecallResultRanked,
+} from "@/lib/memory/orchestrator";
+import {
+  DEFAULT_RECALL_SETTINGS,
+  normalizeRecallSettings,
+  toConflictConfig,
+  type RecallSettings,
+} from "@/lib/memory/settings";
+import type { DeduplicationStats } from "@/lib/memory/dedup";
+import type { ConflictSignal, ConflictStats } from "@/lib/memory/conflict";
+
+export const MEMORY_RECALL_LIMITS = {
+  maxResultCap: 10,
+  maxTokenBudget: 2000,
+  timeoutMs: 5000,
+  maxQueryLength: 1000,
+} as const;
+
+export const MEMORY_RECALL_DEFAULT_AUTO_PROVIDERS = ["noosphere"] as const;
+
+export interface MemoryRecallRequest {
+  query: string;
+  mode?: RecallMode;
+  resultCap?: number;
+  tokenBudget?: number;
+  scope?: string;
+  providers?: string[];
+}
+
+export interface MemoryRecallResponse {
+  results: RecallResultRanked[];
+  totalBeforeCap: number;
+  mode: RecallMode;
+  tokenBudgetUsed?: number;
+  promptInjectionText?: string;
+  providerMeta: RecallProviderMeta[];
+  dedupStats?: DeduplicationStats;
+  conflicts?: ConflictSignal[];
+  conflictStats?: ConflictStats;
+}
+
+export interface MemoryRecallExecutionOptions {
+  providers?: RecallOrchestratorProviderEntry[];
+  settings?: Partial<RecallSettings>;
+  timeoutMs?: number;
+}
+
+export type MemoryRecallValidationResult =
+  | {
+      ok: true;
+      request: Required<
+        Pick<MemoryRecallRequest, "query" | "mode" | "resultCap" | "tokenBudget">
+      > &
+        Pick<MemoryRecallRequest, "scope" | "providers">;
+    }
+  | {
+      ok: false;
+      status: number;
+      error: string;
+    };
+
+export async function getDefaultMemoryRecallProviders(): Promise<RecallOrchestratorProviderEntry[]> {
+  const { createNoosphereProvider } = await import("@/lib/memory/noosphere");
+  return [{ provider: createNoosphereProvider() }];
+}
+
+export function validateMemoryRecallRequest(input: unknown): MemoryRecallValidationResult {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    return { ok: false, status: 400, error: "Request body must be an object" };
+  }
+
+  const body = input as Record<string, unknown>;
+  const query = typeof body.query === "string" ? body.query.trim() : "";
+  if (!query) {
+    return { ok: false, status: 400, error: "query is required" };
+  }
+  if (query.length > MEMORY_RECALL_LIMITS.maxQueryLength) {
+    return { ok: false, status: 400, error: "query is too long" };
+  }
+
+  const mode = body.mode === undefined ? "inspection" : body.mode;
+  if (mode !== "auto" && mode !== "inspection") {
+    return { ok: false, status: 400, error: "mode must be auto or inspection" };
+  }
+
+  const resultCap = clampPositiveInteger(
+    body.resultCap,
+    DEFAULT_RECALL_SETTINGS.maxInjectedMemories,
+    MEMORY_RECALL_LIMITS.maxResultCap,
+  );
+  const tokenBudget = clampPositiveInteger(
+    body.tokenBudget,
+    DEFAULT_RECALL_SETTINGS.maxInjectedTokens,
+    MEMORY_RECALL_LIMITS.maxTokenBudget,
+  );
+
+  const scope = body.scope === undefined
+    ? undefined
+    : typeof body.scope === "string" && body.scope.trim()
+      ? body.scope.trim()
+      : undefined;
+
+  let providers: string[] | undefined;
+  if (body.providers !== undefined) {
+    if (!Array.isArray(body.providers)) {
+      return { ok: false, status: 400, error: "providers must be an array of provider IDs" };
+    }
+    providers = [...new Set(body.providers.map((provider) => {
+      if (typeof provider !== "string") {
+        return "";
+      }
+      return provider.trim();
+    }).filter(Boolean))];
+  }
+
+  return {
+    ok: true,
+    request: {
+      query,
+      mode,
+      resultCap,
+      tokenBudget,
+      scope,
+      providers,
+    },
+  };
+}
+
+export async function executeMemoryRecallRequest(
+  input: unknown,
+  options: MemoryRecallExecutionOptions = {},
+): Promise<{ status: number; body: MemoryRecallResponse | { error: string } }> {
+  const validation = validateMemoryRecallRequest(input);
+  if (!validation.ok) {
+    return { status: validation.status, body: { error: validation.error } };
+  }
+
+  const settings = normalizeRecallSettings(options.settings);
+  const providerEntries = options.providers ?? await getDefaultMemoryRecallProviders();
+  const requestedProviders =
+    validation.request.providers ??
+    (validation.request.mode === "auto"
+      ? [...MEMORY_RECALL_DEFAULT_AUTO_PROVIDERS]
+      : undefined);
+  const providers = filterProviders(
+    providerEntries,
+    requestedProviders,
+  );
+
+  if (!providers.ok) {
+    return { status: 400, body: { error: providers.error } };
+  }
+
+  const timeoutMs = clampPositiveInteger(
+    options.timeoutMs,
+    MEMORY_RECALL_LIMITS.timeoutMs,
+    MEMORY_RECALL_LIMITS.timeoutMs,
+  );
+  const controller = new AbortController();
+
+  try {
+    const orchestrator = createRecallOrchestrator({
+      providers: providers.entries,
+      globalResultCap: Math.min(settings.maxInjectedMemories, MEMORY_RECALL_LIMITS.maxResultCap),
+      autoRecallTokenBudget: Math.min(settings.maxInjectedTokens, MEMORY_RECALL_LIMITS.maxTokenBudget),
+      deduplication: {
+        strategy: settings.deduplicationStrategy,
+        providerPriority: settings.enabledProviders,
+      },
+      conflict: toConflictConfig(settings),
+    });
+
+    const response = await withTimeout(
+      orchestrator.recall({
+        query: validation.request.query,
+        mode: validation.request.mode,
+        resultCap: validation.request.resultCap,
+        tokenBudget: validation.request.tokenBudget,
+        scope: validation.request.scope,
+        signal: controller.signal,
+      }),
+      timeoutMs,
+      () => {
+        controller.abort();
+        return buildTimeoutResponse(
+          validation.request.mode,
+          providers.entries,
+          timeoutMs,
+        );
+      },
+    );
+
+    return { status: 200, body: toMemoryRecallResponse(response) };
+  } finally {
+    controller.abort();
+  }
+}
+
+function buildTimeoutResponse(
+  mode: RecallMode,
+  providers: RecallOrchestratorProviderEntry[],
+  timeoutMs: number,
+): RecallResponse {
+  return {
+    results: [],
+    totalBeforeCap: 0,
+    mode,
+    tokenBudgetUsed: mode === "auto" ? 0 : undefined,
+    promptInjectionText: mode === "auto" ? "" : undefined,
+    providerMeta: providers.map((entry) => ({
+      providerId: entry.provider.descriptor.id,
+      resultCount: 0,
+      enabled: true,
+      error: "Memory recall timed out",
+      durationMs: timeoutMs,
+    })),
+    dedupStats: { totalInput: 0, totalOutput: 0, collapsedTotal: 0 },
+    conflictStats: {
+      totalInput: 0,
+      conflictingPairs: 0,
+      resolved: 0,
+      suppressed: 0,
+      surfaced: 0,
+    },
+  };
+}
+
+async function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  onTimeout: () => T,
+): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((resolve) => {
+        timeout = setTimeout(() => resolve(onTimeout()), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+  }
+}
+
+function toMemoryRecallResponse(response: RecallResponse): MemoryRecallResponse {
+  return {
+    results: response.results,
+    totalBeforeCap: response.totalBeforeCap,
+    mode: response.mode,
+    tokenBudgetUsed: response.tokenBudgetUsed,
+    promptInjectionText:
+      response.mode === "auto" ? response.promptInjectionText : undefined,
+    providerMeta: response.providerMeta,
+    dedupStats: response.dedupStats,
+    conflicts: response.conflicts,
+    conflictStats: response.conflictStats,
+  };
+}
+
+function filterProviders(
+  providers: RecallOrchestratorProviderEntry[],
+  requested: string[] | undefined,
+): { ok: true; entries: RecallOrchestratorProviderEntry[] } | { ok: false; error: string } {
+  if (!requested || requested.length === 0) {
+    return { ok: true, entries: providers };
+  }
+
+  const byId = new Map(
+    providers.map((entry) => [entry.provider.descriptor.id, entry] as const),
+  );
+  const unknown = requested.filter((providerId) => !byId.has(providerId));
+  if (unknown.length > 0) {
+    return { ok: false, error: `Unknown provider ID: ${unknown.join(", ")}` };
+  }
+
+  return {
+    ok: true,
+    entries: requested.map((providerId) => byId.get(providerId)!),
+  };
+}
+
+function clampPositiveInteger(
+  value: unknown,
+  fallback: number,
+  max: number,
+): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    return Math.min(Math.floor(fallback), max);
+  }
+  return Math.min(Math.max(1, Math.floor(value)), max);
+}

--- a/src/lib/memory/api/recall.ts
+++ b/src/lib/memory/api/recall.ts
@@ -187,8 +187,8 @@ export async function executeMemoryRecallRequest(
       orchestrator.recall({
         query: validation.request.query,
         mode: validation.request.mode,
-        resultCap: validation.request.resultCap,
-        tokenBudget: validation.request.tokenBudget,
+        resultCap: Math.min(validation.request.resultCap, Math.min(settings.maxInjectedMemories, MEMORY_RECALL_LIMITS.maxResultCap)),
+        tokenBudget: Math.min(validation.request.tokenBudget, Math.min(settings.maxInjectedTokens, MEMORY_RECALL_LIMITS.maxTokenBudget)),
         scope: validation.request.scope,
         signal: controller.signal,
       }),


### PR DESCRIPTION
## Summary
- Add POST /api/memory/recall with READ auth and orchestration through RecallOrchestrator
- Validate query/mode/provider filters and clamp result/token caps to server-side limits
- Preserve provider failures and timeout behavior as fail-open provider metadata
- Add API helper tests covering validation, auto/inspection modes, provider filtering, caps, and fail-open behavior

## Verification
- npm run test:memory
- npx tsc --noEmit --pretty false
- git diff --check
- npx eslint src/lib/memory/api/recall.ts src/app/api/memory/recall/route.ts src/__tests__/memory/api-recall.test.ts --max-warnings=0

## Summary by Sourcery

Add a new authenticated memory recall API endpoint backed by the existing recall orchestrator and enforce server-side limits and provider selection.

New Features:
- Expose a POST /api/memory/recall endpoint for authenticated memory recall queries using the recall orchestrator.
- Introduce a memory recall API helper that validates requests, applies caps, selects providers, and executes recalls.

Enhancements:
- Clamp recall query length, result caps, and token budgets to configured server-side limits and defaults.
- Propagate provider errors and timeouts as non-fatal metadata in recall responses to support fail-open behavior.

Tests:
- Add unit tests for the memory recall API helper covering validation, modes, provider filtering, limits, and fail-open behavior.
- Update the memory test runner to include the new memory recall API test suite.