### PR TITLE
feat(memory): add save candidate API and OpenClaw tool

### DIFF
--- a/docs/OPENCLAW-NOOSPHERE-BRIDGE-ROADMAP.md
+++ b/docs/OPENCLAW-NOOSPHERE-BRIDGE-ROADMAP.md
@@ -1,6 +1,6 @@
 # OpenClaw ↔ Noosphere Memory Bridge Roadmap
 
-Status: implementation in progress — PRs 0–4 merged; PR 5 underway
+Status: implementation in progress — PRs 0–5 merged; PR 6 underway
 Owner: Noosphere/OpenClaw integration workstream
 Last updated: 2026-04-30
 
@@ -308,6 +308,8 @@ Verification:
 
 ### PR 5 — Lookup endpoint/tool
 
+Status: merged.
+
 Purpose: support direct retrieval by provider-local memory identifier or canonical reference.
 
 Endpoint:
@@ -352,6 +354,8 @@ Constraints:
 - provider lookup failures fail open into `providerMeta.error` rather than 500ing the route.
 
 ### PR 6 — Save/candidate API and tool
+
+Status: in progress.
 
 Purpose: add explicit candidate memory saving.
 

--- a/openclaw-noosphere-memory/openclaw.plugin.json
+++ b/openclaw-noosphere-memory/openclaw.plugin.json
@@ -1,21 +1,18 @@
 {
   "id": "noosphere-memory",
   "name": "Noosphere Memory Bridge",
-  "description": "Explicit OpenClaw tools and optional auto-recall prompt injection for Noosphere memory over HTTP. Recall requires READ permission; status requires an ADMIN-scoped Noosphere API key.",
+  "description": "Explicit OpenClaw tools and optional auto-recall prompt injection for Noosphere memory over HTTP. Recall/get require READ permission; save requires WRITE; status requires an ADMIN-scoped Noosphere API key.",
   "contracts": {
     "tools": [
       "noosphere_status",
       "noosphere_recall",
-      "noosphere_get"
+      "noosphere_get",
+      "noosphere_save"
     ],
-    "hooks": [
-      "before_prompt_build"
-    ]
+    "hooks": ["before_prompt_build"]
   },
   "providerAuthEnvVars": {
-    "noosphere-memory": [
-      "NOOSPHERE_API_KEY"
-    ]
+    "noosphere-memory": ["NOOSPHERE_API_KEY"]
   },
   "uiHints": {
     "baseUrl": {
@@ -25,7 +22,7 @@
     },
     "apiKey": {
       "label": "Noosphere API Key",
-      "help": "API key used as Authorization: Bearer <key>. Recall requires READ permission; status requires ADMIN. Fallback: NOOSPHERE_API_KEY.",
+      "help": "API key used as Authorization: Bearer <key>. Recall/get require READ permission; save requires WRITE; status requires ADMIN. Fallback: NOOSPHERE_API_KEY.",
       "sensitive": true,
       "placeholder": "noo_..."
     },
@@ -78,10 +75,7 @@
         "type": "string"
       },
       "apiKey": {
-        "type": [
-          "string",
-          "object"
-        ]
+        "type": ["string", "object"]
       },
       "timeoutMs": {
         "type": "number",

--- a/openclaw-noosphere-memory/src/client.ts
+++ b/openclaw-noosphere-memory/src/client.ts
@@ -20,6 +20,17 @@ export interface NoosphereRecallRequest {
   providers?: string[];
 }
 
+export interface NoosphereSaveRequest {
+  title: string;
+  content: string;
+  topicId: string;
+  excerpt?: string;
+  tags?: string[];
+  source?: string;
+  authorName?: string;
+  confidence?: "low" | "medium" | "high";
+}
+
 export type NoosphereGetRequest =
   | { canonicalRef: string; provider?: never; id?: never }
   | { provider: string; id: string; canonicalRef?: never };
@@ -27,6 +38,20 @@ export type NoosphereGetRequest =
 export interface NoosphereGetResponse {
   result: NoosphereMemoryResult | null;
   providerMeta: NoosphereMemoryGetProviderMeta[];
+}
+
+export interface NoosphereSaveResponse {
+  success: true;
+  candidate: {
+    id: string;
+    title: string;
+    slug: string;
+    topicId: string;
+    topic?: { id: string; name: string; slug: string };
+    status: "draft";
+    url?: string;
+  };
+  strippedBlocks: string[];
 }
 
 export interface NoosphereRecallResponse {
@@ -63,6 +88,14 @@ export class NoosphereMemoryClient {
 
   async get(request: NoosphereGetRequest): Promise<NoosphereGetResponse> {
     return this.request<NoosphereGetResponse>("/api/memory/get", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(request),
+    });
+  }
+
+  async save(request: NoosphereSaveRequest): Promise<NoosphereSaveResponse> {
+    return this.request<NoosphereSaveResponse>("/api/memory/save", {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify(request),

--- a/openclaw-noosphere-memory/src/index.ts
+++ b/openclaw-noosphere-memory/src/index.ts
@@ -3,18 +3,29 @@ import { createNoosphereAutoRecallHook } from "./auto-recall.js";
 import { createNoosphereClientContext } from "./shared-init.js";
 import { createNoosphereGetTool } from "./tools/get.js";
 import { createNoosphereRecallTool } from "./tools/recall.js";
+import { createNoosphereSaveTool } from "./tools/save.js";
 import { createNoosphereStatusTool } from "./tools/status.js";
 
 export default definePluginEntry({
   id: "noosphere-memory",
   name: "Noosphere Memory Bridge",
-  description: "Explicit OpenClaw tools and optional auto-recall prompt injection for Noosphere memory over HTTP.",
+  description:
+    "Explicit OpenClaw tools and optional auto-recall prompt injection for Noosphere memory over HTTP.",
   register(api) {
     const clientContext = createNoosphereClientContext(api.pluginConfig);
-    api.registerTool(createNoosphereStatusTool(api.pluginConfig, clientContext));
-    api.registerTool(createNoosphereRecallTool(api.pluginConfig, clientContext));
+    api.registerTool(
+      createNoosphereStatusTool(api.pluginConfig, clientContext),
+    );
+    api.registerTool(
+      createNoosphereRecallTool(api.pluginConfig, clientContext),
+    );
     api.registerTool(createNoosphereGetTool(api.pluginConfig, clientContext));
-    const hook = createNoosphereAutoRecallHook(api.pluginConfig, clientContext, api.logger);
+    api.registerTool(createNoosphereSaveTool(api.pluginConfig, clientContext));
+    const hook = createNoosphereAutoRecallHook(
+      api.pluginConfig,
+      clientContext,
+      api.logger,
+    );
     if (typeof api.on === "function") {
       api.on("before_prompt_build", hook);
     } else {

--- a/openclaw-noosphere-memory/src/tools/save.ts
+++ b/openclaw-noosphere-memory/src/tools/save.ts
@@ -35,21 +35,25 @@ const SaveToolParameters = {
     },
     excerpt: {
       type: "string",
+      maxLength: 500,
       description: "Optional short summary/excerpt.",
     },
     tags: {
       type: "array",
       maxItems: SAVE_TAG_MAX_COUNT,
       items: { type: "string", maxLength: SAVE_TAG_MAX_LENGTH },
-      description: "Optional tags. Duplicates are normalized server-side.",
+      description:
+        "Optional tags. Duplicates are normalized by slug server-side while preserving first-seen display casing.",
     },
     source: {
       type: "string",
+      maxLength: 500,
       description:
         "Optional source pointer, e.g. session key, URL, or canonical ref.",
     },
     authorName: {
       type: "string",
+      maxLength: 100,
       description: "Optional display author name.",
     },
     confidence: {

--- a/openclaw-noosphere-memory/src/tools/save.ts
+++ b/openclaw-noosphere-memory/src/tools/save.ts
@@ -1,0 +1,162 @@
+import { NoosphereSaveRequest } from "../client.js";
+import { errorResult, jsonResult } from "../format.js";
+import {
+  createNoosphereClientContext,
+  NoosphereClientContext,
+} from "../shared-init.js";
+
+const SAVE_TITLE_MAX_LENGTH = 160;
+const SAVE_CONTENT_MAX_LENGTH = 50_000;
+const SAVE_TOPIC_ID_MAX_LENGTH = 128;
+const SAVE_TAG_MAX_COUNT = 12;
+const SAVE_TAG_MAX_LENGTH = 64;
+
+const SaveToolParameters = {
+  type: "object",
+  additionalProperties: false,
+  required: ["title", "content", "topicId"],
+  properties: {
+    title: {
+      type: "string",
+      description: "Short title for the draft memory candidate.",
+      maxLength: SAVE_TITLE_MAX_LENGTH,
+    },
+    content: {
+      type: "string",
+      description:
+        "Durable memory content to save as a draft candidate. Injected recall blocks are stripped server-side.",
+      maxLength: SAVE_CONTENT_MAX_LENGTH,
+    },
+    topicId: {
+      type: "string",
+      description:
+        "Noosphere topic ID where the draft candidate should be filed.",
+      maxLength: SAVE_TOPIC_ID_MAX_LENGTH,
+    },
+    excerpt: {
+      type: "string",
+      description: "Optional short summary/excerpt.",
+    },
+    tags: {
+      type: "array",
+      maxItems: SAVE_TAG_MAX_COUNT,
+      items: { type: "string", maxLength: SAVE_TAG_MAX_LENGTH },
+      description: "Optional tags. Duplicates are normalized server-side.",
+    },
+    source: {
+      type: "string",
+      description:
+        "Optional source pointer, e.g. session key, URL, or canonical ref.",
+    },
+    authorName: {
+      type: "string",
+      description: "Optional display author name.",
+    },
+    confidence: {
+      type: "string",
+      enum: ["low", "medium", "high"],
+      description: "Initial confidence for the draft candidate.",
+    },
+  },
+} as const;
+
+export function createNoosphereSaveTool(
+  rawConfig: unknown,
+  context?: NoosphereClientContext,
+) {
+  const { config, client } = context ?? createNoosphereClientContext(rawConfig);
+
+  return {
+    name: "noosphere_save",
+    label: "Noosphere Save Candidate",
+    description:
+      "Save durable content to Noosphere as a draft memory candidate. This never publishes directly.",
+    parameters: SaveToolParameters,
+    async execute(_toolCallId: string, rawParams: unknown) {
+      try {
+        const params = normalizeSaveParams(rawParams);
+        return jsonResult(await client.save(params));
+      } catch (error) {
+        return errorResult(error, config);
+      }
+    },
+  };
+}
+
+function normalizeSaveParams(rawParams: unknown): NoosphereSaveRequest {
+  const params = isRecord(rawParams) ? rawParams : {};
+  return {
+    title: readRequiredString(params.title, "title", SAVE_TITLE_MAX_LENGTH),
+    content: readRequiredString(
+      params.content,
+      "content",
+      SAVE_CONTENT_MAX_LENGTH,
+    ),
+    topicId: readRequiredString(
+      params.topicId,
+      "topicId",
+      SAVE_TOPIC_ID_MAX_LENGTH,
+    ),
+    excerpt: readOptionalString(params.excerpt, "excerpt", 500),
+    tags: readOptionalTags(params.tags),
+    source: readOptionalString(params.source, "source", 500),
+    authorName: readOptionalString(params.authorName, "authorName", 100),
+    confidence: readOptionalConfidence(params.confidence),
+  };
+}
+
+function readRequiredString(
+  value: unknown,
+  field: string,
+  maxLength: number,
+): string {
+  if (typeof value !== "string" || !value.trim()) {
+    throw new Error(`${field} is required`);
+  }
+  const trimmed = value.trim();
+  if (trimmed.length > maxLength) throw new Error(`${field} is too long`);
+  return trimmed;
+}
+
+function readOptionalString(
+  value: unknown,
+  field: string,
+  maxLength: number,
+): string | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value !== "string") throw new Error(`${field} must be a string`);
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  if (trimmed.length > maxLength) throw new Error(`${field} is too long`);
+  return trimmed;
+}
+
+function readOptionalTags(value: unknown): string[] | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (!Array.isArray(value))
+    throw new Error("tags must be an array of strings");
+  if (value.length > SAVE_TAG_MAX_COUNT) throw new Error("too many tags");
+  const tags: string[] = [];
+  for (const tag of value) {
+    if (typeof tag !== "string")
+      throw new Error("tags must be an array of strings");
+    const normalized = tag.trim();
+    if (!normalized) continue;
+    if (normalized.length > SAVE_TAG_MAX_LENGTH)
+      throw new Error("tag is too long");
+    tags.push(normalized);
+  }
+  return tags.length ? tags : undefined;
+}
+
+function readOptionalConfidence(
+  value: unknown,
+): NoosphereSaveRequest["confidence"] {
+  if (value === undefined || value === null || value === "") return undefined;
+  if (value === "low" || value === "medium" || value === "high") return value;
+  throw new Error("confidence must be low, medium, or high");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "prisma generate && next build",
     "start": "next start",
     "test": "npm run test:memory",
-    "test:memory": "node --import tsx --test src/__tests__/memory/api-recall.test.ts src/__tests__/memory/api-get.test.ts src/__tests__/memory/api-status.test.ts src/__tests__/memory/budget.test.ts src/__tests__/memory/conflict.test.ts src/__tests__/memory/dedup.test.ts src/__tests__/memory/hindsight-provider.test.ts src/__tests__/memory/openclaw-plugin-auto-recall.test.ts src/__tests__/memory/promotion.test.ts src/__tests__/memory/backfill.test.ts src/__tests__/memory/recall-orchestrator.test.ts src/__tests__/memory/settings.test.ts src/__tests__/memory/scheduler.test.ts",
+    "test:memory": "node --import tsx --test src/__tests__/memory/api-recall.test.ts src/__tests__/memory/api-get.test.ts src/__tests__/memory/api-save.test.ts src/__tests__/memory/api-status.test.ts src/__tests__/memory/budget.test.ts src/__tests__/memory/conflict.test.ts src/__tests__/memory/dedup.test.ts src/__tests__/memory/hindsight-provider.test.ts src/__tests__/memory/openclaw-plugin-auto-recall.test.ts src/__tests__/memory/promotion.test.ts src/__tests__/memory/backfill.test.ts src/__tests__/memory/recall-orchestrator.test.ts src/__tests__/memory/settings.test.ts src/__tests__/memory/scheduler.test.ts",
     "test:scheduler": "node --import tsx --test src/__tests__/memory/scheduler.test.ts",
     "lint": "eslint",
     "db:migrate": "prisma migrate dev",

--- a/src/__tests__/memory/api-save.test.ts
+++ b/src/__tests__/memory/api-save.test.ts
@@ -1,0 +1,140 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  executeMemorySaveRequest,
+  stripInjectedMemoryBlocks,
+  validateMemorySaveRequest,
+  type SanitizedMemorySaveInput,
+} from "@/lib/memory/api/save";
+
+const durableContent =
+  "This is a durable operational note about the Noosphere bridge workflow. It explains why future agents should preserve draft review before publishing.";
+
+function validRequest(overrides: Record<string, unknown> = {}) {
+  return {
+    title: "Noosphere bridge save candidate",
+    content: durableContent,
+    topicId: "topic-1",
+    tags: [" Memory ", "memory", "bridge"],
+    confidence: "medium",
+    ...overrides,
+  };
+}
+
+test("memory save validation accepts durable draft candidates", () => {
+  const result = validateMemorySaveRequest(validRequest());
+
+  assert.equal(result.ok, true);
+  if (!result.ok) return;
+  assert.equal(result.input.status, "draft");
+  assert.deepEqual(result.input.tags, ["memory", "bridge"]);
+  assert.equal(result.input.confidence, "medium");
+});
+
+test("memory save strips injected memory blocks before validation", () => {
+  const result = validateMemorySaveRequest(
+    validRequest({
+      content: `<recall>old injected recall</recall>\n${durableContent}\n<hindsight_memories>do not save this</hindsight_memories>`,
+    }),
+  );
+
+  assert.equal(result.ok, true);
+  if (!result.ok) return;
+  assert.equal(result.input.content.includes("old injected recall"), false);
+  assert.equal(result.input.content.includes("do not save this"), false);
+  assert.deepEqual(
+    new Set(result.input.strippedBlocks),
+    new Set(["recall", "hindsight_memories"]),
+  );
+});
+
+test("memory save strip helper handles noosphere auto recall blocks", () => {
+  const stripped = stripInjectedMemoryBlocks(
+    "keep this\n<noosphere_auto_recall><recall>nested</recall></noosphere_auto_recall>\nkeep that",
+  );
+
+  assert.equal(stripped.content.includes("nested"), false);
+  assert.deepEqual(stripped.strippedBlocks, ["noosphere_auto_recall"]);
+});
+
+test("memory save rejects empty, transient, and noisy content", () => {
+  assert.deepEqual(validateMemorySaveRequest(validRequest({ content: "ok" })), {
+    ok: false,
+    status: 400,
+    error: "content is too short to save as durable memory",
+  });
+
+  assert.deepEqual(
+    validateMemorySaveRequest(
+      validRequest({
+        content: "1234567890 1234567890 1234567890 1234567890 1234567890",
+      }),
+    ),
+    {
+      ok: false,
+      status: 400,
+      error: "content must contain meaningful prose",
+    },
+  );
+});
+
+test("memory save rejects likely secrets", () => {
+  const result = validateMemorySaveRequest(
+    validRequest({
+      content: `${durableContent}\nToken: noo_abcdefghijklmnopqrstuvwxyz`,
+    }),
+  );
+
+  assert.deepEqual(result, {
+    ok: false,
+    status: 400,
+    error: "content appears to contain a secret (Noosphere API key)",
+  });
+});
+
+test("memory save rejects malformed optional fields", () => {
+  assert.deepEqual(
+    validateMemorySaveRequest(validRequest({ tags: "memory" })),
+    {
+      ok: false,
+      status: 400,
+      error: "tags must be an array of strings",
+    },
+  );
+  assert.deepEqual(
+    validateMemorySaveRequest(validRequest({ confidence: "certain" })),
+    {
+      ok: false,
+      status: 400,
+      error: "confidence must be low/medium/high",
+    },
+  );
+});
+
+test("memory save executes through injected writer", async () => {
+  const seen: SanitizedMemorySaveInput[] = [];
+  const response = await executeMemorySaveRequest(validRequest(), {
+    writer: {
+      async saveCandidate(input) {
+        seen.push(input);
+        return {
+          id: "article-1",
+          title: input.title,
+          slug: "noosphere-bridge-save-candidate",
+          topicId: input.topicId,
+          status: "draft",
+          url: "/wiki/memory/noosphere-bridge-save-candidate",
+        };
+      },
+    },
+  });
+
+  assert.equal(response.status, 201);
+  assert.ok("success" in response.body);
+  if (!("success" in response.body)) return;
+  assert.equal(response.body.success, true);
+  assert.equal(response.body.candidate.status, "draft");
+  assert.equal(seen.length, 1);
+  assert.equal(seen[0].status, "draft");
+});

--- a/src/__tests__/memory/api-save.test.ts
+++ b/src/__tests__/memory/api-save.test.ts
@@ -28,7 +28,7 @@ test("memory save validation accepts durable draft candidates", () => {
   assert.equal(result.ok, true);
   if (!result.ok) return;
   assert.equal(result.input.status, "draft");
-  assert.deepEqual(result.input.tags, ["memory", "bridge"]);
+  assert.deepEqual(result.input.tags, ["Memory", "bridge"]);
   assert.equal(result.input.confidence, "medium");
 });
 
@@ -55,7 +55,19 @@ test("memory save strip helper handles noosphere auto recall blocks", () => {
   );
 
   assert.equal(stripped.content.includes("nested"), false);
-  assert.deepEqual(stripped.strippedBlocks, ["noosphere_auto_recall"]);
+  assert.deepEqual(
+    new Set(stripped.strippedBlocks),
+    new Set(["recall", "noosphere_auto_recall"]),
+  );
+});
+
+test("memory save strip helper handles nested same-type blocks", () => {
+  const stripped = stripInjectedMemoryBlocks(
+    "before <recall>outer <recall>inner</recall> content</recall> after",
+  );
+
+  assert.equal(stripped.content, "before \n after");
+  assert.deepEqual(stripped.strippedBlocks, ["recall"]);
 });
 
 test("memory save rejects empty, transient, and noisy content", () => {
@@ -83,6 +95,20 @@ test("memory save rejects likely secrets", () => {
   const result = validateMemorySaveRequest(
     validRequest({
       content: `${durableContent}\nToken: noo_abcdefghijklmnopqrstuvwxyz`,
+    }),
+  );
+
+  assert.deepEqual(result, {
+    ok: false,
+    status: 400,
+    error: "content appears to contain a secret (Noosphere API key)",
+  });
+});
+
+test("memory save rejects secrets in optional fields", () => {
+  const result = validateMemorySaveRequest(
+    validRequest({
+      excerpt: "Token noo_abcdefghijklmnopqrstuvwxyz should not persist",
     }),
   );
 

--- a/src/__tests__/memory/openclaw-plugin-auto-recall.test.ts
+++ b/src/__tests__/memory/openclaw-plugin-auto-recall.test.ts
@@ -10,12 +10,15 @@ import {
   NoosphereClientError,
   type NoosphereGetRequest,
   type NoosphereGetResponse,
+  type NoosphereSaveRequest,
+  type NoosphereSaveResponse,
 } from "../../../openclaw-noosphere-memory/src/client.js";
 import type {
   NoosphereRecallRequest,
   NoosphereRecallResponse,
 } from "../../../openclaw-noosphere-memory/src/client.js";
 import { createNoosphereGetTool } from "../../../openclaw-noosphere-memory/src/tools/get.js";
+import { createNoosphereSaveTool } from "../../../openclaw-noosphere-memory/src/tools/save.js";
 import type { NoosphereClientContext } from "../../../openclaw-noosphere-memory/src/shared-init.js";
 
 function makeContext(
@@ -525,5 +528,88 @@ describe("OpenClaw Noosphere get tool", () => {
 
     assert.equal(result.isError, true);
     assert.match(String(result.content[0]?.text), /HTTP 401/);
+  });
+});
+
+describe("OpenClaw Noosphere save tool", () => {
+  function makeSaveContext() {
+    const calls: NoosphereSaveRequest[] = [];
+    const response: NoosphereSaveResponse = {
+      success: true,
+      candidate: {
+        id: "article-1",
+        title: "Save Candidate",
+        slug: "save-candidate",
+        topicId: "topic-1",
+        status: "draft",
+        url: "/wiki/memory/save-candidate",
+      },
+      strippedBlocks: [],
+    };
+
+    const context = {
+      config: {
+        baseUrl: "http://noosphere.local",
+        apiKey: "noo_test",
+        timeoutMs: 5000,
+      },
+      client: {
+        async save(request: NoosphereSaveRequest) {
+          calls.push(request);
+          return response;
+        },
+      },
+    } as unknown as NoosphereClientContext;
+
+    return { context, calls };
+  }
+
+  it("normalizes save candidate requests", async () => {
+    const { context, calls } = makeSaveContext();
+    const tool = createNoosphereSaveTool({}, context);
+
+    const result = await tool.execute("tool-1", {
+      title: " Save Candidate ",
+      content: " Durable content worth saving for future agents. ",
+      topicId: " topic-1 ",
+      tags: [" memory ", "bridge"],
+      confidence: "low",
+    });
+
+    assert.equal(result.isError, undefined);
+    assert.deepEqual(calls, [
+      {
+        title: "Save Candidate",
+        content: "Durable content worth saving for future agents.",
+        topicId: "topic-1",
+        excerpt: undefined,
+        tags: ["memory", "bridge"],
+        source: undefined,
+        authorName: undefined,
+        confidence: "low",
+      },
+    ]);
+  });
+
+  it("rejects malformed save params before calling the client", async () => {
+    const { context, calls } = makeSaveContext();
+    const tool = createNoosphereSaveTool({}, context);
+
+    const missing = await tool.execute("tool-1", {
+      title: "Save Candidate",
+      content: "Durable content worth saving for future agents.",
+    });
+    const badTags = await tool.execute("tool-2", {
+      title: "Save Candidate",
+      content: "Durable content worth saving for future agents.",
+      topicId: "topic-1",
+      tags: "memory",
+    });
+
+    assert.equal(missing.isError, true);
+    assert.equal(badTags.isError, true);
+    assert.equal(calls.length, 0);
+    assert.match(String(missing.content[0]?.text), /topicId is required/);
+    assert.match(String(badTags.content[0]?.text), /tags must be an array/);
   });
 });

--- a/src/app/api/memory/save/route.ts
+++ b/src/app/api/memory/save/route.ts
@@ -14,8 +14,12 @@ export async function POST(request: NextRequest) {
 
   let body: unknown;
   try {
-    body = await request.json();
-  } catch {
+    const rawBody = await readBoundedJsonBody(request);
+    body = JSON.parse(rawBody);
+  } catch (error) {
+    if (error instanceof RequestBodyTooLargeError) {
+      return NextResponse.json({ error: error.message }, { status: 413 });
+    }
     return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
   }
 
@@ -36,4 +40,43 @@ export async function POST(request: NextRequest) {
       { status: 503 },
     );
   }
+}
+
+class RequestBodyTooLargeError extends Error {
+  constructor() {
+    super("Request body is too large");
+    this.name = "RequestBodyTooLargeError";
+  }
+}
+
+async function readBoundedJsonBody(request: NextRequest): Promise<string> {
+  const maxBodyBytes = 64 * 1024;
+  const reader = request.body?.getReader();
+  if (!reader) return "";
+
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    totalBytes += value.byteLength;
+    if (totalBytes > maxBodyBytes) {
+      await reader.cancel();
+      throw new RequestBodyTooLargeError();
+    }
+    chunks.push(value);
+  }
+
+  return new TextDecoder().decode(concatChunks(chunks, totalBytes));
+}
+
+function concatChunks(chunks: Uint8Array[], totalBytes: number): Uint8Array {
+  const combined = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    combined.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return combined;
 }

--- a/src/app/api/memory/save/route.ts
+++ b/src/app/api/memory/save/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from "next/server";
+import { Permissions } from "@prisma/client";
+import { requirePermission } from "@/lib/api/auth";
+import {
+  executeMemorySaveRequest,
+  MemorySaveError,
+} from "@/lib/memory/api/save";
+
+export async function POST(request: NextRequest) {
+  const auth = await requirePermission(request, [Permissions.WRITE]);
+  if (!auth.success) {
+    return auth.response;
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  try {
+    const result = await executeMemorySaveRequest(body);
+    return NextResponse.json(result.body, { status: result.status });
+  } catch (error) {
+    if (error instanceof MemorySaveError) {
+      return NextResponse.json(
+        { error: error.message },
+        { status: error.status },
+      );
+    }
+
+    console.error("[POST /api/memory/save]", error);
+    return NextResponse.json(
+      { error: "Memory candidate save unavailable" },
+      { status: 503 },
+    );
+  }
+}

--- a/src/lib/memory/api/save.ts
+++ b/src/lib/memory/api/save.ts
@@ -1,0 +1,474 @@
+import { slugify } from "@/lib/memory/backfill";
+import type { Prisma, PrismaClient } from "@prisma/client";
+
+export const MEMORY_SAVE_LIMITS = {
+  maxTitleLength: 160,
+  maxContentLength: 50_000,
+  maxExcerptLength: 500,
+  maxTopicIdLength: 128,
+  maxTagCount: 12,
+  maxTagLength: 64,
+  minDurableContentLength: 40,
+} as const;
+
+const INJECTED_MEMORY_BLOCKS = [
+  "noosphere_auto_recall",
+  "hindsight_memories",
+  "recall",
+] as const;
+
+const SECRET_PATTERNS: Array<{ name: string; pattern: RegExp }> = [
+  { name: "OpenAI-style API key", pattern: /\bsk-[A-Za-z0-9_-]{20,}\b/ },
+  { name: "Noosphere API key", pattern: /\bnoo_[A-Za-z0-9_-]{16,}\b/ },
+  { name: "GitHub token", pattern: /\bgh[pousr]_[A-Za-z0-9_]{20,}\b/ },
+  {
+    name: "generic bearer token",
+    pattern: /\bBearer\s+[A-Za-z0-9._~+/=-]{20,}\b/i,
+  },
+  { name: "private key block", pattern: /-----BEGIN [A-Z ]*PRIVATE KEY-----/ },
+];
+
+const TRANSIENT_ONLY_PATTERNS = [
+  /^(thanks?|thank you|ok(?:ay)?|done|yes|no|sure|great|nice|cool)[.!\s]*$/i,
+  /^(i'?ll|we'?ll) (check|look|do|handle|get back).{0,80}$/i,
+  /^(remind me|ping me|wake me).{0,120}$/i,
+];
+
+export interface MemorySaveRequest {
+  title?: string;
+  content?: string;
+  topicId?: string;
+  excerpt?: string;
+  tags?: string[];
+  source?: string;
+  authorName?: string;
+  confidence?: "low" | "medium" | "high";
+}
+
+export interface SanitizedMemorySaveInput {
+  title: string;
+  content: string;
+  topicId: string;
+  excerpt?: string;
+  tags: string[];
+  source?: string;
+  authorName?: string;
+  confidence?: "low" | "medium" | "high";
+  status: "draft";
+  strippedBlocks: string[];
+}
+
+export interface SavedMemoryCandidate {
+  id: string;
+  title: string;
+  slug: string;
+  topicId: string;
+  topic?: { id: string; name: string; slug: string };
+  status: "draft";
+  url?: string;
+}
+
+export interface MemorySaveResponse {
+  success: true;
+  candidate: SavedMemoryCandidate;
+  strippedBlocks: string[];
+}
+
+export interface MemorySaveWriter {
+  saveCandidate(input: SanitizedMemorySaveInput): Promise<SavedMemoryCandidate>;
+}
+
+export interface MemorySaveExecutionOptions {
+  writer?: MemorySaveWriter;
+}
+
+export type MemorySaveValidationResult =
+  | { ok: true; input: SanitizedMemorySaveInput }
+  | { ok: false; status: number; error: string };
+
+export async function executeMemorySaveRequest(
+  input: unknown,
+  options: MemorySaveExecutionOptions = {},
+): Promise<{ status: number; body: MemorySaveResponse | { error: string } }> {
+  const validation = validateMemorySaveRequest(input);
+  if (!validation.ok) {
+    return { status: validation.status, body: { error: validation.error } };
+  }
+
+  const writer = options.writer ?? (await getDefaultMemorySaveWriter());
+  const candidate = await writer.saveCandidate(validation.input);
+
+  return {
+    status: 201,
+    body: {
+      success: true,
+      candidate,
+      strippedBlocks: validation.input.strippedBlocks,
+    },
+  };
+}
+
+export function validateMemorySaveRequest(
+  input: unknown,
+): MemorySaveValidationResult {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    return { ok: false, status: 400, error: "Request body must be an object" };
+  }
+
+  const body = input as Record<string, unknown>;
+  const title = readRequiredString(
+    body.title,
+    "title",
+    MEMORY_SAVE_LIMITS.maxTitleLength,
+  );
+  if (!title.ok) return title;
+  const content = readRequiredString(
+    body.content,
+    "content",
+    MEMORY_SAVE_LIMITS.maxContentLength,
+  );
+  if (!content.ok) return content;
+  const topicId = readRequiredString(
+    body.topicId,
+    "topicId",
+    MEMORY_SAVE_LIMITS.maxTopicIdLength,
+  );
+  if (!topicId.ok) return topicId;
+  const excerpt = readOptionalString(
+    body.excerpt,
+    "excerpt",
+    MEMORY_SAVE_LIMITS.maxExcerptLength,
+  );
+  if (!excerpt.ok) return excerpt;
+  const source = readOptionalString(body.source, "source", 500);
+  if (!source.ok) return source;
+  const authorName = readOptionalString(body.authorName, "authorName", 100);
+  if (!authorName.ok) return authorName;
+  const tags = readOptionalTags(body.tags);
+  if (!tags.ok) return tags;
+  const confidence = readOptionalConfidence(body.confidence);
+  if (!confidence.ok) return confidence;
+
+  const stripped = stripInjectedMemoryBlocks(content.value);
+  const sanitizedContent = normalizeContent(stripped.content);
+  const durableError = validateDurableContent(sanitizedContent);
+  if (durableError) return durableError;
+
+  const secretError =
+    detectSecret(sanitizedContent) ?? detectSecret(title.value);
+  if (secretError) return secretError;
+
+  return {
+    ok: true,
+    input: {
+      title: title.value,
+      content: sanitizedContent,
+      topicId: topicId.value,
+      excerpt: excerpt.value,
+      tags: tags.value,
+      source: source.value,
+      authorName: authorName.value,
+      confidence: confidence.value,
+      status: "draft",
+      strippedBlocks: stripped.strippedBlocks,
+    },
+  };
+}
+
+export function stripInjectedMemoryBlocks(content: string): {
+  content: string;
+  strippedBlocks: string[];
+} {
+  let strippedContent = content;
+  const strippedBlocks: string[] = [];
+
+  for (const tag of INJECTED_MEMORY_BLOCKS) {
+    const pattern = new RegExp(`<${tag}\\b[^>]*>[\\s\\S]*?<\\/${tag}>`, "gi");
+    strippedContent = strippedContent.replace(pattern, () => {
+      strippedBlocks.push(tag);
+      return "\n";
+    });
+  }
+
+  return { content: strippedContent, strippedBlocks };
+}
+
+export async function getDefaultMemorySaveWriter(): Promise<MemorySaveWriter> {
+  const { prisma } = await import("@/lib/prisma");
+
+  return {
+    async saveCandidate(input) {
+      const topic = await prisma.topic.findUnique({
+        where: { id: input.topicId },
+        select: { id: true, name: true, slug: true },
+      });
+      if (!topic) {
+        throw new MemorySaveError("Topic not found", 404);
+      }
+
+      const baseSlug = slugify(input.title).slice(0, 80) || "memory-candidate";
+      const slug = await findAvailableSlug(input.topicId, baseSlug);
+      const excerpt =
+        input.excerpt ??
+        input.content
+          .slice(0, 200)
+          .replace(/[#*`_>\-\[\]]/g, "")
+          .trim();
+
+      const article = await prisma.$transaction(async (tx) => {
+        const tagConnections = await buildTagConnectionsForClient(
+          input.tags,
+          tx,
+        );
+        const created = await tx.article.create({
+          data: {
+            title: input.title,
+            slug,
+            content: input.content,
+            excerpt,
+            topicId: input.topicId,
+            authorName: input.authorName ?? "OpenClaw Noosphere Bridge",
+            confidence: input.confidence ?? "low",
+            status: "draft",
+            sourceType: "memory_candidate",
+            sourceUrl: input.source ?? null,
+            tags: { create: tagConnections },
+            revisions: {
+              create: {
+                title: input.title,
+                content: input.content,
+              },
+            },
+          },
+          include: { topic: true },
+        });
+
+        await tx.activityLog.create({
+          data: {
+            type: "memory_candidate_saved",
+            title: `Memory candidate saved as "${input.title}"`,
+            authorName: input.authorName ?? "OpenClaw Noosphere Bridge",
+            sourceUrl: input.source ?? null,
+            details: {
+              articleId: created.id,
+              topicId: input.topicId,
+              topic: topic.name,
+              status: "draft",
+              confidence: input.confidence ?? "low",
+              tagCount: input.tags.length,
+              strippedBlocks: input.strippedBlocks,
+            },
+          },
+        });
+
+        return created;
+      });
+
+      return {
+        id: article.id,
+        title: article.title,
+        slug: article.slug,
+        topicId: article.topicId,
+        topic: {
+          id: article.topic.id,
+          name: article.topic.name,
+          slug: article.topic.slug,
+        },
+        status: "draft",
+        url: `/wiki/${article.topic.slug}/${article.slug}`,
+      };
+    },
+  };
+
+  async function findAvailableSlug(
+    topicId: string,
+    baseSlug: string,
+  ): Promise<string> {
+    for (let index = 0; index < 100; index += 1) {
+      const candidate = index === 0 ? baseSlug : `${baseSlug}-${index + 1}`;
+      const existing = await prisma.article.findUnique({
+        where: { topicId_slug: { topicId, slug: candidate } },
+        select: { id: true },
+      });
+      if (!existing) return candidate;
+    }
+    throw new MemorySaveError(
+      "Could not generate a unique candidate slug",
+      409,
+    );
+  }
+}
+
+type TagWriter = Pick<PrismaClient, "tag"> | Prisma.TransactionClient;
+
+async function buildTagConnectionsForClient(
+  tagNames: string[],
+  client: TagWriter,
+): Promise<Array<{ tagId: string }>> {
+  if (!tagNames.length) return [];
+
+  return Promise.all(
+    tagNames.map(async (tagName) => {
+      const tagSlug = slugify(tagName);
+      const tag = await client.tag.upsert({
+        where: { slug: tagSlug },
+        create: { name: tagName, slug: tagSlug },
+        update: { name: tagName },
+      });
+
+      return { tagId: tag.id };
+    }),
+  );
+}
+
+export class MemorySaveError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+  ) {
+    super(message);
+    this.name = "MemorySaveError";
+  }
+}
+
+function normalizeContent(content: string): string {
+  return content
+    .replace(/\r\n/g, "\n")
+    .replace(/[ \t]+\n/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+function validateDurableContent(
+  content: string,
+): Extract<MemorySaveValidationResult, { ok: false }> | undefined {
+  if (content.length < MEMORY_SAVE_LIMITS.minDurableContentLength) {
+    return {
+      ok: false,
+      status: 400,
+      error: "content is too short to save as durable memory",
+    };
+  }
+
+  if (!/[a-zA-Z]{12,}/.test(content.replace(/\s+/g, ""))) {
+    return {
+      ok: false,
+      status: 400,
+      error: "content must contain meaningful prose",
+    };
+  }
+
+  if (TRANSIENT_ONLY_PATTERNS.some((pattern) => pattern.test(content))) {
+    return {
+      ok: false,
+      status: 400,
+      error:
+        "content looks transient and should not be saved as durable memory",
+    };
+  }
+
+  return undefined;
+}
+
+function detectSecret(
+  value: string,
+): Extract<MemorySaveValidationResult, { ok: false }> | undefined {
+  const match = SECRET_PATTERNS.find((entry) => entry.pattern.test(value));
+  if (!match) return undefined;
+  return {
+    ok: false,
+    status: 400,
+    error: `content appears to contain a secret (${match.name})`,
+  };
+}
+
+function readRequiredString(
+  value: unknown,
+  field: string,
+  maxLength: number,
+):
+  | { ok: true; value: string }
+  | Extract<MemorySaveValidationResult, { ok: false }> {
+  if (typeof value !== "string" || !value.trim()) {
+    return { ok: false, status: 400, error: `${field} is required` };
+  }
+  const trimmed = value.trim();
+  if (trimmed.length > maxLength) {
+    return { ok: false, status: 400, error: `${field} is too long` };
+  }
+  return { ok: true, value: trimmed };
+}
+
+function readOptionalString(
+  value: unknown,
+  field: string,
+  maxLength: number,
+):
+  | { ok: true; value: string | undefined }
+  | Extract<MemorySaveValidationResult, { ok: false }> {
+  if (value === undefined || value === null)
+    return { ok: true, value: undefined };
+  if (typeof value !== "string") {
+    return { ok: false, status: 400, error: `${field} must be a string` };
+  }
+  const trimmed = value.trim();
+  if (!trimmed) return { ok: true, value: undefined };
+  if (trimmed.length > maxLength) {
+    return { ok: false, status: 400, error: `${field} is too long` };
+  }
+  return { ok: true, value: trimmed };
+}
+
+function readOptionalTags(
+  value: unknown,
+):
+  | { ok: true; value: string[] }
+  | Extract<MemorySaveValidationResult, { ok: false }> {
+  if (value === undefined || value === null) return { ok: true, value: [] };
+  if (!Array.isArray(value)) {
+    return {
+      ok: false,
+      status: 400,
+      error: "tags must be an array of strings",
+    };
+  }
+  if (value.length > MEMORY_SAVE_LIMITS.maxTagCount) {
+    return { ok: false, status: 400, error: "too many tags" };
+  }
+
+  const tags: string[] = [];
+  for (const tag of value) {
+    if (typeof tag !== "string") {
+      return {
+        ok: false,
+        status: 400,
+        error: "tags must be an array of strings",
+      };
+    }
+    const normalized = tag.trim().toLowerCase();
+    if (!normalized) continue;
+    if (normalized.length > MEMORY_SAVE_LIMITS.maxTagLength) {
+      return { ok: false, status: 400, error: "tag is too long" };
+    }
+    if (!tags.includes(normalized)) tags.push(normalized);
+  }
+  return { ok: true, value: tags };
+}
+
+function readOptionalConfidence(
+  value: unknown,
+):
+  | { ok: true; value: "low" | "medium" | "high" | undefined }
+  | Extract<MemorySaveValidationResult, { ok: false }> {
+  if (value === undefined || value === null || value === "") {
+    return { ok: true, value: undefined };
+  }
+  if (value === "low" || value === "medium" || value === "high") {
+    return { ok: true, value };
+  }
+  return {
+    ok: false,
+    status: 400,
+    error: "confidence must be low/medium/high",
+  };
+}

--- a/src/lib/memory/api/save.ts
+++ b/src/lib/memory/api/save.ts
@@ -1,5 +1,5 @@
 import { slugify } from "@/lib/memory/backfill";
-import type { Prisma, PrismaClient } from "@prisma/client";
+import type { Prisma } from "@prisma/client";
 
 export const MEMORY_SAVE_LIMITS = {
   maxTitleLength: 160,
@@ -12,9 +12,9 @@ export const MEMORY_SAVE_LIMITS = {
 } as const;
 
 const INJECTED_MEMORY_BLOCKS = [
-  "noosphere_auto_recall",
-  "hindsight_memories",
   "recall",
+  "hindsight_memories",
+  "noosphere_auto_recall",
 ] as const;
 
 const SECRET_PATTERNS: Array<{ name: string; pattern: RegExp }> = [
@@ -154,8 +154,14 @@ export function validateMemorySaveRequest(
   const durableError = validateDurableContent(sanitizedContent);
   if (durableError) return durableError;
 
-  const secretError =
-    detectSecret(sanitizedContent) ?? detectSecret(title.value);
+  const secretError = detectSecretInInputs([
+    sanitizedContent,
+    title.value,
+    excerpt.value,
+    source.value,
+    authorName.value,
+    ...tags.value,
+  ]);
   if (secretError) return secretError;
 
   return {
@@ -183,14 +189,62 @@ export function stripInjectedMemoryBlocks(content: string): {
   const strippedBlocks: string[] = [];
 
   for (const tag of INJECTED_MEMORY_BLOCKS) {
-    const pattern = new RegExp(`<${tag}\\b[^>]*>[\\s\\S]*?<\\/${tag}>`, "gi");
-    strippedContent = strippedContent.replace(pattern, () => {
+    let nextContent = stripOneInjectedTag(strippedContent, tag);
+    while (nextContent.changed) {
       strippedBlocks.push(tag);
-      return "\n";
-    });
+      strippedContent = nextContent.content;
+      nextContent = stripOneInjectedTag(strippedContent, tag);
+    }
   }
 
   return { content: strippedContent, strippedBlocks };
+}
+
+function stripOneInjectedTag(
+  content: string,
+  tag: string,
+): { content: string; changed: boolean } {
+  const openPattern = new RegExp(`<${tag}\\b[^>]*>`, "i");
+  const openMatch = openPattern.exec(content);
+  if (!openMatch) return { content, changed: false };
+
+  const closePattern = new RegExp(`<\/${tag}>`, "gi");
+  const openSearchPattern = new RegExp(`<${tag}\\b[^>]*>`, "gi");
+  closePattern.lastIndex = openMatch.index + openMatch[0].length;
+  openSearchPattern.lastIndex = openMatch.index + openMatch[0].length;
+  let depth = 1;
+  let cursor = openMatch.index + openMatch[0].length;
+
+  while (true) {
+    openSearchPattern.lastIndex = cursor;
+    closePattern.lastIndex = cursor;
+    const nestedOpen = openSearchPattern.exec(content);
+    const closeMatch = closePattern.exec(content);
+
+    if (!closeMatch) {
+      return {
+        content: `${content.slice(0, openMatch.index)}
+`,
+        changed: true,
+      };
+    }
+
+    if (nestedOpen && nestedOpen.index < closeMatch.index) {
+      depth += 1;
+      cursor = nestedOpen.index + nestedOpen[0].length;
+      continue;
+    }
+
+    depth -= 1;
+    cursor = closeMatch.index + closeMatch[0].length;
+    if (depth === 0) {
+      return {
+        content: `${content.slice(0, openMatch.index)}
+${content.slice(cursor)}`,
+        changed: true,
+      };
+    }
+  }
 }
 
 export async function getDefaultMemorySaveWriter(): Promise<MemorySaveWriter> {
@@ -207,19 +261,18 @@ export async function getDefaultMemorySaveWriter(): Promise<MemorySaveWriter> {
       }
 
       const baseSlug = slugify(input.title).slice(0, 80) || "memory-candidate";
-      const slug = await findAvailableSlug(input.topicId, baseSlug);
-      const excerpt =
-        input.excerpt ??
-        input.content
-          .slice(0, 200)
-          .replace(/[#*`_>\-\[\]]/g, "")
-          .trim();
+      const excerpt = input.excerpt ?? createFallbackExcerpt(input.content);
 
       const article = await prisma.$transaction(async (tx) => {
-        const tagConnections = await buildTagConnectionsForClient(
-          input.tags,
-          tx,
-        );
+        const slug = await findAvailableSlug(tx, input.topicId, baseSlug);
+        const tagConnections = input.tags.map((tagName) => ({
+          tag: {
+            connectOrCreate: {
+              where: { slug: slugify(tagName) },
+              create: { name: tagName, slug: slugify(tagName) },
+            },
+          },
+        }));
         const created = await tx.article.create({
           data: {
             title: input.title,
@@ -281,44 +334,28 @@ export async function getDefaultMemorySaveWriter(): Promise<MemorySaveWriter> {
   };
 
   async function findAvailableSlug(
+    tx: Prisma.TransactionClient,
     topicId: string,
     baseSlug: string,
   ): Promise<string> {
+    const existingArticles = await tx.article.findMany({
+      where: { topicId, slug: { startsWith: baseSlug } },
+      select: { slug: true },
+    });
+    const existingSlugs = new Set(
+      existingArticles.map((article) => article.slug),
+    );
+
     for (let index = 0; index < 100; index += 1) {
       const candidate = index === 0 ? baseSlug : `${baseSlug}-${index + 1}`;
-      const existing = await prisma.article.findUnique({
-        where: { topicId_slug: { topicId, slug: candidate } },
-        select: { id: true },
-      });
-      if (!existing) return candidate;
+      if (!existingSlugs.has(candidate)) return candidate;
     }
+
     throw new MemorySaveError(
       "Could not generate a unique candidate slug",
       409,
     );
   }
-}
-
-type TagWriter = Pick<PrismaClient, "tag"> | Prisma.TransactionClient;
-
-async function buildTagConnectionsForClient(
-  tagNames: string[],
-  client: TagWriter,
-): Promise<Array<{ tagId: string }>> {
-  if (!tagNames.length) return [];
-
-  return Promise.all(
-    tagNames.map(async (tagName) => {
-      const tagSlug = slugify(tagName);
-      const tag = await client.tag.upsert({
-        where: { slug: tagSlug },
-        create: { name: tagName, slug: tagSlug },
-        update: { name: tagName },
-      });
-
-      return { tagId: tag.id };
-    }),
-  );
 }
 
 export class MemorySaveError extends Error {
@@ -329,6 +366,27 @@ export class MemorySaveError extends Error {
     super(message);
     this.name = "MemorySaveError";
   }
+}
+
+function createFallbackExcerpt(content: string): string {
+  return content
+    .split(/\n+/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .join(" ")
+    .slice(0, 200)
+    .trim();
+}
+
+function detectSecretInInputs(
+  values: Array<string | undefined>,
+): Extract<MemorySaveValidationResult, { ok: false }> | undefined {
+  for (const value of values) {
+    if (!value) continue;
+    const secretError = detectSecret(value);
+    if (secretError) return secretError;
+  }
+  return undefined;
 }
 
 function normalizeContent(content: string): string {
@@ -445,12 +503,16 @@ function readOptionalTags(
         error: "tags must be an array of strings",
       };
     }
-    const normalized = tag.trim().toLowerCase();
+    const normalized = tag.trim();
     if (!normalized) continue;
     if (normalized.length > MEMORY_SAVE_LIMITS.maxTagLength) {
       return { ok: false, status: 400, error: "tag is too long" };
     }
-    if (!tags.includes(normalized)) tags.push(normalized);
+    const normalizedSlug = slugify(normalized);
+    if (!normalizedSlug) continue;
+    if (!tags.some((existing) => slugify(existing) === normalizedSlug)) {
+      tags.push(normalized);
+    }
   }
   return { ok: true, value: tags };
 }


### PR DESCRIPTION
## Summary

Adds the write-side bridge slice for explicit durable memory capture:

- `POST /api/memory/save` with WRITE auth
- `executeMemorySaveRequest()` validation/writer layer
- draft-only Noosphere article creation (`status: "draft"`, `sourceType: "memory_candidate"`)
- injected memory block stripping for `<recall>`, `<hindsight_memories>`, and `<noosphere_auto_recall>`
- durable-content and secret guards before persistence
- `noosphere_save` OpenClaw plugin tool
- plugin client `save()` request/response types
- roadmap updated: PR #5 merged, PR #6 underway

## Safety contract

This endpoint never publishes directly. It saves candidates as drafts only, with low default confidence unless the caller provides a valid confidence value. It rejects empty/transient/noisy content and likely secrets before writing.

## Verification

- `node --import tsx --test src/__tests__/memory/api-save.test.ts`
- `node --import tsx --test src/__tests__/memory/openclaw-plugin-auto-recall.test.ts`
- `npm run test:memory` → 134/134
- `npx tsc --noEmit --pretty false`
- `npx tsc -p openclaw-noosphere-memory/tsconfig.json --noEmit --pretty false`
- `npm run lint -- src/lib/memory/api/save.ts src/app/api/memory/save/route.ts src/__tests__/memory/api-save.test.ts src/__tests__/memory/openclaw-plugin-auto-recall.test.ts openclaw-noosphere-memory/src --max-warnings=0`
- `git diff --check`

## Summary by Sourcery

Add a write-authenticated memory save API that stores durable content as draft candidates and expose it via a new OpenClaw Noosphere save tool.

New Features:
- Introduce POST /api/memory/save endpoint to persist durable memory candidates as draft Noosphere articles.
- Add OpenClaw noosphere_save tool and client save() method for creating draft memory candidates over HTTP.

Enhancements:
- Implement validation and sanitization layer for memory save requests, including stripping injected recall blocks, durability checks, and secret detection before persistence.
- Persist saved memory candidates with topic linkage, tags, activity logging, and slug de-duplication via a dedicated writer implementation.

Documentation:
- Update the OpenClaw–Noosphere bridge roadmap to reflect the merged lookup work and in-progress save/candidate API and tool.

Tests:
- Add unit tests for the memory save API validation/execution and for the new OpenClaw Noosphere save tool, and wire them into the memory test suite.