### PR TITLE
feat(openclaw-plugin): adopt Hindsight-inspired auto-recall improvements

### DIFF
--- a/openclaw-noosphere-memory/src/auto-recall.ts
+++ b/openclaw-noosphere-memory/src/auto-recall.ts
@@ -1,4 +1,3 @@
-import { createHash } from "node:crypto";
 import { NoosphereRecallRequest, NoosphereRecallResponse, NoosphereSettingsResponse } from "./client.js";
 import {
   clampTimeout,
@@ -146,8 +145,52 @@ export function createNoosphereAutoRecallHook(
   const staticConfig = resolveAutoRecallConfig(rawConfig);
   const settingsCache: SettingsCache = { settings: null, fetchedAt: 0 };
 
-  // In-flight recall deduplication (Hindsight-inspired)
+  // Precompiled glob regexes (cached per config update)
+  const compiledIgnorePatterns: RegExp[] = [];
+  const compiledStatelessPatterns: RegExp[] = [];
+  let lastCompiledPatterns: string[] = [];
+
+  // In-flight recall deduplication - key is normalized query string
   const inflightRecalls = new Map<string, Promise<NoosphereRecallResponse>>();
+
+  /**
+   * Compile glob patterns to regexes once and cache them.
+   * Only recompiles when the pattern list changes.
+   */
+  function ensureCompiledPatterns(patterns: string[], compiled: RegExp[]): RegExp[] {
+    if (patterns.length !== lastCompiledPatterns.length) {
+      lastCompiledPatterns = [...patterns];
+      compiled.length = 0;
+      for (const pattern of patterns) {
+        compiled.push(compileGlobPattern(pattern));
+      }
+    }
+    return compiled;
+  }
+
+  /**
+   * Compile a single glob pattern to a RegExp.
+   * * matches anything except colon
+   * ** matches anything including colon
+   */
+  function compileGlobPattern(pattern: string): RegExp {
+    const regexPattern = pattern
+      .replace(/[.+?^${}()|[\]\\]/g, "\\$&") // Escape special regex chars except * and **
+      .replace(/\*\*/g, "⟨DOUBLE_STAR⟩") // Placeholder for **
+      .replace(/\*/g, "[^:]*") // * matches anything except colon
+      .replace(/⟨DOUBLE_STAR⟩/g, ".*"); // ** matches anything including colon
+    return new RegExp(`^${regexPattern}$`);
+  }
+
+  /**
+   * Check if a session key matches any of the compiled patterns.
+   */
+  function matchesSessionPatternCached(sessionKey: string, compiledPatterns: RegExp[]): boolean {
+    for (const regex of compiledPatterns) {
+      if (regex.test(sessionKey)) return true;
+    }
+    return false;
+  }
 
   /**
    * Fetches recall settings from the DB (with 30s cache TTL).
@@ -201,19 +244,21 @@ export function createNoosphereAutoRecallHook(
   ): Promise<PromptInjectionResult | void> => {
     const effectiveConfig = await getEffectiveConfig();
 
-    // Session pattern filtering (Hindsight-inspired)
+    // Session pattern filtering (Hindsight-inspired) with cached regexes
     const sessionKey = ctx.sessionKey;
     if (sessionKey) {
       // Check ignoreSessionPatterns first
       if (effectiveConfig.ignoreSessionPatterns.length > 0) {
-        if (matchesSessionPattern(sessionKey, effectiveConfig.ignoreSessionPatterns)) {
+        const compiled = ensureCompiledPatterns(effectiveConfig.ignoreSessionPatterns, compiledIgnorePatterns);
+        if (matchesSessionPatternCached(sessionKey, compiled)) {
           logger?.debug?.(`[Noosphere] Skipping recall: session '${sessionKey}' matches ignoreSessionPatterns`);
           return;
         }
       }
       // Check statelessSessionPatterns
       if (effectiveConfig.skipStatelessSessions && effectiveConfig.statelessSessionPatterns.length > 0) {
-        if (matchesSessionPattern(sessionKey, effectiveConfig.statelessSessionPatterns)) {
+        const compiled = ensureCompiledPatterns(effectiveConfig.statelessSessionPatterns, compiledStatelessPatterns);
+        if (matchesSessionPatternCached(sessionKey, compiled)) {
           logger?.debug?.(`[Noosphere] Skipping recall: session '${sessionKey}' matches statelessSessionPatterns (skipStatelessSessions=true)`);
           return;
         }
@@ -227,12 +272,10 @@ export function createNoosphereAutoRecallHook(
     if (!query || query.length < effectiveConfig.minQueryLength) return;
 
     try {
-      // Deduplicate concurrent recalls for the same query (Hindsight-inspired)
+      // Deduplicate concurrent recalls for the same normalized query
       const normalizedQuery = query.trim().toLowerCase().replace(/\s+/g, " ");
-      const queryHash = createHash("sha256").update(normalizedQuery).digest("hex").slice(0, 16);
-      const recallKey = queryHash;
 
-      let recallPromise = inflightRecalls.get(recallKey);
+      let recallPromise = inflightRecalls.get(normalizedQuery);
       if (!recallPromise) {
         recallPromise = clientContext.client.recall(
           {
@@ -244,8 +287,8 @@ export function createNoosphereAutoRecallHook(
           },
           { timeoutMs: effectiveConfig.timeoutMs },
         );
-        inflightRecalls.set(recallKey, recallPromise);
-        void recallPromise.catch(() => {}).finally(() => inflightRecalls.delete(recallKey));
+        inflightRecalls.set(normalizedQuery, recallPromise);
+        void recallPromise.catch(() => {}).finally(() => inflightRecalls.delete(normalizedQuery));
       }
 
       const response = await recallPromise;
@@ -282,49 +325,47 @@ export function createNoosphereAutoRecallHook(
 
 /**
  * Build recall query from the event, using rawMessage first (like Hindsight).
- * Strips channel metadata envelopes from the query text.
+ * Strips OpenClaw-specific channel metadata envelopes from the query text.
  */
 export function buildAutoRecallQuery(event: BeforePromptBuildEventLike, config: NoosphereAutoRecallConfig): string | undefined {
-  // Hindsight-inspired: use rawMessage first (clean user text), then fall back to prompt
-  const rawMessage = readString(event.rawMessage);
-  const prompt = readString(event.prompt);
+  // Hindsight-inspired: use rawMessage first (clean user text), fallback to prompt
+  const source = readString(event.rawMessage) ?? readString(event.prompt);
+  if (!source) return undefined;
 
-  // Try rawMessage first, then prompt as fallback
-  let recallQuery = rawMessage ?? prompt;
-  if (!recallQuery) return undefined;
-
-  // Strip channel metadata envelopes (Hindsight-inspired)
-  recallQuery = stripMetadataEnvelopes(recallQuery);
-
-  // If rawMessage was empty/invalid but prompt worked, clean the prompt too
-  if (!rawMessage && prompt) {
-    recallQuery = stripMetadataEnvelopes(prompt);
-  }
-
-  // Also clean the rawMessage if we're using it directly
-  if (rawMessage) {
-    recallQuery = stripMetadataEnvelopes(rawMessage);
-  }
+  // Clean the source once - removes OpenClaw channel metadata envelopes
+  const recallQuery = stripMetadataEnvelopes(source);
+  if (!recallQuery || recallQuery.length < 5) return undefined;
 
   // Build parts: recent turns (if enabled) + current query
   const parts: string[] = [];
 
   if (config.includeRecentTurns && Array.isArray(event.messages) && config.recentTurnLimit > 0) {
-    const recentTurns = dedupeTurns(extractRecentUserTurns(event.messages, config.recentTurnLimit))
-      .filter((turn) => {
-        if (!turn) return false;
-        const cleaned = stripMetadataEnvelopes(turn);
-        return cleaned && cleaned !== recallQuery;
-      });
-    if (recentTurns.length > 0) {
-      parts.push(...recentTurns);
+    // Extract, clean, and deduplicate recent turns
+    const recentTurns = extractRecentUserTurns(event.messages, config.recentTurnLimit);
+    const cleanedTurns: string[] = [];
+    const seen = new Set<string>();
+
+    for (const turn of recentTurns) {
+      // Clean the turn
+      const cleaned = stripMetadataEnvelopes(turn);
+      const key = cleaned.trim().toLowerCase();
+
+      // Skip empty, too short, or duplicates
+      if (!cleaned || cleaned.length < 5 || seen.has(key)) continue;
+      // Skip if same as the main recall query
+      if (cleaned.toLowerCase() === recallQuery.toLowerCase()) continue;
+
+      seen.add(key);
+      cleanedTurns.push(cleaned);
+    }
+
+    if (cleanedTurns.length > 0) {
+      parts.push(...cleanedTurns);
     }
   }
 
-  // Add the current query
-  if (recallQuery && recallQuery.trim().length >= 5) {
-    parts.push(recallQuery.trim());
-  }
+  // Add the main query
+  parts.push(recallQuery);
 
   if (parts.length === 0) return undefined;
 
@@ -332,13 +373,8 @@ export function buildAutoRecallQuery(event: BeforePromptBuildEventLike, config: 
 }
 
 /**
- * Strip channel metadata envelopes from text (Hindsight-inspired).
- * Removes patterns like:
- * - [Telegram 123456789] message
- * - [Channel metadata ...] blocks
- * - [from: SenderName] metadata
- * - System: ... prefixes
- * - Conversation info (untrusted metadata) blocks
+ * Strip OpenClaw channel metadata envelopes from text.
+ * Only targets OpenClaw-specific patterns, not general bracketed text.
  */
 function stripMetadataEnvelopes(text: string): string {
   if (!text) return text;
@@ -351,22 +387,28 @@ function stripMetadataEnvelopes(text: string): string {
   // Remove session abort hints
   cleaned = cleaned.replace(/^Note: The previous agent run was aborted[^\n]*\n\n/, "");
 
-  // Remove channel envelope headers like [Telegram 1782981446] or [TelegramDirect 1782981446]
-  cleaned = cleaned.replace(/^\[Telegram[^\]]*\]\s*/i, "");
+  // Remove OpenClaw channel envelope headers: [Telegram ...], [TelegramDirect ...], [ChannelName ...]
+  // These are specifically OpenClaw's injected channel metadata, not general user content
+  cleaned = cleaned.replace(/^\[Telegram[^\]]*\]\s*/gim, "");
+  cleaned = cleaned.replace(/^\[Channel[^\]]*\]\s*/gim, "");
+  cleaned = cleaned.replace(/^\[Discord[^\]]*\]\s*/gim, "");
+  cleaned = cleaned.replace(/^\[Slack[^\]]*\]\s*/gim, "");
+  cleaned = cleaned.replace(/^\[Signal[^\]]*\]\s*/gim, "");
+  cleaned = cleaned.replace(/^\[WhatsApp[^\]]*\]\s*/gim, "");
 
