### PR TITLE
Prepare OpenClaw plugin npm publish metadata

### DIFF
--- a/openclaw-noosphere-memory/package.json
+++ b/openclaw-noosphere-memory/package.json
@@ -39,5 +39,17 @@
       "pluginApi": ">=2026.5.3-1",
       "minGatewayVersion": "2026.5.3-1"
     }
-  }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/SweetSophia/noosphere.git",
+    "directory": "openclaw-noosphere-memory"
+  },
+  "bugs": {
+    "url": "https://github.com/SweetSophia/noosphere/issues"
+  },
+  "homepage": "https://github.com/SweetSophia/noosphere#readme"
 }


### PR DESCRIPTION
## Summary

- Adds npm publish metadata for `@sweetsophia/openclaw-noosphere-memory`
- Sets `publishConfig.access=public` so the scoped package publishes publicly by default
- Adds repository, bugs, and homepage metadata

## Verification

From `openclaw-noosphere-memory/`:

- `npm ci`
- `npm run build`
- `npm pack --dry-run`

Dry-run package:

- `sweetsophia-openclaw-noosphere-memory-0.1.0.tgz`
- 68 files
- ~50.5 kB packed
