### PR TITLE
Use v1.3.0 release tag in setup docs

### DIFF
--- a/docs/OPENCLAW-OFFICIAL-PLUGIN-SETUP.md
+++ b/docs/OPENCLAW-OFFICIAL-PLUGIN-SETUP.md
@@ -81,7 +81,7 @@ By default the installer enables Noosphere auto-recall for all OpenClaw agents a
 Example using a pinned image tag and custom port:
 
 ```bash
-NOOSPHERE_VERSION=v1.3 \
+NOOSPHERE_VERSION=v1.3.0 \
 NOOSPHERE_PORT=6678 \
 APP_URL=http://127.0.0.1:6678 \
 bash install-openclaw.sh


### PR DESCRIPTION
## Summary

- Aligns the setup guide's pinned GHCR image example with the approved release tag `v1.3.0`.

## Verification

- Documentation-only change.

## Summary by Sourcery

Documentation:
- Adjust the setup example to pin NOOSPHERE_VERSION to the v1.3.0 GHCR image tag.