### PR TITLE
docs(openclaw): add official plugin setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,74 +414,54 @@ curl -s -X POST http://localhost:4400/api/memory/save \
 
 ## OpenClaw Integration
 
-Noosphere is intended to back OpenClaw-style agent memory workflows.
+Noosphere ships an OpenClaw plugin at `openclaw-noosphere-memory/` and an official local Docker Compose install path for OpenClaw users.
 
-The OpenClaw bridge is a first-class citizen of this repository and lives at `openclaw-noosphere-memory/`.
+For the full setup, operations, troubleshooting, upgrade, and uninstall guide, see:
 
-### Plugin Capabilities
+- [`docs/OPENCLAW-OFFICIAL-PLUGIN-SETUP.md`](docs/OPENCLAW-OFFICIAL-PLUGIN-SETUP.md)
+
+### Quick install
+
+On the machine running OpenClaw Gateway:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/SweetSophia/noosphere/master/install-openclaw.sh | bash
+openclaw noosphere doctor
+openclaw noosphere status
+```
+
+Defaults are local-only and safe for personal OpenClaw deployments:
+
+- Noosphere URL: `http://127.0.0.1:6578`
+- Runtime directory: `~/.noosphere`
+- OpenClaw secret file: `~/.openclaw/secrets/noosphere-memory.json`
+- Docker image: `ghcr.io/sweetsophia/noosphere:latest`
+
+### Plugin capabilities
 
 **Explicit tools:**
 
 | Tool | Permission | Description |
 | --- | --- | --- |
-| `noosphere_status` | READ+ | Health check: providers, settings, capabilities |
-| `noosphere_recall` | READ+ | Multi-provider recall query (auto or inspection mode) |
-| `noosphere_get` | READ+ | Direct lookup by ID or canonical ref |
-| `noosphere_save` | WRITE+ | Save a memory candidate (draft only, never auto-publishes) |
+| `noosphere_status` | ADMIN | Health check: providers, settings, capabilities |
+| `noosphere_recall` | READ | Multi-provider recall query in `auto` or `inspection` mode |
+| `noosphere_get` | READ | Direct lookup by provider/id or canonical ref |
+| `noosphere_save` | WRITE | Save a draft memory candidate; never auto-publishes |
 
-**Auto-injection (via `before_prompt_build` hook):**
+**Auto-injection:**
 
-When `autoRecall: true` and the agent is eligible, the hook injects two XML blocks into `prependContext`:
+When `autoRecall: true`, OpenClaw permits hook injection, and recall returns non-empty prompt text, the plugin's `before_prompt_build` hook can inject:
 
-1. `<noosphere_memory_capture>` — bundled guidance telling the agent when to save important information and how to use the `noosphere_save` tool (topicId, title, content, confidence, tags). Includes "what NOT to save" rules (transient text, secrets, short content).
-2. `<noosphere_auto_recall>` — ranked, deduplicated, conflict-resolved recall results within token budget.
+1. `<noosphere_memory_capture>` — guidance telling agents when/how to call `noosphere_save`.
+2. `<noosphere_auto_recall>` — ranked, deduplicated, conflict-resolved recall results within budget.
 
-After compaction, the next `before_prompt_build` re-injects both blocks automatically.
-
-**Hooks:**
-
-- `before_prompt_build` — optional bounded Noosphere recall injection with bundled memory capture instructions. When `autoRecall` is enabled and gates pass, injects `<noosphere_memory_capture>` block (when/how to save) alongside `<noosphere_auto_recall>` block (recall results). Disabled by default to avoid duplicate Hindsight auto-injection.
-
-**Corpus supplement:**
-
-- `registerMemoryCorpusSupplement` — wires Noosphere into OpenClaw's shared `memory_search`/`memory_get` flows so all agents can query Noosphere content through the unified memory interface.
-
-**OpenClaw CLI helpers:**
-
-```bash
-openclaw noosphere status
-openclaw noosphere doctor
-openclaw noosphere logs [service]
-openclaw noosphere setup
-openclaw noosphere upgrade
-```
-
-- `status` checks Noosphere health and authenticated memory status.
-- `doctor` audits plugin config, API key resolution, `allowPromptInjection`, auto-recall settings, `/api/health`, and authenticated `/api/memory/status`.
-- `logs` prints the safe Docker Compose command to run for logs. The plugin does not execute Docker itself, so package installation stays within OpenClaw's third-party plugin safety policy.
-- `setup` and `upgrade` print the recommended installer/upgrade commands.
-
-### Setup (OpenClaw Agent)
-
-**⚠️ CRITICAL: `allowPromptInjection` Setting**
-
-For the `before_prompt_build` hook to actually inject memory capture instructions and recall results into the agent's context, you **must** set `allowPromptInjection: true` in the `hooks` section of the plugin entry:
+Important: OpenClaw requires this hook permission before any prompt text can be injected:
 
 ```json
 {
   "plugins": {
     "entries": {
       "noosphere-memory": {
-        "enabled": true,
-        "config": {
-          "baseUrl": "http://100.111.85.48:4400",
-          "apiKey": "noo_your_key_here",
-          "autoRecall": false,
-          "autoProviders": ["noosphere"],
-          "maxInjectedMemories": 5,
-          "maxInjectedTokens": 2000,
-          "memoryCaptureInstructionsEnabled": true
-        },
         "hooks": {
           "allowPromptInjection": true
         }
@@ -491,135 +471,25 @@ For the `before_prompt_build` hook to actually inject memory capture instruction
 }
 ```
 
