### PR TITLE
fix(db): add Article.updatedAt index for lint query performance

### DIFF
--- a/prisma/migrations/20260511091912_add_article_updatedat_index/migration.sql
+++ b/prisma/migrations/20260511091912_add_article_updatedat_index/migration.sql
@@ -1,4 +1,5 @@
--- Create index on Article.updatedAt to improve lint query performance
--- The /api/lint endpoint orders by updatedAt desc and is now capped at 2000 rows,
--- but without an index this ORDER BY causes a full table scan + sort on large wikis.
-CREATE INDEX "Article_updatedAt_idx" ON "Article"("updatedAt");
+-- Composite index on Article(updatedAt DESC, id ASC) to support the lint query's
+-- ORDER BY [{ updatedAt: 'desc' }, { id: 'asc' }] without a sort step.
+-- The IF NOT EXISTS guard handles environments where the index was applied manually
+-- (e.g. hotfix) but the migration hadn't been recorded in _prisma_migrations yet.
+CREATE INDEX IF NOT EXISTS "Article_updatedAt_idx" ON "Article"("updatedAt" DESC, "id" ASC);

--- a/prisma/migrations/20260511091912_add_article_updatedat_index/migration.sql
+++ b/prisma/migrations/20260511091912_add_article_updatedat_index/migration.sql
@@ -1,0 +1,4 @@
+-- Create index on Article.updatedAt to improve lint query performance
+-- The /api/lint endpoint orders by updatedAt desc and is now capped at 2000 rows,
+-- but without an index this ORDER BY causes a full table scan + sort on large wikis.
+CREATE INDEX "Article_updatedAt_idx" ON "Article"("updatedAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -77,6 +77,7 @@ model Article {
   @@index([status])
   @@index([confidence])
   @@index([deletedAt])
+  @@index([updatedAt])
 }
 
 // ─────────────────────────────────────────────

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -77,7 +77,7 @@ model Article {
   @@index([status])
   @@index([confidence])
   @@index([deletedAt])
-  @@index([updatedAt])
+  @@index([updatedAt(sort: Desc), id(sort: Asc)])
 }
 
 // ─────────────────────────────────────────────


### PR DESCRIPTION
## What

Add a PostgreSQL index on `Article.updatedAt` to support the capped `/api/lint` query added in PR #64.

## Why

The lint endpoint orders articles by `updatedAt DESC` with a cap of 2000 rows:



Without an index, PostgreSQL must perform a **full table scan + in-memory sort** on large wikis. The new index allows the planner to use an **index scan** instead, keeping lint fast regardless of wiki size.

## Changes

- `prisma/schema.prisma`: `@@index([updatedAt])` on the `Article` model
- `prisma/migrations/20260511091912_add_article_updatedat_index/migration.sql`: creates `Article_updatedAt_idx`

## Testing

Applied locally via `docker compose exec db psql`:

```
# CREATE INDEX
Index verified: Article_updatedAt_idx exists on Article(updatedAt)
```

---

Addressed the Copilot review comment from PR #64.

## Summary by Sourcery

Add a database index on Article.updatedAt to improve performance of the capped /api/lint query on large wikis.

Bug Fixes:
- Improve /api/lint query performance and avoid full table scans by indexing Article.updatedAt.

Deployment:
- Add Prisma migration to create the Article_updatedAt_idx index in PostgreSQL.