### PR TITLE
feat: add Noosphere memory corpus supplement

### DIFF
--- a/openclaw-noosphere-memory/openclaw.plugin.json
+++ b/openclaw-noosphere-memory/openclaw.plugin.json
@@ -9,7 +9,8 @@
       "noosphere_get",
       "noosphere_save"
     ],
-    "hooks": ["before_prompt_build"]
+    "hooks": ["before_prompt_build"],
+    "memoryCorpusSupplements": ["noosphere"]
   },
   "providerAuthEnvVars": {
     "noosphere-memory": ["NOOSPHERE_API_KEY"]

--- a/openclaw-noosphere-memory/src/client.ts
+++ b/openclaw-noosphere-memory/src/client.ts
@@ -4,6 +4,8 @@ import {
   NoosphereMemoryResult,
 } from "./types.js";
 
+const MAX_RESPONSE_BODY_BYTES = 1_000_000;
+
 export interface NoosphereStatusResponse {
   ok: boolean;
   timestamp: string;
@@ -176,7 +178,7 @@ export class NoosphereMemoryClient {
 }
 
 async function parseResponseBody(response: Response): Promise<unknown> {
-  const text = await response.text();
+  const text = await readBoundedResponseText(response);
   if (!text) return null;
 
   const contentType = response.headers.get("content-type") ?? "";
@@ -197,6 +199,55 @@ async function parseResponseBody(response: Response): Promise<unknown> {
       "Noosphere returned invalid JSON",
       response.status,
     );
+  }
+}
+
+async function readBoundedResponseText(response: Response): Promise<string> {
+  const contentLength = response.headers.get("content-length");
+  if (contentLength) {
+    const parsedLength = Number(contentLength);
+    if (Number.isFinite(parsedLength) && parsedLength > MAX_RESPONSE_BODY_BYTES) {
+      throw new NoosphereClientError(
+        "Noosphere response body is too large",
+        response.status,
+      );
+    }
+  }
+
+  if (!response.body) {
+    const text = await response.text();
+    if (text.length > MAX_RESPONSE_BODY_BYTES) {
+      throw new NoosphereClientError(
+        "Noosphere response body is too large",
+        response.status,
+      );
+    }
+    return text;
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let totalBytes = 0;
+  let text = "";
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      totalBytes += value.byteLength;
+      if (totalBytes > MAX_RESPONSE_BODY_BYTES) {
+        await reader.cancel();
+        throw new NoosphereClientError(
+          "Noosphere response body is too large",
+          response.status,
+        );
+      }
+      text += decoder.decode(value, { stream: true });
+    }
+    text += decoder.decode();
+    return text;
+  } finally {
+    reader.releaseLock();
   }
 }
 

--- a/openclaw-noosphere-memory/src/corpus-supplement.ts
+++ b/openclaw-noosphere-memory/src/corpus-supplement.ts
@@ -41,20 +41,23 @@ export interface MemoryCorpusSupplement {
   search(params: {
     query: string;
     maxResults?: number;
-    agentSessionKey?: string;
   }): Promise<MemoryCorpusSearchResult[]>;
   get(params: {
     lookup: string;
     fromLine?: number;
     lineCount?: number;
-    agentSessionKey?: string;
   }): Promise<MemoryCorpusGetResult | null>;
 }
 
 const CORPUS_ID = "noosphere";
+const MAX_QUERY_LENGTH = 1_000;
 const DEFAULT_MAX_RESULTS = 10;
 const MAX_RESULTS = 10;
 const DEFAULT_LINE_COUNT = 200;