-Without `allowPromptInjection: true`, the hook runs but the injection is blocked by the gateway — agents will not see memory capture guidance or recall results auto-injected.
+Without `hooks.allowPromptInjection: true`, explicit tools still work, but auto-recall and memory capture instructions will not appear in agent context.
 
-**1. Load the plugin**
+**Memory corpus supplement:**
 
-The plugin package is at `openclaw-noosphere-memory/` in this repository. Add it to your OpenClaw agent's plugin config (include the `hooks` section as shown above):
+The plugin registers a Noosphere memory corpus supplement so OpenClaw shared memory flows can query Noosphere content through the unified memory interface.
 
-**2. Keys and permissions**
+**OpenClaw CLI helpers:**
 
-| Task | Required permission |
-| --- | --- |
-| `noosphere_status` | ADMIN |
-| `noosphere_recall` (read) | READ |
-| `noosphere_get` (read) | READ |
-| `noosphere_save` (write) | WRITE |
+The plugin registers `openclaw noosphere ...` helpers for status, diagnostics, logs guidance, setup guidance, and upgrade guidance. See the setup guide for the canonical command reference.
 
-Create a key with the appropriate scope at `/wiki/admin/keys`.
+### Safety properties
 
-**3. Conservative first activation**
-
-```json
-{
-  "noosphere-memory": {
-    "baseUrl": "http://100.122.171.30:4400",
-    "apiKey": "noo_admin_key_with_write",
-    "autoRecall": false,
-    "autoProviders": ["noosphere"],
-    "maxInjectedMemories": 3,
-    "maxInjectedTokens": 1000,
-    "recallInjectionPosition": "system-prepend"
-  }
-}
-```
-
-Keep `autoRecall: false` initially. Verify explicit tools first (`noosphere_status` → `noosphere_recall` → `noosphere_get` → `noosphere_save`). Then enable auto-recall conservatively.
-
-**4. Verify**
-
-```bash
-# Explicit tool tests
-/noosphere_status   # should return ok: true and provider list
-/noosphere_recall   # query: "your project name", mode: inspection
-/noosphere_get      # canonicalRef: "noosphere:article:<some-id>"
-
-# Auto-recall verification
-# Enable autoRecall, send a prompt, confirm bounded Noosphere block is injected.
-# Confirm Hindsight is not double-injected in conservative mode (autoProviders: ["noosphere"] only).
-# Confirm timeouts fail open (injects nothing, logs warning).
-```
-
-**5. Enable auto-recall (optional)**
-
-Once explicit tools are verified, enable auto-recall in the plugin config. Make sure `allowPromptInjection: true` is set in the `hooks` section:
-
-```json
-{
-  "noosphere-memory": {
-    "config": {
-      "autoRecall": true,
-      "autoProviders": ["noosphere"],
-      "maxInjectedMemories": 5,
-      "maxInjectedTokens": 2000,
-      "memoryCaptureInstructionsEnabled": true
-    },
-    "hooks": {
-      "allowPromptInjection": true
-    }
-  }
-}
-```
-
-**Memory capture instructions** are enabled by default (`memoryCaptureInstructionsEnabled: true`). When enabled, the `before_prompt_build` hook injects guidance telling the agent:
-
-- **When to save**: after completing significant tasks, error fixes, important decisions, or when the user asks to remember something
-- **How to save**: which parameters to pass to `noosphere_save` (topicId, title, content ≥40 chars, confidence level, tags)
-- **What NOT to save**: transient acknowledgments ("I'll check...", "Got it"), secrets, short content, or non-durable text
-
-Disable by setting `memoryCaptureInstructionsEnabled: false` if you prefer a purely recall-based workflow.
-
-### Key Safety Properties
-
-- Auto-recall **fails open**: if Noosphere is unreachable or the request times out, the agent prompt proceeds with no memory injected rather than erroring.
-- **Memory capture instructions are informational**: the instructions guide agent behavior but do not execute saves. Agents must explicitly call `noosphere_save` to persist anything.
-- **No forced saves**: even with instructions enabled, agents only save when they decide to call `noosphere_save`.
-- **No secrets in error payloads**: `apiKey` and `baseUrl` are never exposed in tool error responses.
-- **Bounded response bodies**: server enforces a hard cap on response body size regardless of what the plugin requests.
-- **Draft-only saves**: `noosphere_save` creates candidate articles, never directly publishes curated knowledge.
-- **Secret scanning**: saves strip content that looks like API keys, tokens, or Bearer credentials before storing.
-
-### Architecture Notes
-
-- The plugin calls Noosphere over HTTP. It does **not** import Noosphere internals directly.
-- Default mode is **conservative coexistence**: Hindsight keeps its own auto-recall; Noosphere auto-recalls curated Noosphere content only. This avoids double injection.
-- **Coordinated mode**: set Hindsight `autoRecall: false` and enable Noosphere `autoRecall: true` with `autoProviders: ["noosphere", "hindsight"]` to get one unified recall block.
-- See [`docs/OPENCLAW-NOOSPHERE-BRIDGE-ROADMAP.md`](docs/OPENCLAW-NOOSPHERE-BRIDGE-ROADMAP.md) for the full implementation history and API contracts.
-
-### Troubleshooting
-
-**Memory capture instructions or recall results not appearing in agent context**
-
-The most common cause is `allowPromptInjection: false` in the gateway config. This blocks the `before_prompt_build` hook from injecting content even when `autoRecall: true` is set.
-
-Check your `openclaw.json`:
-
-```json
-"plugins": {
-  "entries": {
-    "noosphere-memory": {
-      "config": {
-        "autoRecall": true
-      },
-      "hooks": {
-        "allowPromptInjection": true  ← THIS MUST BE TRUE
-      }
-    }
-  }
-}
-```
-
-After changing `openclaw.json`, restart the gateway:
-
-```bash
-openclaw gateway restart
-```
-
-**Gateway config location**: `~/.openclaw/openclaw.json` on the machine running the OpenClaw gateway (not the noosphere server).
-
-**Tools work but auto-injection doesn't**: This is the `allowPromptInjection` issue above. The tools call the HTTP API directly (which works), but the hook's text injection is blocked by the gateway setting.
-
-**Gateway not loading the plugin**: Check that the plugin is registered in `openclaw.json` under `plugins.entries` with `enabled: true`.
+- Default Docker Compose binding is localhost-only: `127.0.0.1:6578`.
+- PostgreSQL stays internal to the production Compose network.
+- API keys are permission-scoped; READ/WRITE/ADMIN are used for different actions.
+- Secrets are stored outside the repo in OpenClaw secret files and `~/.noosphere/.env`.
+- Auto-recall fails open when Noosphere is unreachable.
+- The installer enables broad prompt injection by default (`autoRecall: true`, `allowPromptInjection: true`, no agent/chat allowlist); restrict it with `enabledAgents`/`allowedChatTypes` if needed.
+- `noosphere_save` creates draft candidates only.
 
 ## Environment Variables
 
