### PR TITLE
feat(openclaw): add Noosphere memory plugin skeleton

### DIFF
--- a/docs/OPENCLAW-NOOSPHERE-BRIDGE-ROADMAP.md
+++ b/docs/OPENCLAW-NOOSPHERE-BRIDGE-ROADMAP.md
@@ -1,6 +1,6 @@
 # OpenClaw ↔ Noosphere Memory Bridge Roadmap
 
-Status: planning document
+Status: implementation in progress — PRs 0–2 merged; PR 3 underway
 Owner: Noosphere/OpenClaw integration workstream
 Last updated: 2026-04-29
 
@@ -63,6 +63,8 @@ Therefore the bridge must not assume OpenClaw `memory-core` or QMD (the local-fi
 
 ### PR 0 — Roadmap and contract documentation
 
+Status: merged.
+
 Purpose: document architecture, operating modes, API contract, and PR split before code changes.
 
 Deliverables:
@@ -78,6 +80,8 @@ git diff --check
 ```
 
 ### PR 1 — Memory status API
+
+Status: merged.
 
 Purpose: expose a safe status endpoint for OpenClaw/plugin health checks.
 
@@ -142,6 +146,8 @@ Targeted tests should cover:
 - no secret fields in response.
 
 ### PR 2 — Memory recall API
+
+Status: merged.
 
 Purpose: expose the Noosphere recall orchestrator over HTTP.
 
@@ -219,6 +225,8 @@ Targeted tests should cover:
 - provider error metadata/fail-open behavior.
 
 ### PR 3 — OpenClaw plugin skeleton and explicit tools
+
+Status: in progress.
 
 Purpose: create a thin OpenClaw plugin that calls Noosphere HTTP endpoints manually.
 

--- a/openclaw-noosphere-memory/openclaw.plugin.json
+++ b/openclaw-noosphere-memory/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "noosphere-memory",
   "name": "Noosphere Memory Bridge",
-  "description": "Explicit OpenClaw tools for Noosphere memory status and recall over HTTP.",
+  "description": "Explicit OpenClaw tools for Noosphere memory status and recall over HTTP. Recall requires READ permission; status requires an ADMIN-scoped Noosphere API key.",
   "contracts": {
     "tools": [
       "noosphere_status",
@@ -21,7 +21,7 @@
     },
     "apiKey": {
       "label": "Noosphere API Key",
-      "help": "API key used as Authorization: Bearer <key>. Fallback: NOOSPHERE_API_KEY.",
+      "help": "API key used as Authorization: Bearer <key>. Recall requires READ permission; status requires ADMIN. Fallback: NOOSPHERE_API_KEY.",
       "sensitive": true,
       "placeholder": "noo_..."
     },

--- a/openclaw-noosphere-memory/openclaw.plugin.json
+++ b/openclaw-noosphere-memory/openclaw.plugin.json
@@ -1,0 +1,52 @@
+{
+  "id": "noosphere-memory",
+  "name": "Noosphere Memory Bridge",
+  "description": "Explicit OpenClaw tools for Noosphere memory status and recall over HTTP.",
+  "contracts": {
+    "tools": [
+      "noosphere_status",
+      "noosphere_recall"
+    ]
+  },
+  "providerAuthEnvVars": {
+    "noosphere-memory": [
+      "NOOSPHERE_API_KEY"
+    ]
+  },
+  "uiHints": {
+    "baseUrl": {
+      "label": "Noosphere Base URL",
+      "help": "Base URL for Noosphere, for example http://100.122.171.30:3000.",
+      "placeholder": "http://localhost:3000"
+    },
+    "apiKey": {
+      "label": "Noosphere API Key",
+      "help": "API key used as Authorization: Bearer <key>. Fallback: NOOSPHERE_API_KEY.",
+      "sensitive": true,
+      "placeholder": "noo_..."
+    },
+    "timeoutMs": {
+      "label": "HTTP Timeout (ms)",
+      "help": "Maximum time for explicit status/recall requests before failing safely."
+    }
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "baseUrl": {
+        "type": "string"
+      },
+      "apiKey": {
+        "type": [
+          "string",
+          "object"
+        ]
+      },
+      "timeoutMs": {
+        "type": "number",
+        "minimum": 1
+      }
+    }
+  }
+}

--- a/openclaw-noosphere-memory/package.json
+++ b/openclaw-noosphere-memory/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@sweetsophia/openclaw-noosphere-memory",
+  "version": "0.1.0",
+  "private": true,
+  "description": "OpenClaw plugin for explicit Noosphere memory status and recall tools.",
+  "type": "module",
+  "devDependencies": {
+    "@types/node": "^20",
+    "tsx": "^4.21.0",
+    "typescript": "^5"
+  },
+  "openclaw": {
+    "extensions": [
+      "./src/index.ts"
+    ]
+  }
+}

--- a/openclaw-noosphere-memory/package.json
+++ b/openclaw-noosphere-memory/package.json
@@ -4,6 +4,9 @@
   "private": true,
   "description": "OpenClaw plugin for explicit Noosphere memory status and recall tools.",
   "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
   "devDependencies": {
     "@types/node": "^20",
     "tsx": "^4.21.0",

--- a/openclaw-noosphere-memory/src/client.ts
+++ b/openclaw-noosphere-memory/src/client.ts
@@ -73,13 +73,17 @@ export class NoosphereMemoryClient {
         },
       });
 
-      const payload = await parseJson(response);
+      const payload = await parseResponseBody(response);
       if (!response.ok) {
         throw new NoosphereClientError(
           extractError(payload) ?? `Noosphere request failed with HTTP ${response.status}`,
           response.status,
           payload,
         );
+      }
+
+      if (payload === null) {
+        throw new NoosphereClientError("Noosphere returned an empty response body", response.status);
       }
 
       return payload as T;
@@ -95,24 +99,41 @@ export class NoosphereMemoryClient {
   }
 }
 
-async function parseJson(response: Response): Promise<unknown> {
+async function parseResponseBody(response: Response): Promise<unknown> {
   const text = await response.text();
   if (!text) return null;
+
+  const contentType = response.headers.get("content-type") ?? "";
+  if (!contentType.toLowerCase().includes("application/json")) {
+    if (!response.ok) return { rawBody: text };
+    throw new NoosphereClientError("Noosphere returned a non-JSON response", response.status, { rawBody: text });
+  }
+
   try {
     return JSON.parse(text) as unknown;
   } catch {
+    if (!response.ok) return { rawBody: text };
     throw new NoosphereClientError("Noosphere returned invalid JSON", response.status);
   }
 }
 
 function extractError(payload: unknown): string | undefined {
-  if (payload && typeof payload === "object" && "error" in payload) {
+  if (!payload || typeof payload !== "object") return undefined;
+
+  if ("error" in payload) {
     const error = (payload as { error?: unknown }).error;
-    return typeof error === "string" ? error : undefined;
+    if (typeof error === "string") return error;
   }
+
+  if ("rawBody" in payload) {
+    const rawBody = (payload as { rawBody?: unknown }).rawBody;
+    if (typeof rawBody === "string" && rawBody.trim()) return rawBody.trim();
+  }
+
   return undefined;
 }
 
 function isAbortError(error: unknown): boolean {
-  return error instanceof DOMException && error.name === "AbortError";
+  if (!(error instanceof Error)) return false;
+  return error.name === "AbortError" || /abort/i.test(error.message);
 }

--- a/openclaw-noosphere-memory/src/client.ts
+++ b/openclaw-noosphere-memory/src/client.ts
@@ -1,0 +1,118 @@
+import { ResolvedNoosphereMemoryConfig } from "./config.js";
+
+export interface NoosphereStatusResponse {
+  ok: boolean;
+  timestamp: string;
+  providers: unknown[];
+  settings: Record<string, unknown>;
+}
+
+export interface NoosphereRecallRequest {
+  query: string;
+  mode?: "auto" | "inspection";
+  resultCap?: number;
+  tokenBudget?: number;
+  scope?: string;
+  providers?: string[];
+}
+
+export interface NoosphereRecallResponse {
+  results: unknown[];
+  totalBeforeCap: number;
+  mode: "auto" | "inspection";
+  tokenBudgetUsed?: number;
+  promptInjectionText?: string;
+  providerMeta: unknown[];
+  dedupStats?: unknown;
+  conflicts?: unknown[];
+  conflictStats?: unknown;
+}
+
+export class NoosphereClientError extends Error {
+  constructor(
+    message: string,
+    readonly status?: number,
+    readonly details?: unknown,
+  ) {
+    super(message);
+    this.name = "NoosphereClientError";
+  }
+}
+
+export class NoosphereMemoryClient {
+  constructor(private readonly config: ResolvedNoosphereMemoryConfig) {}
+
+  async status(): Promise<NoosphereStatusResponse> {
+    return this.request<NoosphereStatusResponse>("/api/memory/status", { method: "GET" });
+  }
+
+  async recall(request: NoosphereRecallRequest): Promise<NoosphereRecallResponse> {
+    return this.request<NoosphereRecallResponse>("/api/memory/recall", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(request),
+    });
+  }
+
+  private async request<T>(path: string, init: RequestInit): Promise<T> {
+    if (!this.config.apiKey) {
+      throw new NoosphereClientError("Noosphere API key is not configured");
+    }
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.config.timeoutMs);
+
+    try {
+      const response = await fetch(`${this.config.baseUrl}${path}`, {
+        ...init,
+        signal: controller.signal,
+        headers: {
+          authorization: `Bearer ${this.config.apiKey}`,
+          accept: "application/json",
+          ...init.headers,
+        },
+      });
+
+      const payload = await parseJson(response);
+      if (!response.ok) {
+        throw new NoosphereClientError(
+          extractError(payload) ?? `Noosphere request failed with HTTP ${response.status}`,
+          response.status,
+          payload,
+        );
+      }
+
+      return payload as T;
+    } catch (error) {
+      if (error instanceof NoosphereClientError) throw error;
+      if (isAbortError(error)) {
+        throw new NoosphereClientError(`Noosphere request timed out after ${this.config.timeoutMs}ms`);
+      }
+      throw new NoosphereClientError(error instanceof Error ? error.message : String(error));
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+}
+
+async function parseJson(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (!text) return null;
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    throw new NoosphereClientError("Noosphere returned invalid JSON", response.status);
+  }
+}
+
+function extractError(payload: unknown): string | undefined {
+  if (payload && typeof payload === "object" && "error" in payload) {
+    const error = (payload as { error?: unknown }).error;
+    return typeof error === "string" ? error : undefined;
+  }
+  return undefined;
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === "AbortError";
+}

--- a/openclaw-noosphere-memory/src/config.ts
+++ b/openclaw-noosphere-memory/src/config.ts
@@ -21,7 +21,7 @@ export function resolveNoosphereMemoryConfig(
   const config = isRecord(rawConfig) ? rawConfig as Partial<NoosphereMemoryConfig> : {};
   const baseUrl = normalizeBaseUrl(readString(config.baseUrl) || env.NOOSPHERE_BASE_URL || DEFAULT_NOOSPHERE_BASE_URL);
   const apiKey = readSecret(config.apiKey) || env.NOOSPHERE_API_KEY;
-  const timeoutMs = clampTimeout(config.timeoutMs, DEFAULT_NOOSPHERE_TIMEOUT_MS);
+  const timeoutMs = clampTimeout(config.timeoutMs ?? readNumber(env.NOOSPHERE_TIMEOUT_MS), DEFAULT_NOOSPHERE_TIMEOUT_MS);
 
   return { baseUrl, apiKey, timeoutMs };
 }
@@ -46,6 +46,13 @@ function readSecret(value: unknown): string | undefined {
 
 function readString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function readNumber(value: unknown): number | undefined {
+  if (typeof value === "number") return value;
+  if (typeof value !== "string" || !value.trim()) return undefined;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
 }
 
 function clampTimeout(value: unknown, fallback: number): number {

--- a/openclaw-noosphere-memory/src/config.ts
+++ b/openclaw-noosphere-memory/src/config.ts
@@ -20,7 +20,7 @@ export function resolveNoosphereMemoryConfig(
 ): ResolvedNoosphereMemoryConfig {
   const config = isRecord(rawConfig) ? rawConfig as Partial<NoosphereMemoryConfig> : {};
   const baseUrl = normalizeBaseUrl(readString(config.baseUrl) || env.NOOSPHERE_BASE_URL || DEFAULT_NOOSPHERE_BASE_URL);
-  const apiKey = readSecret(config.apiKey) || env.NOOSPHERE_API_KEY;
+  const apiKey = readSecret(config.apiKey) || readString(env.NOOSPHERE_API_KEY);
   const timeoutMs = clampTimeout(config.timeoutMs ?? readNumber(env.NOOSPHERE_TIMEOUT_MS), DEFAULT_NOOSPHERE_TIMEOUT_MS);
 
   return { baseUrl, apiKey, timeoutMs };
@@ -33,7 +33,7 @@ export function redactSecret(value: string | undefined): string | undefined {
 }
 
 function normalizeBaseUrl(value: string): string {
-  return value.trim().replace(/\/+$/, "");
+  return value.trim().replace(/\/+$/, "") || DEFAULT_NOOSPHERE_BASE_URL;
 }
 
 function readSecret(value: unknown): string | undefined {

--- a/openclaw-noosphere-memory/src/config.ts
+++ b/openclaw-noosphere-memory/src/config.ts
@@ -1,0 +1,60 @@
+export interface NoosphereMemoryConfig {
+  baseUrl?: string;
+  apiKey?: string | { value?: string };
+  timeoutMs?: number;
+}
+
+export interface ResolvedNoosphereMemoryConfig {
+  baseUrl: string;
+  apiKey?: string;
+  timeoutMs: number;
+}
+
+export const DEFAULT_NOOSPHERE_BASE_URL = "http://localhost:3000";
+export const DEFAULT_NOOSPHERE_TIMEOUT_MS = 5_000;
+export const MAX_NOOSPHERE_TIMEOUT_MS = 30_000;
+
+export function resolveNoosphereMemoryConfig(
+  rawConfig: unknown,
+  env: NodeJS.ProcessEnv = process.env,
+): ResolvedNoosphereMemoryConfig {
+  const config = isRecord(rawConfig) ? rawConfig as Partial<NoosphereMemoryConfig> : {};
+  const baseUrl = normalizeBaseUrl(readString(config.baseUrl) || env.NOOSPHERE_BASE_URL || DEFAULT_NOOSPHERE_BASE_URL);
+  const apiKey = readSecret(config.apiKey) || env.NOOSPHERE_API_KEY;
+  const timeoutMs = clampTimeout(config.timeoutMs, DEFAULT_NOOSPHERE_TIMEOUT_MS);
+
+  return { baseUrl, apiKey, timeoutMs };
+}
+
+export function redactSecret(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  if (value.length <= 8) return "[redacted]";
+  return `${value.slice(0, 4)}…${value.slice(-4)}`;
+}
+
+function normalizeBaseUrl(value: string): string {
+  return value.trim().replace(/\/+$/, "");
+}
+
+function readSecret(value: unknown): string | undefined {
+  if (typeof value === "string" && value.trim()) return value.trim();
+  if (isRecord(value) && typeof value.value === "string" && value.value.trim()) {
+    return value.value.trim();
+  }
+  return undefined;
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function clampTimeout(value: unknown, fallback: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    return fallback;
+  }
+  return Math.min(Math.floor(value), MAX_NOOSPHERE_TIMEOUT_MS);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}

--- a/openclaw-noosphere-memory/src/format.ts
+++ b/openclaw-noosphere-memory/src/format.ts
@@ -1,0 +1,43 @@
+import { NoosphereClientError } from "./client.js";
+import { redactSecret, ResolvedNoosphereMemoryConfig } from "./config.js";
+
+export interface ToolTextResult {
+  content: Array<{ type: "text"; text: string }>;
+  details?: unknown;
+  isError?: boolean;
+}
+
+export function jsonResult(payload: unknown): ToolTextResult {
+  return {
+    content: [{ type: "text", text: JSON.stringify(payload, null, 2) }],
+    details: payload,
+  };
+}
+
+export function errorResult(error: unknown, config?: ResolvedNoosphereMemoryConfig): ToolTextResult {
+  const payload = formatError(error, config);
+  return {
+    content: [{ type: "text", text: JSON.stringify(payload, null, 2) }],
+    details: payload,
+    isError: true,
+  };
+}
+
+export function formatError(error: unknown, config?: ResolvedNoosphereMemoryConfig): Record<string, unknown> {
+  if (error instanceof NoosphereClientError) {
+    return {
+      ok: false,
+      error: error.message,
+      status: error.status,
+      baseUrl: config?.baseUrl,
+      apiKey: redactSecret(config?.apiKey),
+    };
+  }
+
+  return {
+    ok: false,
+    error: error instanceof Error ? error.message : String(error),
+    baseUrl: config?.baseUrl,
+    apiKey: redactSecret(config?.apiKey),
+  };
+}

--- a/openclaw-noosphere-memory/src/index.ts
+++ b/openclaw-noosphere-memory/src/index.ts
@@ -1,0 +1,13 @@
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+import { createNoosphereRecallTool } from "./tools/recall.js";
+import { createNoosphereStatusTool } from "./tools/status.js";
+
+export default definePluginEntry({
+  id: "noosphere-memory",
+  name: "Noosphere Memory Bridge",
+  description: "Explicit OpenClaw tools for Noosphere memory status and recall over HTTP.",
+  register(api) {
+    api.registerTool(createNoosphereStatusTool(api.pluginConfig));
+    api.registerTool(createNoosphereRecallTool(api.pluginConfig));
+  },
+});

--- a/openclaw-noosphere-memory/src/sdk-shims.d.ts
+++ b/openclaw-noosphere-memory/src/sdk-shims.d.ts
@@ -1,0 +1,13 @@
+declare module "openclaw/plugin-sdk/plugin-entry" {
+  export interface OpenClawPluginApi {
+    pluginConfig?: unknown;
+    registerTool(tool: unknown, options?: unknown): void;
+  }
+
+  export function definePluginEntry(entry: {
+    id: string;
+    name: string;
+    description: string;
+    register(api: OpenClawPluginApi): void;
+  }): unknown;
+}

--- a/openclaw-noosphere-memory/src/shared-init.ts
+++ b/openclaw-noosphere-memory/src/shared-init.ts
@@ -1,10 +1,15 @@
 import { NoosphereMemoryClient } from "./client.js";
-import { resolveNoosphereMemoryConfig } from "./config.js";
+import {
+  resolveNoosphereMemoryConfig,
+  type ResolvedNoosphereMemoryConfig,
+} from "./config.js";
 
-export interface NoospherePluginRuntimeLike {
-  pluginConfig?: unknown;
+export interface NoosphereClientContext {
+  config: ResolvedNoosphereMemoryConfig;
+  client: NoosphereMemoryClient;
 }
 
-export function createNoosphereClient(api: NoospherePluginRuntimeLike): NoosphereMemoryClient {
-  return new NoosphereMemoryClient(resolveNoosphereMemoryConfig(api.pluginConfig));
+export function createNoosphereClientContext(rawConfig: unknown): NoosphereClientContext {
+  const config = resolveNoosphereMemoryConfig(rawConfig);
+  return { config, client: new NoosphereMemoryClient(config) };
 }

--- a/openclaw-noosphere-memory/src/shared-init.ts
+++ b/openclaw-noosphere-memory/src/shared-init.ts
@@ -1,0 +1,10 @@
+import { NoosphereMemoryClient } from "./client.js";
+import { resolveNoosphereMemoryConfig } from "./config.js";
+
+export interface NoospherePluginRuntimeLike {
+  pluginConfig?: unknown;
+}
+
+export function createNoosphereClient(api: NoospherePluginRuntimeLike): NoosphereMemoryClient {
+  return new NoosphereMemoryClient(resolveNoosphereMemoryConfig(api.pluginConfig));
+}

--- a/openclaw-noosphere-memory/src/tools/recall.ts
+++ b/openclaw-noosphere-memory/src/tools/recall.ts
@@ -2,6 +2,11 @@ import { NoosphereMemoryClient, NoosphereRecallRequest } from "../client.js";
 import { resolveNoosphereMemoryConfig } from "../config.js";
 import { errorResult, jsonResult } from "../format.js";
 
+const RESULT_CAP_MIN = 1;
+const RESULT_CAP_MAX = 10;
+const TOKEN_BUDGET_MIN = 1;
+const TOKEN_BUDGET_MAX = 2000;
+
 const RecallToolParameters = {
   type: "object",
   additionalProperties: false,
@@ -9,8 +14,8 @@ const RecallToolParameters = {
   properties: {
     query: { type: "string", description: "Recall query string." },
     mode: { type: "string", enum: ["auto", "inspection"] },
-    resultCap: { type: "number", minimum: 1, maximum: 10, description: "Maximum ranked results to return." },
-    tokenBudget: { type: "number", minimum: 1, maximum: 2000, description: "Maximum prompt-injection token budget for auto mode." },
+    resultCap: { type: "number", minimum: RESULT_CAP_MIN, maximum: RESULT_CAP_MAX, description: "Maximum ranked results to return." },
+    tokenBudget: { type: "number", minimum: TOKEN_BUDGET_MIN, maximum: TOKEN_BUDGET_MAX, description: "Maximum prompt-injection token budget for auto mode." },
     scope: { type: "string", description: "Optional Noosphere scope hint." },
     providers: {
       type: "array",
@@ -21,14 +26,15 @@ const RecallToolParameters = {
 } as const;
 
 export function createNoosphereRecallTool(rawConfig: unknown) {
+  const config = resolveNoosphereMemoryConfig(rawConfig);
+  const client = new NoosphereMemoryClient(config);
+
   return {
     name: "noosphere_recall",
     label: "Noosphere Recall",
     description: "Recall durable memories from Noosphere over HTTP. Use inspection mode for manual lookup and auto mode to request bounded prompt text.",
     parameters: RecallToolParameters,
     async execute(_toolCallId: string, rawParams: Record<string, unknown>) {
-      const config = resolveNoosphereMemoryConfig(rawConfig);
-      const client = new NoosphereMemoryClient(config);
       try {
         const params = normalizeRecallParams(rawParams);
         return jsonResult(await client.recall(params));
@@ -43,8 +49,8 @@ function normalizeRecallParams(rawParams: Record<string, unknown>): NoosphereRec
   return {
     query: readRequiredString(rawParams.query, "query"),
     mode: rawParams.mode === "auto" ? "auto" : rawParams.mode === "inspection" ? "inspection" : undefined,
-    resultCap: readOptionalNumber(rawParams.resultCap),
-    tokenBudget: readOptionalNumber(rawParams.tokenBudget),
+    resultCap: readOptionalNumber(rawParams.resultCap, RESULT_CAP_MIN, RESULT_CAP_MAX),
+    tokenBudget: readOptionalNumber(rawParams.tokenBudget, TOKEN_BUDGET_MIN, TOKEN_BUDGET_MAX),
     scope: readOptionalString(rawParams.scope),
     providers: readOptionalStringArray(rawParams.providers),
   };
@@ -59,8 +65,9 @@ function readOptionalString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
 }
 
-function readOptionalNumber(value: unknown): number | undefined {
-  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+function readOptionalNumber(value: unknown, min: number, max: number): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
+  return Math.min(max, Math.max(min, value));
 }
 
 function readOptionalStringArray(value: unknown): string[] | undefined {

--- a/openclaw-noosphere-memory/src/tools/recall.ts
+++ b/openclaw-noosphere-memory/src/tools/recall.ts
@@ -1,0 +1,70 @@
+import { NoosphereMemoryClient, NoosphereRecallRequest } from "../client.js";
+import { resolveNoosphereMemoryConfig } from "../config.js";
+import { errorResult, jsonResult } from "../format.js";
+
+const RecallToolParameters = {
+  type: "object",
+  additionalProperties: false,
+  required: ["query"],
+  properties: {
+    query: { type: "string", description: "Recall query string." },
+    mode: { type: "string", enum: ["auto", "inspection"] },
+    resultCap: { type: "number", minimum: 1, maximum: 10, description: "Maximum ranked results to return." },
+    tokenBudget: { type: "number", minimum: 1, maximum: 2000, description: "Maximum prompt-injection token budget for auto mode." },
+    scope: { type: "string", description: "Optional Noosphere scope hint." },
+    providers: {
+      type: "array",
+      items: { type: "string" },
+      description: "Optional provider IDs, for example [\"noosphere\"].",
+    },
+  },
+} as const;
+
+export function createNoosphereRecallTool(rawConfig: unknown) {
+  return {
+    name: "noosphere_recall",
+    label: "Noosphere Recall",
+    description: "Recall durable memories from Noosphere over HTTP. Use inspection mode for manual lookup and auto mode to request bounded prompt text.",
+    parameters: RecallToolParameters,
+    async execute(_toolCallId: string, rawParams: Record<string, unknown>) {
+      const config = resolveNoosphereMemoryConfig(rawConfig);
+      const client = new NoosphereMemoryClient(config);
+      try {
+        const params = normalizeRecallParams(rawParams);
+        return jsonResult(await client.recall(params));
+      } catch (error) {
+        return errorResult(error, config);
+      }
+    },
+  };
+}
+
+function normalizeRecallParams(rawParams: Record<string, unknown>): NoosphereRecallRequest {
+  return {
+    query: readRequiredString(rawParams.query, "query"),
+    mode: rawParams.mode === "auto" ? "auto" : rawParams.mode === "inspection" ? "inspection" : undefined,
+    resultCap: readOptionalNumber(rawParams.resultCap),
+    tokenBudget: readOptionalNumber(rawParams.tokenBudget),
+    scope: readOptionalString(rawParams.scope),
+    providers: readOptionalStringArray(rawParams.providers),
+  };
+}
+
+function readRequiredString(value: unknown, field: string): string {
+  if (typeof value === "string" && value.trim()) return value.trim();
+  throw new Error(`${field} is required`);
+}
+
+function readOptionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function readOptionalNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function readOptionalStringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const values = value.filter((item): item is string => typeof item === "string" && !!item.trim()).map((item) => item.trim());
+  return values.length > 0 ? values : undefined;
+}

--- a/openclaw-noosphere-memory/src/tools/recall.ts
+++ b/openclaw-noosphere-memory/src/tools/recall.ts
@@ -1,7 +1,8 @@
-import { NoosphereMemoryClient, NoosphereRecallRequest } from "../client.js";
-import { resolveNoosphereMemoryConfig } from "../config.js";
+import { NoosphereRecallRequest } from "../client.js";
 import { errorResult, jsonResult } from "../format.js";
+import { createNoosphereClientContext } from "../shared-init.js";
 
+const QUERY_MAX_LENGTH = 1000;
 const RESULT_CAP_MIN = 1;
 const RESULT_CAP_MAX = 10;
 const TOKEN_BUDGET_MIN = 1;
@@ -26,15 +27,14 @@ const RecallToolParameters = {
 } as const;
 
 export function createNoosphereRecallTool(rawConfig: unknown) {
-  const config = resolveNoosphereMemoryConfig(rawConfig);
-  const client = new NoosphereMemoryClient(config);
+  const { config, client } = createNoosphereClientContext(rawConfig);
 
   return {
     name: "noosphere_recall",
     label: "Noosphere Recall",
     description: "Recall durable memories from Noosphere over HTTP. Use inspection mode for manual lookup and auto mode to request bounded prompt text.",
     parameters: RecallToolParameters,
-    async execute(_toolCallId: string, rawParams: Record<string, unknown>) {
+    async execute(_toolCallId: string, rawParams: unknown) {
       try {
         const params = normalizeRecallParams(rawParams);
         return jsonResult(await client.recall(params));
@@ -45,20 +45,34 @@ export function createNoosphereRecallTool(rawConfig: unknown) {
   };
 }
 
-function normalizeRecallParams(rawParams: Record<string, unknown>): NoosphereRecallRequest {
+function normalizeRecallParams(rawParams: unknown): NoosphereRecallRequest {
+  const params = isRecord(rawParams) ? rawParams : {};
+
   return {
-    query: readRequiredString(rawParams.query, "query"),
-    mode: rawParams.mode === "auto" ? "auto" : rawParams.mode === "inspection" ? "inspection" : undefined,
-    resultCap: readOptionalNumber(rawParams.resultCap, RESULT_CAP_MIN, RESULT_CAP_MAX),
-    tokenBudget: readOptionalNumber(rawParams.tokenBudget, TOKEN_BUDGET_MIN, TOKEN_BUDGET_MAX),
-    scope: readOptionalString(rawParams.scope),
-    providers: readOptionalStringArray(rawParams.providers),
+    query: readRequiredString(params.query, "query", QUERY_MAX_LENGTH),
+    mode: readOptionalMode(params.mode) ?? "inspection",
+    resultCap: readOptionalNumber(params.resultCap, RESULT_CAP_MIN, RESULT_CAP_MAX),
+    tokenBudget: readOptionalNumber(params.tokenBudget, TOKEN_BUDGET_MIN, TOKEN_BUDGET_MAX),
+    scope: readOptionalString(params.scope),
+    providers: readOptionalStringArray(params.providers),
   };
 }
 
-function readRequiredString(value: unknown, field: string): string {
-  if (typeof value === "string" && value.trim()) return value.trim();
+function readRequiredString(value: unknown, field: string, maxLength?: number): string {
+  if (typeof value === "string" && value.trim()) {
+    const trimmed = value.trim();
+    if (maxLength !== undefined && trimmed.length > maxLength) {
+      throw new Error(`${field} is too long (max ${maxLength} characters)`);
+    }
+    return trimmed;
+  }
   throw new Error(`${field} is required`);
+}
+
+function readOptionalMode(value: unknown): NoosphereRecallRequest["mode"] {
+  if (value === undefined) return undefined;
+  if (value === "auto" || value === "inspection") return value;
+  throw new Error("mode must be auto or inspection");
 }
 
 function readOptionalString(value: unknown): string | undefined {
@@ -71,7 +85,16 @@ function readOptionalNumber(value: unknown, min: number, max: number): number | 
 }
 
 function readOptionalStringArray(value: unknown): string[] | undefined {
-  if (!Array.isArray(value)) return undefined;
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value)) throw new Error("providers must be an array of provider ID strings");
+  if (value.some((item) => typeof item !== "string")) {
+    throw new Error("providers must be an array of provider ID strings");
+  }
   const values = value.filter((item): item is string => typeof item === "string" && !!item.trim()).map((item) => item.trim());
-  return values.length > 0 ? values : undefined;
+  if (values.length === 0) throw new Error("providers must contain at least one non-empty provider ID");
+  return values;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
 }

--- a/openclaw-noosphere-memory/src/tools/status.ts
+++ b/openclaw-noosphere-memory/src/tools/status.ts
@@ -1,15 +1,13 @@
-import { NoosphereMemoryClient } from "../client.js";
-import { resolveNoosphereMemoryConfig } from "../config.js";
 import { errorResult, jsonResult } from "../format.js";
+import { createNoosphereClientContext } from "../shared-init.js";
 
 export function createNoosphereStatusTool(rawConfig: unknown) {
-  const config = resolveNoosphereMemoryConfig(rawConfig);
-  const client = new NoosphereMemoryClient(config);
+  const { config, client } = createNoosphereClientContext(rawConfig);
 
   return {
     name: "noosphere_status",
     label: "Noosphere Status",
-    description: "Check Noosphere memory API health, provider metadata, and public recall settings.",
+    description: "Check Noosphere memory API health, provider metadata, and public recall settings. Requires an ADMIN-scoped Noosphere API key.",
     parameters: {
       type: "object",
       additionalProperties: false,

--- a/openclaw-noosphere-memory/src/tools/status.ts
+++ b/openclaw-noosphere-memory/src/tools/status.ts
@@ -3,6 +3,9 @@ import { resolveNoosphereMemoryConfig } from "../config.js";
 import { errorResult, jsonResult } from "../format.js";
 
 export function createNoosphereStatusTool(rawConfig: unknown) {
+  const config = resolveNoosphereMemoryConfig(rawConfig);
+  const client = new NoosphereMemoryClient(config);
+
   return {
     name: "noosphere_status",
     label: "Noosphere Status",
@@ -13,8 +16,6 @@ export function createNoosphereStatusTool(rawConfig: unknown) {
       properties: {},
     },
     async execute() {
-      const config = resolveNoosphereMemoryConfig(rawConfig);
-      const client = new NoosphereMemoryClient(config);
       try {
         return jsonResult(await client.status());
       } catch (error) {

--- a/openclaw-noosphere-memory/src/tools/status.ts
+++ b/openclaw-noosphere-memory/src/tools/status.ts
@@ -1,0 +1,25 @@
+import { NoosphereMemoryClient } from "../client.js";
+import { resolveNoosphereMemoryConfig } from "../config.js";
+import { errorResult, jsonResult } from "../format.js";
+
+export function createNoosphereStatusTool(rawConfig: unknown) {
+  return {
+    name: "noosphere_status",
+    label: "Noosphere Status",
+    description: "Check Noosphere memory API health, provider metadata, and public recall settings.",
+    parameters: {
+      type: "object",
+      additionalProperties: false,
+      properties: {},
+    },
+    async execute() {
+      const config = resolveNoosphereMemoryConfig(rawConfig);
+      const client = new NoosphereMemoryClient(config);
+      try {
+        return jsonResult(await client.status());
+      } catch (error) {
+        return errorResult(error, config);
+      }
+    },
+  };
+}

--- a/openclaw-noosphere-memory/tsconfig.json
+++ b/openclaw-noosphere-memory/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/openclaw-noosphere-memory/tsconfig.json
+++ b/openclaw-noosphere-memory/tsconfig.json
@@ -9,5 +9,5 @@
     "forceConsistentCasingInFileNames": true,
     "noEmit": true
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts", "src/**/*.d.ts"]
 }


### PR DESCRIPTION
## Summary
- Add an OpenClaw native plugin scaffold under openclaw-noosphere-memory
- Register explicit noosphere_status and noosphere_recall tools over HTTP
- Add config resolution, secret redaction, strict timeout handling, and fail-clear tool errors
- Update the bridge roadmap to mark PRs 0-2 merged and PR 3 in progress

## Verification
- npx tsc -p openclaw-noosphere-memory/tsconfig.json --noEmit --pretty false
- npm run test:memory
- npx tsc --noEmit --pretty false
- git diff --check
- npm run lint -- openclaw-noosphere-memory/src --max-warnings=0

## Notes
- This PR intentionally does not add auto-recall hooks yet; that remains PR 4.
- noosphere_get remains deferred until the lookup endpoint exists.

## Summary by Sourcery

Introduce a new OpenClaw plugin package that bridges to the Noosphere memory HTTP APIs and registers explicit status and recall tools.

New Features:
- Add a Noosphere memory client wrapper with typed status and recall operations over HTTP.
- Expose explicit noosphere_status and noosphere_recall tools via an OpenClaw plugin entrypoint using configurable runtime settings.

Enhancements:
- Implement configuration resolution with sane defaults, environment variable support, secret redaction, and bounded request timeouts for Noosphere memory calls.
- Standardize tool success/error formatting with JSON text payloads and structured error metadata for safe, clear failure handling.
- Update the OpenClaw–Noosphere bridge roadmap document to reflect merged and in-progress PR milestones.