+const MAX_LINE_COUNT = 500;
+const MAX_CONTENT_LENGTH = 1_000_000;
+const MAX_SNIPPET_SOURCE_LENGTH = 10_000;
+const CANONICAL_REF_PATTERN = /^[A-Za-z][\w-]*:[A-Za-z][\w-]*:.+$/;
 
 export function createNoosphereCorpusSupplement(
   context: NoosphereClientContext,
@@ -62,7 +65,7 @@ export function createNoosphereCorpusSupplement(
 ): MemoryCorpusSupplement {
   return {
     async search(input) {
-      const query = input.query.trim();
+      const query = normalizeQuery(input.query);
       if (!query) return [];
 
       try {
@@ -88,7 +91,9 @@ export function createNoosphereCorpusSupplement(
 
       try {
         const response = await context.client.get(toNoosphereGetRequest(lookup));
-        if (!response.result) return null;
+        if (!response.result || !isNoosphereMemoryResult(response.result)) {
+          return null;
+        }
         return toCorpusGetResult(response.result, input.fromLine, input.lineCount);
       } catch (error) {
         warnAndFailOpen(logger, "get", error, context);
@@ -123,11 +128,17 @@ function toCorpusGetResult(
   result: NoosphereMemoryResult,
   fromLine: number | undefined,
   lineCount: number | undefined,
-): MemoryCorpusGetResult {
-  const lines = result.content.split(/\r?\n/);
+): MemoryCorpusGetResult | null {
+  const safeContent = result.content.slice(0, MAX_CONTENT_LENGTH);
+  const lines = safeContent.split(/\r?\n/);
   const startLine = normalizePositiveInteger(fromLine, 1);
-  const count = normalizePositiveInteger(lineCount, DEFAULT_LINE_COUNT);
+  const count = normalizePositiveInteger(
+    lineCount,
+    DEFAULT_LINE_COUNT,
+    MAX_LINE_COUNT,
+  );
   const selectedLines = lines.slice(startLine - 1, startLine - 1 + count);
+  if (selectedLines.length === 0) return null;
   const path = toCorpusPath(result);
 
   return {
@@ -147,19 +158,29 @@ function toCorpusGetResult(
 }
 
 function toNoosphereGetRequest(lookup: string) {
-  if (lookup.includes(":")) return { canonicalRef: lookup } as const;
+  if (lookup.includes(":")) {
+    if (!CANONICAL_REF_PATTERN.test(lookup)) {
+      throw new Error("lookup must be a valid canonicalRef or provider-local ID");
+    }
+    return { canonicalRef: lookup } as const;
+  }
   return { provider: "noosphere", id: lookup } as const;
 }
 
 function toCorpusPath(result: NoosphereMemoryResult): string {
   const ref = result.canonicalRef ?? `${result.provider}:${result.sourceType}:${result.id}`;
-  return ref.replace(/[^a-zA-Z0-9._:-]+/g, "-");
+  return ref.replace(/[^a-zA-Z0-9_:-]+/g, "-").replace(/-+/g, "-");
 }
 
 function toSnippet(result: NoosphereMemoryResult): string {
-  const source = result.summary?.trim() || result.content.trim();
+  const source = (result.summary?.trim() || result.content.slice(0, MAX_SNIPPET_SOURCE_LENGTH)).trim();
   const collapsed = source.replace(/\s+/g, " ").trim();
   return collapsed.length > 240 ? `${collapsed.slice(0, 237)}...` : collapsed;
+}
+
+function normalizeQuery(query: string): string {
+  const trimmed = query.trim();
+  return trimmed.length > MAX_QUERY_LENGTH ? trimmed.slice(0, MAX_QUERY_LENGTH) : trimmed;
 }
 
 function normalizeScore(score: number | undefined): number {
@@ -172,11 +193,16 @@ function clampMaxResults(value: number | undefined): number {
   return Math.max(1, Math.min(MAX_RESULTS, Math.floor(value)));
 }
 
-function normalizePositiveInteger(value: number | undefined, fallback: number): number {
+function normalizePositiveInteger(
+  value: number | undefined,
+  fallback: number,
+  max?: number,
+): number {
   if (typeof value !== "number" || !Number.isFinite(value) || value < 1) {
     return fallback;
   }
-  return Math.floor(value);
+  const normalized = Math.floor(value);
+  return max === undefined ? normalized : Math.min(max, normalized);
 }
 
 function isNoosphereMemoryResult(value: unknown): value is NoosphereMemoryResult {

--- a/openclaw-noosphere-memory/src/corpus-supplement.ts
+++ b/openclaw-noosphere-memory/src/corpus-supplement.ts
@@ -1,0 +1,203 @@
+import { formatError } from "./format.js";
+import type { NoosphereMemoryResult } from "./types.js";
+import type { NoosphereClientContext } from "./shared-init.js";
+
+export interface CorpusSupplementLogger {
+  warn?: (message: string) => void;
+}
+
+export interface MemoryCorpusSearchResult {
+  corpus: string;
+  path: string;
+  title?: string;
+  kind?: string;
+  score: number;
+  snippet: string;
+  id?: string;
+  citation?: string;
+  source?: string;
+  provenanceLabel?: string;
+  sourceType?: string;
+  sourcePath?: string;
+  updatedAt?: string;
+}
+
+export interface MemoryCorpusGetResult {
+  corpus: string;
+  path: string;
+  title?: string;
+  kind?: string;
+  content: string;
+  fromLine: number;
+  lineCount: number;
+  id?: string;
+  provenanceLabel?: string;
+  sourceType?: string;
+  sourcePath?: string;
+  updatedAt?: string;
+}
+
+export interface MemoryCorpusSupplement {
+  search(params: {
+    query: string;
+    maxResults?: number;
+    agentSessionKey?: string;
+  }): Promise<MemoryCorpusSearchResult[]>;
+  get(params: {
+    lookup: string;
+    fromLine?: number;
+    lineCount?: number;
+    agentSessionKey?: string;
+  }): Promise<MemoryCorpusGetResult | null>;
+}
+
+const CORPUS_ID = "noosphere";
+const DEFAULT_MAX_RESULTS = 10;
+const MAX_RESULTS = 10;
+const DEFAULT_LINE_COUNT = 200;
+
+export function createNoosphereCorpusSupplement(
+  context: NoosphereClientContext,
+  logger?: CorpusSupplementLogger,
+): MemoryCorpusSupplement {
+  return {
+    async search(input) {
+      const query = input.query.trim();
+      if (!query) return [];
+
+      try {
+        const response = await context.client.recall({
+          query,
+          mode: "inspection",
+          resultCap: clampMaxResults(input.maxResults),
+          providers: ["noosphere"],
+        });
+
+        return response.results
+          .filter(isNoosphereMemoryResult)
+          .map(toCorpusSearchResult);
+      } catch (error) {
+        warnAndFailOpen(logger, "search", error, context);
+        return [];
+      }
+    },
+
+    async get(input) {
+      const lookup = input.lookup.trim();
+      if (!lookup) return null;
+
+      try {
+        const response = await context.client.get(toNoosphereGetRequest(lookup));
+        if (!response.result) return null;
+        return toCorpusGetResult(response.result, input.fromLine, input.lineCount);
+      } catch (error) {
+        warnAndFailOpen(logger, "get", error, context);
+        return null;
+      }
+    },
+  };
+}
+
+function toCorpusSearchResult(
+  result: NoosphereMemoryResult,
+): MemoryCorpusSearchResult {
+  const path = toCorpusPath(result);
+  return {
+    corpus: CORPUS_ID,
+    path,
+    title: result.title,
+    kind: result.sourceType,
+    score: normalizeScore(result.relevanceScore),
+    snippet: toSnippet(result),
+    id: result.canonicalRef ?? result.id,
+    citation: result.canonicalRef ?? path,
+    source: result.provider,
+    provenanceLabel: "Noosphere",
+    sourceType: result.sourceType,
+    sourcePath: path,
+    updatedAt: result.updatedAt ?? result.createdAt,
+  };
+}
+
+function toCorpusGetResult(
+  result: NoosphereMemoryResult,
+  fromLine: number | undefined,
+  lineCount: number | undefined,
+): MemoryCorpusGetResult {
+  const lines = result.content.split(/\r?\n/);
+  const startLine = normalizePositiveInteger(fromLine, 1);
+  const count = normalizePositiveInteger(lineCount, DEFAULT_LINE_COUNT);
+  const selectedLines = lines.slice(startLine - 1, startLine - 1 + count);
+  const path = toCorpusPath(result);
+
+  return {
+    corpus: CORPUS_ID,
+    path,
+    title: result.title,
+    kind: result.sourceType,
+    content: selectedLines.join("\n"),
+    fromLine: startLine,
+    lineCount: selectedLines.length,
+    id: result.canonicalRef ?? result.id,
+    provenanceLabel: "Noosphere",
+    sourceType: result.sourceType,
+    sourcePath: path,
+    updatedAt: result.updatedAt ?? result.createdAt,
+  };
+}
+
+function toNoosphereGetRequest(lookup: string) {
+  if (lookup.includes(":")) return { canonicalRef: lookup } as const;
+  return { provider: "noosphere", id: lookup } as const;
+}
+
+function toCorpusPath(result: NoosphereMemoryResult): string {
+  const ref = result.canonicalRef ?? `${result.provider}:${result.sourceType}:${result.id}`;
+  return ref.replace(/[^a-zA-Z0-9._:-]+/g, "-");
+}
+
+function toSnippet(result: NoosphereMemoryResult): string {
+  const source = result.summary?.trim() || result.content.trim();
+  const collapsed = source.replace(/\s+/g, " ").trim();
+  return collapsed.length > 240 ? `${collapsed.slice(0, 237)}...` : collapsed;
+}
+
+function normalizeScore(score: number | undefined): number {
+  if (typeof score !== "number" || !Number.isFinite(score)) return 0;
+  return Math.max(0, Math.min(1, score));
+}
+
+function clampMaxResults(value: number | undefined): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return DEFAULT_MAX_RESULTS;
+  return Math.max(1, Math.min(MAX_RESULTS, Math.floor(value)));
+}
+
+function normalizePositiveInteger(value: number | undefined, fallback: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 1) {
+    return fallback;
+  }
+  return Math.floor(value);
+}
+
+function isNoosphereMemoryResult(value: unknown): value is NoosphereMemoryResult {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as Partial<NoosphereMemoryResult>;
+  return (
+    typeof candidate.id === "string" &&
+    typeof candidate.provider === "string" &&
+    typeof candidate.sourceType === "string" &&
+    typeof candidate.content === "string"
+  );
+}
+
+function warnAndFailOpen(
+  logger: CorpusSupplementLogger | undefined,
+  operation: "search" | "get",
+  error: unknown,
+  context: NoosphereClientContext,
+): void {
+  const formatted = formatError(error, context.config);
+  logger?.warn?.(
+    `Noosphere corpus supplement ${operation} skipped: ${String(formatted.error)}`,
+  );
+}

--- a/openclaw-noosphere-memory/src/format.ts
+++ b/openclaw-noosphere-memory/src/format.ts
@@ -1,5 +1,5 @@
 import { NoosphereClientError } from "./client.js";
-import { redactSecret, ResolvedNoosphereMemoryConfig } from "./config.js";
+import type { ResolvedNoosphereMemoryConfig } from "./config.js";
 
 export interface ToolTextResult {
   content: Array<{ type: "text"; text: string }>;
@@ -24,20 +24,18 @@ export function errorResult(error: unknown, config?: ResolvedNoosphereMemoryConf
 }
 
 export function formatError(error: unknown, config?: ResolvedNoosphereMemoryConfig): Record<string, unknown> {
+  void config;
+
   if (error instanceof NoosphereClientError) {
     return {
       ok: false,
       error: error.message,
       status: error.status,
-      baseUrl: config?.baseUrl,
-      apiKey: redactSecret(config?.apiKey),
     };
   }
 
   return {
     ok: false,
     error: error instanceof Error ? error.message : String(error),
-    baseUrl: config?.baseUrl,
-    apiKey: redactSecret(config?.apiKey),
   };
 }

--- a/openclaw-noosphere-memory/src/index.ts
+++ b/openclaw-noosphere-memory/src/index.ts
@@ -1,5 +1,6 @@
 import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
 import { createNoosphereAutoRecallHook } from "./auto-recall.js";
+import { createNoosphereCorpusSupplement } from "./corpus-supplement.js";
 import { createNoosphereClientContext } from "./shared-init.js";
 import { createNoosphereGetTool } from "./tools/get.js";
 import { createNoosphereRecallTool } from "./tools/recall.js";
@@ -21,6 +22,11 @@ export default definePluginEntry({
     );
     api.registerTool(createNoosphereGetTool(api.pluginConfig, clientContext));
     api.registerTool(createNoosphereSaveTool(api.pluginConfig, clientContext));
+    if (typeof api.registerMemoryCorpusSupplement === "function") {
+      api.registerMemoryCorpusSupplement(
+        createNoosphereCorpusSupplement(clientContext, api.logger),
+      );
+    }
     const hook = createNoosphereAutoRecallHook(
       api.pluginConfig,
       clientContext,

--- a/openclaw-noosphere-memory/src/sdk-shims.d.ts
+++ b/openclaw-noosphere-memory/src/sdk-shims.d.ts
@@ -8,6 +8,7 @@ declare module "openclaw/plugin-sdk/plugin-entry" {
       error?: (message: string) => void;
     };
     registerTool(tool: unknown, options?: unknown): void;
+    registerMemoryCorpusSupplement?(supplement: unknown): void;
     on?<TEvent = unknown, TContext = unknown>(
       hookName: "before_prompt_build",
       handler: ((event: TEvent, ctx: TContext) => unknown | Promise<unknown>) & { registrationWarning?: () => void },

--- a/src/__tests__/memory/openclaw-plugin-auto-recall.test.ts
+++ b/src/__tests__/memory/openclaw-plugin-auto-recall.test.ts
@@ -9,6 +9,7 @@ import {
 import { createNoosphereCorpusSupplement } from "../../../openclaw-noosphere-memory/src/corpus-supplement.js";
 import {
   NoosphereClientError,
+  NoosphereMemoryClient,
   type NoosphereGetRequest,
   type NoosphereGetResponse,
   type NoosphereSaveRequest,
@@ -542,14 +543,168 @@ describe("OpenClaw Noosphere corpus supplement", () => {
     });
   });
 
-  it("returns empty/null for blank corpus supplement inputs", async () => {
+  it("bounds corpus supplement search queries", async () => {
+    const { context, recallCalls } = makeCorpusContext();
+    const supplement = createNoosphereCorpusSupplement(context);
+
+    await supplement.search({ query: ` ${"x".repeat(1_100)} ` });
+
+    assert.equal(recallCalls.length, 1);
+    assert.equal(recallCalls[0].query.length, 1_000);
+  });
+
+  it("returns null for blank or empty-range corpus get inputs", async () => {
     const { context, recallCalls, getCalls } = makeCorpusContext();
     const supplement = createNoosphereCorpusSupplement(context);
 
     assert.deepEqual(await supplement.search({ query: "   " }), []);
     assert.equal(await supplement.get({ lookup: "   " }), null);
+    assert.equal(
+      await supplement.get({
+        lookup: "noosphere:article:article-1",
+        fromLine: 100,
+      }),
+      null,
+    );
     assert.equal(recallCalls.length, 0);
-    assert.equal(getCalls.length, 0);
+    assert.equal(getCalls.length, 1);
+  });
+
+  it("validates corpus get results and canonical refs", async () => {
+    const getCalls: NoosphereGetRequest[] = [];
+    const context = {
+      config: {
+        baseUrl: "http://noosphere.local",
+        apiKey: "noo_test",
+        timeoutMs: 5000,
+      },
+      client: {
+        async recall(): Promise<NoosphereRecallResponse> {
+          throw new Error("recall should not be called");
+        },
+        async get(request: NoosphereGetRequest): Promise<NoosphereGetResponse> {
+          getCalls.push(request);
+          return {
+            result: {
+              id: "article-1",
+              provider: "noosphere",
+              sourceType: "noosphere_article",
+            } as unknown as NoosphereGetResponse["result"],
+            providerMeta: [],
+          };
+        },
+      },
+    } as unknown as NoosphereClientContext;
+    const supplement = createNoosphereCorpusSupplement(context);
+
+    assert.equal(await supplement.get({ lookup: "article-1" }), null);
+    assert.equal(await supplement.get({ lookup: "noosphere:article:" }), null);
+    assert.deepEqual(getCalls, [{ provider: "noosphere", id: "article-1" }]);
+  });
+
+  it("bounds corpus get line counts", async () => {
+    const getCalls: NoosphereGetRequest[] = [];
+    const longContent = Array.from({ length: 600 }, (_, index) => `Line ${index + 1}`).join("\n");
+    const context = {
+      config: {
+        baseUrl: "http://noosphere.local",
+        apiKey: "noo_test",
+        timeoutMs: 5000,
+      },
+      client: {
+        async recall(): Promise<NoosphereRecallResponse> {
+          throw new Error("recall should not be called");
+        },
+        async get(request: NoosphereGetRequest): Promise<NoosphereGetResponse> {
+          getCalls.push(request);
+          return {
+            result: {
+              id: "article-1",
+              provider: "noosphere",
+              sourceType: "noosphere_article",
+              canonicalRef: "noosphere:article:article-1",
+              content: longContent,
+            },
+            providerMeta: [],
+          };
+        },
+      },
+    } as unknown as NoosphereClientContext;
+    const supplement = createNoosphereCorpusSupplement(context);
+
+    const result = await supplement.get({
+      lookup: "article-1",
+      lineCount: 2_147_483_647,
+    });
+
+    assert.equal(result?.lineCount, 500);
+    assert.equal(getCalls.length, 1);
+  });
+
+  it("normalizes snippets and relevance scores in corpus supplement search results", async () => {
+    const longContent = `   This   is   text \n\n with  irregular   whitespace ${"and more text ".repeat(40)}`;
+    const context = {
+      config: {
+        baseUrl: "http://noosphere.local",
+        apiKey: "noo_test",
+        timeoutMs: 5000,
+      },
+      client: {
+        async recall(): Promise<NoosphereRecallResponse> {
+          return {
+            results: [
+              {
+                id: "missing-summary",
+                provider: "noosphere",
+                sourceType: "noosphere_article",
+                content: longContent,
+                relevanceScore: undefined,
+              },
+              {
+                id: "high-score",
+                provider: "noosphere",
+                sourceType: "noosphere_article",
+                summary: "   Short    summary   text   ",
+                content: "Body not used when summary exists",
+                relevanceScore: 10,
+              },
+              {
+                id: "negative-score",
+                provider: "noosphere",
+                sourceType: "noosphere_article",
+                content: "Negative score",
+                relevanceScore: -5,
+              },
+              {
+                id: "nan-score",
+                provider: "noosphere",
+                sourceType: "noosphere_article",
+                content: "NaN score",
+                relevanceScore: NaN,
+              },
+            ],
+            totalBeforeCap: 4,
+            mode: "inspection",
+            providerMeta: [],
+          };
+        },
+        async get(): Promise<NoosphereGetResponse> {
+          throw new Error("get should not be called");
+        },
+      },
+    } as unknown as NoosphereClientContext;
+    const supplement = createNoosphereCorpusSupplement(context);
+
+    const results = await supplement.search({ query: "deployment" });
+
+    assert.equal(results.length, 4);
+    assert.equal(results[0].snippet.length, 240);
+    assert.equal(/\s{2,}/.test(results[0].snippet), false);
+    assert.equal(results[1].snippet, "Short summary text");
+    for (const result of results) {
+      assert.equal(Number.isFinite(result.score), true);
+      assert.equal(result.score >= 0 && result.score <= 1, true);
+    }
   });
 
   it("fails open and warns when corpus supplement HTTP calls fail", async () => {
@@ -578,6 +733,35 @@ describe("OpenClaw Noosphere corpus supplement", () => {
     assert.equal(warnings.length, 2);
     assert.match(warnings[0], /search skipped: network down/);
     assert.match(warnings[1], /get skipped: network down/);
+  });
+});
+
+describe("OpenClaw Noosphere client", () => {
+  it("rejects oversized response bodies before JSON parsing", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async () =>
+      new Response("{\"ok\":true}", {
+        status: 200,
+        headers: {
+          "content-type": "application/json",
+          "content-length": "1000001",
+        },
+      });
+
+    try {
+      const client = new NoosphereMemoryClient({
+        baseUrl: "http://noosphere.local",
+        apiKey: "noo_test",
+        timeoutMs: 5000,
+      });
+
+      await assert.rejects(
+        () => client.status(),
+        /Noosphere response body is too large/,
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 });
 
@@ -688,6 +872,8 @@ describe("OpenClaw Noosphere get tool", () => {
 
     assert.equal(result.isError, true);
     assert.match(String(result.content[0]?.text), /HTTP 401/);
+    assert.doesNotMatch(String(result.content[0]?.text), /noo_test/);
+    assert.doesNotMatch(String(result.content[0]?.text), /noosphere\.local/);
   });
 });
 

--- a/src/__tests__/memory/openclaw-plugin-auto-recall.test.ts
+++ b/src/__tests__/memory/openclaw-plugin-auto-recall.test.ts
@@ -6,6 +6,7 @@ import {
   MAX_QUERY_LENGTH,
   resolveAutoRecallConfig,
 } from "../../../openclaw-noosphere-memory/src/auto-recall.js";
+import { createNoosphereCorpusSupplement } from "../../../openclaw-noosphere-memory/src/corpus-supplement.js";
 import {
   NoosphereClientError,
   type NoosphereGetRequest,
@@ -418,6 +419,165 @@ describe("OpenClaw Noosphere plugin auto-recall", () => {
     );
 
     assert.equal(query, "repeat\n\nunique\n\ncurrent question");
+  });
+});
+
+describe("OpenClaw Noosphere corpus supplement", () => {
+  function makeCorpusContext() {
+    const recallCalls: NoosphereRecallRequest[] = [];
+    const getCalls: NoosphereGetRequest[] = [];
+    const context = {
+      config: {
+        baseUrl: "http://noosphere.local",
+        apiKey: "noo_test",
+        timeoutMs: 5000,
+      },
+      client: {
+        async recall(request: NoosphereRecallRequest) {
+          recallCalls.push(request);
+          return {
+            results: [
+              {
+                id: "article-1",
+                provider: "noosphere",
+                sourceType: "noosphere_article",
+                canonicalRef: "noosphere:article:article-1",
+                title: "Deployment Notes",
+                content: "Line one.\nLine two.\nLine three.",
+                summary: "Use the deployment workflow.",
+                relevanceScore: 0.75,
+                updatedAt: "2026-04-30T12:00:00.000Z",
+              },
+              { malformed: true },
+            ],
+            totalBeforeCap: 2,
+            mode: "inspection",
+            providerMeta: [],
+          } as NoosphereRecallResponse;
+        },
+        async get(request: NoosphereGetRequest) {
+          getCalls.push(request);
+          return {
+            result: {
+              id: "article-1",
+              provider: "noosphere",
+              sourceType: "noosphere_article",
+              canonicalRef: "noosphere:article:article-1",
+              title: "Deployment Notes",
+              content: "Line one.\nLine two.\nLine three.",
+              updatedAt: "2026-04-30T12:00:00.000Z",
+            },
+            providerMeta: [
+              { providerId: "noosphere", enabled: true, found: true },
+            ],
+          } as NoosphereGetResponse;
+        },
+      },
+    } as unknown as NoosphereClientContext;
+
+    return { context, recallCalls, getCalls };
+  }
+
+  it("adapts Noosphere recall results into memory corpus search results", async () => {
+    const { context, recallCalls } = makeCorpusContext();
+    const supplement = createNoosphereCorpusSupplement(context);
+
+    const results = await supplement.search({
+      query: " deployment workflow ",
+      maxResults: 25,
+    });
+
+    assert.deepEqual(recallCalls, [
+      {
+        query: "deployment workflow",
+        mode: "inspection",
+        resultCap: 10,
+        providers: ["noosphere"],
+      },
+    ]);
+    assert.equal(results.length, 1);
+    assert.deepEqual(results[0], {
+      corpus: "noosphere",
+      path: "noosphere:article:article-1",
+      title: "Deployment Notes",
+      kind: "noosphere_article",
+      score: 0.75,
+      snippet: "Use the deployment workflow.",
+      id: "noosphere:article:article-1",
+      citation: "noosphere:article:article-1",
+      source: "noosphere",
+      provenanceLabel: "Noosphere",
+      sourceType: "noosphere_article",
+      sourcePath: "noosphere:article:article-1",
+      updatedAt: "2026-04-30T12:00:00.000Z",
+    });
+  });
+
+  it("adapts corpus get lookups through canonical refs and line ranges", async () => {
+    const { context, getCalls } = makeCorpusContext();
+    const supplement = createNoosphereCorpusSupplement(context);
+
+    const result = await supplement.get({
+      lookup: " noosphere:article:article-1 ",
+      fromLine: 2,
+      lineCount: 1,
+    });
+
+    assert.deepEqual(getCalls, [
+      { canonicalRef: "noosphere:article:article-1" },
+    ]);
+    assert.deepEqual(result, {
+      corpus: "noosphere",
+      path: "noosphere:article:article-1",
+      title: "Deployment Notes",
+      kind: "noosphere_article",
+      content: "Line two.",
+      fromLine: 2,
+      lineCount: 1,
+      id: "noosphere:article:article-1",
+      provenanceLabel: "Noosphere",
+      sourceType: "noosphere_article",
+      sourcePath: "noosphere:article:article-1",
+      updatedAt: "2026-04-30T12:00:00.000Z",
+    });
+  });
+
+  it("returns empty/null for blank corpus supplement inputs", async () => {
+    const { context, recallCalls, getCalls } = makeCorpusContext();
+    const supplement = createNoosphereCorpusSupplement(context);
+
+    assert.deepEqual(await supplement.search({ query: "   " }), []);
+    assert.equal(await supplement.get({ lookup: "   " }), null);
+    assert.equal(recallCalls.length, 0);
+    assert.equal(getCalls.length, 0);
+  });
+
+  it("fails open and warns when corpus supplement HTTP calls fail", async () => {
+    const warnings: string[] = [];
+    const context = {
+      config: {
+        baseUrl: "http://noosphere.local",
+        apiKey: "noo_test",
+        timeoutMs: 5000,
+      },
+      client: {
+        async recall(): Promise<NoosphereRecallResponse> {
+          throw new NoosphereClientError("network down");
+        },
+        async get(): Promise<NoosphereGetResponse> {
+          throw new NoosphereClientError("network down");
+        },
+      },
+    } as unknown as NoosphereClientContext;
+    const supplement = createNoosphereCorpusSupplement(context, {
+      warn: (message) => warnings.push(message),
+    });
+
+    assert.deepEqual(await supplement.search({ query: "deployment" }), []);
+    assert.equal(await supplement.get({ lookup: "article-1" }), null);
+    assert.equal(warnings.length, 2);
+    assert.match(warnings[0], /search skipped: network down/);
+    assert.match(warnings[1], /get skipped: network down/);
   });
 });
 


### PR DESCRIPTION
## Summary
- register an optional Noosphere `MemoryCorpusSupplement` in the OpenClaw plugin
- adapt Noosphere recall results into shared corpus search results
- route corpus get lookups through canonical refs/provider IDs with line slicing
- fail open with warnings on Noosphere HTTP errors

## Verification
- `node --import tsx --test src/__tests__/memory/openclaw-plugin-auto-recall.test.ts`
- `npm run test:memory` (144/144 passing)
- `npx tsc -p tsconfig.json --noEmit`
- `npx tsc -p openclaw-noosphere-memory/tsconfig.json --noEmit`
- `npx eslint openclaw-noosphere-memory/src/corpus-supplement.ts openclaw-noosphere-memory/src/index.ts openclaw-noosphere-memory/src/sdk-shims.d.ts src/__tests__/memory/openclaw-plugin-auto-recall.test.ts`
- `git diff --check`

## Notes
Full-repo `npm run lint` still reports pre-existing unrelated lint issues in untouched files (not introduced by this PR). Changed-file lint is clean.

## Summary by Sourcery

Integrate a Noosphere-backed memory corpus supplement into the OpenClaw plugin and wire it into the plugin lifecycle when supported by the host SDK.

New Features:
- Introduce a Noosphere memory corpus supplement that exposes search and get operations over Noosphere recall/get APIs.
- Register the Noosphere corpus supplement with the OpenClaw plugin when the host SDK provides corpus supplement registration.

Enhancements:
- Normalize Noosphere recall results into shared corpus search/get result shapes, including canonical path derivation, score normalization, line-range slicing, and snippet generation.
- Add optional logging for corpus supplement failures that fail open while emitting structured warnings instead of interrupting normal operation.

Tests:
- Add unit tests covering Noosphere corpus supplement search and get behavior, blank input handling, and fail-open behavior on client errors.