@@ -646,6 +516,8 @@ docker compose logs -f app
 
 ## Documentation
 
+- [`docs/OPENCLAW-OFFICIAL-PLUGIN-SETUP.md`](docs/OPENCLAW-OFFICIAL-PLUGIN-SETUP.md) — official OpenClaw install, operations, upgrade, and troubleshooting guide
+- [`docs/OPENCLAW-OFFICIAL-PLUGIN-DEVELOPMENT-PLAN.md`](docs/OPENCLAW-OFFICIAL-PLUGIN-DEVELOPMENT-PLAN.md) — productization plan and release checklist
 - [`docs/NOOSPHERE-MEMORY-ARCHITECTURE.md`](docs/NOOSPHERE-MEMORY-ARCHITECTURE.md) — memory architecture and configuration model
 - [`docs/NOOSPHERE-SKILL.md`](docs/NOOSPHERE-SKILL.md) — agent-facing wiki skill reference
 - [`docs/OBSIDIAN-SYNC-SPEC.md`](docs/OBSIDIAN-SYNC-SPEC.md) — Obsidian sync design

--- a/docs/NOOSPHERE-MEMORY-ARCHITECTURE.md
+++ b/docs/NOOSPHERE-MEMORY-ARCHITECTURE.md
@@ -525,6 +525,7 @@ openclaw-noosphere-memory/src/
 ├── config.ts          — NoosphereMemoryPluginConfig + defaults
 ├── client.ts          — NoosphereMemoryClient (HTTP API wrapper)
 ├── auto-recall.ts     — before_prompt_build hook implementation
+├── cli.ts             — OpenClaw `noosphere` CLI helpers
 ├── corpus-supplement.ts — memory corpus supplement wiring
 ├── format.ts          — XML output formatting
 ├── types.ts           — shared TypeScript types
@@ -537,30 +538,36 @@ openclaw-noosphere-memory/src/
 
 ### NoosphereAutoRecallConfig
 
-Source: `openclaw-noosphere-memory/src/config.ts`
+Source: `openclaw-noosphere-memory/src/config.ts` and
+`openclaw-noosphere-memory/src/auto-recall.ts`
 
-The auto-recall hook uses `NoosphereAutoRecallConfig`:
+The auto-recall hook uses `NoosphereAutoRecallConfig` for prompt injection gates,
+query construction, timeouts, and memory-capture guidance. The official installer
+sets secure local connection defaults plus installer-specific prompt-injection
+budget/timeout values that differ from the plugin's raw library defaults.
 
