### PR TITLE
fix(memory): tidy save candidate validation

### DIFF
--- a/src/__tests__/memory/api-save.test.ts
+++ b/src/__tests__/memory/api-save.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   executeMemorySaveRequest,
+  MemorySaveError,
   stripInjectedMemoryBlocks,
   validateMemorySaveRequest,
   type SanitizedMemorySaveInput,
@@ -91,6 +92,21 @@ test("memory save rejects empty, transient, and noisy content", () => {
   );
 });
 
+for (const content of [
+  "I'll check this after the deployment review finishes.",
+  "We'll handle this once the deployment review has finished.",
+  "Remind me to check this tomorrow morning.",
+]) {
+  test(`memory save rejects transient-only content: ${content}`, () => {
+    assert.deepEqual(validateMemorySaveRequest(validRequest({ content })), {
+      ok: false,
+      status: 400,
+      error:
+        "content looks transient and should not be saved as durable memory",
+    });
+  });
+}
+
 test("memory save rejects likely secrets", () => {
   const result = validateMemorySaveRequest(
     validRequest({
@@ -105,7 +121,7 @@ test("memory save rejects likely secrets", () => {
   });
 });
 
-test("memory save rejects secrets in optional fields", () => {
+test("memory save rejects secrets in optional fields with field-aware errors", () => {
   const result = validateMemorySaveRequest(
     validRequest({
       excerpt: "Token noo_abcdefghijklmnopqrstuvwxyz should not persist",
@@ -115,7 +131,7 @@ test("memory save rejects secrets in optional fields", () => {
   assert.deepEqual(result, {
     ok: false,
     status: 400,
-    error: "content appears to contain a secret (Noosphere API key)",
+    error: "excerpt appears to contain a secret (Noosphere API key)",
   });
 });
 
@@ -163,4 +179,20 @@ test("memory save executes through injected writer", async () => {
   assert.equal(response.body.candidate.status, "draft");
   assert.equal(seen.length, 1);
   assert.equal(seen[0].status, "draft");
+});
+
+test("memory save propagates writer MemorySaveError", async () => {
+  await assert.rejects(
+    executeMemorySaveRequest(validRequest(), {
+      writer: {
+        async saveCandidate() {
+          throw new MemorySaveError("Topic not found", 404);
+        },
+      },
+    }),
+    (error: unknown) =>
+      error instanceof MemorySaveError &&
+      error.message === "Topic not found" &&
+      error.status === 404,
+  );
 });

--- a/src/lib/memory/api/save.ts
+++ b/src/lib/memory/api/save.ts
@@ -155,12 +155,12 @@ export function validateMemorySaveRequest(
   if (durableError) return durableError;
 
   const secretError = detectSecretInInputs([
-    sanitizedContent,
-    title.value,
-    excerpt.value,
-    source.value,
-    authorName.value,
-    ...tags.value,
+    { field: "content", value: sanitizedContent },
+    { field: "title", value: title.value },
+    { field: "excerpt", value: excerpt.value },
+    { field: "source", value: source.value },
+    { field: "authorName", value: authorName.value },
+    ...tags.value.map((value) => ({ field: "tags", value })),
   ]);
   if (secretError) return secretError;
 
@@ -260,7 +260,7 @@ export async function getDefaultMemorySaveWriter(): Promise<MemorySaveWriter> {
         throw new MemorySaveError("Topic not found", 404);
       }
 
-      const baseSlug = slugify(input.title).slice(0, 80) || "memory-candidate";
+      const baseSlug = slugify(input.title).slice(0, 80);
       const excerpt = input.excerpt ?? createFallbackExcerpt(input.content);
 
       const article = await prisma.$transaction(async (tx) => {
@@ -379,11 +379,11 @@ function createFallbackExcerpt(content: string): string {
 }
 
 function detectSecretInInputs(
-  values: Array<string | undefined>,
+  values: Array<{ field: string; value: string | undefined }>,
 ): Extract<MemorySaveValidationResult, { ok: false }> | undefined {
-  for (const value of values) {
+  for (const { field, value } of values) {
     if (!value) continue;
-    const secretError = detectSecret(value);
+    const secretError = detectSecret(value, field);
     if (secretError) return secretError;
   }
   return undefined;
@@ -430,13 +430,14 @@ function validateDurableContent(
 
 function detectSecret(
   value: string,
+  field: string,
 ): Extract<MemorySaveValidationResult, { ok: false }> | undefined {
   const match = SECRET_PATTERNS.find((entry) => entry.pattern.test(value));
   if (!match) return undefined;
   return {
     ok: false,
     status: 400,
-    error: `content appears to contain a secret (${match.name})`,
+    error: `${field} appears to contain a secret (${match.name})`,
   };
 }
 


### PR DESCRIPTION
## Summary
- remove unreachable memory-candidate fallback after slugify()
- report secret validation errors with the field where the secret was detected
- add save API regression coverage for transient-only content and writer MemorySaveError propagation

## Verification
- npm run test:memory
- npx tsc --noEmit --pretty false
- npx tsc -p openclaw-noosphere-memory/tsconfig.json --noEmit --pretty false
- npm run lint -- src/lib/memory/api/save.ts src/__tests__/memory/api-save.test.ts src/app/api/memory/save/route.ts openclaw-noosphere-memory/src --max-warnings=0
- git diff --check

## Summary by Sourcery

Tighten memory save validation by improving secret detection granularity and aligning behavior and tests around transient content and save error propagation.

Bug Fixes:
- Ensure secret validation errors identify the specific input field that contains the suspected secret.
- Remove an unreachable fallback slug value when generating article slugs for memory candidates.

Enhancements:
- Propagate MemorySaveError instances from the injected memory writer without swallowing details.

Tests:
- Add regression tests for rejecting transient-only memory content and for propagating MemorySaveError from the writer, and update secret validation tests to assert field-specific error messages.