### PR TITLE
docs(openclaw): document installer success and bootstrap troubleshooting

### DIFF
--- a/docs/OPENCLAW-OFFICIAL-PLUGIN-SETUP.md
+++ b/docs/OPENCLAW-OFFICIAL-PLUGIN-SETUP.md
@@ -59,10 +59,12 @@ A successful installer run prints these progress markers before the final summar
 ```text
 Applying database schema and bootstrap data...
 Bootstrap completed successfully.
-Installing OpenClaw plugin: npm:@sweetsophia/openclaw-noosphere-memory
+Installing OpenClaw plugin: ...
 ```
 
-Verify after install. If you selected a non-localhost IP address, use that address instead of `127.0.0.1` for the health check:
+By default, the plugin line ends with `npm:@sweetsophia/openclaw-noosphere-memory`; it differs only when `NOOSPHERE_PLUGIN_SPEC` is overridden.
+
+Verify after install. Use the exact Noosphere URL printed by the installer, or the `APP_URL` value you supplied, for the health check. For a default localhost install:
 
 ```bash
 curl -fsS http://127.0.0.1:6578/api/health
@@ -436,15 +438,16 @@ First make sure you are using the latest installer from `master`:
 curl -fsSL https://raw.githubusercontent.com/SweetSophia/noosphere/master/install-openclaw.sh | bash
 ```
 
-The current installer protects `curl | bash` runs by redirecting the bootstrap container's stdin from `/dev/null`, so Docker Compose cannot consume the remaining installer script before app/plugin setup. If the issue persists, inspect the partial state and bootstrap log before retrying:
+The current installer protects `curl | bash` runs by redirecting the bootstrap container's stdin from `/dev/null`, so Docker Compose cannot consume the remaining installer script before app/plugin setup. If the issue persists, inspect the partial state before retrying:
 
 ```bash
 docker ps -a --filter 'name=noosphere-openclaw'
 ls -l ~/.noosphere/.env ~/.openclaw/secrets/noosphere-memory.json
-find /tmp -maxdepth 1 -type f -mmin -30 -print | xargs -r grep -l 'bootstrap\|Prisma\|No pending migrations' 2>/dev/null
+cd ~/.noosphere
+docker compose logs --tail 80 db
 ```
 
-A rerun is safe after bootstrap failures because the installer preserves `~/.noosphere/.env` before starting persistent containers.
+The installer prints bootstrap failure output directly before exiting. It also preserves `~/.noosphere/.env` before starting persistent containers, so reruns after bootstrap failures keep the original database password.
 
 ### Plugin installed but CLI commands are missing
 

--- a/docs/OPENCLAW-OFFICIAL-PLUGIN-SETUP.md
+++ b/docs/OPENCLAW-OFFICIAL-PLUGIN-SETUP.md
@@ -54,7 +54,15 @@ The installer:
 
 > **Note:** The installer can still prompt when run through `curl | bash` by reading from `/dev/tty` if a controlling terminal is available. The interactive IP prompt is skipped when `APP_URL` is set, or when no interactive terminal is available (for example CI/cron/background automation). In non-interactive mode, the script auto-detects the best available IP (Tailscale > localhost). Set `APP_URL` beforehand to force a specific address in any mode.
 
-Verify after install:
+A successful installer run prints these progress markers before the final summary banner:
+
+```text
+Applying database schema and bootstrap data...
+Bootstrap completed successfully.
+Installing OpenClaw plugin: npm:@sweetsophia/openclaw-noosphere-memory
+```
+
+Verify after install. If you selected a non-localhost IP address, use that address instead of `127.0.0.1` for the health check:
 
 ```bash
 curl -fsS http://127.0.0.1:6578/api/health
@@ -411,6 +419,32 @@ node -e 'const fs=require("fs"); const p=process.env.HOME+"/.openclaw/secrets/no
 ```
 
 Do not paste real keys or full secret files into issue comments, chats, terminal transcripts, or commits.
+
+### Installer stops after bootstrap starts
+
+If the installer returns to your shell immediately after this line:
+
+```text
+Applying database schema and bootstrap data...
+```
+
+then the install did not complete. A healthy run must continue with `Bootstrap completed successfully.` and `Installing OpenClaw plugin: ...`.
+
+First make sure you are using the latest installer from `master`:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/SweetSophia/noosphere/master/install-openclaw.sh | bash
+```
+
+The current installer protects `curl | bash` runs by redirecting the bootstrap container's stdin from `/dev/null`, so Docker Compose cannot consume the remaining installer script before app/plugin setup. If the issue persists, inspect the partial state and bootstrap log before retrying:
+
+```bash
+docker ps -a --filter 'name=noosphere-openclaw'
+ls -l ~/.noosphere/.env ~/.openclaw/secrets/noosphere-memory.json
+find /tmp -maxdepth 1 -type f -mmin -30 -print | xargs -r grep -l 'bootstrap\|Prisma\|No pending migrations' 2>/dev/null
+```
+
+A rerun is safe after bootstrap failures because the installer preserves `~/.noosphere/.env` before starting persistent containers.
 
 ### Plugin installed but CLI commands are missing
 


### PR DESCRIPTION
Updates the OpenClaw Noosphere setup guide after the installer fixes.\n\nChanges:\n- Documents expected successful installer progress markers.\n- Notes that health checks should use the selected non-localhost IP when applicable.\n- Adds troubleshooting for installs that stop after 'Applying database schema and bootstrap data...'.\n- Explains the current curl|bash stdin protection and safe rerun behavior.\n\nValidation:\n- git diff --check\n- inspected against current install-openclaw.sh behavior

## Summary by Sourcery

Update the OpenClaw Noosphere setup guide with clearer installer success indicators and bootstrap troubleshooting guidance.

Documentation:
- Document expected installer progress markers and clarify IP selection for health checks in the OpenClaw setup guide.
- Add troubleshooting steps and rerun safety notes for installs that stop after the bootstrap phase.