### PR TITLE
Align release metadata for v1.3

### DIFF
--- a/docs/OPENCLAW-OFFICIAL-PLUGIN-SETUP.md
+++ b/docs/OPENCLAW-OFFICIAL-PLUGIN-SETUP.md
@@ -81,7 +81,7 @@ By default the installer enables Noosphere auto-recall for all OpenClaw agents a
 Example using a pinned image tag and custom port:
 
 ```bash
-NOOSPHERE_VERSION=0.1.0 \
+NOOSPHERE_VERSION=v1.3 \
 NOOSPHERE_PORT=6678 \
 APP_URL=http://127.0.0.1:6678 \
 bash install-openclaw.sh

--- a/docs/OPENCLAW-PHASE-8-RELEASE-CHECKLIST.md
+++ b/docs/OPENCLAW-PHASE-8-RELEASE-CHECKLIST.md
@@ -10,8 +10,8 @@ Branch: `feat/phase-8-release-checklist`
 - [x] Root memory tests pass: `npm run test:memory` → 156/156 passing.
 - [x] Root production build passes: `npm run build` completed successfully.
 - [x] Plugin package builds: `openclaw-noosphere-memory npm run build` completed successfully.
-- [x] Plugin package archive builds: `npm pack` produced `sweetsophia-openclaw-noosphere-memory-0.1.0.tgz`.
-- [x] Plugin package archive installs: `openclaw plugins install ./sweetsophia-openclaw-noosphere-memory-0.1.0.tgz --force` completed.
+- [x] Plugin package archive builds: `npm pack` produced `sweetsophia-openclaw-noosphere-memory-1.3.0.tgz`.
+- [x] Plugin package archive installs: `openclaw plugins install ./sweetsophia-openclaw-noosphere-memory-1.3.0.tgz --force` completed.
 - [x] Plugin runtime inspect shows expected registrations:
   - Tools: `noosphere_status`, `noosphere_recall`, `noosphere_get`, `noosphere_save`
   - Hook: `before_prompt_build`

--- a/openclaw-noosphere-memory/package-lock.json
+++ b/openclaw-noosphere-memory/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sweetsophia/openclaw-noosphere-memory",
-  "version": "0.1.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sweetsophia/openclaw-noosphere-memory",
-      "version": "0.1.0",
+      "version": "1.3.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20",

--- a/openclaw-noosphere-memory/package.json
+++ b/openclaw-noosphere-memory/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@sweetsophia/openclaw-noosphere-memory",
-  "version": "0.1.0",
+  "version": "1.3.0",
   "private": false,
-  "description": "OpenClaw plugin for Noosphere memory status, recall tools, and optional auto-recall prompt injection.",
+  "description": "OpenClaw plugin for Noosphere: agent memory tools, Noosphere recall, draft memory saving, and automatic prompt-time memory injection.",
   "type": "module",
   "license": "MIT",
   "main": "./dist/index.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "noosphere",
-  "version": "0.1.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "noosphere",
-      "version": "0.1.0",
+      "version": "1.3.0",
       "dependencies": {
         "@prisma/adapter-pg": "^7.7.0",
         "@prisma/client": "^7.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "noosphere",
-  "version": "0.1.0",
+  "version": "1.3.0",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary

- Aligns Noosphere and OpenClaw plugin package metadata with release v1.3
- Sets npm package version to `1.3.0` for semver compliance
- Updates the public npm description for `@sweetsophia/openclaw-noosphere-memory`
- Updates release/setup docs to reference the v1.3 package/image naming

## Notes

- npm package versions require full semver, so the package is `1.3.0`.
- We can still use the GitHub release/tag name `v1.3` if desired.
- This PR does **not** publish to npm.

## Verification

- `npm run lint`
- `npm run build`
- `npm audit --omit=dev`
- `cd openclaw-noosphere-memory && npm ci && npm run build`
- `git diff --exit-code -- dist`
- `npm pack --dry-run` → `sweetsophia-openclaw-noosphere-memory-1.3.0.tgz`

## Summary by Sourcery

Align release metadata and documentation with the v1.3 Noosphere/OpenClaw plugin release.

Enhancements:
- Update Noosphere and OpenClaw plugin package versions to 1.3.0 for semver alignment and release consistency.
- Revise the OpenClaw Noosphere memory plugin npm description to better reflect its capabilities.

Documentation:
- Adjust release checklist and official plugin setup docs to reference the v1.3 package archive name and image tag.