### PR TITLE
fix(perf): cap lint articles, bump tsconfig target to ES2022

### DIFF
--- a/src/__tests__/api/lint.test.ts
+++ b/src/__tests__/api/lint.test.ts
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+// Test the same parsing logic used in the lint route
+// Constants must match src/app/api/lint/route.ts
+const LINT_MAX_ARTICLES_DEFAULT = 500;
+const LINT_MAX_ARTICLES_HARD_LIMIT = 2000;
+
+function parseMaxArticles(value: unknown): number {
+  const parsed = Number(value);
+  if (Number.isNaN(parsed)) {
+    return LINT_MAX_ARTICLES_DEFAULT;
+  }
+  return Math.min(Math.max(1, parsed), LINT_MAX_ARTICLES_HARD_LIMIT);
+}
+
+test.describe("maxArticles parsing logic", () => {
+  test("uses default when undefined", () => {
+    assert.equal(parseMaxArticles(undefined), 500);
+  });
+
+  test("uses default when NaN", () => {
+    assert.equal(parseMaxArticles(NaN), 500);
+  });
+
+  test("uses default when string 'invalid'", () => {
+    assert.equal(parseMaxArticles("invalid"), 500);
+  });
+
+  test("uses default when object", () => {
+    assert.equal(parseMaxArticles({}), 500);
+  });
+
+  test("clamps null to 1 (Number(null) === 0)", () => {
+    // Number(null) === 0, which gets clamped to 1
+    assert.equal(parseMaxArticles(null), 1);
+  });
+
+  test("accepts valid number within range", () => {
+    assert.equal(parseMaxArticles(100), 100);
+    assert.equal(parseMaxArticles(500), 500);
+    assert.equal(parseMaxArticles(2000), 2000);
+  });
+
+  test("accepts string number", () => {
+    assert.equal(parseMaxArticles("100"), 100);
+    assert.equal(parseMaxArticles("500"), 500);
+  });
+
+  test("clamps negative to 1", () => {
+    assert.equal(parseMaxArticles(-1), 1);
+    assert.equal(parseMaxArticles(-100), 1);
+  });
+
+  test("clamps zero to 1", () => {
+    assert.equal(parseMaxArticles(0), 1);
+  });
+
+  test("clamps above hard limit to 2000", () => {
+    assert.equal(parseMaxArticles(99999), 2000);
+    assert.equal(parseMaxArticles(5000), 2000);
+  });
+
+  test("accepts boundary values", () => {
+    assert.equal(parseMaxArticles(1), 1);
+    assert.equal(parseMaxArticles(2000), 2000);
+  });
+
+  test("handles decimal numbers", () => {
+    // Number() preserves decimals; Math.min/max don't truncate
+    // So 10.7 stays 10.7 (not clamped by min/max since it's between 1 and 2000)
+    assert.equal(parseMaxArticles(10.7), 10.7);
+    assert.equal(parseMaxArticles(10.3), 10.3);
+    // But decimals above hard limit get clamped
+    assert.equal(parseMaxArticles(3000.5), 2000);
+  });
+
+  test("handles boolean values", () => {
+    // Number(true) === 1, Number(false) === 0
+    assert.equal(parseMaxArticles(true), 1);
+    assert.equal(parseMaxArticles(false), 1); // 0 clamped to 1
+  });
+});
+
+test.describe("LINT_MAX_ARTICLES constants", () => {
+  test("DEFAULT is 500", () => {
+    assert.equal(LINT_MAX_ARTICLES_DEFAULT, 500);
+  });
+
+  test("HARD_LIMIT is 2000", () => {
+    assert.equal(LINT_MAX_ARTICLES_HARD_LIMIT, 2000);
+  });
+
+  test("HARD_LIMIT is greater than DEFAULT", () => {
+    assert.ok(LINT_MAX_ARTICLES_HARD_LIMIT > LINT_MAX_ARTICLES_DEFAULT);
+  });
+
+  test("values are positive integers", () => {
+    assert.ok(Number.isInteger(LINT_MAX_ARTICLES_DEFAULT));
+    assert.ok(Number.isInteger(LINT_MAX_ARTICLES_HARD_LIMIT));
+    assert.ok(LINT_MAX_ARTICLES_DEFAULT > 0);
+    assert.ok(LINT_MAX_ARTICLES_HARD_LIMIT > 0);
+  });
+});

--- a/src/app/api/lint/route.ts
+++ b/src/app/api/lint/route.ts
@@ -210,6 +210,8 @@ export async function POST(request: NextRequest) {
   }
 
   // ── 5. Unlinked mentions ──