-| Field | Default | Purpose |
-| --- | --- | --- |
-| `autoRecall` | `false` | Enable/disable auto-injection |
-| `enabledAgents` | `[]` | Agent IDs allowed to receive auto-injection |
-| `chatTypes` | `["direct"]` | Chat types for injection (direct, group, etc.) |
-| `maxInjectedMemories` | `5` | Result count cap for injected recall |
-| `maxInjectedTokens` | `1200` | Token budget for injected recall |
-| `recallInjectionPosition` | `prepend` | Where to inject in prompt context |
-| `memoryCaptureInstructionsEnabled` | `true` | Inject memory capture guidance block |
-| `memoryCaptureInstructions` | (see below) | Custom override for capture guidance text |
-| `autoProviders` | `["noosphere"]` | Which providers to query in auto mode |
-| `baseUrl` | (required) | Noosphere API base URL |
-| `apiKey` | (required) | API key for authentication |
-| `timeoutMs` | `5000` | Request timeout |
+To avoid duplicated default tables drifting across documents, the canonical
+operator-facing field reference lives in
+[`OPENCLAW-OFFICIAL-PLUGIN-SETUP.md`](OPENCLAW-OFFICIAL-PLUGIN-SETUP.md#plugin-configuration-fields).
+
+Key groups:
+
+- **Connection**: `baseUrl`, `apiKey`, `timeoutMs`
+- **Auto-recall gates**: `autoRecall`, `enabledAgents`, `allowedChatTypes`,
+  `ignoreSessionPatterns`, `statelessSessionPatterns`, `skipStatelessSessions`
+- **Query construction**: `includeRecentTurns`, `recentTurnLimit`,
+  `minQueryLength`, `autoProviders`
+- **Prompt budget/placement**: `maxInjectedMemories`, `maxInjectedTokens`,
+  `recallInjectionPosition`, `autoRecallTimeoutMs`
+- **Capture guidance**: `memoryCaptureInstructionsEnabled`,
+  `memoryCaptureInstructions`
 
 ### Memory Capture Instructions
 
 When `memoryCaptureInstructionsEnabled: true`, the `before_prompt_build` hook injects
 a `<noosphere_memory_capture>` XML block containing guidance on when and how to use
-`noosphere_save`. The default instructions tell agents:
+`noosphere_save`. This block is appended only when auto-recall succeeds and returns
+non-empty prompt injection text. The default instructions tell agents:
 
 **WHEN TO SAVE:**
 - After completing a significant task (deployment, bug fix, feature implementation)
@@ -597,11 +604,27 @@ before_prompt_build hook
       → return undefined (no injection)
 ```
 
+### OpenClaw CLI Helpers
+
+The plugin registers a `noosphere` CLI command group:
+
+```bash
+openclaw noosphere status
+openclaw noosphere doctor
+openclaw noosphere logs [service]
+openclaw noosphere setup
+openclaw noosphere upgrade
+```
+
+`status` and `doctor` use the Noosphere HTTP API and resolved OpenClaw plugin
+config. `logs`, `setup`, and `upgrade` print operator commands instead of
+executing Docker or shell commands from the plugin package.
+
 ### Settings Cache
 
 The auto-recall hook caches recall settings from the DB for 30 seconds to avoid
-excessive API calls. This cache is invalidated on any settings change through the
-admin UI or API.
+excessive API calls. The effective settings are refreshed after the cache TTL;
+changes made through the admin UI or API are picked up on the next refresh.
 
 ### Backward Compatibility
 
@@ -620,3 +643,7 @@ The plugin guards against older config shapes that may not have new fields:
   agent decides to call the tool.
 - **Bounded results**: orchestrator enforces `maxInjectedMemories` and
   `maxInjectedTokens` caps at the server level.
+- **Local-first setup**: the official OpenClaw setup binds Noosphere to
+  `127.0.0.1:6578` by default and stores secrets outside the repository.
+
+See also: [`OPENCLAW-OFFICIAL-PLUGIN-SETUP.md`](OPENCLAW-OFFICIAL-PLUGIN-SETUP.md).

--- a/docs/OPENCLAW-OFFICIAL-PLUGIN-SETUP.md
+++ b/docs/OPENCLAW-OFFICIAL-PLUGIN-SETUP.md
@@ -1,0 +1,435 @@
+# OpenClaw Noosphere Official Plugin Setup
+
+This guide documents the official OpenClaw-facing Noosphere install path: a local Noosphere Docker Compose runtime plus the `noosphere-memory` OpenClaw plugin.
+
+The default install is intentionally local-only:
+
+- Noosphere web app: `http://127.0.0.1:6578`
+- App container port: `3000`
+- PostgreSQL: Compose-internal only
+- Runtime directory: `~/.noosphere`
+- OpenClaw secret file: `~/.openclaw/secrets/noosphere-memory.json`
+
+## Prerequisites
+
+Install these on the machine running OpenClaw Gateway:
+
+- Docker
+- Docker Compose v2 (`docker compose`)
+- Node.js 22+
+- OpenClaw CLI
+- `curl`
+
+Verify:
+
+```bash
+docker --version
+docker compose version
+node --version
+openclaw --version
+curl --version
+```
+
+## Quick install
+
+Use the installer from the repository:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/SweetSophia/noosphere/master/install-openclaw.sh | bash
+```
+
+The installer:
+
+1. Creates `~/.noosphere/`.
+2. Generates local secrets.
+3. Writes a production `docker-compose.yml` using `ghcr.io/sweetsophia/noosphere`.
+4. Starts PostgreSQL and Noosphere.
+5. Runs Prisma migrations through `docker/migrate-or-baseline.mjs`.
+6. Runs repeatable bootstrap through `docker/bootstrap.mjs` using the same generated admin/API credentials that are later written to `.env` and OpenClaw secrets.
+7. Writes `~/.openclaw/secrets/noosphere-memory.json`.
+8. Installs or updates `noosphere-memory` in OpenClaw.
+9. Patches OpenClaw config with the Noosphere base URL, API key secret reference, and `hooks.allowPromptInjection: true`.
+10. Restarts OpenClaw Gateway when available.
+
+Verify after install:
+
+```bash
+curl -fsS http://127.0.0.1:6578/api/health
+openclaw noosphere doctor
+openclaw noosphere status
+openclaw plugins inspect noosphere-memory --runtime --json
+```
+
+## Installer options
+
+Set these environment variables before running the installer when you need non-default behavior:
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `NOOSPHERE_HOME` | `~/.noosphere` | Runtime directory for Compose files and `.env`. |
+| `NOOSPHERE_PORT` | `6578` | Localhost port exposed by the app. |
+| `NOOSPHERE_VERSION` | `latest` | GHCR image tag. |
+| `NOOSPHERE_IMAGE` | `ghcr.io/sweetsophia/noosphere:${NOOSPHERE_VERSION}` | Full image reference override. |
+| `APP_URL` | `http://127.0.0.1:${NOOSPHERE_PORT}` | URL stored in Noosphere/OpenClaw config. |
+| `NOOSPHERE_PLUGIN_SPEC` | `npm:@sweetsophia/openclaw-noosphere-memory` | Plugin install spec. Useful for testing local tarballs. |
+| `OPENCLAW_SECRETS_DIR` | `~/.openclaw/secrets` | OpenClaw secret directory. |
+| `NOOSPHERE_SECRETS_FILE` | `${OPENCLAW_SECRETS_DIR}/noosphere-memory.json` | Secret file written by installer. |
+| `NOOSPHERE_SECRET_PROVIDER_ID` | `noosphereMemory` | OpenClaw secret provider ID used in config. |
+
+By default the installer enables Noosphere auto-recall for all OpenClaw agents and chat types (`autoRecall: true`, `hooks.allowPromptInjection: true`, no agent/chat allowlist). Restrict or disable this after install if you do not want global prompt injection.
+
+Example using a pinned image tag and custom port:
+
+```bash
+NOOSPHERE_VERSION=0.1.0 \
+NOOSPHERE_PORT=6678 \
+APP_URL=http://127.0.0.1:6678 \
+bash install-openclaw.sh
+```
+
+## OpenClaw CLI helpers
+
+After the plugin is installed, OpenClaw exposes:
+
+```bash
+openclaw noosphere status
+openclaw noosphere doctor
+openclaw noosphere logs [service]
+openclaw noosphere setup
+openclaw noosphere upgrade
+```
+
+Command behavior:
+
+| Command | Behavior |
+| --- | --- |
+| `status` | Checks `/api/health` and authenticated `/api/memory/status`. Exits non-zero if the integration is unusable. |
+| `doctor` | Audits base URL, API key, auto-recall config, `allowPromptInjection`, Noosphere health, memory status, and DB auto-recall setting. |
+| `logs [service]` | Prints the Docker Compose logs command to run manually. It does not execute Docker from the plugin. |
+| `setup` | Prints the recommended installer command. |
+| `upgrade` | Prints the recommended upgrade flow. |
+
+The plugin intentionally avoids shell execution. Docker/log operations are guidance-only so the third-party plugin package stays within OpenClaw package safety policy.
+
+## Manual Docker Compose install
+
+Use this when you want to run Noosphere yourself instead of using the installer. Run these commands from a Noosphere repository checkout:
+
+```bash
+git clone https://github.com/SweetSophia/noosphere.git
+cd noosphere
+mkdir -p ~/.noosphere
+cp docker-compose.noosphere.yml ~/.noosphere/docker-compose.yml
+cp noosphere.env.example ~/.noosphere/.env
+chmod 600 ~/.noosphere/.env
+```
+
+If you do not want a checkout, download the two files directly:
+
+```bash
+mkdir -p ~/.noosphere
+curl -fsSLo ~/.noosphere/docker-compose.yml https://raw.githubusercontent.com/SweetSophia/noosphere/master/docker-compose.noosphere.yml
+curl -fsSLo ~/.noosphere/.env https://raw.githubusercontent.com/SweetSophia/noosphere/master/noosphere.env.example
+chmod 600 ~/.noosphere/.env
+```
+
+Edit `~/.noosphere/.env` and set strong values for:
+
+- `POSTGRES_PASSWORD`
+- `NEXTAUTH_SECRET`
+- `NOOSPHERE_ADMIN_PASSWORD`
+- `NOOSPHERE_BOOTSTRAP_API_KEY`
+
+Start and wait for health:
+
+```bash
+cd ~/.noosphere
+docker compose pull
+docker compose up -d
+for i in {1..60}; do
+  curl -fsS http://127.0.0.1:6578/api/health && break
+  sleep 2
+done
+```
+
+The production Compose template includes a one-shot `init` service. It waits for PostgreSQL, applies migrations, runs bootstrap, then allows the app service to start.
+
+## Manual OpenClaw plugin install
+
+Install the plugin package:
+
+```bash
+openclaw plugins install npm:@sweetsophia/openclaw-noosphere-memory
+```
+
+Create an OpenClaw secret file. Use an ADMIN-scoped Noosphere API key when you want `openclaw noosphere doctor` and `openclaw noosphere status` to pass; READ/WRITE-only keys can still work for narrower recall/save tools but will fail authenticated status checks. Do not paste real API keys into shared docs or commits:
+
+```bash
+mkdir -p ~/.openclaw/secrets
+chmod 700 ~/.openclaw/secrets
+cat > ~/.openclaw/secrets/noosphere-memory.json <<'JSON'
+{
+  "baseUrl": "http://127.0.0.1:6578",
+  "apiKey": "REPLACE_WITH_NOOSPHERE_API_KEY"
+}
+JSON
+chmod 600 ~/.openclaw/secrets/noosphere-memory.json
+```
+
+Patch OpenClaw config:
+
+```bash
+cat > /tmp/noosphere-openclaw-patch.json5 <<'JSON5'
+{
+  secrets: {
+    providers: {
+      noosphereMemory: {
+        source: "file",
+        path: "~/.openclaw/secrets/noosphere-memory.json",
+        mode: "json",
+      },
+    },
+  },
+  plugins: {
+    entries: {
+      "noosphere-memory": {
+        enabled: true,
+        config: {
+          baseUrl: "http://127.0.0.1:6578",
+          apiKey: { source: "file", provider: "noosphereMemory", id: "/apiKey" },
+          autoRecall: true,
+          autoProviders: ["noosphere"],
+          maxInjectedMemories: 10,
+          maxInjectedTokens: 1000,
+          recallInjectionPosition: "system-prepend",
+          autoRecallTimeoutMs: 5000,
+        },
+        hooks: {
+          allowPromptInjection: true,
+        },
+      },
+    },
+  },
+}
+JSON5
+openclaw config patch --file /tmp/noosphere-openclaw-patch.json5
+openclaw gateway restart
+```
+
+Verify:
+
+```bash
+openclaw noosphere doctor
+openclaw noosphere status
+```
+
+## Plugin configuration fields
+
+This is the canonical operator-facing field reference. "Plugin default" is the
+value used by the plugin when no config is supplied. "Installer value" is what
+`install-openclaw.sh` writes for the official local setup path.
+
+| Field | Plugin default | Installer value | Notes |
+| --- | --- | --- | --- |
+| `baseUrl` | `http://localhost:3000` | `http://127.0.0.1:6578` | Noosphere server base URL. |
+| `apiKey` | unset | file secret reference | String, `{ value }`, or OpenClaw file secret reference. Required for memory APIs. |
+| `timeoutMs` | `5000` | default | Explicit HTTP request timeout. Max `30000`. |
+| `autoRecall` | `false` | `true` | Enables `before_prompt_build` recall injection. |
+| `autoProviders` | `["noosphere"]` | `["noosphere"]` | Providers requested from Noosphere auto recall. |
+| `maxInjectedMemories` | `5` | `10` | Auto-recall result cap. Max `10`. |
+| `maxInjectedTokens` | `1200` | `1000` | Auto-recall token budget. Max `2000`. |
+| `recallInjectionPosition` | `prepend` | `system-prepend` | `prepend`, `system-prepend`, or `system-append`. |
+| `autoRecallTimeoutMs` | `1500` | `5000` | Per-prompt auto-recall timeout. Max `5000`. Fails open. |
+| `minQueryLength` | `8` | default | Skip auto-recall for shorter composed queries. |
+| `enabledAgents` | `[]` | unset | Optional agent allowlist. Empty/unset means all agents. |
+| `allowedChatTypes` | `[]` | unset | Optional chat/provider allowlist. Empty/unset means all chat types. |
+| `includeRecentTurns` | `true` | default | Include recent user turns in the recall query. |
+| `recentTurnLimit` | `4` | default | Recent turn cap. Max `10`. |
+| `memoryCaptureInstructionsEnabled` | `true` | default | Adds guidance for when/how to call `noosphere_save` only when auto-recall succeeds and returns non-empty prompt text. |
+| `memoryCaptureInstructions` | built-in text | default | Optional custom guidance override. |
+| `ignoreSessionPatterns` | `[]` | unset | Glob patterns for sessions to skip. |
+| `statelessSessionPatterns` | `[]` | unset | Glob patterns for stateless sessions. |
+| `skipStatelessSessions` | `true` | default | Skip sessions matching stateless patterns. |
+
+Important hook setting:
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "noosphere-memory": {
+        "hooks": {
+          "allowPromptInjection": true
+        }
+      }
+    }
+  }
+}
+```
+
+Without `hooks.allowPromptInjection: true`, tools still work, but auto-recall and
+memory capture instructions are not injected into prompts.
+
+## Security model
+
+- **Localhost by default**: Compose binds the app to `127.0.0.1:${NOOSPHERE_PORT:-6578}`.
+- **PostgreSQL is not exposed publicly** in the production Compose template.
+- **API keys are permission-scoped**. READ is enough for recall/get; WRITE is required for save; ADMIN is required for status/settings/admin operations.
+- **Secrets live outside the repo**. The installer writes OpenClaw secrets to `~/.openclaw/secrets/noosphere-memory.json` and runtime values to `~/.noosphere/.env`.
+- **Auto-recall fails open**. If Noosphere is unavailable, OpenClaw continues without injected memory.
+- **`noosphere_save` creates draft candidates only**. It never auto-publishes curated knowledge.
+- **Prompt injection is explicit but broad by default in the installer**. OpenClaw requires `hooks.allowPromptInjection: true` before plugin hook text can enter the prompt; the installer enables it with no `enabledAgents` or `allowedChatTypes` allowlist.
+
+## Restricting auto-recall scope
+
+The installer opts all agents/chats into Noosphere auto-recall. To limit injection, patch the plugin config with `enabledAgents` and/or `allowedChatTypes`, or set `autoRecall: false` while keeping explicit tools enabled.
+
+Example:
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "noosphere-memory": {
+        "config": {
+          "autoRecall": true,
+          "enabledAgents": ["main", "cylena"],
+          "allowedChatTypes": ["direct"]
+        },
+        "hooks": {
+          "allowPromptInjection": true
+        }
+      }
+    }
+  }
+}
+```
+
+## Hindsight coexistence
+
+- **Conservative mode**: keep Noosphere auto-recall scoped to `autoProviders: ["noosphere"]`. Hindsight, if installed, continues to manage its own recall/injection separately.
+- **Coordinated mode**: disable Hindsight auto-recall and configure Noosphere to orchestrate both providers with `autoProviders: ["noosphere", "hindsight"]`. Use this only when the Noosphere server has a configured Hindsight provider and you want a single unified recall block.
+
+Avoid enabling two independent broad prompt-injection systems without understanding the resulting token and duplication behavior.
+
+## Upgrade
+
+Recommended flow:
+
+```bash
+cd ~/.noosphere
+docker compose pull
+docker compose up -d
+openclaw plugins update noosphere-memory
+openclaw noosphere doctor
+```
+
+The Compose `init` service runs migration/bootstrap logic before app startup. Bootstrap is repeatable and preserves article/topic content, but it reconciles the bootstrap admin account: it may reset that account's name/password to the values in `.env`, and `NOOSPHERE_FORCE_ADMIN=true` can force its role back to ADMIN.
+
+## Uninstall
+
+Disable or remove the plugin:
+
+```bash
+openclaw plugins disable noosphere-memory
+# or, when you want to remove the installed package:
+openclaw plugins uninstall noosphere-memory
+openclaw gateway restart
+```
+
+Stop Noosphere while preserving data:
+
+```bash
+cd ~/.noosphere
+docker compose down
+```
+
+Remove runtime files and data only when you are sure you no longer need them. If you want to delete Compose volumes, do that before removing `~/.noosphere` so Docker can still read the Compose project:
+
+```bash
+cd ~/.noosphere
+# DANGER: deletes Postgres/uploads volumes for this Compose project
+docker compose down -v
+cd ~
+rm -f ~/.openclaw/secrets/noosphere-memory.json
+rm -rf ~/.noosphere
+```
+
+## Troubleshooting
+
+### Tools work but auto-recall does not inject
+
+Check:
+
+```bash
+openclaw noosphere doctor
+```
+
+The usual cause is missing hook permission:
+
+```json
+"hooks": {
+  "allowPromptInjection": true
+}
+```
+
+Restart Gateway after changing config:
+
+```bash
+openclaw gateway restart
+```
+
+### Noosphere is unreachable
+
+Check health and containers:
+
+```bash
+curl -fsS http://127.0.0.1:6578/api/health
+cd ~/.noosphere
+docker compose ps
+docker compose logs --tail 80 app
+```
+
+### API key failures
+
+Run:
+
+```bash
+openclaw noosphere doctor --json
+```
+
+Then verify the configured secret file exists, has restrictive permissions, and contains the expected JSON keys without printing values:
+
+```bash
+test -f ~/.openclaw/secrets/noosphere-memory.json
+stat -c '%a %n' ~/.openclaw/secrets/noosphere-memory.json
+node -e 'const fs=require("fs"); const p=process.env.HOME+"/.openclaw/secrets/noosphere-memory.json"; const j=JSON.parse(fs.readFileSync(p,"utf8")); for (const k of ["baseUrl","apiKey"]) console.log(`${k}: ${typeof j[k] === "string" && j[k] ? "present" : "missing"}`)'
+```
+
+Do not paste real keys or full secret files into issue comments, chats, terminal transcripts, or commits.
+
+### Plugin installed but CLI commands are missing
+
+Check package/runtime registration:
+
+```bash
+openclaw plugins inspect noosphere-memory --runtime --json
+openclaw noosphere --help
+```
+
+If the package is stale:
+
+```bash
+openclaw plugins update noosphere-memory
+openclaw gateway restart
+```
+
+### Port conflict
+
+Choose a different local port:
+
+```bash
+NOOSPHERE_PORT=6678 APP_URL=http://127.0.0.1:6678 bash install-openclaw.sh
+```
+
+Or edit `~/.noosphere/.env`, then restart Compose.

