### PR TITLE
feat(memory): add get API and OpenClaw tool

### DIFF
--- a/docs/OPENCLAW-NOOSPHERE-BRIDGE-ROADMAP.md
+++ b/docs/OPENCLAW-NOOSPHERE-BRIDGE-ROADMAP.md
@@ -2,7 +2,7 @@
 
 Status: implementation in progress — PRs 0–4 merged; PR 5 underway
 Owner: Noosphere/OpenClaw integration workstream
-Last updated: 2026-04-29
+Last updated: 2026-04-30
 
 ## Goal
 
@@ -269,7 +269,7 @@ Verification:
 
 ### PR 4 — Auto-recall prompt injection
 
-Status: in progress.
+Status: merged in PR #43.
 
 Purpose: add optional bounded Noosphere recall injection to OpenClaw.
 

--- a/docs/OPENCLAW-NOOSPHERE-BRIDGE-ROADMAP.md
+++ b/docs/OPENCLAW-NOOSPHERE-BRIDGE-ROADMAP.md
@@ -1,6 +1,6 @@
 # OpenClaw ↔ Noosphere Memory Bridge Roadmap
 
-Status: implementation in progress — PRs 0–3 merged; PR 4 underway
+Status: implementation in progress — PRs 0–4 merged; PR 5 underway
 Owner: Noosphere/OpenClaw integration workstream
 Last updated: 2026-04-29
 
@@ -308,18 +308,39 @@ Verification:
 
 ### PR 5 — Lookup endpoint/tool
 
-Purpose: support direct retrieval by Noosphere article/memory identifier.
+Purpose: support direct retrieval by provider-local memory identifier or canonical reference.
 
-Possible endpoint:
-
-```http
-GET /api/memory/get?provider=noosphere&id=<id>
-```
-
-or:
+Endpoint:
 
 ```http
 POST /api/memory/get
+Authorization: Bearer <key with READ or higher>
+Content-Type: application/json
+```
+
+Request shape:
+
+```ts
+interface MemoryGetRequest {
+  provider?: string;
+  id?: string;
+  canonicalRef?: string; // e.g. "noosphere:article:<id>"
+}
+```
+
+Response shape:
+
+```ts
+interface MemoryGetResponse {
+  result: MemoryResult | null;
+  providerMeta: Array<{
+    providerId: string;
+    enabled: boolean;
+    found: boolean;
+    error?: string;
+    durationMs?: number;
+  }>;
+}
 ```
 
 Constraints:
@@ -327,7 +348,8 @@ Constraints:
 - support canonical refs like `noosphere:article:<id>`;
 - return the normalized memory result shape used by `MemoryProvider.getById()`;
 - preserve provider-agnostic shape for future providers;
-- define the concrete response interface in the lookup PR, reusing the shared memory provider/result fields instead of adding a Noosphere-only shape.
+- route-level provider selection mirrors recall API provider filtering;
+- provider lookup failures fail open into `providerMeta.error` rather than 500ing the route.
 
 ### PR 6 — Save/candidate API and tool
 