+  // NOTE: This check is O(N²) within the maxArticles cap. For very large wikis,
+  // consider batching or offloading to a background job.
   // Detect when an article title (or slug) appears in another article's content
   // but is not linked with [[slug]] or href
   for (const a of articles) {
@@ -285,6 +287,7 @@ export async function POST(request: NextRequest) {
         bySeverity: summary.bySeverity,
         staleDays,
         tagMin,
+        maxArticles,
       },
     },
   });

--- a/src/app/api/lint/route.ts
+++ b/src/app/api/lint/route.ts
@@ -75,7 +75,7 @@ export async function POST(request: NextRequest) {
   const articles = await prisma.article.findMany({
     where: { deletedAt: null },
     take: maxArticles,
-    orderBy: { updatedAt: "desc" },
+    orderBy: [{ updatedAt: "desc" }, { id: "asc" }],
     select: {
       id: true,
       title: true,

--- a/src/app/api/lint/route.ts
+++ b/src/app/api/lint/route.ts
@@ -60,13 +60,16 @@ export async function POST(request: NextRequest) {
 
   const staleDays = body.staleDays ?? 90;
   const tagMin = body.tagMin ?? 2;
+  const maxArticles = Math.min(Math.max(1, body.maxArticles ?? 500), 2000);
   const staleThreshold = new Date(Date.now() - staleDays * 24 * 60 * 60 * 1000);
 
   const issues: LintIssue[] = [];
 
-  // ── Fetch all non-deleted articles ──
+  // ── Fetch non-deleted articles (capped for performance) ──
   const articles = await prisma.article.findMany({
     where: { deletedAt: null },
+    take: maxArticles,
+    orderBy: { updatedAt: "desc" },
     select: {
       id: true,
       title: true,

--- a/src/app/api/lint/route.ts
+++ b/src/app/api/lint/route.ts
@@ -4,6 +4,9 @@ import { requireApiKey } from "@/lib/api/keys";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 
+const LINT_MAX_ARTICLES_DEFAULT = 500;
+const LINT_MAX_ARTICLES_HARD_LIMIT = 2000;
+
 // POST /api/lint — Wiki health check
 //
 // Scans the wiki for quality issues:
@@ -51,7 +54,7 @@ export async function POST(request: NextRequest) {
   }
 
   // --- Parse options ---
-  let body: { staleDays?: number; tagMin?: number } = {};
+  let body: { staleDays?: number; tagMin?: number; maxArticles?: unknown } = {};
   try {
     body = await request.json();
   } catch {
@@ -60,7 +63,10 @@ export async function POST(request: NextRequest) {
 
   const staleDays = body.staleDays ?? 90;
   const tagMin = body.tagMin ?? 2;
-  const maxArticles = Math.min(Math.max(1, body.maxArticles ?? 500), 2000);
+  const parsedMaxArticles = Number(body.maxArticles);
+  const maxArticles = Number.isNaN(parsedMaxArticles)
+    ? LINT_MAX_ARTICLES_DEFAULT
+    : Math.min(Math.max(1, parsedMaxArticles), LINT_MAX_ARTICLES_HARD_LIMIT);
   const staleThreshold = new Date(Date.now() - staleDays * 24 * 60 * 60 * 1000);
 
   const issues: LintIssue[] = [];
@@ -286,7 +292,7 @@ export async function POST(request: NextRequest) {
   return NextResponse.json({
     success: true,
     runAt: new Date().toISOString(),
-    options: { staleDays, tagMin },
+    options: { staleDays, tagMin, maxArticles },
     issues,
     summary,
   });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2017",
+    "target": "ES2022",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Summary
Performance guardrails and modern TypeScript target.

## Changes
- **Cap lint articles**:  now accepts an optional  body field (default 500, hard max 2000) to prevent O(N²) regex processing on large wikis. The query uses  +  for deterministic results.
- **Bump TypeScript target**:  target upgraded from  to . Next.js 16 fully supports this and it unlocks native , , and other modern features without polyfill assumptions.

## Files Changed
- 
- 

---
*Part of code review remediation (#60)*

## Summary by Sourcery

Limit the number of articles processed by the lint API for performance and update the TypeScript compilation target to ES2022.

New Features:
- Allow the lint API to accept an optional maxArticles parameter to control how many articles are inspected per request.

Enhancements:
- Cap linted articles and sort them by most recently updated to avoid excessive processing on large datasets.
- Upgrade the TypeScript compiler target from ES2017 to ES2022 to leverage more modern JavaScript features.