### PR TITLE
fix(install): prevent bootstrap from consuming piped installer

### DIFF
--- a/install-openclaw.sh
+++ b/install-openclaw.sh
@@ -484,7 +484,7 @@ echo "Applying database schema and bootstrap data..."
 # Admin/API credentials are passed through exported Compose variables.
 BOOTSTRAP_TMP=$(mktemp)
 BOOTSTRAP_EXIT=0
-docker compose run --rm -T init > "$BOOTSTRAP_TMP" 2>&1 || BOOTSTRAP_EXIT=$?
+docker compose run --rm -T init < /dev/null > "$BOOTSTRAP_TMP" 2>&1 || BOOTSTRAP_EXIT=$?
 if [ "$BOOTSTRAP_EXIT" -ne 0 ]; then
   echo "Bootstrap failed with exit code $BOOTSTRAP_EXIT:" >&2
   cat "$BOOTSTRAP_TMP" >&2


### PR DESCRIPTION
When install-openclaw.sh runs as curl | bash, Bash reads the installer from stdin. The bootstrap command inherited that stdin:\n\n  docker compose run --rm -T init\n\nDocker Compose can consume the rest of the script stream, causing Bash to hit EOF after 'Applying database schema and bootstrap data...' and exit 0 before app/plugin setup.\n\nFix: redirect bootstrap container stdin from /dev/null.\n\nValidation:\n- bash -n install-openclaw.sh\n- git diff --check\n- piped-installer regression test with fake docker compose run that attempts to read stdin; verified it does not consume the script and the installer reaches the OpenClaw plugin step/setup-complete banner.

## Summary by Sourcery

Bug Fixes:
- Redirect stdin for the bootstrap init container from /dev/null to ensure the remaining installer script executes when run as curl | bash.