--- a/openclaw-noosphere-memory/openclaw.plugin.json
+++ b/openclaw-noosphere-memory/openclaw.plugin.json
@@ -5,7 +5,8 @@
   "contracts": {
     "tools": [
       "noosphere_status",
-      "noosphere_recall"
+      "noosphere_recall",
+      "noosphere_get"
     ],
     "hooks": [
       "before_prompt_build"

--- a/openclaw-noosphere-memory/src/client.ts
+++ b/openclaw-noosphere-memory/src/client.ts
@@ -1,4 +1,5 @@
 import { ResolvedNoosphereMemoryConfig } from "./config.js";
+import { NoosphereMemoryGetProviderMeta, NoosphereMemoryResult } from "./types.js";
 
 export interface NoosphereStatusResponse {
   ok: boolean;
@@ -23,8 +24,8 @@ export interface NoosphereGetRequest {
 }
 
 export interface NoosphereGetResponse {
-  result: unknown | null;
-  providerMeta: unknown[];
+  result: NoosphereMemoryResult | null;
+  providerMeta: NoosphereMemoryGetProviderMeta[];
 }
 
 export interface NoosphereRecallResponse {

--- a/openclaw-noosphere-memory/src/client.ts
+++ b/openclaw-noosphere-memory/src/client.ts
@@ -16,6 +16,17 @@ export interface NoosphereRecallRequest {
   providers?: string[];
 }
 
+export interface NoosphereGetRequest {
+  provider?: string;
+  id?: string;
+  canonicalRef?: string;
+}
+
+export interface NoosphereGetResponse {
+  result: unknown | null;
+  providerMeta: unknown[];
+}
+
 export interface NoosphereRecallResponse {
   results: unknown[];
   totalBeforeCap: number;
@@ -44,6 +55,14 @@ export class NoosphereMemoryClient {
 
   async status(): Promise<NoosphereStatusResponse> {
     return this.request<NoosphereStatusResponse>("/api/memory/status", { method: "GET" });
+  }
+
+  async get(request: NoosphereGetRequest): Promise<NoosphereGetResponse> {
+    return this.request<NoosphereGetResponse>("/api/memory/get", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(request),
+    });
   }
 
   async recall(request: NoosphereRecallRequest, options: { timeoutMs?: number } = {}): Promise<NoosphereRecallResponse> {

--- a/openclaw-noosphere-memory/src/client.ts
+++ b/openclaw-noosphere-memory/src/client.ts
@@ -1,5 +1,8 @@
 import { ResolvedNoosphereMemoryConfig } from "./config.js";
-import { NoosphereMemoryGetProviderMeta, NoosphereMemoryResult } from "./types.js";
+import {
+  NoosphereMemoryGetProviderMeta,
+  NoosphereMemoryResult,
+} from "./types.js";
 
 export interface NoosphereStatusResponse {
   ok: boolean;
@@ -17,11 +20,9 @@ export interface NoosphereRecallRequest {
   providers?: string[];
 }
 
-export interface NoosphereGetRequest {
-  provider?: string;
-  id?: string;
-  canonicalRef?: string;
-}
+export type NoosphereGetRequest =
+  | { canonicalRef: string; provider?: never; id?: never }
+  | { provider: string; id: string; canonicalRef?: never };
 
 export interface NoosphereGetResponse {
   result: NoosphereMemoryResult | null;
@@ -55,7 +56,9 @@ export class NoosphereMemoryClient {
   constructor(private readonly config: ResolvedNoosphereMemoryConfig) {}
 
   async status(): Promise<NoosphereStatusResponse> {
-    return this.request<NoosphereStatusResponse>("/api/memory/status", { method: "GET" });
+    return this.request<NoosphereStatusResponse>("/api/memory/status", {
+      method: "GET",
+    });
   }
 
   async get(request: NoosphereGetRequest): Promise<NoosphereGetResponse> {
@@ -66,7 +69,10 @@ export class NoosphereMemoryClient {
     });
   }
 
-  async recall(request: NoosphereRecallRequest, options: { timeoutMs?: number } = {}): Promise<NoosphereRecallResponse> {
+  async recall(
+    request: NoosphereRecallRequest,
+    options: { timeoutMs?: number } = {},
+  ): Promise<NoosphereRecallResponse> {
     return this.request<NoosphereRecallResponse>(
       "/api/memory/recall",
       {
@@ -78,7 +84,11 @@ export class NoosphereMemoryClient {
     );
   }
 
-  private async request<T>(path: string, init: RequestInit, options: { timeoutMs?: number } = {}): Promise<T> {
+  private async request<T>(
+    path: string,
+    init: RequestInit,
+    options: { timeoutMs?: number } = {},
+  ): Promise<T> {
     if (!this.config.apiKey) {
       throw new NoosphereClientError("Noosphere API key is not configured");
     }
@@ -101,23 +111,31 @@ export class NoosphereMemoryClient {
       const payload = await parseResponseBody(response);
       if (!response.ok) {
         throw new NoosphereClientError(
-          extractError(payload) ?? `Noosphere request failed with HTTP ${response.status}`,
+          extractError(payload) ??
+            `Noosphere request failed with HTTP ${response.status}`,
           response.status,
           payload,
         );
       }
 
       if (payload === null) {
-        throw new NoosphereClientError("Noosphere returned an empty response body", response.status);
+        throw new NoosphereClientError(
+          "Noosphere returned an empty response body",
+          response.status,
+        );
       }
 
       return payload as T;
     } catch (error) {
       if (error instanceof NoosphereClientError) throw error;
       if (isAbortError(error)) {
-        throw new NoosphereClientError(`Noosphere request timed out after ${requestTimeoutMs}ms`);
+        throw new NoosphereClientError(
+          `Noosphere request timed out after ${requestTimeoutMs}ms`,
+        );
       }
-      throw new NoosphereClientError(error instanceof Error ? error.message : String(error));
+      throw new NoosphereClientError(
+        error instanceof Error ? error.message : String(error),
+      );
     } finally {
       clearTimeout(timeout);
     }
@@ -131,14 +149,21 @@ async function parseResponseBody(response: Response): Promise<unknown> {
   const contentType = response.headers.get("content-type") ?? "";
   if (!contentType.toLowerCase().includes("application/json")) {
     if (!response.ok) return { rawBody: text };
-    throw new NoosphereClientError("Noosphere returned a non-JSON response", response.status, { rawBody: text });
+    throw new NoosphereClientError(
+      "Noosphere returned a non-JSON response",
+      response.status,
+      { rawBody: text },
+    );
   }
 
   try {
     return JSON.parse(text) as unknown;
   } catch {
     if (!response.ok) return { rawBody: text };
-    throw new NoosphereClientError("Noosphere returned invalid JSON", response.status);
+    throw new NoosphereClientError(
+      "Noosphere returned invalid JSON",
+      response.status,
+    );
   }
 }
 

--- a/openclaw-noosphere-memory/src/index.ts
+++ b/openclaw-noosphere-memory/src/index.ts
@@ -1,6 +1,7 @@
 import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
 import { createNoosphereAutoRecallHook } from "./auto-recall.js";
 import { createNoosphereClientContext } from "./shared-init.js";
+import { createNoosphereGetTool } from "./tools/get.js";
 import { createNoosphereRecallTool } from "./tools/recall.js";
 import { createNoosphereStatusTool } from "./tools/status.js";
 
@@ -12,6 +13,7 @@ export default definePluginEntry({
     const clientContext = createNoosphereClientContext(api.pluginConfig);
     api.registerTool(createNoosphereStatusTool(api.pluginConfig, clientContext));
     api.registerTool(createNoosphereRecallTool(api.pluginConfig, clientContext));
+    api.registerTool(createNoosphereGetTool(api.pluginConfig, clientContext));
     const hook = createNoosphereAutoRecallHook(api.pluginConfig, clientContext, api.logger);
     if (typeof api.on === "function") {
       api.on("before_prompt_build", hook);

--- a/openclaw-noosphere-memory/src/tools/get.ts
+++ b/openclaw-noosphere-memory/src/tools/get.ts
@@ -1,0 +1,61 @@
+import { NoosphereGetRequest } from "../client.js";
+import { errorResult, jsonResult } from "../format.js";
+import { createNoosphereClientContext, NoosphereClientContext } from "../shared-init.js";
+
+const ID_MAX_LENGTH = 512;
+
+const GetToolParameters = {
+  type: "object",
+  additionalProperties: false,
+  properties: {
+    provider: { type: "string", description: "Provider ID, for example noosphere." },
+    id: { type: "string", description: "Provider-local ID, or a canonical ref accepted by that provider." },
+    canonicalRef: { type: "string", description: "Canonical memory reference, for example noosphere:article:<id>." },
+  },
+} as const;
+
+export function createNoosphereGetTool(rawConfig: unknown, context?: NoosphereClientContext) {
+  const { config, client } = context ?? createNoosphereClientContext(rawConfig);
+
+  return {
+    name: "noosphere_get",
+    label: "Noosphere Get",
+    description: "Fetch one normalized memory result by provider/id or canonical reference.",
+    parameters: GetToolParameters,
+    async execute(_toolCallId: string, rawParams: unknown) {
+      try {
+        const params = normalizeGetParams(rawParams);
+        return jsonResult(await client.get(params));
+      } catch (error) {
+        return errorResult(error, config);
+      }
+    },
+  };
+}
+
+function normalizeGetParams(rawParams: unknown): NoosphereGetRequest {
+  const params = isRecord(rawParams) ? rawParams : {};
+  const canonicalRef = readOptionalString(params.canonicalRef, "canonicalRef");
+  const provider = readOptionalString(params.provider, "provider");
+  const id = readOptionalString(params.id, "id");
+
+  if (canonicalRef && (provider || id)) {
+    throw new Error("Use either canonicalRef or provider + id, not both");
+  }
+  if (canonicalRef) return { canonicalRef };
+  if (!provider) throw new Error("provider is required");
+  if (!id) throw new Error("id is required");
+  return { provider, id };
+}
+
+function readOptionalString(value: unknown, field: string): string | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== "string" || !value.trim()) throw new Error(`${field} must be a non-empty string`);
+  const trimmed = value.trim();
+  if (trimmed.length > ID_MAX_LENGTH) throw new Error(`${field} is too long (max ${ID_MAX_LENGTH} characters)`);
+  return trimmed;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}

--- a/openclaw-noosphere-memory/src/tools/get.ts
+++ b/openclaw-noosphere-memory/src/tools/get.ts
@@ -2,8 +2,6 @@ import { NoosphereGetRequest } from "../client.js";
 import { errorResult, jsonResult } from "../format.js";
 import { createNoosphereClientContext, NoosphereClientContext } from "../shared-init.js";
 
-const ID_MAX_LENGTH = 512;
-
 const GetToolParameters = {
   type: "object",
   additionalProperties: false,
@@ -51,9 +49,7 @@ function normalizeGetParams(rawParams: unknown): NoosphereGetRequest {
 function readOptionalString(value: unknown, field: string): string | undefined {
   if (value === undefined) return undefined;
   if (typeof value !== "string" || !value.trim()) throw new Error(`${field} must be a non-empty string`);
-  const trimmed = value.trim();
-  if (trimmed.length > ID_MAX_LENGTH) throw new Error(`${field} is too long (max ${ID_MAX_LENGTH} characters)`);
-  return trimmed;
+  return value.trim();
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/openclaw-noosphere-memory/src/tools/get.ts
+++ b/openclaw-noosphere-memory/src/tools/get.ts
@@ -1,24 +1,48 @@
 import { NoosphereGetRequest } from "../client.js";
 import { errorResult, jsonResult } from "../format.js";
-import { createNoosphereClientContext, NoosphereClientContext } from "../shared-init.js";
+import {
+  createNoosphereClientContext,
+  NoosphereClientContext,
+} from "../shared-init.js";
 
 const GetToolParameters = {
   type: "object",
   additionalProperties: false,
   properties: {
-    provider: { type: "string", description: "Provider ID, for example noosphere." },
-    id: { type: "string", description: "Provider-local ID, or a canonical ref accepted by that provider." },
-    canonicalRef: { type: "string", description: "Canonical memory reference, for example noosphere:article:<id>." },
+    provider: {
+      type: "string",
+      description: "Provider ID, for example noosphere.",
+    },
+    id: { type: "string", description: "Provider-local ID." },
+    canonicalRef: {
+      type: "string",
+      description:
+        "Canonical memory reference, for example noosphere:article:<id>.",
+    },
   },
+  oneOf: [
+    {
+      required: ["canonicalRef"],
+      not: { anyOf: [{ required: ["provider"] }, { required: ["id"] }] },
+    },
+    {
+      required: ["provider", "id"],
+      not: { required: ["canonicalRef"] },
+    },
+  ],
 } as const;
 
-export function createNoosphereGetTool(rawConfig: unknown, context?: NoosphereClientContext) {
+export function createNoosphereGetTool(
+  rawConfig: unknown,
+  context?: NoosphereClientContext,
+) {
   const { config, client } = context ?? createNoosphereClientContext(rawConfig);
 
   return {
     name: "noosphere_get",
     label: "Noosphere Get",
-    description: "Fetch one normalized memory result by provider/id or canonical reference.",
+    description:
+      "Fetch one normalized memory result. Provide either canonicalRef, or provider + id; do not mix both forms.",
     parameters: GetToolParameters,
     async execute(_toolCallId: string, rawParams: unknown) {
       try {
@@ -48,7 +72,8 @@ function normalizeGetParams(rawParams: unknown): NoosphereGetRequest {
 
 function readOptionalString(value: unknown, field: string): string | undefined {
   if (value === undefined) return undefined;
-  if (typeof value !== "string" || !value.trim()) throw new Error(`${field} must be a non-empty string`);
+  if (typeof value !== "string" || !value.trim())
+    throw new Error(`${field} must be a non-empty string`);
   return value.trim();
 }
 

--- a/openclaw-noosphere-memory/src/types.ts
+++ b/openclaw-noosphere-memory/src/types.ts
@@ -1,0 +1,26 @@
+export interface NoosphereMemoryResult {
+  id: string;
+  provider: string;
+  sourceType: string;
+  title?: string;
+  content: string;
+  summary?: string;
+  relevanceScore?: number;
+  confidenceScore?: number;
+  recencyScore?: number;
+  curationLevel?: "ephemeral" | "managed" | "curated";
+  createdAt?: string;
+  updatedAt?: string;
+  tokenEstimate?: number;
+  canonicalRef?: string;
+  tags?: string[];
+  metadata?: Record<string, unknown>;
+}
+
+export interface NoosphereMemoryGetProviderMeta {
+  providerId: string;
+  enabled: boolean;
+  found: boolean;
+  error?: string;
+  durationMs?: number;
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "prisma generate && next build",
     "start": "next start",
     "test": "npm run test:memory",
-    "test:memory": "node --import tsx --test src/__tests__/memory/api-recall.test.ts src/__tests__/memory/api-status.test.ts src/__tests__/memory/budget.test.ts src/__tests__/memory/conflict.test.ts src/__tests__/memory/dedup.test.ts src/__tests__/memory/hindsight-provider.test.ts src/__tests__/memory/openclaw-plugin-auto-recall.test.ts src/__tests__/memory/promotion.test.ts src/__tests__/memory/backfill.test.ts src/__tests__/memory/recall-orchestrator.test.ts src/__tests__/memory/settings.test.ts src/__tests__/memory/scheduler.test.ts",
+    "test:memory": "node --import tsx --test src/__tests__/memory/api-recall.test.ts src/__tests__/memory/api-get.test.ts src/__tests__/memory/api-status.test.ts src/__tests__/memory/budget.test.ts src/__tests__/memory/conflict.test.ts src/__tests__/memory/dedup.test.ts src/__tests__/memory/hindsight-provider.test.ts src/__tests__/memory/openclaw-plugin-auto-recall.test.ts src/__tests__/memory/promotion.test.ts src/__tests__/memory/backfill.test.ts src/__tests__/memory/recall-orchestrator.test.ts src/__tests__/memory/settings.test.ts src/__tests__/memory/scheduler.test.ts",
     "test:scheduler": "node --import tsx --test src/__tests__/memory/scheduler.test.ts",
     "lint": "eslint",
     "db:migrate": "prisma migrate dev",

--- a/src/__tests__/memory/api-get.test.ts
+++ b/src/__tests__/memory/api-get.test.ts
@@ -8,7 +8,9 @@ import {
 import type { MemoryProvider } from "@/lib/memory/provider";
 import type { MemoryResult } from "@/lib/memory/types";
 
-function mockResult(overrides: Partial<MemoryResult> & { id: string; provider: string }): MemoryResult {
+function mockResult(
+  overrides: Partial<MemoryResult> & { id: string; provider: string },
+): MemoryResult {
   return {
     sourceType: overrides.provider as MemoryResult["sourceType"],
     content: `Content for ${overrides.id}`,
@@ -47,21 +49,55 @@ function mockProvider(
 }
 
 test("memory get validation accepts provider and id", () => {
-  assert.deepEqual(validateMemoryGetRequest({ provider: " noosphere ", id: " article-1 " }), {
-    ok: true,
-    request: { provider: "noosphere", id: "article-1" },
-  });
+  assert.deepEqual(
+    validateMemoryGetRequest({ provider: " noosphere ", id: " article-1 " }),
+    {
+      ok: true,
+      request: { provider: "noosphere", id: "article-1" },
+    },
+  );
 });
 
 test("memory get validation parses canonical refs", () => {
-  assert.deepEqual(validateMemoryGetRequest({ canonicalRef: "noosphere:article:article-1" }), {
-    ok: true,
-    request: {
-      provider: "noosphere",
-      id: "article-1",
-      canonicalRef: "noosphere:article:article-1",
+  assert.deepEqual(
+    validateMemoryGetRequest({ canonicalRef: "noosphere:article:article-1" }),
+    {
+      ok: true,
+      request: {
+        provider: "noosphere",
+        id: "article-1",
+        canonicalRef: "noosphere:article:article-1",
+      },
     },
-  });
+  );
+});
+
+test("memory get validation trims canonical ref segments", () => {
+  assert.deepEqual(
+    validateMemoryGetRequest({ canonicalRef: " noosphere : article : abc " }),
+    {
+      ok: true,
+      request: {
+        provider: "noosphere",
+        id: "abc",
+        canonicalRef: "noosphere:article:abc",
+      },
+    },
+  );
+});
+
+test("memory get validation preserves colons in canonical ref ids", () => {
+  assert.deepEqual(
+    validateMemoryGetRequest({ canonicalRef: "noosphere:article:a:b:c" }),
+    {
+      ok: true,
+      request: {
+        provider: "noosphere",
+        id: "a:b:c",
+        canonicalRef: "noosphere:article:a:b:c",
+      },
+    },
+  );
 });
 
 test("memory get validation rejects malformed inputs", () => {
@@ -80,11 +116,43 @@ test("memory get validation rejects malformed inputs", () => {
     status: 400,
     error: "canonicalRef must look like provider:type:id",
   });
-  assert.deepEqual(validateMemoryGetRequest({ provider: "noosphere", id: "1", canonicalRef: "noosphere:article:1" }), {
-    ok: false,
-    status: 400,
-    error: "Use either canonicalRef or provider + id, not both",
-  });
+  assert.deepEqual(
+    validateMemoryGetRequest({
+      provider: "noosphere",
+      id: "1",
+      canonicalRef: "noosphere:article:1",
+    }),
+    {
+      ok: false,
+      status: 400,
+      error: "Use either canonicalRef or provider + id, not both",
+    },
+  );
+  assert.deepEqual(
+    validateMemoryGetRequest({ canonicalRef: "noosphere:note:article-1" }),
+    {
+      ok: false,
+      status: 400,
+      error: "Unsupported canonicalRef type for noosphere: note",
+    },
+  );
+  assert.deepEqual(
+    validateMemoryGetRequest({ provider: "Noosphere", id: "article-1" }),
+    {
+      ok: false,
+      status: 400,
+      error:
+        "provider must contain only lowercase letters, numbers, and hyphens",
+    },
+  );
+  assert.deepEqual(
+    validateMemoryGetRequest({ provider: "n".repeat(65), id: "article-1" }),
+    {
+      ok: false,
+      status: 400,
+      error: "provider is too long",
+    },
+  );
 });
 
 test("memory get returns normalized provider result", async () => {
@@ -104,8 +172,12 @@ test("memory get returns normalized provider result", async () => {
   if (!("result" in response.body)) return;
   assert.equal(response.body.result?.id, "article-1");
   assert.equal(response.body.result?.provider, "noosphere");
-  assert.deepEqual(response.body.providerMeta.map((meta) => meta.providerId), ["noosphere"]);
+  assert.deepEqual(
+    response.body.providerMeta.map((meta) => meta.providerId),
+    ["noosphere"],
+  );
   assert.equal(response.body.providerMeta[0]?.found, true);
+  assertProviderDuration(response.body.providerMeta[0]);
 });
 
 test("memory get returns null for missing results", async () => {
@@ -119,8 +191,8 @@ test("memory get returns null for missing results", async () => {
   if (!("result" in response.body)) return;
   assert.equal(response.body.result, null);
   assert.equal(response.body.providerMeta[0]?.found, false);
+  assertProviderDuration(response.body.providerMeta[0]);
 });
-
 
 test("memory get reports disabled providers distinctly", async () => {
   const response = await executeMemoryGetRequest(
@@ -142,6 +214,39 @@ test("memory get reports disabled providers distinctly", async () => {
   assert.equal(response.body.providerMeta[0]?.enabled, false);
   assert.equal(response.body.providerMeta[0]?.found, false);
   assert.equal(response.body.providerMeta[0]?.error, undefined);
+  assertProviderDuration(response.body.providerMeta[0]);
+});
+
+test("memory get reports unsupported getById capability", async () => {
+  const response = await executeMemoryGetRequest(
+    { provider: "noosphere", id: "article-1" },
+    {
+      providers: [
+        mockProvider("noosphere", null, {
+          descriptor: {
+            ...mockProvider("noosphere").descriptor,
+            capabilities: {
+              ...mockProvider("noosphere").descriptor.capabilities,
+              getById: false,
+            },
+          },
+          getById: () => Promise.reject(new Error("should not be called")),
+        }),
+      ],
+    },
+  );
+
+  assert.equal(response.status, 200);
+  assert.ok("result" in response.body);
+  if (!("result" in response.body)) return;
+  assert.equal(response.body.result, null);
+  assert.equal(response.body.providerMeta[0]?.enabled, true);
+  assert.equal(response.body.providerMeta[0]?.found, false);
+  assert.equal(
+    response.body.providerMeta[0]?.error,
+    "Provider does not support getById",
+  );
+  assertProviderDuration(response.body.providerMeta[0]);
 });
 
 test("memory get rejects unknown providers", async () => {
@@ -171,4 +276,10 @@ test("memory get preserves provider errors as metadata", async () => {
   if (!("result" in response.body)) return;
   assert.equal(response.body.result, null);
   assert.equal(response.body.providerMeta[0]?.error, "provider unavailable");
+  assertProviderDuration(response.body.providerMeta[0]);
 });
+
+function assertProviderDuration(meta: { durationMs?: number } | undefined) {
+  assert.equal(typeof meta?.durationMs, "number");
+  assert.ok((meta?.durationMs ?? -1) >= 0);
+}

--- a/src/__tests__/memory/api-get.test.ts
+++ b/src/__tests__/memory/api-get.test.ts
@@ -56,7 +56,11 @@ test("memory get validation accepts provider and id", () => {
 test("memory get validation parses canonical refs", () => {
   assert.deepEqual(validateMemoryGetRequest({ canonicalRef: "noosphere:article:article-1" }), {
     ok: true,
-    request: { provider: "noosphere", id: "noosphere:article:article-1" },
+    request: {
+      provider: "noosphere",
+      id: "article-1",
+      canonicalRef: "noosphere:article:article-1",
+    },
   });
 });
 
@@ -74,7 +78,7 @@ test("memory get validation rejects malformed inputs", () => {
   assert.deepEqual(validateMemoryGetRequest({ canonicalRef: "not-a-ref" }), {
     ok: false,
     status: 400,
-    error: "canonicalRef must look like provider:article:id",
+    error: "canonicalRef must look like provider:type:id",
   });
   assert.deepEqual(validateMemoryGetRequest({ provider: "noosphere", id: "1", canonicalRef: "noosphere:article:1" }), {
     ok: false,
@@ -115,6 +119,29 @@ test("memory get returns null for missing results", async () => {
   if (!("result" in response.body)) return;
   assert.equal(response.body.result, null);
   assert.equal(response.body.providerMeta[0]?.found, false);
+});
+
+
+test("memory get reports disabled providers distinctly", async () => {
+  const response = await executeMemoryGetRequest(
+    { provider: "noosphere", id: "article-1" },
+    {
+      providerOptions: { config: { enabled: false } },
+      providers: [
+        mockProvider("noosphere", null, {
+          getById: () => Promise.reject(new Error("should not be called")),
+        }),
+      ],
+    },
+  );
+
+  assert.equal(response.status, 200);
+  assert.ok("result" in response.body);
+  if (!("result" in response.body)) return;
+  assert.equal(response.body.result, null);
+  assert.equal(response.body.providerMeta[0]?.enabled, false);
+  assert.equal(response.body.providerMeta[0]?.found, false);
+  assert.equal(response.body.providerMeta[0]?.error, undefined);
 });
 
 test("memory get rejects unknown providers", async () => {

--- a/src/__tests__/memory/api-get.test.ts
+++ b/src/__tests__/memory/api-get.test.ts
@@ -1,0 +1,147 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  executeMemoryGetRequest,
+  validateMemoryGetRequest,
+} from "@/lib/memory/api/get";
+import type { MemoryProvider } from "@/lib/memory/provider";
+import type { MemoryResult } from "@/lib/memory/types";
+
+function mockResult(overrides: Partial<MemoryResult> & { id: string; provider: string }): MemoryResult {
+  return {
+    sourceType: overrides.provider as MemoryResult["sourceType"],
+    content: `Content for ${overrides.id}`,
+    canonicalRef: `${overrides.provider}:article:${overrides.id}`,
+    ...overrides,
+  };
+}
+
+function mockProvider(
+  id: string,
+  result: MemoryResult | null = null,
+  overrides: Partial<MemoryProvider> = {},
+): MemoryProvider {
+  return {
+    descriptor: {
+      id,
+      displayName: id,
+      sourceType: id as MemoryResult["sourceType"],
+      defaultConfig: {
+        enabled: true,
+        priorityWeight: 1,
+        allowAutoRecall: true,
+      },
+      capabilities: {
+        search: true,
+        getById: true,
+        score: true,
+        autoRecall: true,
+      },
+    },
+    search: () => Promise.resolve([]),
+    getById: () => Promise.resolve(result),
+    score: () => ({}),
+    ...overrides,
+  } as MemoryProvider;
+}
+
+test("memory get validation accepts provider and id", () => {
+  assert.deepEqual(validateMemoryGetRequest({ provider: " noosphere ", id: " article-1 " }), {
+    ok: true,
+    request: { provider: "noosphere", id: "article-1" },
+  });
+});
+
+test("memory get validation parses canonical refs", () => {
+  assert.deepEqual(validateMemoryGetRequest({ canonicalRef: "noosphere:article:article-1" }), {
+    ok: true,
+    request: { provider: "noosphere", id: "noosphere:article:article-1" },
+  });
+});
+
+test("memory get validation rejects malformed inputs", () => {
+  assert.deepEqual(validateMemoryGetRequest({}), {
+    ok: false,
+    status: 400,
+    error: "provider is required",
+  });
+  assert.deepEqual(validateMemoryGetRequest({ provider: "noosphere" }), {
+    ok: false,
+    status: 400,
+    error: "id is required",
+  });
+  assert.deepEqual(validateMemoryGetRequest({ canonicalRef: "not-a-ref" }), {
+    ok: false,
+    status: 400,
+    error: "canonicalRef must look like provider:article:id",
+  });
+  assert.deepEqual(validateMemoryGetRequest({ provider: "noosphere", id: "1", canonicalRef: "noosphere:article:1" }), {
+    ok: false,
+    status: 400,
+    error: "Use either canonicalRef or provider + id, not both",
+  });
+});
+
+test("memory get returns normalized provider result", async () => {
+  const result = mockResult({
+    id: "article-1",
+    provider: "noosphere",
+    title: "Deployment Notes",
+    content: "Use the documented deployment workflow.",
+  });
+  const response = await executeMemoryGetRequest(
+    { provider: "noosphere", id: "article-1" },
+    { providers: [mockProvider("noosphere", result)] },
+  );
+
+  assert.equal(response.status, 200);
+  assert.ok("result" in response.body);
+  if (!("result" in response.body)) return;
+  assert.equal(response.body.result?.id, "article-1");
+  assert.equal(response.body.result?.provider, "noosphere");
+  assert.deepEqual(response.body.providerMeta.map((meta) => meta.providerId), ["noosphere"]);
+  assert.equal(response.body.providerMeta[0]?.found, true);
+});
+
+test("memory get returns null for missing results", async () => {
+  const response = await executeMemoryGetRequest(
+    { provider: "noosphere", id: "missing" },
+    { providers: [mockProvider("noosphere", null)] },
+  );
+
+  assert.equal(response.status, 200);
+  assert.ok("result" in response.body);
+  if (!("result" in response.body)) return;
+  assert.equal(response.body.result, null);
+  assert.equal(response.body.providerMeta[0]?.found, false);
+});
+
+test("memory get rejects unknown providers", async () => {
+  const response = await executeMemoryGetRequest(
+    { provider: "missing", id: "article-1" },
+    { providers: [mockProvider("noosphere")] },
+  );
+
+  assert.equal(response.status, 400);
+  assert.deepEqual(response.body, { error: "Unknown provider ID: missing" });
+});
+
+test("memory get preserves provider errors as metadata", async () => {
+  const response = await executeMemoryGetRequest(
+    { provider: "broken", id: "article-1" },
+    {
+      providers: [
+        mockProvider("broken", null, {
+          getById: () => Promise.reject(new Error("provider unavailable")),
+        }),
+      ],
+    },
+  );
+
+  assert.equal(response.status, 200);
+  assert.ok("result" in response.body);
+  if (!("result" in response.body)) return;
+  assert.equal(response.body.result, null);
+  assert.equal(response.body.providerMeta[0]?.error, "provider unavailable");
+});

--- a/src/__tests__/memory/api-get.test.ts
+++ b/src/__tests__/memory/api-get.test.ts
@@ -5,7 +5,10 @@ import {
   executeMemoryGetRequest,
   validateMemoryGetRequest,
 } from "@/lib/memory/api/get";
-import type { MemoryProvider } from "@/lib/memory/provider";
+import type {
+  MemoryProvider,
+  MemoryProviderGetOptions,
+} from "@/lib/memory/provider";
 import type { MemoryResult } from "@/lib/memory/types";
 
 function mockResult(
@@ -153,6 +156,23 @@ test("memory get validation rejects malformed inputs", () => {
       error: "provider is too long",
     },
   );
+  assert.deepEqual(
+    validateMemoryGetRequest({
+      provider: "noosphere",
+      id: "x",
+      canonicalRef: 123,
+    }),
+    {
+      ok: false,
+      status: 400,
+      error: "canonicalRef must be a string",
+    },
+  );
+  assert.deepEqual(validateMemoryGetRequest({ provider: 123, id: "x" }), {
+    ok: false,
+    status: 400,
+    error: "provider must be a string",
+  });
 });
 
 test("memory get returns normalized provider result", async () => {
@@ -257,6 +277,35 @@ test("memory get rejects unknown providers", async () => {
 
   assert.equal(response.status, 400);
   assert.deepEqual(response.body, { error: "Unknown provider ID: missing" });
+});
+
+test("memory get times out hanging providers", async () => {
+  let observedSignal: AbortSignal | undefined;
+  const response = await executeMemoryGetRequest(
+    { provider: "slow", id: "article-1" },
+    {
+      timeoutMs: 1,
+      providers: [
+        mockProvider("slow", null, {
+          getById: (_id: string, options?: MemoryProviderGetOptions) => {
+            observedSignal = options?.signal;
+            return new Promise(() => undefined);
+          },
+        }),
+      ],
+    },
+  );
+
+  assert.equal(response.status, 200);
+  assert.ok("result" in response.body);
+  if (!("result" in response.body)) return;
+  assert.equal(response.body.result, null);
+  assert.equal(
+    response.body.providerMeta[0]?.error,
+    "Provider lookup timed out after 1ms",
+  );
+  assert.equal(observedSignal?.aborted, true);
+  assertProviderDuration(response.body.providerMeta[0]);
 });
 
 test("memory get preserves provider errors as metadata", async () => {

--- a/src/__tests__/memory/openclaw-plugin-auto-recall.test.ts
+++ b/src/__tests__/memory/openclaw-plugin-auto-recall.test.ts
@@ -6,10 +6,21 @@ import {
   MAX_QUERY_LENGTH,
   resolveAutoRecallConfig,
 } from "../../../openclaw-noosphere-memory/src/auto-recall.js";
-import type { NoosphereRecallRequest, NoosphereRecallResponse } from "../../../openclaw-noosphere-memory/src/client.js";
+import {
+  NoosphereClientError,
+  type NoosphereGetRequest,
+  type NoosphereGetResponse,
+} from "../../../openclaw-noosphere-memory/src/client.js";
+import type {
+  NoosphereRecallRequest,
+  NoosphereRecallResponse,
+} from "../../../openclaw-noosphere-memory/src/client.js";
+import { createNoosphereGetTool } from "../../../openclaw-noosphere-memory/src/tools/get.js";
 import type { NoosphereClientContext } from "../../../openclaw-noosphere-memory/src/shared-init.js";
 
-function makeContext(overrides: Partial<NoosphereClientContext["config"]> = {}) {
+function makeContext(
+  overrides: Partial<NoosphereClientContext["config"]> = {},
+) {
   const calls: NoosphereRecallRequest[] = [];
   const response: NoosphereRecallResponse = {
     results: [],
@@ -17,7 +28,8 @@ function makeContext(overrides: Partial<NoosphereClientContext["config"]> = {}) 
     mode: "auto",
     tokenBudgetUsed: 12,
     providerMeta: [],
-    promptInjectionText: "<recall>\n  <item>Remember the Omnissiah.</item>\n</recall>",
+    promptInjectionText:
+      "<recall>\n  <item>Remember the Omnissiah.</item>\n</recall>",
   };
 
   const context = {
@@ -59,16 +71,31 @@ describe("resolveAutoRecallConfig", () => {
     assert.deepEqual(truthy.enabledAgents, ["cylena", "seriania"]);
     assert.deepEqual(truthy.allowedChatTypes, ["telegram", "discord"]);
 
-    const falsy = resolveAutoRecallConfig({ autoRecall: "false", includeRecentTurns: "0" });
+    const falsy = resolveAutoRecallConfig({
+      autoRecall: "false",
+      includeRecentTurns: "0",
+    });
 
     assert.equal(falsy.autoRecall, false);
     assert.equal(falsy.includeRecentTurns, false);
   });
 
   it("normalizes recallInjectionPosition with prepend as fallback", () => {
-    assert.equal(resolveAutoRecallConfig({ recallInjectionPosition: "system-prepend" }).recallInjectionPosition, "system-prepend");
-    assert.equal(resolveAutoRecallConfig({ recallInjectionPosition: "append" }).recallInjectionPosition, "prepend");
-    assert.equal(resolveAutoRecallConfig({ recallInjectionPosition: "unexpected" }).recallInjectionPosition, "prepend");
+    assert.equal(
+      resolveAutoRecallConfig({ recallInjectionPosition: "system-prepend" })
+        .recallInjectionPosition,
+      "system-prepend",
+    );
+    assert.equal(
+      resolveAutoRecallConfig({ recallInjectionPosition: "append" })
+        .recallInjectionPosition,
+      "prepend",
+    );
+    assert.equal(
+      resolveAutoRecallConfig({ recallInjectionPosition: "unexpected" })
+        .recallInjectionPosition,
+      "prepend",
+    );
   });
 });
 
@@ -77,10 +104,19 @@ describe("OpenClaw Noosphere plugin auto-recall", () => {
     const { context, calls } = makeContext();
     const hook = createNoosphereAutoRecallHook({ autoRecall: true }, context);
 
-    const result = await hook({ prompt: "what do we know about Noosphere?", messages: [] }, { agentId: "cylena" });
+    const result = await hook(
+      { prompt: "what do we know about Noosphere?", messages: [] },
+      { agentId: "cylena" },
+    );
 
-    assert.equal(result?.prependContext?.includes("<noosphere_auto_recall>"), true);
-    assert.equal(result?.prependContext?.includes("<hindsight_memories>"), false);
+    assert.equal(
+      result?.prependContext?.includes("<noosphere_auto_recall>"),
+      true,
+    );
+    assert.equal(
+      result?.prependContext?.includes("<hindsight_memories>"),
+      false,
+    );
     assert.equal(calls.length, 1);
     assert.equal(calls[0].mode, "auto");
     assert.deepEqual(calls[0].providers, ["noosphere"]);
@@ -91,17 +127,32 @@ describe("OpenClaw Noosphere plugin auto-recall", () => {
   it("returns nothing when recall is empty", async () => {
     const calls: NoosphereRecallRequest[] = [];
     const context = {
-      config: { baseUrl: "http://noosphere.local", apiKey: "noo_test", timeoutMs: 5000 },
+      config: {
+        baseUrl: "http://noosphere.local",
+        apiKey: "noo_test",
+        timeoutMs: 5000,
+      },
       client: {
-        async recall(request: NoosphereRecallRequest): Promise<NoosphereRecallResponse> {
+        async recall(
+          request: NoosphereRecallRequest,
+        ): Promise<NoosphereRecallResponse> {
           calls.push(request);
-          return { results: [], totalBeforeCap: 0, mode: "auto", providerMeta: [], promptInjectionText: "   " };
+          return {
+            results: [],
+            totalBeforeCap: 0,
+            mode: "auto",
+            providerMeta: [],
+            promptInjectionText: "   ",
+          };
         },
       },
     } as unknown as NoosphereClientContext;
     const hook = createNoosphereAutoRecallHook({ autoRecall: true }, context);
 
-    const result = await hook({ prompt: "No matching durable memory", messages: [] }, {});
+    const result = await hook(
+      { prompt: "No matching durable memory", messages: [] },
+      {},
+    );
 
     assert.equal(result, undefined);
     assert.equal(calls.length, 1);
@@ -110,14 +161,20 @@ describe("OpenClaw Noosphere plugin auto-recall", () => {
   it("fails open and logs a warning on recall errors", async () => {
     const warnings: string[] = [];
     const context = {
-      config: { baseUrl: "http://noosphere.local", apiKey: "noo_test", timeoutMs: 5000 },
+      config: {
+        baseUrl: "http://noosphere.local",
+        apiKey: "noo_test",
+        timeoutMs: 5000,
+      },
       client: {
         async recall(): Promise<NoosphereRecallResponse> {
           throw new Error("network down");
         },
       },
     } as unknown as NoosphereClientContext;
-    const hook = createNoosphereAutoRecallHook({ autoRecall: true }, context, { warn: (message) => warnings.push(message) });
+    const hook = createNoosphereAutoRecallHook({ autoRecall: true }, context, {
+      warn: (message) => warnings.push(message),
+    });
 
     const result = await hook({ prompt: "Noosphere bridge", messages: [] }, {});
 
@@ -129,16 +186,38 @@ describe("OpenClaw Noosphere plugin auto-recall", () => {
   it("honors enabledAgents and allowedChatTypes gates", async () => {
     const { context, calls } = makeContext();
     const hook = createNoosphereAutoRecallHook(
-      { autoRecall: true, enabledAgents: ["cylena"], allowedChatTypes: ["telegram"] },
+      {
+        autoRecall: true,
+        enabledAgents: ["cylena"],
+        allowedChatTypes: ["telegram"],
+      },
       context,
     );
 
-    assert.equal(await hook({ prompt: "Noosphere memory", messages: [] }, { agentId: "other", messageProvider: "telegram" }), undefined);
-    assert.equal(await hook({ prompt: "Noosphere memory", messages: [] }, { agentId: "cylena", messageProvider: "discord" }), undefined);
+    assert.equal(
+      await hook(
+        { prompt: "Noosphere memory", messages: [] },
+        { agentId: "other", messageProvider: "telegram" },
+      ),
+      undefined,
+    );
+    assert.equal(
+      await hook(
+        { prompt: "Noosphere memory", messages: [] },
+        { agentId: "cylena", messageProvider: "discord" },
+      ),
+      undefined,
+    );
 
-    const result = await hook({ prompt: "Noosphere memory", messages: [] }, { agentId: "cylena", messageProvider: "telegram" });
+    const result = await hook(
+      { prompt: "Noosphere memory", messages: [] },
+      { agentId: "cylena", messageProvider: "telegram" },
+    );
 
-    assert.equal(result?.prependContext?.includes("<noosphere_auto_recall>"), true);
+    assert.equal(
+      result?.prependContext?.includes("<noosphere_auto_recall>"),
+      true,
+    );
     assert.equal(calls.length, 1);
   });
 
@@ -149,7 +228,10 @@ describe("OpenClaw Noosphere plugin auto-recall", () => {
         messages: [
           { role: "user", content: "older user turn" },
           { role: "assistant", content: "assistant text ignored" },
-          { role: "user", content: [{ type: "text", text: "recent user turn" }] },
+          {
+            role: "user",
+            content: [{ type: "text", text: "recent user turn" }],
+          },
         ],
       },
       resolveAutoRecallConfig({ autoRecall: true, recentTurnLimit: 1 }),
@@ -160,22 +242,39 @@ describe("OpenClaw Noosphere plugin auto-recall", () => {
 
   it("supports configured injection positions", async () => {
     const { context } = makeContext();
-    const hook = createNoosphereAutoRecallHook({ autoRecall: true, recallInjectionPosition: "system-prepend" }, context);
+    const hook = createNoosphereAutoRecallHook(
+      { autoRecall: true, recallInjectionPosition: "system-prepend" },
+      context,
+    );
 
     const result = await hook({ prompt: "Noosphere bridge", messages: [] }, {});
 
     assert.equal(result?.prependContext, undefined);
-    assert.equal(result?.prependSystemContext?.includes("<noosphere_auto_recall>"), true);
+    assert.equal(
+      result?.prependSystemContext?.includes("<noosphere_auto_recall>"),
+      true,
+    );
   });
 
   it("returns nothing when promptInjectionText is missing", async () => {
     const calls: NoosphereRecallRequest[] = [];
     const context = {
-      config: { baseUrl: "http://noosphere.local", apiKey: "noo_test", timeoutMs: 5000 },
+      config: {
+        baseUrl: "http://noosphere.local",
+        apiKey: "noo_test",
+        timeoutMs: 5000,
+      },
       client: {
-        async recall(request: NoosphereRecallRequest): Promise<NoosphereRecallResponse> {
+        async recall(
+          request: NoosphereRecallRequest,
+        ): Promise<NoosphereRecallResponse> {
           calls.push(request);
-          return { results: [], totalBeforeCap: 0, mode: "auto", providerMeta: [] } as NoosphereRecallResponse;
+          return {
+            results: [],
+            totalBeforeCap: 0,
+            mode: "auto",
+            providerMeta: [],
+          } as NoosphereRecallResponse;
         },
       },
     } as unknown as NoosphereClientContext;
@@ -187,14 +286,18 @@ describe("OpenClaw Noosphere plugin auto-recall", () => {
     assert.equal(calls.length, 1);
   });
 
-
-
   it("skips injection when Noosphere does not return auto-mode prompt text", async () => {
     const calls: NoosphereRecallRequest[] = [];
     const context = {
-      config: { baseUrl: "http://noosphere.local", apiKey: "noo_test", timeoutMs: 5000 },
+      config: {
+        baseUrl: "http://noosphere.local",
+        apiKey: "noo_test",
+        timeoutMs: 5000,
+      },
       client: {
-        async recall(request: NoosphereRecallRequest): Promise<NoosphereRecallResponse> {
+        async recall(
+          request: NoosphereRecallRequest,
+        ): Promise<NoosphereRecallResponse> {
           calls.push(request);
           return {
             results: [],
@@ -219,9 +322,16 @@ describe("OpenClaw Noosphere plugin auto-recall", () => {
     const calls: NoosphereRecallRequest[] = [];
     const timeouts: Array<number | undefined> = [];
     const context = {
-      config: { baseUrl: "http://noosphere.local", apiKey: "noo_test", timeoutMs: 5000 },
+      config: {
+        baseUrl: "http://noosphere.local",
+        apiKey: "noo_test",
+        timeoutMs: 5000,
+      },
       client: {
-        async recall(request: NoosphereRecallRequest, options?: { timeoutMs?: number }): Promise<NoosphereRecallResponse> {
+        async recall(
+          request: NoosphereRecallRequest,
+          options?: { timeoutMs?: number },
+        ): Promise<NoosphereRecallResponse> {
           calls.push(request);
           timeouts.push(options?.timeoutMs);
           return {
@@ -235,7 +345,10 @@ describe("OpenClaw Noosphere plugin auto-recall", () => {
         },
       },
     } as unknown as NoosphereClientContext;
-    const hook = createNoosphereAutoRecallHook({ autoRecall: true, autoRecallTimeoutMs: 1234 }, context);
+    const hook = createNoosphereAutoRecallHook(
+      { autoRecall: true, autoRecallTimeoutMs: 1234 },
+      context,
+    );
 
     await hook({ prompt: "Noosphere bridge", messages: [] }, {});
 
@@ -245,9 +358,15 @@ describe("OpenClaw Noosphere plugin auto-recall", () => {
 
   it("skips recall when the assembled query is shorter than minQueryLength", async () => {
     const { context, calls } = makeContext();
-    const hook = createNoosphereAutoRecallHook({ autoRecall: true, minQueryLength: 1000 }, context);
+    const hook = createNoosphereAutoRecallHook(
+      { autoRecall: true, minQueryLength: 1000 },
+      context,
+    );
 
-    const result = await hook({ prompt: "short", messages: [{ role: "user", content: "tiny" }] }, {});
+    const result = await hook(
+      { prompt: "short", messages: [{ role: "user", content: "tiny" }] },
+      {},
+    );
 
     assert.equal(result, undefined);
     assert.equal(calls.length, 0);
@@ -256,13 +375,19 @@ describe("OpenClaw Noosphere plugin auto-recall", () => {
   it("truncates overlong auto-recall queries from the start to preserve the current prompt", async () => {
     const { context, calls } = makeContext();
     const currentPrompt = `${"x".repeat(MAX_QUERY_LENGTH + 100)} current question`;
-    const hook = createNoosphereAutoRecallHook({ autoRecall: true, recentTurnLimit: 3 }, context);
+    const hook = createNoosphereAutoRecallHook(
+      { autoRecall: true, recentTurnLimit: 3 },
+      context,
+    );
 
     await hook(
       {
         prompt: currentPrompt,
         messages: [
-          { role: "user", content: "older user turn that should be dropped first" },
+          {
+            role: "user",
+            content: "older user turn that should be dropped first",
+          },
           { role: "user", content: "recent user turn" },
         ],
       },
@@ -290,5 +415,115 @@ describe("OpenClaw Noosphere plugin auto-recall", () => {
     );
 
     assert.equal(query, "repeat\n\nunique\n\ncurrent question");
+  });
+});
+
+describe("OpenClaw Noosphere get tool", () => {
+  function makeGetContext() {
+    const calls: NoosphereGetRequest[] = [];
+    const response: NoosphereGetResponse = {
+      result: {
+        id: "article-1",
+        provider: "noosphere",
+        sourceType: "noosphere_article",
+        canonicalRef: "noosphere:article:article-1",
+        title: "Deployment Notes",
+        content: "Use the deployment workflow.",
+      },
+      providerMeta: [{ providerId: "noosphere", enabled: true, found: true }],
+    };
+
+    const context = {
+      config: {
+        baseUrl: "http://noosphere.local",
+        apiKey: "noo_test",
+        timeoutMs: 5000,
+      },
+      client: {
+        async get(request: NoosphereGetRequest) {
+          calls.push(request);
+          return response;
+        },
+      },
+    } as unknown as NoosphereClientContext;
+
+    return { context, calls, response };
+  }
+
+  it("normalizes provider/id get requests", async () => {
+    const { context, calls } = makeGetContext();
+    const tool = createNoosphereGetTool({}, context);
+
+    const result = await tool.execute("tool-1", {
+      provider: " noosphere ",
+      id: " article-1 ",
+    });
+
+    assert.equal(result.isError, undefined);
+    assert.deepEqual(calls, [{ provider: "noosphere", id: "article-1" }]);
+  });
+
+  it("normalizes canonicalRef get requests", async () => {
+    const { context, calls } = makeGetContext();
+    const tool = createNoosphereGetTool({}, context);
+
+    const result = await tool.execute("tool-1", {
+      canonicalRef: " noosphere:article:article-1 ",
+    });
+
+    assert.equal(result.isError, undefined);
+    assert.deepEqual(calls, [{ canonicalRef: "noosphere:article:article-1" }]);
+  });
+
+  it("rejects mixed or wrong-typed get params before calling the client", async () => {
+    const { context, calls } = makeGetContext();
+    const tool = createNoosphereGetTool({}, context);
+
+    const mixed = await tool.execute("tool-1", {
+      provider: "noosphere",
+      id: "article-1",
+      canonicalRef: "noosphere:article:article-1",
+    });
+    const wrongTyped = await tool.execute("tool-2", {
+      provider: "noosphere",
+      id: 123,
+    });
+
+    assert.equal(mixed.isError, true);
+    assert.equal(wrongTyped.isError, true);
+    assert.equal(calls.length, 0);
+    assert.match(String(mixed.content[0]?.text), /Use either canonicalRef/);
+    assert.match(
+      String(wrongTyped.content[0]?.text),
+      /id must be a non-empty string/,
+    );
+  });
+
+  it("formats get client errors as tool errors", async () => {
+    const context = {
+      config: {
+        baseUrl: "http://noosphere.local",
+        apiKey: "noo_test",
+        timeoutMs: 5000,
+      },
+      client: {
+        async get(): Promise<NoosphereGetResponse> {
+          throw new NoosphereClientError(
+            "Noosphere request failed with HTTP 401",
+            401,
+            { error: "Unauthorized" },
+          );
+        },
+      },
+    } as unknown as NoosphereClientContext;
+    const tool = createNoosphereGetTool({}, context);
+
+    const result = await tool.execute("tool-1", {
+      provider: "noosphere",
+      id: "article-1",
+    });
+
+    assert.equal(result.isError, true);
+    assert.match(String(result.content[0]?.text), /HTTP 401/);
   });
 });

--- a/src/app/api/memory/get/route.ts
+++ b/src/app/api/memory/get/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { Permissions } from "@prisma/client";
 import { requirePermission } from "@/lib/api/auth";
-import { executeMemoryRecallRequest } from "@/lib/memory/api/recall";
+import { executeMemoryGetRequest } from "@/lib/memory/api/get";
 
 export async function POST(request: NextRequest) {
   const auth = await requirePermission(request, [Permissions.READ]);
@@ -20,12 +20,12 @@ export async function POST(request: NextRequest) {
   }
 
   try {
-    const result = await executeMemoryRecallRequest(body);
+    const result = await executeMemoryGetRequest(body);
     return NextResponse.json(result.body, { status: result.status });
   } catch (error) {
-    console.error("[POST /api/memory/recall]", error);
+    console.error("[POST /api/memory/get]", error);
     return NextResponse.json(
-      { error: "Memory recall unavailable" },
+      { error: "Memory lookup unavailable" },
       { status: 503 },
     );
   }

--- a/src/lib/memory/api/get.ts
+++ b/src/lib/memory/api/get.ts
@@ -1,4 +1,4 @@
-import type { MemoryProvider, MemoryProviderGetOptions } from "@/lib/memory/provider";
+import { normalizeMemoryProviderConfig, type MemoryProvider, type MemoryProviderGetOptions } from "@/lib/memory/provider";
 import type { MemoryResult } from "@/lib/memory/types";
 
 export const MEMORY_GET_LIMITS = {
@@ -35,6 +35,7 @@ export type MemoryGetValidationResult =
       request: {
         provider: string;
         id: string;
+        canonicalRef?: string;
       };
     }
   | {
@@ -95,6 +96,28 @@ export async function executeMemoryGetRequest(
   }
 
   const startedAt = Date.now();
+  const config = normalizeMemoryProviderConfig({
+    ...provider.descriptor.defaultConfig,
+    ...options.providerOptions?.config,
+  });
+
+  if (!config.enabled) {
+    return {
+      status: 200,
+      body: {
+        result: null,
+        providerMeta: [
+          {
+            providerId: provider.descriptor.id,
+            enabled: false,
+            found: false,
+            durationMs: Date.now() - startedAt,
+          },
+        ],
+      },
+    };
+  }
+
   try {
     const result = await provider.getById(validation.request.id, options.providerOptions);
     return {
@@ -135,17 +158,17 @@ function parseCanonicalRef(canonicalRef: string): MemoryGetValidationResult {
     return { ok: false, status: 400, error: "canonicalRef is too long" };
   }
 
-  const separator = ":article:";
-  const separatorIndex = canonicalRef.indexOf(separator);
-  if (separatorIndex <= 0 || separatorIndex + separator.length >= canonicalRef.length) {
-    return { ok: false, status: 400, error: "canonicalRef must look like provider:article:id" };
+  const segments = canonicalRef.split(":");
+  if (segments.length < 3 || segments.some((segment) => !segment.trim())) {
+    return { ok: false, status: 400, error: "canonicalRef must look like provider:type:id" };
   }
 
   return {
     ok: true,
     request: {
-      provider: canonicalRef.slice(0, separatorIndex),
-      id: canonicalRef,
+      provider: segments[0],
+      id: segments.slice(2).join(":"),
+      canonicalRef,
     },
   };
 }

--- a/src/lib/memory/api/get.ts
+++ b/src/lib/memory/api/get.ts
@@ -1,0 +1,155 @@
+import type { MemoryProvider, MemoryProviderGetOptions } from "@/lib/memory/provider";
+import type { MemoryResult } from "@/lib/memory/types";
+
+export const MEMORY_GET_LIMITS = {
+  maxIdLength: 512,
+} as const;
+
+export interface MemoryGetRequest {
+  provider?: string;
+  id?: string;
+  canonicalRef?: string;
+}
+
+export interface MemoryGetResponse {
+  result: MemoryResult | null;
+  providerMeta: MemoryGetProviderMeta[];
+}
+
+export interface MemoryGetProviderMeta {
+  providerId: string;
+  enabled: boolean;
+  found: boolean;
+  error?: string;
+  durationMs?: number;
+}
+
+export interface MemoryGetExecutionOptions {
+  providers?: MemoryProvider[];
+  providerOptions?: MemoryProviderGetOptions;
+}
+
+export type MemoryGetValidationResult =
+  | {
+      ok: true;
+      request: {
+        provider: string;
+        id: string;
+      };
+    }
+  | {
+      ok: false;
+      status: number;
+      error: string;
+    };
+
+export async function getDefaultMemoryGetProviders(): Promise<MemoryProvider[]> {
+  const { createNoosphereProvider } = await import("@/lib/memory/noosphere");
+  return [createNoosphereProvider()];
+}
+
+export function validateMemoryGetRequest(input: unknown): MemoryGetValidationResult {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    return { ok: false, status: 400, error: "Request body must be an object" };
+  }
+
+  const body = input as Record<string, unknown>;
+  const explicitProvider = readOptionalString(body.provider);
+  const explicitId = readOptionalString(body.id);
+  const canonicalRef = readOptionalString(body.canonicalRef);
+
+  if (canonicalRef && (explicitProvider || explicitId)) {
+    return { status: 400, ok: false, error: "Use either canonicalRef or provider + id, not both" };
+  }
+
+  if (canonicalRef) {
+    return parseCanonicalRef(canonicalRef);
+  }
+
+  if (!explicitProvider) {
+    return { ok: false, status: 400, error: "provider is required" };
+  }
+  if (!explicitId) {
+    return { ok: false, status: 400, error: "id is required" };
+  }
+  if (explicitId.length > MEMORY_GET_LIMITS.maxIdLength) {
+    return { ok: false, status: 400, error: "id is too long" };
+  }
+
+  return { ok: true, request: { provider: explicitProvider, id: explicitId } };
+}
+
+export async function executeMemoryGetRequest(
+  input: unknown,
+  options: MemoryGetExecutionOptions = {},
+): Promise<{ status: number; body: MemoryGetResponse | { error: string } }> {
+  const validation = validateMemoryGetRequest(input);
+  if (!validation.ok) {
+    return { status: validation.status, body: { error: validation.error } };
+  }
+
+  const providers = options.providers ?? await getDefaultMemoryGetProviders();
+  const provider = providers.find((entry) => entry.descriptor.id === validation.request.provider);
+  if (!provider) {
+    return { status: 400, body: { error: `Unknown provider ID: ${validation.request.provider}` } };
+  }
+
+  const startedAt = Date.now();
+  try {
+    const result = await provider.getById(validation.request.id, options.providerOptions);
+    return {
+      status: 200,
+      body: {
+        result,
+        providerMeta: [
+          {
+            providerId: provider.descriptor.id,
+            enabled: true,
+            found: result !== null,
+            durationMs: Date.now() - startedAt,
+          },
+        ],
+      },
+    };
+  } catch (error) {
+    return {
+      status: 200,
+      body: {
+        result: null,
+        providerMeta: [
+          {
+            providerId: provider.descriptor.id,
+            enabled: true,
+            found: false,
+            error: error instanceof Error ? error.message : String(error),
+            durationMs: Date.now() - startedAt,
+          },
+        ],
+      },
+    };
+  }
+}
+
+function parseCanonicalRef(canonicalRef: string): MemoryGetValidationResult {
+  if (canonicalRef.length > MEMORY_GET_LIMITS.maxIdLength) {
+    return { ok: false, status: 400, error: "canonicalRef is too long" };
+  }
+
+  const separator = ":article:";
+  const separatorIndex = canonicalRef.indexOf(separator);
+  if (separatorIndex <= 0 || separatorIndex + separator.length >= canonicalRef.length) {
+    return { ok: false, status: 400, error: "canonicalRef must look like provider:article:id" };
+  }
+
+  return {
+    ok: true,
+    request: {
+      provider: canonicalRef.slice(0, separatorIndex),
+      id: canonicalRef,
+    },
+  };
+}
+
+function readOptionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}

--- a/src/lib/memory/api/get.ts
+++ b/src/lib/memory/api/get.ts
@@ -8,6 +8,7 @@ import type { MemoryResult } from "@/lib/memory/types";
 export const MEMORY_GET_LIMITS = {
   maxIdLength: 512,
   maxProviderLength: 64,
+  timeoutMs: 5000,
 } as const;
 
 const PROVIDER_ID_PATTERN = /^[a-z0-9-]+$/;
@@ -37,6 +38,7 @@ export interface MemoryGetProviderMeta {
 export interface MemoryGetExecutionOptions {
   providers?: MemoryProvider[];
   providerOptions?: MemoryProviderGetOptions;
+  timeoutMs?: number;
 }
 
 export type MemoryGetValidationResult =
@@ -69,9 +71,16 @@ export function validateMemoryGetRequest(
   }
 
   const body = input as Record<string, unknown>;
-  const explicitProvider = readOptionalString(body.provider);
-  const explicitId = readOptionalString(body.id);
-  const canonicalRef = readOptionalString(body.canonicalRef);
+  const providerField = readOptionalRequestField(body, "provider");
+  if (!providerField.ok) return providerField;
+  const idField = readOptionalRequestField(body, "id");
+  if (!idField.ok) return idField;
+  const canonicalRefField = readOptionalRequestField(body, "canonicalRef");
+  if (!canonicalRefField.ok) return canonicalRefField;
+
+  const explicitProvider = providerField.value;
+  const explicitId = idField.value;
+  const canonicalRef = canonicalRefField.value;
 
   if (canonicalRef && (explicitProvider || explicitId)) {
     return {
@@ -163,10 +172,26 @@ export async function executeMemoryGetRequest(
     };
   }
 
+  const controller = new AbortController();
+  const timeoutMs = clampPositiveInteger(
+    options.timeoutMs,
+    MEMORY_GET_LIMITS.timeoutMs,
+    Number.MAX_SAFE_INTEGER,
+  );
+
   try {
-    const result = await provider.getById(
-      validation.request.id,
-      options.providerOptions,
+    const result = await withTimeout(
+      provider.getById(validation.request.id, {
+        ...options.providerOptions,
+        signal: controller.signal,
+      }),
+      timeoutMs,
+      () => {
+        controller.abort();
+        return Promise.reject(
+          new Error(`Provider lookup timed out after ${timeoutMs}ms`),
+        );
+      },
     );
     return {
       status: 200,
@@ -198,6 +223,8 @@ export async function executeMemoryGetRequest(
         ],
       },
     };
+  } finally {
+    controller.abort();
   }
 }
 
@@ -238,8 +265,23 @@ function parseCanonicalRef(canonicalRef: string): MemoryGetValidationResult {
   };
 }
 
-function readOptionalString(value: unknown): string | undefined {
-  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+function readOptionalRequestField(
+  body: Record<string, unknown>,
+  field: keyof MemoryGetRequest,
+):
+  | { ok: true; value: string | undefined }
+  | Extract<MemoryGetValidationResult, { ok: false }> {
+  if (!(field in body) || body[field] === undefined) {
+    return { ok: true, value: undefined };
+  }
+  if (typeof body[field] !== "string") {
+    return { ok: false, status: 400, error: `${field} must be a string` };
+  }
+  const value = body[field].trim();
+  if (!value) {
+    return { ok: true, value: undefined };
+  }
+  return { ok: true, value };
 }
 
 function validateProviderId(
@@ -257,4 +299,34 @@ function validateProviderId(
     };
   }
   return undefined;
+}
+
+function clampPositiveInteger(
+  value: unknown,
+  fallback: number,
+  max: number,
+): number {
+  const parsed = typeof value === "number" ? value : Number.NaN;
+  if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
+  return Math.min(Math.floor(parsed), max);
+}
+
+export async function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  onTimeout: () => T | Promise<T>,
+): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((resolve, reject) => {
+        timeout = setTimeout(() => {
+          Promise.resolve(onTimeout()).then(resolve, reject);
+        }, timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
 }

--- a/src/lib/memory/api/get.ts
+++ b/src/lib/memory/api/get.ts
@@ -1,9 +1,19 @@
-import { normalizeMemoryProviderConfig, type MemoryProvider, type MemoryProviderGetOptions } from "@/lib/memory/provider";
+import {
+  normalizeMemoryProviderConfig,
+  type MemoryProvider,
+  type MemoryProviderGetOptions,
+} from "@/lib/memory/provider";
 import type { MemoryResult } from "@/lib/memory/types";
 
 export const MEMORY_GET_LIMITS = {
   maxIdLength: 512,
+  maxProviderLength: 64,
 } as const;
+
+const PROVIDER_ID_PATTERN = /^[a-z0-9-]+$/;
+const CANONICAL_REF_TYPES_BY_PROVIDER: Record<string, Set<string>> = {
+  noosphere: new Set(["article"]),
+};
 
 export interface MemoryGetRequest {
   provider?: string;
@@ -44,12 +54,16 @@ export type MemoryGetValidationResult =
       error: string;
     };
 
-export async function getDefaultMemoryGetProviders(): Promise<MemoryProvider[]> {
+export async function getDefaultMemoryGetProviders(): Promise<
+  MemoryProvider[]
+> {
   const { createNoosphereProvider } = await import("@/lib/memory/noosphere");
   return [createNoosphereProvider()];
 }
 
-export function validateMemoryGetRequest(input: unknown): MemoryGetValidationResult {
+export function validateMemoryGetRequest(
+  input: unknown,
+): MemoryGetValidationResult {
   if (!input || typeof input !== "object" || Array.isArray(input)) {
     return { ok: false, status: 400, error: "Request body must be an object" };
   }
@@ -60,7 +74,11 @@ export function validateMemoryGetRequest(input: unknown): MemoryGetValidationRes
   const canonicalRef = readOptionalString(body.canonicalRef);
 
   if (canonicalRef && (explicitProvider || explicitId)) {
-    return { status: 400, ok: false, error: "Use either canonicalRef or provider + id, not both" };
+    return {
+      status: 400,
+      ok: false,
+      error: "Use either canonicalRef or provider + id, not both",
+    };
   }
 
   if (canonicalRef) {
@@ -73,6 +91,10 @@ export function validateMemoryGetRequest(input: unknown): MemoryGetValidationRes
   if (!explicitId) {
     return { ok: false, status: 400, error: "id is required" };
   }
+
+  const providerValidationError = validateProviderId(explicitProvider);
+  if (providerValidationError) return providerValidationError;
+
   if (explicitId.length > MEMORY_GET_LIMITS.maxIdLength) {
     return { ok: false, status: 400, error: "id is too long" };
   }
@@ -89,10 +111,15 @@ export async function executeMemoryGetRequest(
     return { status: validation.status, body: { error: validation.error } };
   }
 
-  const providers = options.providers ?? await getDefaultMemoryGetProviders();
-  const provider = providers.find((entry) => entry.descriptor.id === validation.request.provider);
+  const providers = options.providers ?? (await getDefaultMemoryGetProviders());
+  const provider = providers.find(
+    (entry) => entry.descriptor.id === validation.request.provider,
+  );
   if (!provider) {
-    return { status: 400, body: { error: `Unknown provider ID: ${validation.request.provider}` } };
+    return {
+      status: 400,
+      body: { error: `Unknown provider ID: ${validation.request.provider}` },
+    };
   }
 
   const startedAt = Date.now();
@@ -118,8 +145,29 @@ export async function executeMemoryGetRequest(
     };
   }
 
+  if (!provider.descriptor.capabilities.getById) {
+    return {
+      status: 200,
+      body: {
+        result: null,
+        providerMeta: [
+          {
+            providerId: provider.descriptor.id,
+            enabled: true,
+            found: false,
+            error: "Provider does not support getById",
+            durationMs: Date.now() - startedAt,
+          },
+        ],
+      },
+    };
+  }
+
   try {
-    const result = await provider.getById(validation.request.id, options.providerOptions);
+    const result = await provider.getById(
+      validation.request.id,
+      options.providerOptions,
+    );
     return {
       status: 200,
       body: {
@@ -158,21 +206,55 @@ function parseCanonicalRef(canonicalRef: string): MemoryGetValidationResult {
     return { ok: false, status: 400, error: "canonicalRef is too long" };
   }
 
-  const segments = canonicalRef.split(":");
-  if (segments.length < 3 || segments.some((segment) => !segment.trim())) {
-    return { ok: false, status: 400, error: "canonicalRef must look like provider:type:id" };
+  const segments = canonicalRef.split(":").map((segment) => segment.trim());
+  if (segments.length < 3 || segments.some((segment) => !segment)) {
+    return {
+      ok: false,
+      status: 400,
+      error: "canonicalRef must look like provider:type:id",
+    };
+  }
+
+  const [provider, type] = segments;
+  const providerValidationError = validateProviderId(provider);
+  if (providerValidationError) return providerValidationError;
+
+  const allowedTypes = CANONICAL_REF_TYPES_BY_PROVIDER[provider];
+  if (allowedTypes && !allowedTypes.has(type)) {
+    return {
+      ok: false,
+      status: 400,
+      error: `Unsupported canonicalRef type for ${provider}: ${type}`,
+    };
   }
 
   return {
     ok: true,
     request: {
-      provider: segments[0],
+      provider,
       id: segments.slice(2).join(":"),
-      canonicalRef,
+      canonicalRef: segments.join(":"),
     },
   };
 }
 
 function readOptionalString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function validateProviderId(
+  provider: string,
+): Extract<MemoryGetValidationResult, { ok: false }> | undefined {
+  if (provider.length > MEMORY_GET_LIMITS.maxProviderLength) {
+    return { ok: false, status: 400, error: "provider is too long" };
+  }
+  if (!PROVIDER_ID_PATTERN.test(provider)) {
+    return {
+      ok: false,
+      status: 400,
+      error:
+        "provider must contain only lowercase letters, numbers, and hyphens",
+    };
+  }
+  return undefined;
 }


### PR DESCRIPTION
## Summary

Implements roadmap PR 5: direct memory lookup by provider/id or canonical reference.

- Adds POST /api/memory/get with READ auth and provider-agnostic response shape
- Adds src/lib/memory/api/get.ts validation/execution helper
- Supports canonical refs like noosphere:article:<id> and provider-local lookup
- Fails open on provider lookup errors via providerMeta.error
- Adds noosphere_get OpenClaw tool and client method
- Updates bridge roadmap and includes API get tests in test:memory

## Verification

- npm run test:memory → 116/116
- npx tsc --noEmit --pretty false
- npx tsc -p openclaw-noosphere-memory/tsconfig.json --noEmit --pretty false
- npm run lint -- src/lib/memory/api/get.ts src/app/api/memory/get/route.ts src/__tests__/memory/api-get.test.ts openclaw-noosphere-memory/src --max-warnings=0
- git diff --check
