### PR TITLE
fix(ui): improve MarkdownPreviewTabs safety and initial render

### DIFF
--- a/src/app/wiki/[topicSlug]/[articleSlug]/edit/page.tsx
+++ b/src/app/wiki/[topicSlug]/[articleSlug]/edit/page.tsx
@@ -136,7 +136,7 @@ export default async function EditArticlePage({ params }: Props) {
           <p className="form-hint">
             Supports GitHub-flavored Markdown. Code blocks with syntax highlighting.
           </p>
-          <MarkdownPreviewTabs targetTextareaId="content" />
+          <MarkdownPreviewTabs targetTextareaId="content" defaultValue={article.content} />
         </div>
 
         <div className="form-actions-row">

--- a/src/components/wiki/MarkdownPreviewTabs.tsx
+++ b/src/components/wiki/MarkdownPreviewTabs.tsx
@@ -25,16 +25,23 @@ export function MarkdownPreviewTabs({ targetTextareaId, defaultValue = "" }: Mar
   const [content, setContent] = useState(defaultValue);
 
   const sync = useCallback(() => {
-    const textarea = document.getElementById(targetTextareaId) as HTMLTextAreaElement | null;
-    if (textarea) {
+    const textarea = document.getElementById(targetTextareaId);
+    if (textarea instanceof HTMLTextAreaElement) {
       setContent(textarea.value);
     }
   }, [targetTextareaId]);
 
+  // Sync content when defaultValue prop changes (e.g., switching articles)
   useEffect(() => {
+    setContent(defaultValue);
+  }, [defaultValue]);
+
+  useEffect(() => {
+    const textarea = document.getElementById(targetTextareaId);
+    if (!(textarea instanceof HTMLTextAreaElement)) return;
+
+    // Initial sync — textarea found, content already set from defaultValue or useEffect
     sync();
-    const textarea = document.getElementById(targetTextareaId) as HTMLTextAreaElement | null;
-    if (!textarea) return;
 
     textarea.addEventListener("input", sync, { passive: true });
     return () => {

--- a/src/components/wiki/MarkdownPreviewTabs.tsx
+++ b/src/components/wiki/MarkdownPreviewTabs.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState, useCallback } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
@@ -17,21 +17,30 @@ const sanitizeSchema = {
 
 interface MarkdownPreviewTabsProps {
   targetTextareaId: string;
+  defaultValue?: string;
 }
 
-export function MarkdownPreviewTabs({ targetTextareaId }: MarkdownPreviewTabsProps) {
+export function MarkdownPreviewTabs({ targetTextareaId, defaultValue = "" }: MarkdownPreviewTabsProps) {
   const [activeTab, setActiveTab] = useState<"write" | "preview">("write");
-  const [content, setContent] = useState("");
+  const [content, setContent] = useState(defaultValue);
+
+  const sync = useCallback(() => {
+    const textarea = document.getElementById(targetTextareaId) as HTMLTextAreaElement | null;
+    if (textarea) {
+      setContent(textarea.value);
+    }
+  }, [targetTextareaId]);
 
   useEffect(() => {
+    sync();
     const textarea = document.getElementById(targetTextareaId) as HTMLTextAreaElement | null;
     if (!textarea) return;
 
-    const sync = () => setContent(textarea.value);
-    sync();
-    textarea.addEventListener("input", sync);
-    return () => textarea.removeEventListener("input", sync);
-  }, [targetTextareaId]);
+    textarea.addEventListener("input", sync, { passive: true });
+    return () => {
+      textarea.removeEventListener("input", sync);
+    };
+  }, [targetTextareaId, sync]);
 
   const preview = useMemo(() => content.trim(), [content]);
 


### PR DESCRIPTION
## Summary
Makes the markdown preview component more robust and eliminates the initial content flash.

## Changes
- **Add  prop**: The preview now renders correctly on first paint without waiting for the  DOM sync, eliminating the empty-preview flash when switching to preview tab.
- **Safer DOM interaction**: Added  for the sync function and  for the input listener. Guards against missing textarea element.
- **Edit page updated**: Passes  as  so the preview is immediately populated.

## Files Changed
- 
- 

---
*Part of code review remediation (#60)*

## Summary by Sourcery

Improve Markdown preview tab robustness and initial content rendering.

New Features:
- Allow MarkdownPreviewTabs to accept an optional defaultValue for initial preview content.

Bug Fixes:
- Ensure the Markdown preview initializes with existing textarea content to avoid an empty preview flash when switching tabs.
- Guard DOM access for the target textarea and make the input listener safer to prevent issues when the element is missing.