--- a/install-openclaw.sh
+++ b/install-openclaw.sh
@@ -85,7 +85,12 @@ API_KEY="${API_KEY:-noo_$(random_secret 32)}"
 # Export compose variables instead of writing .env before bootstrap.
 # The persistent .env is written atomically only after bootstrap succeeds, so a
 # failed install does not leave generated secrets behind on disk.
+# Bootstrap credentials are exported too because docker compose up may run the
+# init service again through app.depends_on; the second run must see the same
+# admin/API credentials as the explicit bootstrap run below.
 export NOOSPHERE_VERSION NOOSPHERE_PORT NOOSPHERE_IMAGE APP_URL POSTGRES_PASSWORD NEXTAUTH_SECRET
+export NOOSPHERE_ADMIN_PASSWORD="$ADMIN_PASSWORD"
+export NOOSPHERE_BOOTSTRAP_API_KEY="$API_KEY"
 
 cat > "$NOOSPHERE_HOME/docker-compose.yml" <<YAML
 services:
@@ -95,6 +100,8 @@ services:
     restart: "no"
     environment:
       DATABASE_URL: postgresql://noosphere:\${POSTGRES_PASSWORD}@db:5432/noosphere
+      NOOSPHERE_ADMIN_PASSWORD: \${NOOSPHERE_ADMIN_PASSWORD}
+      NOOSPHERE_BOOTSTRAP_API_KEY: \${NOOSPHERE_BOOTSTRAP_API_KEY}
       NEXTAUTH_SECRET: \${NEXTAUTH_SECRET}
       NEXTAUTH_URL: \${APP_URL:-http://127.0.0.1:6578}
       APP_URL: \${APP_URL:-http://127.0.0.1:6578}
@@ -162,12 +169,10 @@ wait_for_container_healthy noosphere-openclaw-db 60
 
 echo "Applying database schema and bootstrap data..."
 # Run bootstrap to a temp file so we can check exit status separately.
-# Admin/API credentials passed via -e flags -- never written to .env before bootstrap succeeds.
+# Admin/API credentials are passed through exported Compose variables; they are
+# not written to .env until bootstrap succeeds.
 BOOTSTRAP_TMP=$(mktemp)
-docker compose run --rm -T \
-  -e NOOSPHERE_ADMIN_PASSWORD="${ADMIN_PASSWORD}" \
-  -e NOOSPHERE_BOOTSTRAP_API_KEY="${API_KEY}" \
-  init > "$BOOTSTRAP_TMP" 2>&1
+docker compose run --rm -T init > "$BOOTSTRAP_TMP" 2>&1
 BOOTSTRAP_EXIT=$?
 if [ $BOOTSTRAP_EXIT -ne 0 ]; then
   echo "Bootstrap failed with exit code $BOOTSTRAP_EXIT:" >&2

--- a/openclaw-noosphere-memory/openclaw.plugin.json
+++ b/openclaw-noosphere-memory/openclaw.plugin.json
@@ -9,8 +9,12 @@
       "noosphere_get",
       "noosphere_save"
     ],
-    "hooks": ["before_prompt_build"],
-    "memoryCorpusSupplements": ["noosphere"],
+    "hooks": [
+      "before_prompt_build"
+    ],
+    "memoryCorpusSupplements": [
+      "noosphere"
+    ],
     "config": {
       "secretInputs": {
         "paths": [
@@ -26,15 +30,17 @@
     "providers": [
       {
         "id": "noosphere-memory",
-        "envVars": ["NOOSPHERE_API_KEY"]
+        "envVars": [
+          "NOOSPHERE_API_KEY"
+        ]
       }
     ]
   },
   "uiHints": {
     "baseUrl": {
       "label": "Noosphere Base URL",
-      "help": "Base URL for Noosphere, for example http://100.122.171.30:3000.",
-      "placeholder": "http://localhost:3000"
+      "help": "Base URL for Noosphere, for example http://127.0.0.1:6578.",
+      "placeholder": "http://127.0.0.1:6578"
     },
     "apiKey": {
       "label": "Noosphere API Key",
@@ -91,7 +97,10 @@
         "type": "string"
       },
       "apiKey": {
-        "type": ["string", "object"]
+        "type": [
+          "string",
+          "object"
+        ]
       },
       "timeoutMs": {
         "type": "number",
@@ -103,8 +112,12 @@
       },
       "autoProviders": {
         "type": "array",
-        "items": { "type": "string" },
-        "default": ["noosphere"]
+        "items": {
+          "type": "string"
+        },
+        "default": [
+          "noosphere"
+        ]
       },
       "maxInjectedMemories": {
         "type": "number",
@@ -120,7 +133,11 @@
       },
       "recallInjectionPosition": {
         "type": "string",
-        "enum": ["prepend", "system-prepend", "system-append"],
+        "enum": [
+          "prepend",
+          "system-prepend",
+          "system-append"
+        ],
         "default": "prepend"
       },
       "autoRecallTimeoutMs": {
@@ -136,11 +153,15 @@
       },
       "enabledAgents": {
         "type": "array",
-        "items": { "type": "string" }
+        "items": {
+          "type": "string"
+        }
       },
       "allowedChatTypes": {
         "type": "array",
-        "items": { "type": "string" }
+        "items": {
+          "type": "string"
+        }
       },
       "includeRecentTurns": {
         "type": "boolean",
@@ -151,6 +172,29 @@
         "minimum": 0,
         "maximum": 10,
         "default": 4
+      },
+      "memoryCaptureInstructionsEnabled": {
+        "type": "boolean",
+        "default": true
+      },
+      "memoryCaptureInstructions": {
+        "type": "string"
+      },
+      "ignoreSessionPatterns": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "statelessSessionPatterns": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "skipStatelessSessions": {
+        "type": "boolean",
+        "default": true
       }
     }
   }


### PR DESCRIPTION
## Summary
- add `docs/OPENCLAW-OFFICIAL-PLUGIN-SETUP.md` covering official install, manual install, config fields, security model, upgrade, uninstall, and troubleshooting
- simplify README OpenClaw section and link to the dedicated setup guide
- update memory architecture docs with CLI helper notes and a canonical setup-guide config reference
- refresh plugin UI hint examples to the official localhost `127.0.0.1:6578` default
- harden installer/bootstrap docs and script behavior so repeated init runs use the same generated bootstrap credentials
- extend plugin config schema for documented auto-recall/capture/session-pattern fields

## Review fixes
- kept generated bootstrap admin/API credentials available to both explicit `docker compose run init` and later `app.depends_on` init runs without writing `.env` before bootstrap success
- replaced cleartext secret-printing troubleshooting with redacted key-presence checks
- clarified ADMIN key requirement for `doctor`/`status`
- documented broad default prompt injection and how to restrict agents/chats
- clarified memory capture instructions only inject when recall returns non-empty prompt text
- restored Hindsight coexistence guidance
- fixed manual Compose checkout/download guidance, health retry, upgrade/bootstrap wording, and uninstall volume cleanup order

## Verification
- `bash -n install-openclaw.sh`
- `jq empty openclaw-noosphere-memory/openclaw.plugin.json`
- `POSTGRES_PASSWORD=dummy NEXTAUTH_SECRET=dummy NOOSPHERE_ADMIN_PASSWORD=dummy NOOSPHERE_BOOTSTRAP_API_KEY=noo_dummy docker compose -f docker-compose.noosphere.yml config`
- local markdown link existence check for README/setup/architecture docs
- no cleartext `cat ~/.openclaw/secrets/noosphere-memory.json` troubleshooting command remains
- `git diff --check`
- `npm run lint`
- `npm run test:memory` (156/156 passing)
