### PR TITLE
fix(auth+graph): address remaining PR #68 review comments

### DIFF
--- a/src/app/api/graph/route.ts
+++ b/src/app/api/graph/route.ts
@@ -28,7 +28,8 @@ export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url);
     const topicSlug = searchParams.get("topic");
-    const limit = Math.min(parseInt(searchParams.get("limit") ?? "100", 10), 500);
+    const rawLimit = parseInt(searchParams.get("limit") ?? "100", 10);
+    const limit = Math.max(1, Math.min(rawLimit || 100, 500));
 
     // Fetch all non-deleted articles with their tags and topic
     const articles = await prisma.article.findMany({

--- a/src/app/api/graph/route.ts
+++ b/src/app/api/graph/route.ts
@@ -1,8 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { requireApiKey } from "@/lib/api/keys";
-import { getServerSession } from "next-auth";
-import { authOptions } from "@/lib/auth";
+import { requirePermission } from "@/lib/api/auth";
 
 // GET /api/graph — Wiki knowledge graph
 //
@@ -21,36 +19,36 @@ import { authOptions } from "@/lib/auth";
 //   }
 
 export async function GET(request: NextRequest) {
-  // Auth: API key (any permission) or session
-  const apiAuth = await requireApiKey(request);
-  const session = await getServerSession(authOptions);
-  if (!apiAuth.authorized && !session?.user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  // Auth: API key (any permission) or session — empty array = any authenticated caller
+  const auth = await requirePermission(request, []);
+  if (!auth.success) {
+    return auth.response;
   }
 
-  const { searchParams } = new URL(request.url);
-  const topicSlug = searchParams.get("topic");
-  const limit = Math.min(parseInt(searchParams.get("limit") ?? "100", 10), 500);
+  try {
+    const { searchParams } = new URL(request.url);
+    const topicSlug = searchParams.get("topic");
+    const limit = Math.min(parseInt(searchParams.get("limit") ?? "100", 10), 500);
 
-  // Fetch all non-deleted articles with their tags and topic
-  const articles = await prisma.article.findMany({
-    where: {
-      deletedAt: null,
-      ...(topicSlug ? { topic: { slug: topicSlug } } : {}),
-    },
-    select: {
-      id: true,
-      title: true,
-      slug: true,
-      excerpt: true,
-      content: true,
-      createdAt: true,
-      topic: { select: { slug: true } },
-      tags: { select: { tag: { select: { id: true, name: true, slug: true } } } },
-    },
-    take: limit,
-    orderBy: { updatedAt: "desc" },
-  });
+    // Fetch all non-deleted articles with their tags and topic
+    const articles = await prisma.article.findMany({
+      where: {
+        deletedAt: null,
+        ...(topicSlug ? { topic: { slug: topicSlug } } : {}),
+      },
+      select: {
+        id: true,
+        title: true,
+        slug: true,
+        excerpt: true,
+        content: true,
+        createdAt: true,
+        topic: { select: { slug: true } },
+        tags: { select: { tag: { select: { id: true, name: true, slug: true } } } },
+      },
+      take: limit,
+      orderBy: { updatedAt: "desc" },
+    });
 
   // Build nodes
   const nodes = articles.map((a) => ({
@@ -145,14 +143,18 @@ export async function GET(request: NextRequest) {
     prisma.topic.count(),
   ]);
 
-  return NextResponse.json({
-    nodes,
-    edges,
-    stats: {
-      articleCount,
-      tagCount,
-      topicCount,
-      edgeCount: edges.length,
-    },
-  });
+    return NextResponse.json({
+      nodes,
+      edges,
+      stats: {
+        articleCount,
+        tagCount,
+        topicCount,
+        edgeCount: edges.length,
+      },
+    });
+  } catch (error) {
+    console.error("[GET /api/graph]", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
 }

--- a/src/app/api/ingest/route.ts
+++ b/src/app/api/ingest/route.ts
@@ -64,7 +64,6 @@ export async function POST(request: NextRequest) {
 
   const { source, articles, tags: globalTags } = body;
   // authorName from body is accepted but sanitized to prevent HTML injection / spoofing
-  const userName = auth.auth.name ?? "Unknown";
   const rawAuthorName = body.authorName ?? "";
   const sanitizedAuthorName = sanitizeAuthorName(
     rawAuthorName,


### PR DESCRIPTION
## Summary

Addresses the remaining non-critical review comments from PR #68 that weren't caught before merging.

## Changes

### graph/route.ts
- Convert from manual dual-auth ( + ) to centralized  — any authenticated caller
- Add  around all DB operations
- Resolves: GET /api/graph had no  check (comment 28)

### ingest/route.ts  
- Remove unused  variable declared but never used (the  expression uses  directly)
- Resolves: pre-existing lint warning

## What was already correct on master (comments 1-29 triage)

| Comments | Issue | Why resolved |
|----------|-------|-------------|
| 10-18, 24 |  missing |  already on master |
| 1, 7, 8, 21, 25, 29 | / not imported | Old-base branch issue; master has correct imports |
| 2, 3, 19 | TDZ +  missing | TDZ fixed in ingest;  already in interface |
| 4, 26 |  missing type | Already declared  in  |
| 9 | WRITE key blocked in obsidian sync | Master has  |
| 22 | graph  after topic filter | Acceptable perf trade-off, documented in PR |

## Checks

- [x] lint clean
- [x] build successful
- [x] docker deploys

## Summary by Sourcery

Centralize graph API authentication and harden error handling while cleaning up an unused variable in ingest.

Bug Fixes:
- Ensure the graph API requires a unified permission-based auth check for any authenticated caller.
- Wrap graph database access in error handling to return a 500 response on internal failures.
- Remove an unused username variable in the ingest API to resolve a lint warning.