### PR TITLE
Update GitHub Actions for Node 24 runtime

### DIFF
--- a/.github/workflows/autoreview.yml
+++ b/.github/workflows/autoreview.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Verify OpenClaw plugin dist is current
         run: |
@@ -43,10 +43,10 @@ jobs:
           git diff --exit-code -- dist
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -54,7 +54,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository_owner }}/noosphere
           tags: |
@@ -63,7 +63,7 @@ jobs:
             type=sha,prefix=sha-
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -28,10 +28,10 @@ jobs:
         working-directory: openclaw-noosphere-memory
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org
@@ -59,10 +59,10 @@ jobs:
         working-directory: openclaw-noosphere-memory
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org


### PR DESCRIPTION
## Summary

- Updates first-party and Docker GitHub Actions to Node-24-ready major versions:
  - `actions/checkout` v4 → v6
  - `actions/setup-node` v4 → v6
  - `docker/setup-buildx-action` v3 → v4
  - `docker/login-action` v3 → v4
  - `docker/metadata-action` v5 → v6
  - `docker/build-push-action` v6 → v7

## Why

GitHub Actions emitted a Node 20 deprecation warning during the v1.3.0 release workflows. These updates address the warning before GitHub forces Node 24 by default.

## Verification

- `git diff --check`
- PR workflows will verify Docker publishing and npm package-check paths.

## Summary by Sourcery

Update GitHub Actions workflows to use newer action versions compatible with the latest Node.js runtime.

CI:
- Bump actions/checkout from v4 to v6 across Docker publish, npm publish, and autoreview workflows.
- Upgrade actions/setup-node from v4 to v6 in npm publish workflows to align with newer Node.js versions.
- Update Docker-related GitHub Actions (setup-buildx-action, login-action, metadata-action, build-push-action) to their latest major versions in the docker publish workflow.