### PR TITLE
fix(auth): unify auth patterns and improve type safety

### DIFF
--- a/src/app/api/answer/route.ts
+++ b/src/app/api/answer/route.ts
@@ -37,7 +37,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Insufficient permissions" }, { status: 403 });
     }
   } else {
-    const role = (session?.user as { role?: string }).role;
+    const role = session?.user?.role;
     if (role !== "EDITOR" && role !== "ADMIN") {
       return NextResponse.json({ error: "Insufficient permissions" }, { status: 403 });
     }

--- a/src/app/api/articles/[id]/route.ts
+++ b/src/app/api/articles/[id]/route.ts
@@ -1,8 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
+import { Permissions } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
-import { requireApiKey } from "@/lib/api/keys";
-import { getServerSession } from "next-auth";
-import { authOptions } from "@/lib/auth";
+import { requirePermission } from "@/lib/api/auth";
 import { buildTagConnections } from "@/lib/wiki";
 
 // PATCH /api/articles/[id] — Update article
@@ -10,23 +9,9 @@ import { buildTagConnections } from "@/lib/wiki";
 export async function PATCH(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
 
-  const apiAuth = await requireApiKey(request);
-  const session = await getServerSession(authOptions);
-
-  if (!apiAuth.authorized && !session?.user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
-  // Check permissions
-  if (apiAuth.authorized) {
-    if (apiAuth.permissions !== "WRITE" && apiAuth.permissions !== "ADMIN") {
-      return NextResponse.json({ error: "Insufficient permissions" }, { status: 403 });
-    }
-  } else {
-    const role = (session?.user as { role?: string }).role;
-    if (role !== "EDITOR" && role !== "ADMIN") {
-      return NextResponse.json({ error: "Insufficient permissions" }, { status: 403 });
-    }
+  const auth = await requirePermission(request, [Permissions.WRITE]);
+  if (!auth.success) {
+    return auth.response;
   }
 
   try {
@@ -184,7 +169,7 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
     if (titleChanged || contentChanged) {
       updateData.revisions = {
         create: {
-          authorId: session?.user ? (session.user as { id: string }).id : null,
+          authorId: auth.auth.userId ?? null,
           title: (title ?? existing.title) as string,
           content: (content ?? existing.content) as string,
         },

--- a/src/app/api/articles/route.ts
+++ b/src/app/api/articles/route.ts
@@ -1,8 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
+import { Permissions } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
-import { requireApiKey } from "@/lib/api/keys";
-import { getServerSession } from "next-auth";
-import { authOptions } from "@/lib/auth";
+import { requirePermission } from "@/lib/api/auth";
 import { buildTagConnections, countSearchArticles, searchArticleIds } from "@/lib/wiki";
 
 // Constants for security limits
@@ -144,23 +143,9 @@ export async function GET(request: NextRequest) {
 // POST /api/articles — Create article
 // Auth: API key (WRITE/ADMIN) or session (EDITOR/ADMIN)
 export async function POST(request: NextRequest) {
-  const apiAuth = await requireApiKey(request);
-  const session = await getServerSession(authOptions);
-
-  if (!apiAuth.authorized && !session?.user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
-  // Check permissions
-  if (apiAuth.authorized) {
-    if (apiAuth.permissions !== "WRITE" && apiAuth.permissions !== "ADMIN") {
-      return NextResponse.json({ error: "Insufficient permissions" }, { status: 403 });
-    }
-  } else {
-    const role = (session?.user as { role?: string }).role;
-    if (role !== "EDITOR" && role !== "ADMIN") {
-      return NextResponse.json({ error: "Insufficient permissions" }, { status: 403 });
-    }
+  const auth = await requirePermission(request, [Permissions.WRITE]);
+  if (!auth.success) {
+    return auth.response;
   }
 
   try {
@@ -281,14 +266,14 @@ export async function POST(request: NextRequest) {
           content,
           excerpt: excerpt || content.slice(0, 160).replace(/[#*`_]/g, ""),
           topicId,
-          authorId: session?.user ? (session.user as { id: string }).id : null,
-          authorName: authorName || (session?.user?.name ?? null),
+          authorId: auth.auth.userId ?? null,
+          authorName: authorName || (auth.auth.name ?? null),
           tags: { create: tagConnections },
           confidence: confidence || null,
           status: status || "published",
           revisions: {
             create: {
-              authorId: session?.user ? (session.user as { id: string }).id : null,
+              authorId: auth.auth.userId ?? null,
               title,
               content,
             },

--- a/src/app/api/import/route.ts
+++ b/src/app/api/import/route.ts
@@ -84,7 +84,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Insufficient permissions" }, { status: 403 });
     }
   } else {
-    const role = (session?.user as { role?: string }).role;
+    const role = session?.user?.role;
     if (role !== "EDITOR" && role !== "ADMIN") {
       return NextResponse.json({ error: "Insufficient permissions" }, { status: 403 });
     }

--- a/src/app/api/ingest/route.ts
+++ b/src/app/api/ingest/route.ts
@@ -1,8 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { requireApiKey } from "@/lib/api/keys";
-import { getServerSession } from "next-auth";
-import { authOptions } from "@/lib/auth";
+import { requirePermission } from "@/lib/api/auth";
+import { Permissions } from "@prisma/client";
 
 
 // Security limits
@@ -47,23 +46,8 @@ interface IngestArticle {
 
 export async function POST(request: NextRequest) {
   // --- Auth ---
-  const apiAuth = await requireApiKey(request);
-  const session = await getServerSession(authOptions);
-
-  if (!apiAuth.authorized && !session?.user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
-  if (apiAuth.authorized) {
-    if (apiAuth.permissions !== "WRITE" && apiAuth.permissions !== "ADMIN") {
-      return NextResponse.json({ error: "Insufficient permissions" }, { status: 403 });
-    }
-  } else {
-    const role = session?.user?.role;
-    if (role !== "EDITOR" && role !== "ADMIN") {
-      return NextResponse.json({ error: "Insufficient permissions" }, { status: 403 });
-    }
-  }
+  const auth = await requirePermission(request, [Permissions.WRITE]);
+  if (!auth.authorized) return auth.response;
 
   // --- Parse body ---
   let body: {

--- a/src/app/api/ingest/route.ts
+++ b/src/app/api/ingest/route.ts
@@ -59,7 +59,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Insufficient permissions" }, { status: 403 });
     }
   } else {
-    const role = (session?.user as { role?: string }).role;
+    const role = session?.user?.role;
     if (role !== "EDITOR" && role !== "ADMIN") {
       return NextResponse.json({ error: "Insufficient permissions" }, { status: 403 });
     }
@@ -86,7 +86,7 @@ export async function POST(request: NextRequest) {
     .replace(/<[^>]*>/g, "") // strip any HTML tags
     .trim()
     .slice(0, MAX_AUTHOR_NAME_LENGTH) || session?.user?.name || "Unknown";
-  const userId = session?.user ? (session.user as { id?: string }).id ?? null : null;
+  const userId = session?.user ? session.user.id ?? null : null;
 
   // --- Validate ---
   if (!source?.title) {

--- a/src/app/api/lint/route.ts
+++ b/src/app/api/lint/route.ts
@@ -44,7 +44,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Insufficient permissions" }, { status: 403 });
     }
   } else {
-    const role = (session?.user as { role?: string }).role;
+    const role = session?.user?.role;
     if (role !== "EDITOR" && role !== "ADMIN") {
       return NextResponse.json({ error: "Insufficient permissions" }, { status: 403 });
     }

--- a/src/app/api/sync/obsidian/route.ts
+++ b/src/app/api/sync/obsidian/route.ts
@@ -30,7 +30,7 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: "Insufficient permissions" }, { status: 403 });
     }
   } else {
-    const role = (session?.user as { role?: string }).role;
+    const role = session?.user?.role;
     if (role !== "ADMIN") {
       return NextResponse.json({ error: "Insufficient permissions" }, { status: 403 });
     }
@@ -74,7 +74,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Insufficient permissions" }, { status: 403 });
     }
   } else {
-    const role = (session?.user as { role?: string }).role;
+    const role = session?.user?.role;
     if (role !== "ADMIN") {
       return NextResponse.json({ error: "Insufficient permissions" }, { status: 403 });
     }

--- a/src/app/wiki/[topicSlug]/[articleSlug]/edit/page.tsx
+++ b/src/app/wiki/[topicSlug]/[articleSlug]/edit/page.tsx
@@ -24,7 +24,7 @@ export default async function EditArticlePage({ params }: Props) {
   if (!session?.user) {
     redirect("/wiki/login");
   }
-  const role = (session.user as { role?: string }).role;
+  const role = session.user.role;
   if (role !== "EDITOR" && role !== "ADMIN") {
     redirect("/wiki");
   }

--- a/src/app/wiki/[topicSlug]/new/page.tsx
+++ b/src/app/wiki/[topicSlug]/new/page.tsx
@@ -22,7 +22,7 @@ export default async function NewArticlePage({ params }: Props) {
   if (!session?.user) {
     redirect("/wiki/login");
   }
-  const role = (session.user as { role?: string }).role;
+  const role = session.user.role;
   if (role !== "EDITOR" && role !== "ADMIN") {
     redirect("/wiki");
   }

--- a/src/lib/api/auth.ts
+++ b/src/lib/api/auth.ts
@@ -92,12 +92,8 @@ export function hasPermission(
   // Check session role with hierarchy
   if (auth.role) {
     const userLevel = ROLE_LEVELS[auth.role] ?? 0;
-    // Map permissions to equivalent role levels
-    const requiredLevels = required.map((p) => {
-      if (p === "ADMIN") return 3;
-      if (p === "WRITE") return 2;
-      return 1;
-    });
+    // Reuse PERMISSION_LEVELS — role and permission hierarchies use the same values
+    const requiredLevels = required.map((p) => PERMISSION_LEVELS[p]);
     return requiredLevels.some((level) => level <= userLevel);
   }
 

--- a/src/lib/api/auth.ts
+++ b/src/lib/api/auth.ts
@@ -1,67 +1,71 @@
 import { NextRequest, NextResponse } from "next/server";
-import type { Permissions } from "@prisma/client";
+import type { Permissions, Role } from "@prisma/client";
 import { requireApiKey } from "./keys";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 
 export interface AuthResult {
-    authorized: boolean;
-    permissions?: Permissions;
-    keyId?: string;
-    role?: string;
-    userId?: string;
+  authorized: boolean;
+  permissions?: Permissions;
+  keyId?: string;
+  role?: Role;
+  userId?: string;
+  name?: string;
 }
 
 /**
  * Check API key or session authorization for a route.
  */
 export async function checkRouteAuth(
-    request: NextRequest
+  request: NextRequest
 ): Promise<AuthResult> {
-    // First check API key - return immediately if valid
-    const apiAuth = await requireApiKey(request);
-    if (apiAuth.authorized) {
-        return {
-            authorized: true,
-            permissions: apiAuth.permissions,
-            keyId: apiAuth.keyId,
-        };
-    }
+  // First check API key - return immediately if valid
+  const apiAuth = await requireApiKey(request);
+  if (apiAuth.authorized) {
+    return {
+      authorized: true,
+      permissions: apiAuth.permissions,
+      keyId: apiAuth.keyId,
+    };
+  }
 
-    // Only check session if API key is not authorized
-    try {
-        const session = await getServerSession(authOptions);
-        if (!session?.user) {
-            return { authorized: false };
-        }
-        const user = session?.user as { role?: string; id?: string };
-        return {
-            authorized: true,
-            role: user?.role,
-            userId: user?.id,
-        };
-    } catch (error) {
-        console.error("[Auth] Session error:", error instanceof Error ? error.message : "Unknown error");
-        return { authorized: false };
+  // Only check session if API key is not authorized
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user) {
+      return { authorized: false };
     }
+    return {
+      authorized: true,
+      role: session.user.role,
+      userId: session.user.id,
+      name: session.user.name ?? undefined,
+    };
+  } catch (error) {
+    console.error(
+      "[Auth] Session error:",
+      error instanceof Error ? error.message : "Unknown error"
+    );
+    return { authorized: false };
+  }
 }
 
 /**
  * Map permissions to numeric level for hierarchical comparison.
  */
 const PERMISSION_LEVELS: Record<Permissions, number> = {
-    READ: 1,
-    WRITE: 2,
-    ADMIN: 3,
+  READ: 1,
+  WRITE: 2,
+  ADMIN: 3,
 };
 
 /**
  * Map roles to numeric level for hierarchical comparison.
  */
-const ROLE_LEVELS: Record<string, number> = {
-    VIEWER: 1,
-    EDITOR: 2,
-    ADMIN: 3,
+const ROLE_LEVELS: Record<Role, number> = {
+  VIEWER: 1,
+  EDITOR: 2,
+  ADMIN: 3,
 };
 
 /**
@@ -70,58 +74,64 @@ const ROLE_LEVELS: Record<string, number> = {
  * Uses hierarchical comparison (ADMIN can access WRITE/READ routes)
  */
 export function hasPermission(
-    auth: AuthResult,
-    required: Permissions[]
+  auth: AuthResult,
+  required: Permissions[]
 ): boolean {
-    // Empty required array = allow any authenticated user
-    if (required.length === 0) {
-        return auth.authorized;
-    }
+  // Empty required array = allow any authenticated user
+  if (required.length === 0) {
+    return auth.authorized;
+  }
 
-    // Check API key permissions with hierarchy
-    if (auth.permissions) {
-        const userLevel = PERMISSION_LEVELS[auth.permissions];
-        const requiredLevels = required.map((p) => PERMISSION_LEVELS[p]);
-        return requiredLevels.some((level) => level <= userLevel);
-    }
+  // Check API key permissions with hierarchy
+  if (auth.permissions) {
+    const userLevel = PERMISSION_LEVELS[auth.permissions];
+    const requiredLevels = required.map((p) => PERMISSION_LEVELS[p]);
+    return requiredLevels.some((level) => level <= userLevel);
+  }
 
-    // Check session role with hierarchy
-    if (auth.role) {
-        const userLevel = ROLE_LEVELS[auth.role] ?? 0;
-        // Map permissions to equivalent role levels
-        const requiredLevels = required.map((p) => {
-            if (p === "ADMIN") return 3;
-            if (p === "WRITE") return 2;
-            return 1;
-        });
-        return requiredLevels.some((level) => level <= userLevel);
-    }
+  // Check session role with hierarchy
+  if (auth.role) {
+    const userLevel = ROLE_LEVELS[auth.role] ?? 0;
+    // Map permissions to equivalent role levels
+    const requiredLevels = required.map((p) => {
+      if (p === "ADMIN") return 3;
+      if (p === "WRITE") return 2;
+      return 1;
+    });
+    return requiredLevels.some((level) => level <= userLevel);
+  }
 
-    return false;
+  return false;
 }
 
 /**
  * Require authenticated request with specific permissions.
  */
 export async function requirePermission(
-    request: NextRequest,
-    required: Permissions[]
-): Promise<{ success: true; auth: AuthResult } | { success: false; response: NextResponse }> {
-    const auth = await checkRouteAuth(request);
+  request: NextRequest,
+  required: Permissions[]
+): Promise<
+  | { success: true; auth: AuthResult }
+  | { success: false; response: NextResponse }
+> {
+  const auth = await checkRouteAuth(request);
 
-    if (!auth.authorized) {
-        return {
-            success: false,
-            response: NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
-        };
-    }
+  if (!auth.authorized) {
+    return {
+      success: false,
+      response: NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+    };
+  }
 
-    if (!hasPermission(auth, required)) {
-        return {
-            success: false,
-            response: NextResponse.json({ error: "Insufficient permissions" }, { status: 403 }),
-        };
-    }
+  if (!hasPermission(auth, required)) {
+    return {
+      success: false,
+      response: NextResponse.json(
+        { error: "Insufficient permissions" },
+        { status: 403 }
+      ),
+    };
+  }
 
-    return { success: true, auth };
+  return { success: true, auth };
 }

--- a/src/lib/auth/index.ts
+++ b/src/lib/auth/index.ts
@@ -2,6 +2,7 @@ import { NextAuthOptions } from "next-auth";
 import CredentialsProvider from "next-auth/providers/credentials";
 import bcrypt from "bcryptjs";
 import { prisma } from "@/lib/prisma";
+import type { Role } from "@prisma/client";
 
 export const authOptions: NextAuthOptions = {
   providers: [
@@ -59,8 +60,8 @@ export const authOptions: NextAuthOptions = {
     },
     async session({ session, token }) {
       if (session.user) {
-        (session.user as { role: string; id: string }).role = token.role as string;
-        (session.user as { role: string; id: string }).id = token.id as string;
+        session.user.role = token.role as Role;
+        session.user.id = token.id as string;
       }
       return session;
     },

--- a/src/lib/auth/index.ts
+++ b/src/lib/auth/index.ts
@@ -53,7 +53,7 @@ export const authOptions: NextAuthOptions = {
   callbacks: {
     async jwt({ token, user }) {
       if (user) {
-        token.role = (user as unknown as { role: string }).role;
+        token.role = user.role;
         token.id = user.id;
       }
       return token;

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -1,10 +1,11 @@
 import { DefaultSession } from "next-auth";
+import type { Role } from "@prisma/client";
 
 declare module "next-auth" {
   interface Session {
     user: {
       id: string;
-      role: string;
+      role: Role;
     } & DefaultSession["user"];
   }
 }

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -8,4 +8,8 @@ declare module "next-auth" {
       role: Role;
     } & DefaultSession["user"];
   }
+
+  interface User {
+    role: Role;
+  }
 }


### PR DESCRIPTION
## Summary
Removes unsafe type casts and unifies authentication checks across API routes.

## Changes
- **Type-safe Session**: `next-auth.d.ts` now imports the Prisma `Role` enum so `session.user.role` is typed as `Role` instead of `string`.
- **AuthResult Improvements**: `AuthResult.role` is now `Role` (not `string`), and a `name` field was added so routes can access the user's display name without a separate session fetch.
- **Removed Casts**: Eliminated all `(session?.user as { role?: string }).role` and `(session.user as { id: string }).id` casts from API routes and wiki pages.
- **Unified Permission Checks**: `POST /api/articles` and `PATCH /api/articles/[id]` now use the centralized `requirePermission()` helper instead of duplicated manual API-key + session checks.

## Files Changed
- `src/types/next-auth.d.ts`
- `src/lib/api/auth.ts`
- `src/lib/auth/index.ts`
- `src/app/api/articles/route.ts`
- `src/app/api/articles/[id]/route.ts`
- `src/app/api/answer/route.ts`
- `src/app/api/ingest/route.ts`
- `src/app/api/import/route.ts`
- `src/app/api/lint/route.ts`
- `src/app/api/sync/obsidian/route.ts`
- `src/app/wiki/[topicSlug]/new/page.tsx`
- `src/app/wiki/[topicSlug]/[articleSlug]/edit/page.tsx`

---
*Part of code review remediation (#60)*

## Summary by Sourcery

Improve authentication consistency and type safety across API routes and session handling.

New Features:
- Expose user display name and typed role via the shared AuthResult object for downstream route handlers.

Bug Fixes:
- Ensure permission checks respect strongly typed Role and Permissions enums instead of relying on untyped string roles.

Enhancements:
- Unify API article creation and update routes around the shared requirePermission helper to centralize authorization logic.
- Remove unsafe type assertions from session usage in API routes and wiki pages by relying on a strongly typed Session.user.
- Tighten NextAuth session typing so user.role is a Prisma Role and user.id is propagated without casting.