### PR TITLE
feat(api): add DELETE endpoint for articles, unify PATCH auth

### DIFF
--- a/src/app/api/articles/[id]/route.ts
+++ b/src/app/api/articles/[id]/route.ts
@@ -252,3 +252,33 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
     return NextResponse.json({ error: "Internal server error" }, { status: 500 });
   }
 }
+
+// DELETE /api/articles/[id] — Soft-delete article
+// Auth: API key (ADMIN) or session (ADMIN)
+export async function DELETE(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+
+  const auth = await requirePermission(request, [Permissions.ADMIN]);
+  if (!auth.success) {
+    return auth.response;
+  }
+
+  try {
+    const existing = await prisma.article.findUnique({
+      where: { id },
+    });
+    if (!existing || existing.deletedAt) {
+      return NextResponse.json({ error: "Article not found" }, { status: 404 });
+    }
+
+    await prisma.article.update({
+      where: { id },
+      data: { deletedAt: new Date(), updatedAt: new Date() },
+    });
+
+    return new NextResponse(null, { status: 204 });
+  } catch (error) {
+    console.error("[DELETE /api/articles/[id]]", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/app/api/articles/[id]/route.ts
+++ b/src/app/api/articles/[id]/route.ts
@@ -267,13 +267,18 @@ export async function DELETE(request: NextRequest, { params }: { params: Promise
     const existing = await prisma.article.findUnique({
       where: { id },
     });
-    if (!existing || existing.deletedAt) {
+    if (!existing) {
       return NextResponse.json({ error: "Article not found" }, { status: 404 });
     }
+    if (existing.deletedAt) {
+      // Already deleted — return 204 for idempotency so repeated deletes don't error
+      return new NextResponse(null, { status: 204 });
+    }
 
+    const now = new Date();
     await prisma.article.update({
       where: { id },
-      data: { deletedAt: new Date(), updatedAt: new Date() },
+      data: { deletedAt: now, updatedAt: now },
     });
 
     return new NextResponse(null, { status: 204 });

--- a/src/app/api/articles/[id]/route.ts
+++ b/src/app/api/articles/[id]/route.ts
@@ -1,4 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
 import { Permissions } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
 import { requirePermission } from "@/lib/api/auth";
@@ -263,27 +265,39 @@ export async function DELETE(request: NextRequest, { params }: { params: Promise
     return auth.response;
   }
 
-  try {
-    const existing = await prisma.article.findUnique({
-      where: { id },
-    });
-    if (!existing) {
-      return NextResponse.json({ error: "Article not found" }, { status: 404 });
-    }
-    if (existing.deletedAt) {
-      // Already deleted — return 204 for idempotency so repeated deletes don't error
-      return new NextResponse(null, { status: 204 });
-    }
+  const now = new Date();
 
-    const now = new Date();
-    await prisma.article.update({
-      where: { id },
-      data: { deletedAt: now, updatedAt: now },
-    });
+  // Atomic soft-delete: only succeeds if article exists AND is not already deleted.
+  // This eliminates the read-then-write race condition.
+  const count = await prisma.article.updateMany({
+    where: { id, deletedAt: null },
+    data: { deletedAt: now, updatedAt: now },
+  });
 
-    return new NextResponse(null, { status: 204 });
-  } catch (error) {
-    console.error("[DELETE /api/articles/[id]]", error);
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  if (count.count === 0) {
+    // Either article doesn't exist, or was already deleted.
+    // Fetch to distinguish — for security we don't reveal which.
+    const existing = await prisma.article.findUnique({ where: { id } });
+    if (!existing || existing.deletedAt) {
+      return new NextResponse(null, { status: 204 }); // idempotent
+    }
+    return NextResponse.json({ error: "Article not found" }, { status: 404 });
   }
+
+  // Log the deletion for audit trail
+  const session = await getServerSession(authOptions);
+  const authorName = session?.user?.name ?? auth.auth.name ?? "API";
+  try {
+    await prisma.activityLog.create({
+      data: {
+        type: "delete",
+        title: `Article deleted — ${id}`,
+        authorName,
+      },
+    });
+  } catch {
+    // Log failures are non-fatal; don't fail the delete itself
+  }
+
+  return new NextResponse(null, { status: 204 });
 }


### PR DESCRIPTION
## Summary
Adds the missing REST API endpoint for article deletion and modernizes the PATCH handler auth.

## Changes
- **DELETE /api/articles/[id]**: New endpoint for soft-deleting articles via REST API. Requires ADMIN permission (API key or session). Returns `204 No Content` on success.
- **PATCH auth modernization**: Converted from manual dual-auth checks to centralized `requirePermission()` helper, removing unsafe type casts.

## Files Changed
- `src/app/api/articles/[id]/route.ts`

---
*Part of code review remediation (#60)*

## Summary by Sourcery

Add a soft-delete REST endpoint for articles and centralize authorization handling for article updates and deletions.

New Features:
- Introduce DELETE /api/articles/[id] endpoint to soft-delete articles with admin-only access.

Enhancements:
- Refactor PATCH /api/articles/[id] authorization to use the shared requirePermission helper and standardized auth metadata.