### PR TITLE
docs(readme): clarify OpenClaw installer flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,12 +430,22 @@ openclaw noosphere doctor
 openclaw noosphere status
 ```
 
-Defaults are local-only and safe for personal OpenClaw deployments:
+In an interactive terminal, the installer asks which IP address Noosphere should bind to and prints the resulting URL. Choose `127.0.0.1` for a local-only install, or a Tailscale/public address when OpenClaw and browsers need to reach Noosphere over that interface. For non-interactive installs, set `APP_URL` and `BIND_ADDRESS` explicitly when you need deterministic network binding.
 
-- Noosphere URL: `http://127.0.0.1:6578`
+A healthy run reaches these markers before the final summary banner:
+
+```text
+Applying database schema and bootstrap data...
+Bootstrap completed successfully.
+Installing OpenClaw plugin: ...
+```
+
+Default runtime locations:
+
 - Runtime directory: `~/.noosphere`
 - OpenClaw secret file: `~/.openclaw/secrets/noosphere-memory.json`
 - Docker image: `ghcr.io/sweetsophia/noosphere:latest`
+- Default port: `6578`
 
 ### Plugin capabilities
 

--- a/README.md
+++ b/README.md
@@ -430,7 +430,7 @@ openclaw noosphere doctor
 openclaw noosphere status
 ```
 
-In an interactive terminal, the installer asks which IP address Noosphere should bind to and prints the resulting URL. Choose `127.0.0.1` for a local-only install, or a Tailscale/public address when OpenClaw and browsers need to reach Noosphere over that interface. For non-interactive installs, set `APP_URL` and `BIND_ADDRESS` explicitly when you need deterministic network binding.
+In an interactive terminal, the installer asks which IP address Noosphere should bind to and prints the resulting URL. Choose `127.0.0.1` for a local-only install, or another network address (e.g., from Tailscale or your LAN) when OpenClaw and browsers need to reach Noosphere over that interface. For non-interactive installs, set `APP_URL` and `BIND_ADDRESS` explicitly when you need deterministic network binding.
 
 A healthy run reaches these markers before the final summary banner:
 


### PR DESCRIPTION
Updates the main README's OpenClaw quick install section to match the verified installer behavior.\n\nChanges:\n- clarifies that interactive installs prompt for the bind IP and print the resulting URL\n- tells users to choose localhost for local-only installs or set APP_URL/BIND_ADDRESS for deterministic non-interactive installs\n- adds the success markers from the fixed installer\n- replaces the misleading 'Noosphere URL: 127.0.0.1' default with runtime locations and default port\n\nValidation:\n- git diff --check

## Summary by Sourcery

Clarify the OpenClaw quick install README section to describe interactive and non-interactive installer behavior, success markers, and default runtime locations.

Documentation:
- Document interactive installer prompts, recommended bind IP choices, and deterministic non-interactive configuration via APP_URL and BIND_ADDRESS.
- Describe the expected success markers emitted by a healthy OpenClaw installer run.
- Update default runtime location documentation to remove a misleading hardcoded Noosphere URL and note the default port instead.