### PR TITLE
fix(db): add deletedAt index, debounce lastUsedAt, fix log where typing

### DIFF
--- a/prisma/migrations/20260510225000_add_article_deleted_at_index/migration.sql
+++ b/prisma/migrations/20260510225000_add_article_deleted_at_index/migration.sql
@@ -1,0 +1,3 @@
+-- Ensure soft-delete filtering remains indexed on databases created before
+-- Article_deletedAt_idx was added to the initial migration snapshot.
+CREATE INDEX IF NOT EXISTS "Article_deletedAt_idx" ON "Article"("deletedAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -76,6 +76,7 @@ model Article {
   @@index([sourceUrl])
   @@index([status])
   @@index([confidence])
+  @@index([deletedAt])
 }
 
 // ─────────────────────────────────────────────

--- a/src/app/api/log/route.ts
+++ b/src/app/api/log/route.ts
@@ -47,13 +47,14 @@ export async function GET(request: NextRequest) {
   }
 
   if (from || to) {
-    where.createdAt = {};
+    const createdAt: Prisma.DateTimeFilter = {};
     if (from) {
-      where.createdAt.gte = new Date(from);
+      createdAt.gte = new Date(from);
     }
     if (to) {
-      where.createdAt.lt = new Date(to);
+      createdAt.lt = new Date(to);
     }
+    where.createdAt = createdAt;
   }
 
   const [entries, total] = await Promise.all([

--- a/src/app/api/log/route.ts
+++ b/src/app/api/log/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { Prisma } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
 import { requireApiKey } from "@/lib/api/keys";
 import { getServerSession } from "next-auth";
@@ -35,8 +36,7 @@ export async function GET(request: NextRequest) {
   const offset = parseInt(searchParams.get("offset") ?? "0", 10);
 
   // Build where clause
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const where: any = {};
+  const where: Prisma.ActivityLogWhereInput = {};
 
   if (type) {
     where.type = type;

--- a/src/lib/api/keys.ts
+++ b/src/lib/api/keys.ts
@@ -5,6 +5,9 @@ import type { Permissions } from "@prisma/client";
 const ALGORITHM = "sha256";
 const KEY_PREFIX_LENGTH = 8;
 
+/** How long to wait before re-recording a lastUsedAt timestamp (5 minutes). */
+const LAST_USED_DEBOUNCE_MS = 5 * 60 * 1000;
+
 /**
  * Hash an API key for storage.
  * Never store the raw key — only store the hash.
@@ -56,7 +59,7 @@ export async function validateApiKey(
 
   // Update last-used timestamp (debounced: only write if > 5 min since last update)
   const lastUsedAt = record.lastUsedAt;
-  if (!lastUsedAt || Date.now() - lastUsedAt.getTime() > 5 * 60 * 1000) {
+  if (!lastUsedAt || Date.now() - lastUsedAt.getTime() > LAST_USED_DEBOUNCE_MS) {
     await prisma.apiKey.update({
       where: { id: record.id },
       data: { lastUsedAt: new Date() },

--- a/src/lib/api/keys.ts
+++ b/src/lib/api/keys.ts
@@ -57,14 +57,16 @@ export async function validateApiKey(
     return { valid: false };
   }
 
-  // Update last-used timestamp (debounced: only write if > 5 min since last update)
-  const lastUsedAt = record.lastUsedAt;
-  if (!lastUsedAt || Date.now() - lastUsedAt.getTime() > LAST_USED_DEBOUNCE_MS) {
-    await prisma.apiKey.update({
-      where: { id: record.id },
-      data: { lastUsedAt: new Date() },
-    });
-  }
+  // Update last-used timestamp atomically and at most once per debounce window.
+  const now = new Date();
+  const cutoff = new Date(now.getTime() - LAST_USED_DEBOUNCE_MS);
+  await prisma.apiKey.updateMany({
+    where: {
+      id: record.id,
+      OR: [{ lastUsedAt: null }, { lastUsedAt: { lt: cutoff } }],
+    },
+    data: { lastUsedAt: now },
+  });
 
   return { valid: true, permissions: record.permissions, keyId: record.id };
 }

--- a/src/lib/api/keys.ts
+++ b/src/lib/api/keys.ts
@@ -54,11 +54,14 @@ export async function validateApiKey(
     return { valid: false };
   }
 
-  // Update last-used timestamp
-  await prisma.apiKey.update({
-    where: { id: record.id },
-    data: { lastUsedAt: new Date() },
-  });
+  // Update last-used timestamp (debounced: only write if > 5 min since last update)
+  const lastUsedAt = record.lastUsedAt;
+  if (!lastUsedAt || Date.now() - lastUsedAt.getTime() > 5 * 60 * 1000) {
+    await prisma.apiKey.update({
+      where: { id: record.id },
+      data: { lastUsedAt: new Date() },
+    });
+  }
 
   return { valid: true, permissions: record.permissions, keyId: record.id };
 }


### PR DESCRIPTION
## Summary
Database performance and type-safety improvements.

## Changes
- **Add  index**: Almost every article query filters ; the new index avoids sequential scans on large tables.
- **Debounce **: API key validation was doing an unconditional  on every request. Now it only writes if > 5 minutes have passed since the last update, eliminating a DB write per API call.
- **Fix  in log route**: Replaced  with proper  typing.

## Files Changed
- 
- 
- 

---
*Part of code review remediation (#60)*

## Summary by Sourcery

Improve database performance and type-safety for API key usage tracking and activity log querying.

New Features:
- Add a database index on soft-deletion timestamp to speed up article queries filtering by deletion state.

Bug Fixes:
- Use a strongly typed Prisma ActivityLogWhereInput for log route filters instead of an untyped any object.

Enhancements:
- Debounce API key lastUsedAt updates to avoid unnecessary write operations on every validated request.