-  // Remove [ChannelName ...] style envelope headers
-  cleaned = cleaned.replace(/\[[A-Z][A-Za-z]*(?:\s[^\]]+)?\]\s*/g, "");
+  // Remove conversation info metadata blocks (OpenClaw-injected)
+  cleaned = cleaned.replace(/^---\nConversation info \(untrusted metadata\)[^\n]*\n```json[\s\S]*?```\n?/gm, "");
+  cleaned = cleaned.replace(/^Conversation info \(untrusted metadata\)[^\n]*\n```json[\s\S]*?```\n?/gm, "");
+
+  // Remove sender metadata blocks (OpenClaw-injected)
+  cleaned = cleaned.replace(/^---\nSender \(untrusted metadata\)[^\n]*\n```json[\s\S]*?```\n?/gm, "");
+  cleaned = cleaned.replace(/^Sender \(untrusted metadata\)[^\n]*\n```json[\s\S]*?```\n?/gm, "");
 
   // Remove trailing [from: SenderName] metadata (group chats)
   cleaned = cleaned.replace(/\n\[from:[^\]]*\]\s*$/, "");
 
-  // Remove conversation info metadata blocks
-  cleaned = cleaned.replace(/^\s*conversation info\s*\(untrusted metadata\).*$/gim, "");
-  cleaned = cleaned.replace(/^\s*\(untrusted metadata\).*$/gim, "");
-  cleaned = cleaned.replace(/^\s*\[Channel metadata[^\]]*\].*$/gim, "");
-
-  // Remove any remaining channel envelope patterns
-  cleaned = cleaned.replace(/^\s*\[[^\]]*\]\s*/gm, "");
+  // Remove trailing --- markers from metadata blocks
+  cleaned = cleaned.replace(/\n---$/, "");
 
   return cleaned.trim();
 }
