### PR TITLE
fix(db): make Article updatedAt index migration idempotent

### DIFF
--- a/prisma/migrations/20260511091912_add_article_updatedat_index/migration.sql
+++ b/prisma/migrations/20260511091912_add_article_updatedat_index/migration.sql
@@ -1,4 +1,4 @@
 -- Create index on Article.updatedAt to improve lint query performance
 -- The /api/lint endpoint orders by updatedAt desc and is now capped at 2000 rows,
 -- but without an index this ORDER BY causes a full table scan + sort on large wikis.
-CREATE INDEX "Article_updatedAt_idx" ON "Article"("updatedAt");
+CREATE INDEX IF NOT EXISTS "Article_updatedAt_idx" ON "Article"("updatedAt");

--- a/prisma/migrations/20260511091912_add_article_updatedat_index/migration.sql
+++ b/prisma/migrations/20260511091912_add_article_updatedat_index/migration.sql
@@ -1,0 +1,4 @@
+-- Create index on Article.updatedAt to improve lint query performance
+-- The /api/lint endpoint orders by updatedAt desc and is now capped at 2000 rows,
+-- but without an index this ORDER BY causes a full table scan + sort on large wikis.
+CREATE INDEX "Article_updatedAt_idx" ON "Article"("updatedAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -77,6 +77,7 @@ model Article {
   @@index([status])
   @@index([confidence])
   @@index([deletedAt])
+  @@index([updatedAt])
 }
 
 // ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fix PR #70 by making the  migration idempotent using .

## Changes

- Update migration to use  instead of 

## Why

If the migration runs twice (e.g., after a failed first attempt or in CI/CD with manual intervention), it would fail with:

```
ERROR: relation "Article_updatedAt_idx" already exists
```

Using  makes it safe for re-runs.

## Related

- PR #70 (base)
- Addresses review feedback on PR #64

## Summary by Sourcery

Bug Fixes:
- Prevent migration failures when the Article_updatedAt_idx index already exists by making the index creation idempotent.