### PR TITLE
fix(install): make bootstrap JSON extraction non-fragile

### DIFF
--- a/install-openclaw.sh
+++ b/install-openclaw.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
+trap 'echo "Installer failed near line ${LINENO}: ${BASH_COMMAND}" >&2' ERR
 
 NOOSPHERE_HOME="${NOOSPHERE_HOME:-$HOME/.noosphere}"
 NOOSPHERE_PORT="${NOOSPHERE_PORT:-6578}"
@@ -81,6 +82,27 @@ NOOSPHERE_BOOTSTRAP_API_KEY=${API_KEY}
 ENV
   chmod 600 "$env_tmp"
   mv "$env_tmp" "$NOOSPHERE_HOME/.env"
+}
+
+extract_bootstrap_json() {
+  local file="$1"
+  BOOTSTRAP_JSON_FILE="$file" node -e '
+    const fs = require("fs");
+    const path = process.env.BOOTSTRAP_JSON_FILE;
+    const lines = fs.readFileSync(path, "utf8").split(/\r?\n/);
+    for (let i = lines.length - 1; i >= 0; i -= 1) {
+      const line = lines[i].trim();
+      if (!line || line.startsWith("[bootstrap]")) continue;
+      try {
+        JSON.parse(line);
+        process.stdout.write(line);
+        process.exit(0);
+      } catch {
+        // Keep walking upward; Docker/Prisma may emit status lines after JSON.
+      }
+    }
+    process.exit(1);
+  '
 }
 
 has_controlling_tty() {
@@ -471,19 +493,19 @@ if [ "$BOOTSTRAP_EXIT" -ne 0 ]; then
   rm -f "$BOOTSTRAP_TMP"
   exit 1
 fi
-# Bootstrap writes JSON to stdout. Filter out [bootstrap] log lines and extract last non-empty line.
-BOOTSTRAP_JSON=$(grep -v '^\[bootstrap\]' "$BOOTSTRAP_TMP" | grep -v '^$' | tail -n 1)
+# Bootstrap writes JSON to stdout, mixed with Docker/Prisma status output.
+# Extract it in one Node process instead of a grep|tail pipeline so set -euo
+# pipefail cannot silently abort before we can print a useful diagnostic.
+BOOTSTRAP_JSON=""
+if ! BOOTSTRAP_JSON="$(extract_bootstrap_json "$BOOTSTRAP_TMP")"; then
+  echo "Bootstrap produced no parseable JSON output. Full bootstrap log:" >&2
+  cat "$BOOTSTRAP_TMP" >&2
+  rm -f "$BOOTSTRAP_TMP"
+  exit 1
+fi
 rm -f "$BOOTSTRAP_TMP"
-if [ -z "$BOOTSTRAP_JSON" ]; then
-  echo "Bootstrap produced no parseable JSON output" >&2
-  exit 1
-fi
-# Validate JSON is parseable
-if ! printf '%s' "$BOOTSTRAP_JSON" | node -e 'let s=""; process.stdin.on("data", d => s += d); process.stdin.on("end", () => { try { JSON.parse(s); process.exit(0); } catch { console.error(s); process.exit(1); } });' >/dev/null 2>&1; then
-  echo "Bootstrap output was not valid JSON:" >&2
-  echo "$BOOTSTRAP_JSON" >&2
-  exit 1
-fi
+
+echo "Bootstrap completed successfully."
 
 docker compose up -d app
 wait_for_container_healthy noosphere-openclaw-app 30


### PR DESCRIPTION
The installer could still stop silently immediately after 'Applying database schema and bootstrap data...' even when bootstrap succeeded. The likely fragile point was the post-bootstrap grep|grep|tail command substitution under set -euo pipefail, before the script reached app/plugin installation.\n\nFix:\n- Replace the grep pipeline with a single Node helper that scans for the last parseable JSON line in the bootstrap log.\n- If no JSON is found, print the full bootstrap log before exiting.\n- Add a non-secret ERR trap so future installer failures show the line/command instead of returning silently.\n- Print 'Bootstrap completed successfully.' before app/plugin setup to make progress obvious.\n\nValidation:\n- bash -n install-openclaw.sh\n- git diff --check\n- extract_bootstrap_json success/failure unit checks\n- stubbed full installer run confirms it reaches the plugin install step and setup-complete banner.

## Summary by Sourcery

Improve robustness and diagnostics of the installer bootstrap JSON extraction step.

Bug Fixes:
- Prevent silent installer termination by replacing the fragile grep-based bootstrap JSON extraction with a Node-based helper that scans the bootstrap log for the last valid JSON line.

Enhancements:
- Add an ERR trap to report the failing line and command when the installer exits with an error.
- Log an explicit 'Bootstrap completed successfully.' message after bootstrap JSON validation to clarify progress for users.