@@ -388,46 +430,34 @@ function readInjectionPosition(value: unknown): RecallInjectionPosition {
   return "prepend";
 }
 
-function dedupeTurns(turns: string[]): string[] {
-  const seen = new Set<string>();
-  const deduped: string[] = [];
-  for (const turn of turns) {
-    const key = turn.trim();
-    if (!key || seen.has(key)) continue;
-    seen.add(key);
-    deduped.push(turn);
+function extractRecentUserTurns(messages: unknown[], limit: number): string[] {
+  const turns: string[] = [];
+  for (let index = messages.length - 1; index >= 0 && turns.length < limit; index -= 1) {
+    const message = messages[index];
+    if (!isRecord(message)) continue;
+    const role = readString(message.role);
+    if (role !== "user") continue;
+    const text = extractMessageText(message.content);
+    if (text) turns.push(text);
   }
-  return deduped;
+  return turns.reverse();
 }
 
-/**
- * Match a session key against glob patterns (Hindsight-inspired).
- * Supports:
- * - * matches any characters except colon
- * - ** matches any characters including colon
- */
-function matchesSessionPattern(sessionKey: string, patterns: string[]): boolean {
-  for (const pattern of patterns) {
-    if (matchGlob(sessionKey, pattern)) return true;
+function extractMessageText(content: unknown): string | undefined {
+  if (typeof content === "string") return content.trim() || undefined;
+  if (Array.isArray(content)) {
+    const text = content
+      .map((item) => {
+        if (typeof item === "string") return item;
+        if (isRecord(item) && typeof item.text === "string") return item.text;
+        return undefined;
+      })
+      .filter((item): item is string => !!item && !!item.trim())
+      .join("\n");
+    return text.trim() || undefined;
   }
-  return false;
-}
-
-/**
- * Simple glob matching for session patterns.
- * * matches anything except colon
- * ** matches anything including colon
- */
-function matchGlob(str: string, pattern: string): boolean {
-  // Convert glob pattern to regex
-  const regexPattern = pattern
-    .replace(/[.+?^${}()|[\]\\]/g, "\\$&") // Escape special regex chars except * and **
-    .replace(/\*\*/g, "⟨DOUBLE_STAR⟩") // Placeholder for **
-    .replace(/\*/g, "[^:]*") // * matches anything except colon
-    .replace(/⟨DOUBLE_STAR⟩/g, ".*"); // ** matches anything including colon
-
-  const regex = new RegExp(`^${regexPattern}$`);
-  return regex.test(str);
+  if (isRecord(content) && typeof content.text === "string") return content.text.trim() || undefined;
+  return undefined;
 }
 
 function shouldAutoRecall(
@@ -464,36 +494,6 @@ function wrapPromptInjectionText(promptText: string): string {
     promptText,
     "</noosphere_auto_recall>",
   ].join("\n");
-}
-
-function extractRecentUserTurns(messages: unknown[], limit: number): string[] {
-  const turns: string[] = [];
-  for (let index = messages.length - 1; index >= 0 && turns.length < limit; index -= 1) {
-    const message = messages[index];
-    if (!isRecord(message)) continue;
-    const role = readString(message.role);
-    if (role !== "user") continue;
-    const text = extractMessageText(message.content);
-    if (text) turns.push(text);
-  }
-  return turns.reverse();
-}
-
-function extractMessageText(content: unknown): string | undefined {
-  if (typeof content === "string") return content.trim() || undefined;
-  if (Array.isArray(content)) {
-    const text = content
-      .map((item) => {
-        if (typeof item === "string") return item;
-        if (isRecord(item) && typeof item.text === "string") return item.text;
-        return undefined;
-      })
-      .filter((item): item is string => !!item && !!item.trim())
-      .join("\n");
-    return text.trim() || undefined;
-  }
-  if (isRecord(content) && typeof content.text === "string") return content.text.trim() || undefined;
-  return undefined;
 }
 
 function resolveChatType(ctx: BeforePromptBuildContextLike): string | undefined {

--- a/openclaw-noosphere-memory/src/auto-recall.ts
+++ b/openclaw-noosphere-memory/src/auto-recall.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { NoosphereRecallRequest, NoosphereRecallResponse, NoosphereSettingsResponse } from "./client.js";
 import {
   clampTimeout,
@@ -74,6 +75,10 @@ export interface NoosphereAutoRecallConfig {
   timeoutMs: number;
   memoryCaptureInstructionsEnabled: boolean;
   memoryCaptureInstructions: string;
+  // Session pattern filtering (Hindsight-inspired)
+  ignoreSessionPatterns: string[];
+  statelessSessionPatterns: string[];
+  skipStatelessSessions: boolean;
 }
 
 export type RecallInjectionPosition = "prepend" | "system-prepend" | "system-append";
@@ -86,6 +91,7 @@ export interface NoospherePluginLogger {
 
 export interface BeforePromptBuildEventLike {
   prompt?: unknown;
+  rawMessage?: unknown; // Hindsight-inspired: clean user text without metadata envelopes
   messages?: unknown[];
 }
 
@@ -125,6 +131,10 @@ export function resolveAutoRecallConfig(rawConfig: unknown): NoosphereAutoRecall
     ),
     memoryCaptureInstructionsEnabled: readBoolean(config.memoryCaptureInstructionsEnabled) ?? true,
     memoryCaptureInstructions: readString(config.memoryCaptureInstructions) ?? DEFAULT_MEMORY_CAPTURE_INSTRUCTIONS,
+    // Session pattern filtering
+    ignoreSessionPatterns: readStringArray(config.ignoreSessionPatterns) ?? [],
+    statelessSessionPatterns: readStringArray(config.statelessSessionPatterns) ?? [],
+    skipStatelessSessions: readBoolean(config.skipStatelessSessions) ?? true,
   };
 }
 
@@ -135,6 +145,9 @@ export function createNoosphereAutoRecallHook(
 ) {
   const staticConfig = resolveAutoRecallConfig(rawConfig);
   const settingsCache: SettingsCache = { settings: null, fetchedAt: 0 };
+
+  // In-flight recall deduplication (Hindsight-inspired)
+  const inflightRecalls = new Map<string, Promise<NoosphereRecallResponse>>();
 
   /**
    * Fetches recall settings from the DB (with 30s cache TTL).
@@ -188,6 +201,25 @@ export function createNoosphereAutoRecallHook(
   ): Promise<PromptInjectionResult | void> => {
     const effectiveConfig = await getEffectiveConfig();
 
+    // Session pattern filtering (Hindsight-inspired)
+    const sessionKey = ctx.sessionKey;
+    if (sessionKey) {
+      // Check ignoreSessionPatterns first
+      if (effectiveConfig.ignoreSessionPatterns.length > 0) {
+        if (matchesSessionPattern(sessionKey, effectiveConfig.ignoreSessionPatterns)) {
+          logger?.debug?.(`[Noosphere] Skipping recall: session '${sessionKey}' matches ignoreSessionPatterns`);
+          return;
+        }
+      }
+      // Check statelessSessionPatterns
+      if (effectiveConfig.skipStatelessSessions && effectiveConfig.statelessSessionPatterns.length > 0) {
+        if (matchesSessionPattern(sessionKey, effectiveConfig.statelessSessionPatterns)) {
+          logger?.debug?.(`[Noosphere] Skipping recall: session '${sessionKey}' matches statelessSessionPatterns (skipStatelessSessions=true)`);
+          return;
+        }
+      }
+    }
+
     // Only proceed if auto-recall is enabled and agent is eligible
     if (!shouldAutoRecall(effectiveConfig, event, ctx, clientContext.config)) return;
 
@@ -195,16 +227,28 @@ export function createNoosphereAutoRecallHook(
     if (!query || query.length < effectiveConfig.minQueryLength) return;
 
     try {
-      const response = await clientContext.client.recall(
-        {
-          query,
-          mode: "auto",
-          resultCap: effectiveConfig.resultCap,
-          tokenBudget: effectiveConfig.tokenBudget,
-          providers: effectiveConfig.autoProviders,
-        },
-        { timeoutMs: effectiveConfig.timeoutMs },
-      );
+      // Deduplicate concurrent recalls for the same query (Hindsight-inspired)
+      const normalizedQuery = query.trim().toLowerCase().replace(/\s+/g, " ");
+      const queryHash = createHash("sha256").update(normalizedQuery).digest("hex").slice(0, 16);
+      const recallKey = queryHash;
+
+      let recallPromise = inflightRecalls.get(recallKey);
+      if (!recallPromise) {
+        recallPromise = clientContext.client.recall(
+          {
+            query,
+            mode: "auto",
+            resultCap: effectiveConfig.resultCap,
+            tokenBudget: effectiveConfig.tokenBudget,
+            providers: effectiveConfig.autoProviders,
+          },
+          { timeoutMs: effectiveConfig.timeoutMs },
+        );
+        inflightRecalls.set(recallKey, recallPromise);
+        void recallPromise.catch(() => {}).finally(() => inflightRecalls.delete(recallKey));
+      }
+
+      const response = await recallPromise;
 
       // Build injection parts: instructions (if enabled) + recall results
       const recallText = extractPromptInjectionText(response, effectiveConfig);
@@ -236,20 +280,95 @@ export function createNoosphereAutoRecallHook(
   return hook;
 }
 
+/**
+ * Build recall query from the event, using rawMessage first (like Hindsight).
+ * Strips channel metadata envelopes from the query text.
+ */
 export function buildAutoRecallQuery(event: BeforePromptBuildEventLike, config: NoosphereAutoRecallConfig): string | undefined {
+  // Hindsight-inspired: use rawMessage first (clean user text), then fall back to prompt
+  const rawMessage = readString(event.rawMessage);
   const prompt = readString(event.prompt);
-  if (!prompt) return undefined;
 
-  const parts = [prompt];
+  // Try rawMessage first, then prompt as fallback
+  let recallQuery = rawMessage ?? prompt;
+  if (!recallQuery) return undefined;
+
+  // Strip channel metadata envelopes (Hindsight-inspired)
+  recallQuery = stripMetadataEnvelopes(recallQuery);
+
+  // If rawMessage was empty/invalid but prompt worked, clean the prompt too
+  if (!rawMessage && prompt) {
+    recallQuery = stripMetadataEnvelopes(prompt);
+  }
+
+  // Also clean the rawMessage if we're using it directly
+  if (rawMessage) {
+    recallQuery = stripMetadataEnvelopes(rawMessage);
+  }
+
+  // Build parts: recent turns (if enabled) + current query
+  const parts: string[] = [];
+
   if (config.includeRecentTurns && Array.isArray(event.messages) && config.recentTurnLimit > 0) {
     const recentTurns = dedupeTurns(extractRecentUserTurns(event.messages, config.recentTurnLimit))
-      .filter((turn) => turn && turn !== prompt);
+      .filter((turn) => {
+        if (!turn) return false;
+        const cleaned = stripMetadataEnvelopes(turn);
+        return cleaned && cleaned !== recallQuery;
+      });
     if (recentTurns.length > 0) {
-      parts.unshift(...recentTurns);
+      parts.push(...recentTurns);
     }
   }
 
+  // Add the current query
+  if (recallQuery && recallQuery.trim().length >= 5) {
+    parts.push(recallQuery.trim());
+  }
+
+  if (parts.length === 0) return undefined;
+
   return parts.join("\n\n").slice(-MAX_QUERY_LENGTH);
+}
+
+/**
+ * Strip channel metadata envelopes from text (Hindsight-inspired).
+ * Removes patterns like:
+ * - [Telegram 123456789] message
+ * - [Channel metadata ...] blocks
+ * - [from: SenderName] metadata
+ * - System: ... prefixes
+ * - Conversation info (untrusted metadata) blocks
+ */
+function stripMetadataEnvelopes(text: string): string {
+  if (!text) return text;
+
+  let cleaned = text;
+
+  // Remove leading "System: ..." lines (from prependSystemEvents)
+  cleaned = cleaned.replace(/^(?:System:.*\n)+\n?/gm, "");
+
+  // Remove session abort hints
+  cleaned = cleaned.replace(/^Note: The previous agent run was aborted[^\n]*\n\n/, "");
+
+  // Remove channel envelope headers like [Telegram 1782981446] or [TelegramDirect 1782981446]
+  cleaned = cleaned.replace(/^\[Telegram[^\]]*\]\s*/i, "");
+
+  // Remove [ChannelName ...] style envelope headers
+  cleaned = cleaned.replace(/\[[A-Z][A-Za-z]*(?:\s[^\]]+)?\]\s*/g, "");
+
+  // Remove trailing [from: SenderName] metadata (group chats)
+  cleaned = cleaned.replace(/\n\[from:[^\]]*\]\s*$/, "");
+
+  // Remove conversation info metadata blocks
+  cleaned = cleaned.replace(/^\s*conversation info\s*\(untrusted metadata\).*$/gim, "");
+  cleaned = cleaned.replace(/^\s*\(untrusted metadata\).*$/gim, "");
+  cleaned = cleaned.replace(/^\s*\[Channel metadata[^\]]*\].*$/gim, "");
+
+  // Remove any remaining channel envelope patterns
+  cleaned = cleaned.replace(/^\s*\[[^\]]*\]\s*/gm, "");
+
+  return cleaned.trim();
 }
 
 function buildInjectionResult(promptText: string, position: RecallInjectionPosition): PromptInjectionResult {
@@ -281,6 +400,36 @@ function dedupeTurns(turns: string[]): string[] {
   return deduped;
 }
 
+/**
+ * Match a session key against glob patterns (Hindsight-inspired).
+ * Supports:
+ * - * matches any characters except colon
+ * - ** matches any characters including colon
+ */
+function matchesSessionPattern(sessionKey: string, patterns: string[]): boolean {
+  for (const pattern of patterns) {
+    if (matchGlob(sessionKey, pattern)) return true;
+  }
+  return false;
+}
+
+/**
+ * Simple glob matching for session patterns.
+ * * matches anything except colon
+ * ** matches anything including colon
+ */
+function matchGlob(str: string, pattern: string): boolean {
+  // Convert glob pattern to regex
+  const regexPattern = pattern
+    .replace(/[.+?^${}()|[\]\\]/g, "\\$&") // Escape special regex chars except * and **
+    .replace(/\*\*/g, "⟨DOUBLE_STAR⟩") // Placeholder for **
+    .replace(/\*/g, "[^:]*") // * matches anything except colon
+    .replace(/⟨DOUBLE_STAR⟩/g, ".*"); // ** matches anything including colon
+
+  const regex = new RegExp(`^${regexPattern}$`);
+  return regex.test(str);
+}
+
 function shouldAutoRecall(
   config: NoosphereAutoRecallConfig,
   event: BeforePromptBuildEventLike,
@@ -289,7 +438,10 @@ function shouldAutoRecall(
 ): boolean {
   if (!config.autoRecall) return false;
   if (!resolvedConfig.apiKey) return false;
-  if (!readString(event.prompt)) return false;
+
+  // Hindsight-inspired: check rawMessage first, then prompt
+  const hasMessage = readString(event.rawMessage) || readString(event.prompt);
+  if (!hasMessage) return false;
 
   if (config.enabledAgents.length > 0 && !matchesAny(config.enabledAgents, ctx.agentId)) return false;
   if (config.allowedChatTypes.length > 0 && !matchesAny(config.allowedChatTypes, resolveChatType(ctx))) return false;


### PR DESCRIPTION
## Summary

Adopts key improvements from the vectorize-io/hindsight OpenClaw plugin which has a working  hook implementation.

## Changes

### 1. Use  first (clean user text)
- Hindsight uses  (clean user text without metadata) as the primary query source
- Falls back to  if  is not available
- This ensures the recall query is not polluted with channel metadata envelopes

### 2. Strip channel metadata envelopes
- Removes patterns like 
- Removes  blocks
- Removes  prefixes and session abort hints
- Removes trailing  metadata

### 3. Session pattern filtering
Added three new config options:
- : Array of glob patterns for sessions to skip entirely
- : Array of glob patterns for read-only sessions
- : Boolean to skip recall for stateless sessions (default: true)

### 4. Inflight recall deduplication
- Added  Map to track in-flight recall requests
- Concurrent recalls for the same query are deduplicated
- Prevents redundant API calls when multiple hooks fire simultaneously

## Config additions


## Testing
- All 149 existing tests pass
- TypeScript compiles cleanly

## Summary by Sourcery

Adopt Hindsight-inspired improvements to the OpenClaw Noosphere auto-recall hook to make recall queries cleaner, more efficient, and configurable per session.

New Features:
- Add support for using a clean rawMessage field as the primary source for auto-recall queries, falling back to the prompt when needed.
- Introduce session pattern filtering options to ignore sessions, mark stateless sessions, and optionally skip recall for stateless sessions based on glob-style patterns.

Enhancements:
- Strip channel and metadata envelopes from recall queries and recent turns to avoid polluting recall with transport-level information.
- Deduplicate concurrent recall requests for the same normalized query using an in-memory in-flight recall map to reduce redundant API calls.
- Relax auto-recall eligibility to consider either rawMessage or prompt presence when deciding to run recall.