### PR TITLE
feat(restricted-tags): per-article access control for multi-agent wiki

### DIFF
--- a/prisma/migrations/20260514220000_add_restricted_tags_scope/migration.sql
+++ b/prisma/migrations/20260514220000_add_restricted_tags_scope/migration.sql
@@ -1,0 +1,75 @@
+-- Add restricted access scopes to articles
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'Article' AND column_name = 'restrictedTags'
+  ) THEN
+    ALTER TABLE "Article" ADD COLUMN "restrictedTags" TEXT[] DEFAULT '{}'::TEXT[];
+  END IF;
+END $$;
+
+-- Add allowed scopes to API keys
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'ApiKey' AND column_name = 'allowedScopes'
+  ) THEN
+    ALTER TABLE "ApiKey" ADD COLUMN "allowedScopes" TEXT[] DEFAULT '{}'::TEXT[];
+  END IF;
+END $$;
+
+-- Create RestrictedScope registry table
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'RestrictedScope') THEN
+    CREATE TABLE "RestrictedScope" (
+      "id" TEXT NOT NULL PRIMARY KEY DEFAULT replace(gen_random_uuid()::text, '-', ''),
+      "tag" TEXT NOT NULL UNIQUE,
+      "description" TEXT,
+      "isSystem" BOOLEAN NOT NULL DEFAULT false,
+      "createdAt" TIMESTAMPTZ NOT NULL DEFAULT now()
+    );
+  END IF;
+END $$;
+
+-- Index for fast scope lookups
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_indexes WHERE indexname = 'Article_restrictedTags_idx'
+  ) THEN
+    CREATE INDEX "Article_restrictedTags_idx" ON "Article" USING GIN ("restrictedTags");
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_indexes WHERE indexname = 'ApiKey_allowedScopes_idx'
+  ) THEN
+    CREATE INDEX "ApiKey_allowedScopes_idx" ON "ApiKey" USING GIN ("allowedScopes");
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_indexes WHERE indexname = 'RestrictedScope_tag_idx'
+  ) THEN
+    CREATE INDEX "RestrictedScope_tag_idx" ON "RestrictedScope"("tag");
+  END IF;
+END $$;
+
+-- Seed system scopes (idempotent — uses ON CONFLICT DO NOTHING)
+INSERT INTO "RestrictedScope" ("id", "tag", "description", "isSystem", "createdAt")
+SELECT replace(gen_random_uuid()::text, '-', ''), tag, description, true, now()
+FROM (VALUES
+  ('health',    'Personal health and medical information'),
+  ('intimate', 'Intimate and relationship content'),
+  ('identity', 'Personal identity and self-discovery'),
+  ('financial', 'Financial data and sensitive business info'),
+  ('social',   'Social relationships and external contacts')
+) AS v(tag, description)
+ON CONFLICT ("tag") DO NOTHING;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -69,6 +69,10 @@ model Article {
 
   deletedAt DateTime?
 
+  // Restricted access scopes — empty array = unrestricted (visible to all keys)
+  // Non-empty = only keys with at least one matching scope can access
+  restrictedTags String[] @default([])
+
   @@unique([topicId, slug])
   @@index([topicId])
   @@index([slug])
@@ -177,6 +181,10 @@ model ApiKey {
 
   permissions Permissions @default(WRITE)
 
+  // Scopes this key is allowed to access. Empty = only unrestricted articles.
+  // "*" = admin access to all restricted articles.
+  allowedScopes String[] @default([])
+
   createdAt   DateTime @default(now())
   lastUsedAt DateTime?
   revokedAt  DateTime?
@@ -188,6 +196,20 @@ enum Permissions {
   READ
   WRITE
   ADMIN
+}
+
+// ─────────────────────────────────────────────
+// Restricted Scopes — registry of valid restricted tag values
+// ─────────────────────────────────────────────
+model RestrictedScope {
+  id          String   @id @default(cuid())
+  tag         String   @unique  // "health", "intimate", "company-x", etc.
+  description String?
+  isSystem    Boolean  @default(false)  // system scopes cannot be deleted
+
+  createdAt   DateTime @default(now())
+
+  @@index([tag])
 }
 
 // ─────────────────────────────────────────────

--- a/src/app/api/articles/[id]/route.ts
+++ b/src/app/api/articles/[id]/route.ts
@@ -167,8 +167,8 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
 
     // restrictedTags — validate and apply
     if (restrictedTags !== undefined) {
-      if (!Array.isArray(restrictedTags) || !(restrictedTags as unknown[]).every((t) => typeof t === "string")) {
-        return NextResponse.json({ error: "restrictedTags must be an array of strings" }, { status: 400 });
+      if (!Array.isArray(restrictedTags) || !(restrictedTags as unknown[]).every((t) => typeof t === "string" && t.length > 0)) {
+        return NextResponse.json({ error: "restrictedTags must be an array of non-empty strings" }, { status: 400 });
       }
       if (restrictedTags.length > 0) {
         const validScopes = await prisma.restrictedScope.findMany({

--- a/src/app/api/articles/[id]/route.ts
+++ b/src/app/api/articles/[id]/route.ts
@@ -3,7 +3,7 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { Permissions } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
-import { requirePermission } from "@/lib/api/auth";
+import { requirePermission, canAccessScopes } from "@/lib/api/auth";
 import { buildTagConnections } from "@/lib/wiki";
 import {
   ARTICLE_LIMITS,
@@ -36,6 +36,11 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
       return NextResponse.json({ error: "Article not found" }, { status: 404 });
     }
 
+    // Scope check: article's restrictedTags must have at least one match with key's allowedScopes
+    if (!canAccessScopes(existing.restrictedTags ?? [], auth.auth.allowedScopes)) {
+      return NextResponse.json({ error: "Article not found" }, { status: 404 });
+    }
+
     const body = await request.json();
     const {
       title,
@@ -48,6 +53,7 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
       status,
       relatedArticleIds,
       lastReviewed,
+      restrictedTags,
     } = body;
 
     // Build update data — all fields optional
@@ -159,6 +165,28 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
       updateData.lastReviewed = lastReviewed ? new Date(lastReviewed) : null;
     }
 
+    // restrictedTags — validate and apply
+    if (restrictedTags !== undefined) {
+      if (!Array.isArray(restrictedTags) || !(restrictedTags as unknown[]).every((t) => typeof t === "string")) {
+        return NextResponse.json({ error: "restrictedTags must be an array of strings" }, { status: 400 });
+      }
+      if (restrictedTags.length > 0) {
+        const validScopes = await prisma.restrictedScope.findMany({
+          where: { tag: { in: restrictedTags } },
+          select: { tag: true },
+        });
+        const validSet = new Set(validScopes.map((s) => s.tag));
+        const invalid = (restrictedTags as string[]).filter((t) => !validSet.has(t));
+        if (invalid.length > 0) {
+          return NextResponse.json(
+            { error: `Unknown restricted tag(s): ${invalid.join(", ")}. Valid tags: ${validScopes.map((s) => s.tag).join(", ")}` },
+            { status: 400 }
+          );
+        }
+      }
+      updateData.restrictedTags = restrictedTags;
+    }
+
     // tags — validate early if provided
     if (tags !== undefined) {
       if (!Array.isArray(tags) || !(tags as unknown[]).every((t) => typeof t === "string")) {
@@ -265,6 +293,15 @@ export async function DELETE(request: NextRequest, { params }: { params: Promise
     return auth.response;
   }
 
+  // Fetch to check scope before deleting
+  const existing = await prisma.article.findUnique({ where: { id } });
+  if (!existing || existing.deletedAt) {
+    return NextResponse.json({ error: "Article not found" }, { status: 404 });
+  }
+  if (!canAccessScopes(existing.restrictedTags ?? [], auth.auth.allowedScopes)) {
+    return NextResponse.json({ error: "Article not found" }, { status: 404 });
+  }
+
   const now = new Date();
 
   // Atomic soft-delete: only succeeds if article exists AND is not already deleted.
@@ -275,13 +312,8 @@ export async function DELETE(request: NextRequest, { params }: { params: Promise
   });
 
   if (count.count === 0) {
-    // Either article doesn't exist, or was already deleted.
-    // Fetch to distinguish — for security we don't reveal which.
-    const existing = await prisma.article.findUnique({ where: { id } });
-    if (!existing || existing.deletedAt) {
-      return new NextResponse(null, { status: 204 }); // idempotent
-    }
-    return NextResponse.json({ error: "Article not found" }, { status: 404 });
+    // Article was already deleted — safe to return 204 idempotently
+    return new NextResponse(null, { status: 204 });
   }
 
   // Log the deletion for audit trail

--- a/src/app/api/articles/[id]/route.ts
+++ b/src/app/api/articles/[id]/route.ts
@@ -251,7 +251,7 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
           tags: { include: { tag: true } },
           relatedTo: {
             include: {
-              target: { select: { id: true, title: true, slug: true, topic: true } },
+              target: { select: { id: true, title: true, slug: true, topic: true, restrictedTags: true } },
             },
           },
         },
@@ -268,12 +268,14 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
       confidence: updatedArticle!.confidence,
       status: updatedArticle!.status,
       lastReviewed: updatedArticle!.lastReviewed,
-      relatedArticles: updatedArticle!.relatedTo.map((r) => ({
-        id: r.target.id,
-        title: r.target.title,
-        slug: r.target.slug,
-        topicSlug: r.target.topic.slug,
-      })),
+      relatedArticles: updatedArticle!.relatedTo
+        .filter((r) => canAccessScopes(r.target.restrictedTags ?? [], auth.auth.allowedScopes))
+        .map((r) => ({
+          id: r.target.id,
+          title: r.target.title,
+          slug: r.target.slug,
+          topicSlug: r.target.topic.slug,
+        })),
       createdAt: updatedArticle!.createdAt,
       updatedAt: updatedArticle!.updatedAt,
     });

--- a/src/app/api/articles/route.ts
+++ b/src/app/api/articles/route.ts
@@ -231,8 +231,8 @@ export async function POST(request: NextRequest) {
 
     // Validate restrictedTags
     if (restrictedTags !== undefined) {
-      if (!Array.isArray(restrictedTags) || !(restrictedTags as unknown[]).every((t) => typeof t === "string")) {
-        return NextResponse.json({ error: "restrictedTags must be an array of strings" }, { status: 400 });
+      if (!Array.isArray(restrictedTags) || !(restrictedTags as unknown[]).every((t) => typeof t === "string" && t.length > 0)) {
+        return NextResponse.json({ error: "restrictedTags must be an array of non-empty strings" }, { status: 400 });
       }
       // Validate each tag exists in RestrictedScope registry
       if (restrictedTags.length > 0) {

--- a/src/app/api/articles/route.ts
+++ b/src/app/api/articles/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { Permissions } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
-import { requirePermission, buildScopeFilter } from "@/lib/api/auth";
+import { requirePermission, buildScopeFilter, canAccessScopes } from "@/lib/api/auth";
 import { buildTagConnections, countSearchArticles, searchArticleIds } from "@/lib/wiki";
 import {
   ARTICLE_LIMITS,
@@ -80,7 +80,7 @@ export async function GET(request: NextRequest) {
               author: { select: { id: true, name: true } },
               relatedTo: {
                 include: {
-                  target: { select: { id: true, title: true, slug: true, topic: true } },
+                  target: { select: { id: true, title: true, slug: true, topic: true, restrictedTags: true } },
                 },
               },
             },
@@ -99,7 +99,7 @@ export async function GET(request: NextRequest) {
             author: { select: { id: true, name: true } },
             relatedTo: {
               include: {
-                target: { select: { id: true, title: true, slug: true, topic: true } },
+                target: { select: { id: true, title: true, slug: true, topic: true, restrictedTags: true } },
               },
             },
           },
@@ -113,6 +113,7 @@ export async function GET(request: NextRequest) {
           tagSlug: tag ?? undefined,
           status: status ?? undefined,
           confidence: confidence ?? undefined,
+          allowedScopes: auth.auth.allowedScopes,
         })
         : prisma.article.count({ where }),
     ]);
@@ -128,12 +129,14 @@ export async function GET(request: NextRequest) {
       confidence: a.confidence,
       status: a.status,
       lastReviewed: a.lastReviewed,
-      relatedArticles: a.relatedTo.map((r) => ({
-        id: r.target.id,
-        title: r.target.title,
-        slug: r.target.slug,
-        topicSlug: r.target.topic.slug,
-      })),
+      relatedArticles: a.relatedTo
+        .filter((r) => canAccessScopes(r.target.restrictedTags ?? [], auth.auth.allowedScopes))
+        .map((r) => ({
+          id: r.target.id,
+          title: r.target.title,
+          slug: r.target.slug,
+          topicSlug: r.target.topic.slug,
+        })),
       createdAt: a.createdAt,
       updatedAt: a.updatedAt,
     }));

--- a/src/app/api/articles/route.ts
+++ b/src/app/api/articles/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { Permissions } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
-import { requirePermission } from "@/lib/api/auth";
+import { requirePermission, buildScopeFilter } from "@/lib/api/auth";
 import { buildTagConnections, countSearchArticles, searchArticleIds } from "@/lib/wiki";
 import {
   ARTICLE_LIMITS,
@@ -16,6 +16,11 @@ import { parsePagination } from "@/lib/pagination";
 // GET /api/articles — List articles (with filters)
 // Auth: API key (READ/WRITE/ADMIN) or session (human)
 export async function GET(request: NextRequest) {
+  const auth = await requirePermission(request, [Permissions.READ]);
+  if (!auth.success) {
+    return auth.response;
+  }
+
   const { searchParams } = new URL(request.url);
   const topicSlug = searchParams.get("topic");
   const tag = searchParams.get("tag");
@@ -33,7 +38,8 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    const where: Record<string, unknown> = { deletedAt: null };
+    // Build scope-filtered where clause — restricts articles based on key scopes
+    const where = buildScopeFilter(auth.auth.allowedScopes, { deletedAt: null });
 
     if (topicSlug) {
       where.topic = { slug: topicSlug };
@@ -57,6 +63,7 @@ export async function GET(request: NextRequest) {
         tagSlug: tag ?? undefined,
         status: status ?? undefined,
         confidence: confidence ?? undefined,
+        allowedScopes: auth.auth.allowedScopes,
         limit,
         offset,
       })
@@ -151,7 +158,7 @@ export async function POST(request: NextRequest) {
 
   try {
     const body = await request.json();
-    const { title, slug, content, topicId, tags, excerpt, authorName, confidence, status, relatedArticleIds } = body;
+    const { title, slug, content, topicId, tags, excerpt, authorName, confidence, status, relatedArticleIds, restrictedTags } = body;
 
     // Validate relatedArticleIds is an array of valid CUIDs
     if (relatedArticleIds !== undefined) {
@@ -222,6 +229,28 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    // Validate restrictedTags
+    if (restrictedTags !== undefined) {
+      if (!Array.isArray(restrictedTags) || !(restrictedTags as unknown[]).every((t) => typeof t === "string")) {
+        return NextResponse.json({ error: "restrictedTags must be an array of strings" }, { status: 400 });
+      }
+      // Validate each tag exists in RestrictedScope registry
+      if (restrictedTags.length > 0) {
+        const validScopes = await prisma.restrictedScope.findMany({
+          where: { tag: { in: restrictedTags } },
+          select: { tag: true },
+        });
+        const validSet = new Set(validScopes.map((s) => s.tag));
+        const invalid = restrictedTags.filter((t) => !validSet.has(t));
+        if (invalid.length > 0) {
+          return NextResponse.json(
+            { error: `Unknown restricted tag(s): ${invalid.join(", ")}. Valid tags: ${validScopes.map((s) => s.tag).join(", ")}` },
+            { status: 400 }
+          );
+        }
+      }
+    }
+
     // Validate slug format
     const slugValidation = validateSlug(slug);
     if (!slugValidation.ok) {
@@ -270,6 +299,7 @@ export async function POST(request: NextRequest) {
           tags: { create: tagConnections },
           confidence: confidence || null,
           status: status || "published",
+          restrictedTags: restrictedTags ?? [],
           revisions: {
             create: {
               authorId: auth.auth.userId ?? null,
@@ -304,6 +334,7 @@ export async function POST(request: NextRequest) {
         slug: article.slug,
         topic: article.topic,
         tags: article.tags.map((t: { tag: { id: string; name: string; slug: string } }) => t.tag),
+        restrictedTags: article.restrictedTags,
         createdAt: article.createdAt,
       },
       { status: 201 }

--- a/src/app/api/export/route.ts
+++ b/src/app/api/export/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { requireApiKey } from "@/lib/api/keys";
+import { buildScopeFilter } from "@/lib/api/auth";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import JSZip from "jszip";
@@ -16,9 +17,16 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
+  // Determine effective scopes for export filtering
+  const allowedScopes = apiAuth.authorized
+    ? apiAuth.allowedScopes
+    : ["*"]; // Sessions get full access
+
+  const scopeWhere = buildScopeFilter(allowedScopes, { deletedAt: null });
+
   try {
     const articles = await prisma.article.findMany({
-      where: { deletedAt: null },
+      where: scopeWhere,
       include: {
         topic: { select: { slug: true, name: true } },
         tags: { include: { tag: { select: { name: true, slug: true } } } },

--- a/src/app/api/graph/route.ts
+++ b/src/app/api/graph/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { requirePermission } from "@/lib/api/auth";
+import { requirePermission, buildScopeFilter } from "@/lib/api/auth";
 
 // GET /api/graph — Wiki knowledge graph
 //
@@ -31,10 +31,13 @@ export async function GET(request: NextRequest) {
     const rawLimit = parseInt(searchParams.get("limit") ?? "100", 10);
     const limit = Math.max(1, Math.min(rawLimit || 100, 500));
 
+    // Build scope-filtered where clause — restricts articles based on key scopes
+    const scopeWhere = buildScopeFilter(auth.auth.allowedScopes, { deletedAt: null });
+
     // Fetch all non-deleted articles with their tags and topic
     const articles = await prisma.article.findMany({
       where: {
-        deletedAt: null,
+        ...scopeWhere,
         ...(topicSlug ? { topic: { slug: topicSlug } } : {}),
       },
       select: {
@@ -137,9 +140,9 @@ export async function GET(request: NextRequest) {
     }
   }
 
-  // Stats
+  // Stats — article count is scope-filtered; tag/topic counts are not restricted
   const [articleCount, tagCount, topicCount] = await Promise.all([
-    prisma.article.count({ where: { deletedAt: null } }),
+    prisma.article.count({ where: scopeWhere }),
     prisma.tag.count(),
     prisma.topic.count(),
   ]);

--- a/src/app/api/import/route.ts
+++ b/src/app/api/import/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { requireApiKey } from "@/lib/api/keys";
+import { canAccessScopes } from "@/lib/api/auth";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import JSZip from "jszip";
@@ -87,6 +88,11 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Insufficient permissions" }, { status: 403 });
     }
   }
+
+  // Determine effective allowedScopes for scope-based article filtering
+  const allowedScopes = apiAuth.authorized
+    ? apiAuth.allowedScopes
+    : ["*"]; // Sessions get admin-level access
 
   // Parse multipart form using Web API
   let formData: FormData;
@@ -263,6 +269,12 @@ export async function POST(request: NextRequest) {
 
       if (existing) {
         if (overwrite && !existing.deletedAt) {
+          // Scope check: can the caller update this article?
+          if (!canAccessScopes(existing.restrictedTags ?? [], allowedScopes)) {
+            // Restricted article — caller has no matching scope, skip
+            results.skipped++;
+            continue;
+          }
           // Update existing article
           await tx.article.update({
             where: { id: existing.id },

--- a/src/app/api/keys/[id]/route.ts
+++ b/src/app/api/keys/[id]/route.ts
@@ -1,0 +1,153 @@
+import { NextRequest, NextResponse } from "next/server";
+import { Permissions } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+import { requirePermission } from "@/lib/api/auth";
+
+// GET /api/keys/[id] — Get a single key's metadata
+// Auth: ADMIN only
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  const auth = await requirePermission(_request, [Permissions.ADMIN]);
+  if (!auth.success) {
+    return auth.response;
+  }
+
+  const key = await prisma.apiKey.findFirst({
+    where: { id, revokedAt: null },
+    select: {
+      id: true,
+      name: true,
+      keyPrefix: true,
+      permissions: true,
+      allowedScopes: true,
+      lastUsedAt: true,
+      createdAt: true,
+    },
+  });
+
+  if (!key) {
+    return NextResponse.json({ error: "API key not found" }, { status: 404 });
+  }
+
+  return NextResponse.json({ key });
+}
+
+// PATCH /api/keys/[id] — Update allowedScopes on a key
+// Auth: ADMIN only
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  const auth = await requirePermission(request, [Permissions.ADMIN]);
+  if (!auth.success) {
+    return auth.response;
+  }
+
+  try {
+    const body = await request.json();
+    const { allowedScopes, permissions, name } = body;
+
+    const existing = await prisma.apiKey.findFirst({
+      where: { id, revokedAt: null },
+    });
+
+    if (!existing) {
+      return NextResponse.json({ error: "API key not found" }, { status: 404 });
+    }
+
+    const updateData: { allowedScopes?: string[]; permissions?: Permissions; name?: string } = {};
+
+    if (name !== undefined) {
+      if (typeof name !== "string" || !name.trim()) {
+        return NextResponse.json({ error: "name must be a non-empty string" }, { status: 400 });
+      }
+      if (name.length > 64) {
+        return NextResponse.json({ error: "name must be 64 characters or less" }, { status: 400 });
+      }
+      updateData.name = name.trim();
+    }
+
+    if (permissions !== undefined) {
+      if (!["READ", "WRITE", "ADMIN"].includes(permissions)) {
+        return NextResponse.json({ error: "permissions must be READ, WRITE, or ADMIN" }, { status: 400 });
+      }
+      updateData.permissions = permissions;
+    }
+
+    if (allowedScopes !== undefined) {
+      if (!Array.isArray(allowedScopes) || !(allowedScopes as unknown[]).every((s) => typeof s === "string")) {
+        return NextResponse.json({ error: "allowedScopes must be an array of strings" }, { status: 400 });
+      }
+      if (allowedScopes.length > 0) {
+        const validScopes = await prisma.restrictedScope.findMany({
+          where: { tag: { in: allowedScopes } },
+          select: { tag: true },
+        });
+        const validSet = new Set(validScopes.map((s) => s.tag));
+        const invalid = (allowedScopes as string[]).filter((s) => !validSet.has(s) && s !== "*");
+        if (invalid.length > 0) {
+          return NextResponse.json(
+            { error: `Unknown scope(s): ${invalid.join(", ")}. Valid scopes: ${validScopes.map((s) => s.tag).join(", ")}` },
+            { status: 400 }
+          );
+        }
+      }
+      updateData.allowedScopes = allowedScopes;
+    }
+
+    if (Object.keys(updateData).length === 0) {
+      return NextResponse.json({ error: "No valid fields to update" }, { status: 400 });
+    }
+
+    const updated = await prisma.apiKey.update({
+      where: { id },
+      data: updateData,
+      select: {
+        id: true,
+        name: true,
+        keyPrefix: true,
+        permissions: true,
+        allowedScopes: true,
+        lastUsedAt: true,
+        createdAt: true,
+      },
+    });
+
+    return NextResponse.json({ key: updated });
+  } catch (error) {
+    console.error("[Keys] PATCH error:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}
+
+// DELETE /api/keys/[id] — Revoke an API key
+// Auth: ADMIN only
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  const auth = await requirePermission(_request, [Permissions.ADMIN]);
+  if (!auth.success) {
+    return auth.response;
+  }
+
+  const existing = await prisma.apiKey.findFirst({
+    where: { id, revokedAt: null },
+  });
+
+  if (!existing) {
+    return NextResponse.json({ error: "API key not found" }, { status: 404 });
+  }
+
+  await prisma.apiKey.update({
+    where: { id },
+    data: { revokedAt: new Date() },
+  });
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/keys/[id]/route.ts
+++ b/src/app/api/keys/[id]/route.ts
@@ -79,8 +79,8 @@ export async function PATCH(
     }
 
     if (allowedScopes !== undefined) {
-      if (!Array.isArray(allowedScopes) || !(allowedScopes as unknown[]).every((s) => typeof s === "string")) {
-        return NextResponse.json({ error: "allowedScopes must be an array of strings" }, { status: 400 });
+      if (!Array.isArray(allowedScopes) || !(allowedScopes as unknown[]).every((s) => typeof s === "string" && s.length > 0)) {
+        return NextResponse.json({ error: "allowedScopes must be an array of non-empty strings" }, { status: 400 });
       }
       if (allowedScopes.length > 0) {
         const validScopes = await prisma.restrictedScope.findMany({

--- a/src/app/api/keys/route.ts
+++ b/src/app/api/keys/route.ts
@@ -1,0 +1,109 @@
+import { NextRequest, NextResponse } from "next/server";
+import { Permissions } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+import { requirePermission } from "@/lib/api/auth";
+import { generateApiKey } from "@/lib/api/keys";
+
+// GET /api/keys — List all API keys (metadata only)
+// Auth: ADMIN only
+export async function GET(_request: NextRequest) {
+  const auth = await requirePermission(_request, [Permissions.ADMIN]);
+  if (!auth.success) {
+    return auth.response;
+  }
+
+  const keys = await prisma.apiKey.findMany({
+    where: { revokedAt: null },
+    select: {
+      id: true,
+      name: true,
+      keyPrefix: true,
+      permissions: true,
+      allowedScopes: true,
+      lastUsedAt: true,
+      createdAt: true,
+    },
+    orderBy: { createdAt: "desc" },
+  });
+
+  return NextResponse.json({ keys });
+}
+
+// POST /api/keys — Create a new API key
+// Auth: ADMIN only
+export async function POST(request: NextRequest) {
+  const auth = await requirePermission(request, [Permissions.ADMIN]);
+  if (!auth.success) {
+    return auth.response;
+  }
+
+  try {
+    const { name, permissions, allowedScopes } = await request.json();
+
+    if (!name || typeof name !== "string" || !name.trim()) {
+      return NextResponse.json({ error: "name is required and must be a non-empty string" }, { status: 400 });
+    }
+    if (name.length > 64) {
+      return NextResponse.json({ error: "name must be 64 characters or less" }, { status: 400 });
+    }
+    if (!/^[a-zA-Z0-9-]+$/.test(name)) {
+      return NextResponse.json({ error: "name must be alphanumeric with hyphens only" }, { status: 400 });
+    }
+
+    if (permissions !== undefined) {
+      if (!["READ", "WRITE", "ADMIN"].includes(permissions)) {
+        return NextResponse.json({ error: "permissions must be READ, WRITE, or ADMIN" }, { status: 400 });
+      }
+    }
+
+    if (allowedScopes !== undefined) {
+      if (!Array.isArray(allowedScopes) || !(allowedScopes as unknown[]).every((s) => typeof s === "string")) {
+        return NextResponse.json({ error: "allowedScopes must be an array of strings" }, { status: 400 });
+      }
+      // Validate all scopes exist
+      if (allowedScopes.length > 0) {
+        const validScopes = await prisma.restrictedScope.findMany({
+          where: { tag: { in: allowedScopes } },
+          select: { tag: true },
+        });
+        const validSet = new Set(validScopes.map((s) => s.tag));
+        const invalid = (allowedScopes as string[]).filter((s) => !validSet.has(s) && s !== "*");
+        if (invalid.length > 0) {
+          return NextResponse.json(
+            { error: `Unknown scope(s): ${invalid.join(", ")}. Valid scopes: ${validScopes.map((s) => s.tag).join(", ")}` },
+            { status: 400 }
+          );
+        }
+      }
+    }
+
+    const { raw, hash, prefix } = generateApiKey(name);
+
+    const key = await prisma.apiKey.create({
+      data: {
+        name: name.trim(),
+        keyHash: hash,
+        keyPrefix: prefix,
+        permissions: (permissions as Permissions) ?? Permissions.WRITE,
+        allowedScopes: allowedScopes ?? [],
+      },
+      select: {
+        id: true,
+        name: true,
+        keyPrefix: true,
+        permissions: true,
+        allowedScopes: true,
+        createdAt: true,
+      },
+    });
+
+    // Return raw key ONCE — it cannot be recovered
+    return NextResponse.json(
+      { ...key, key: raw },
+      { status: 201 }
+    );
+  } catch (error) {
+    console.error("[Keys] POST error:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/app/api/keys/route.ts
+++ b/src/app/api/keys/route.ts
@@ -57,8 +57,8 @@ export async function POST(request: NextRequest) {
     }
 
     if (allowedScopes !== undefined) {
-      if (!Array.isArray(allowedScopes) || !(allowedScopes as unknown[]).every((s) => typeof s === "string")) {
-        return NextResponse.json({ error: "allowedScopes must be an array of strings" }, { status: 400 });
+      if (!Array.isArray(allowedScopes) || !(allowedScopes as unknown[]).every((s) => typeof s === "string" && s.length > 0)) {
+        return NextResponse.json({ error: "allowedScopes must be an array of non-empty strings" }, { status: 400 });
       }
       // Validate all scopes exist
       if (allowedScopes.length > 0) {

--- a/src/app/api/lint/route.ts
+++ b/src/app/api/lint/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { requireApiKey } from "@/lib/api/keys";
+import { buildScopeFilter } from "@/lib/api/auth";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 
@@ -53,6 +54,12 @@ export async function POST(request: NextRequest) {
     }
   }
 
+  // Determine effective scopes for lint filtering
+  const allowedScopes = apiAuth.authorized
+    ? apiAuth.allowedScopes
+    : ["*"]; // Sessions get full access
+  const scopeWhere = buildScopeFilter(allowedScopes, { deletedAt: null });
+
   // --- Parse options ---
   let body: { staleDays?: number; tagMin?: number; maxArticles?: unknown } = {};
   try {
@@ -73,7 +80,7 @@ export async function POST(request: NextRequest) {
 
   // ── Fetch non-deleted articles (capped for performance) ──
   const articles = await prisma.article.findMany({
-    where: { deletedAt: null },
+    where: scopeWhere,
     take: maxArticles,
     orderBy: [{ updatedAt: "desc" }, { id: "asc" }],
     select: {

--- a/src/app/api/memory/get/route.ts
+++ b/src/app/api/memory/get/route.ts
@@ -21,7 +21,9 @@ export async function POST(request: NextRequest) {
   }
 
   try {
-    const result = await executeMemoryGetRequest(body);
+    const result = await executeMemoryGetRequest(body, {
+      allowedScopes: auth.auth.allowedScopes,
+    });
     return NextResponse.json(result.body, { status: result.status });
   } catch (error) {
     console.error("[POST /api/memory/get]", error);

--- a/src/app/api/memory/recall/route.ts
+++ b/src/app/api/memory/recall/route.ts
@@ -21,7 +21,9 @@ export async function POST(request: NextRequest) {
   }
 
   try {
-    const result = await executeMemoryRecallRequest(body);
+    const result = await executeMemoryRecallRequest(body, {
+      allowedScopes: auth.auth.allowedScopes,
+    });
     return NextResponse.json(result.body, { status: result.status });
   } catch (error) {
     console.error("[POST /api/memory/recall]", error);

--- a/src/app/api/scopes/route.ts
+++ b/src/app/api/scopes/route.ts
@@ -5,7 +5,12 @@ import { requirePermission } from "@/lib/api/auth";
 
 // GET /api/scopes — List all available restricted scopes
 // Auth: Any valid API key (READ minimum)
-export async function GET(_request: NextRequest) {
+export async function GET(request: NextRequest) {
+  const auth = await requirePermission(request, [Permissions.READ]);
+  if (!auth.success) {
+    return auth.response;
+  }
+
   const scopes = await prisma.restrictedScope.findMany({
     orderBy: [{ isSystem: "desc" }, { tag: "asc" }],
     select: { tag: true, description: true, isSystem: true, createdAt: true },

--- a/src/app/api/scopes/route.ts
+++ b/src/app/api/scopes/route.ts
@@ -1,0 +1,60 @@
+import { NextRequest, NextResponse } from "next/server";
+import { Permissions } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+import { requirePermission } from "@/lib/api/auth";
+
+// GET /api/scopes — List all available restricted scopes
+// Auth: Any valid API key (READ minimum)
+export async function GET(_request: NextRequest) {
+  const scopes = await prisma.restrictedScope.findMany({
+    orderBy: [{ isSystem: "desc" }, { tag: "asc" }],
+    select: { tag: true, description: true, isSystem: true, createdAt: true },
+  });
+
+  return NextResponse.json({ scopes });
+}
+
+// POST /api/scopes — Register a new custom scope
+// Auth: ADMIN only
+export async function POST(request: NextRequest) {
+  const auth = await requirePermission(request, [Permissions.ADMIN]);
+  if (!auth.success) {
+    return auth.response;
+  }
+
+  try {
+    const { tag, description } = await request.json();
+
+    if (!tag || typeof tag !== "string") {
+      return NextResponse.json({ error: "tag is required and must be a string" }, { status: 400 });
+    }
+
+    // Validate tag format: lowercase alphanumeric + hyphen only
+    if (!/^[a-z0-9-]+$/.test(tag)) {
+      return NextResponse.json(
+        { error: "tag must be lowercase alphanumeric with hyphens only (e.g. 'company-x')" },
+        { status: 400 }
+      );
+    }
+
+    if (description !== undefined && typeof description !== "string") {
+      return NextResponse.json({ error: "description must be a string" }, { status: 400 });
+    }
+
+    // Check tag doesn't already exist
+    const existing = await prisma.restrictedScope.findUnique({ where: { tag } });
+    if (existing) {
+      return NextResponse.json({ error: `Scope '${tag}' already exists` }, { status: 409 });
+    }
+
+    const scope = await prisma.restrictedScope.create({
+      data: { tag, description: description ?? null, isSystem: false },
+      select: { tag: true, description: true, isSystem: true, createdAt: true },
+    });
+
+    return NextResponse.json(scope, { status: 201 });
+  } catch (error) {
+    console.error("[Scopes] POST error:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/lib/api/auth.ts
+++ b/src/lib/api/auth.ts
@@ -150,20 +150,20 @@ export function buildScopeFilter(
   allowedScopes: string[] | undefined,
   extraWhere: Record<string, unknown> = {}
 ): Record<string, unknown> {
-  // If scopes include "*", grant admin access to all restricted content
-  const hasAdmin = allowedScopes?.includes("*");
+  // If scopes include "*", grant admin access — no scope restriction at all
+  if (allowedScopes?.includes("*")) {
+    return extraWhere;
+  }
 
-  if (hasAdmin || !allowedScopes || allowedScopes.length === 0) {
-    // Admin or no scopes: can only access unrestricted articles
+  // No scopes at all (undefined or empty): can only access unrestricted articles
+  if (!allowedScopes || allowedScopes.length === 0) {
     return {
       ...extraWhere,
-      OR: allowedScopes
-        ? [{ restrictedTags: { isEmpty: true } }]
-        : [],
+      restrictedTags: { isEmpty: true },
     };
   }
 
-  // Non-admin key: can access unrestricted articles OR articles with at least one matching scope
+  // Non-admin key with scopes: unrestricted OR at least one matching scope
   return {
     ...extraWhere,
     OR: [

--- a/src/lib/api/auth.ts
+++ b/src/lib/api/auth.ts
@@ -8,6 +8,9 @@ export interface AuthResult {
   authorized: boolean;
   permissions?: Permissions;
   keyId?: string;
+  /** Scopes this key is allowed to access. Empty = only unrestricted articles.
+   *  Sessions always get ["*"] (full access). */
+  allowedScopes?: string[];
   role?: Role;
   userId?: string;
   name?: string;
@@ -26,6 +29,7 @@ export async function checkRouteAuth(
       authorized: true,
       permissions: apiAuth.permissions,
       keyId: apiAuth.keyId,
+      allowedScopes: apiAuth.allowedScopes,
     };
   }
 
@@ -35,11 +39,13 @@ export async function checkRouteAuth(
     if (!session?.user) {
       return { authorized: false };
     }
+    // Sessions (humans) have full access to all content including restricted
     return {
       authorized: true,
       role: session.user.role,
       userId: session.user.id,
       name: session.user.name ?? undefined,
+      allowedScopes: ["*"], // Human sessions bypass all scope restrictions
     };
   } catch (error) {
     console.error(
@@ -130,4 +136,56 @@ export async function requirePermission(
   }
 
   return { success: true, auth };
+}
+
+/**
+ * Build a Prisma WHERE clause that filters articles based on key scopes.
+ * Articles with no restrictedTags are always accessible.
+ * Articles with restrictedTags require at least one matching scope.
+ *
+ * @param allowedScopes - The scopes available to the current key (from AuthResult)
+ * @param extraWhere - Additional Prisma filters to AND with the scope filter
+ */
+export function buildScopeFilter(
+  allowedScopes: string[] | undefined,
+  extraWhere: Record<string, unknown> = {}
+): Record<string, unknown> {
+  // If scopes include "*", grant admin access to all restricted content
+  const hasAdmin = allowedScopes?.includes("*");
+
+  if (hasAdmin || !allowedScopes || allowedScopes.length === 0) {
+    // Admin or no scopes: can only access unrestricted articles
+    return {
+      ...extraWhere,
+      OR: allowedScopes
+        ? [{ restrictedTags: { isEmpty: true } }]
+        : [],
+    };
+  }
+
+  // Non-admin key: can access unrestricted articles OR articles with at least one matching scope
+  return {
+    ...extraWhere,
+    OR: [
+      { restrictedTags: { isEmpty: true } },
+      { restrictedTags: { hasSome: allowedScopes } },
+    ],
+  };
+}
+
+/**
+ * Check whether the current auth context grants access to a given article's restricted scopes.
+ * Returns true if the article is unrestricted OR has at least one matching scope.
+ *
+ * @param articleScopes - restrictedTags from the article
+ * @param allowedScopes - scopes from AuthResult
+ */
+export function canAccessScopes(
+  articleScopes: string[],
+  allowedScopes: string[] | undefined
+): boolean {
+  if (articleScopes.length === 0) return true; // unrestricted
+  if (allowedScopes?.includes("*")) return true; // admin bypass
+  if (!allowedScopes || allowedScopes.length === 0) return false; // no scope access
+  return articleScopes.some((s) => allowedScopes.includes(s));
 }

--- a/src/lib/api/keys.ts
+++ b/src/lib/api/keys.ts
@@ -41,7 +41,10 @@ export function generateApiKey(_name: string): {
  */
 export async function validateApiKey(
   rawKey: string
-): Promise<{ valid: true; permissions: Permissions; keyId: string } | { valid: false }> {
+): Promise<
+  | { valid: true; permissions: Permissions; keyId: string; allowedScopes: string[] }
+  | { valid: false }
+> {
   const prefix = rawKey.slice(0, KEY_PREFIX_LENGTH);
   const hash = hashApiKey(rawKey);
 
@@ -68,7 +71,12 @@ export async function validateApiKey(
     data: { lastUsedAt: now },
   });
 
-  return { valid: true, permissions: record.permissions, keyId: record.id };
+  return {
+    valid: true,
+    permissions: record.permissions,
+    keyId: record.id,
+    allowedScopes: record.allowedScopes,
+  };
 }
 
 /**
@@ -80,7 +88,10 @@ export async function validateApiKey(
  */
 export async function requireApiKey(
   request: Request
-): Promise<{ authorized: true; permissions: Permissions; keyId: string } | { authorized: false }> {
+): Promise<
+  | { authorized: true; permissions: Permissions; keyId: string; allowedScopes: string[] }
+  | { authorized: false }
+> {
   const authHeader = request.headers.get("Authorization");
   if (!authHeader?.startsWith("Bearer ")) {
     return { authorized: false };
@@ -93,5 +104,10 @@ export async function requireApiKey(
 
   const result = await validateApiKey(rawKey);
   if (!result.valid) return { authorized: false };
-  return { authorized: true, permissions: result.permissions, keyId: result.keyId };
+  return {
+    authorized: true,
+    permissions: result.permissions,
+    keyId: result.keyId,
+    allowedScopes: result.allowedScopes,
+  };
 }

--- a/src/lib/memory/api/get.ts
+++ b/src/lib/memory/api/get.ts
@@ -39,6 +39,8 @@ export interface MemoryGetExecutionOptions {
   providers?: MemoryProvider[];
   providerOptions?: MemoryProviderGetOptions;
   timeoutMs?: number;
+  /** Scopes for restricted-article filtering in the noosphere provider. */
+  allowedScopes?: string[];
 }
 
 export type MemoryGetValidationResult =
@@ -56,11 +58,11 @@ export type MemoryGetValidationResult =
       error: string;
     };
 
-export async function getDefaultMemoryGetProviders(): Promise<
-  MemoryProvider[]
-> {
+export async function getDefaultMemoryGetProviders(
+  allowedScopes?: string[],
+): Promise<MemoryProvider[]> {
   const { createNoosphereProvider } = await import("@/lib/memory/noosphere");
-  return [createNoosphereProvider()];
+  return [createNoosphereProvider({ allowedScopes })];
 }
 
 export function validateMemoryGetRequest(
@@ -120,7 +122,8 @@ export async function executeMemoryGetRequest(
     return { status: validation.status, body: { error: validation.error } };
   }
 
-  const providers = options.providers ?? (await getDefaultMemoryGetProviders());
+  const providers =
+    options.providers ?? (await getDefaultMemoryGetProviders(options.allowedScopes));
   const provider = providers.find(
     (entry) => entry.descriptor.id === validation.request.provider,
   );

--- a/src/lib/memory/api/recall.ts
+++ b/src/lib/memory/api/recall.ts
@@ -49,6 +49,8 @@ export interface MemoryRecallExecutionOptions {
   providers?: RecallOrchestratorProviderEntry[];
   settings?: Partial<RecallSettings>;
   timeoutMs?: number;
+  /** Scopes for restricted-article filtering in the noosphere provider. */
+  allowedScopes?: string[];
 }
 
 export type MemoryRecallValidationResult =
@@ -65,9 +67,11 @@ export type MemoryRecallValidationResult =
       error: string;
     };
 
-export async function getDefaultMemoryRecallProviders(): Promise<RecallOrchestratorProviderEntry[]> {
+export async function getDefaultMemoryRecallProviders(
+  allowedScopes?: string[],
+): Promise<RecallOrchestratorProviderEntry[]> {
   const { createNoosphereProvider } = await import("@/lib/memory/noosphere");
-  return [{ provider: createNoosphereProvider() }];
+  return [{ provider: createNoosphereProvider({ allowedScopes }) }];
 }
 
 export function validateMemoryRecallRequest(input: unknown): MemoryRecallValidationResult {
@@ -149,7 +153,8 @@ export async function executeMemoryRecallRequest(
   }
 
   const settings = normalizeRecallSettings(options.settings);
-  const providerEntries = options.providers ?? await getDefaultMemoryRecallProviders();
+  const providerEntries =
+    options.providers ?? await getDefaultMemoryRecallProviders(options.allowedScopes);
   const requestedProviders =
     validation.request.providers ??
     (validation.request.mode === "auto"

--- a/src/lib/memory/article-search.ts
+++ b/src/lib/memory/article-search.ts
@@ -19,6 +19,8 @@ export interface ArticleSearchFilters {
   tagSlug?: string;
   status?: string;
   confidence?: string;
+  /** Scopes to filter restricted articles. Unrestricted articles are always included. */
+  allowedScopes?: string[];
 }
 
 // ─── Filter builder ──────────────────────────────────────────────────────────
@@ -51,6 +53,20 @@ export function buildArticleSearchFilters(
   }
   if (options.confidence) {
     clauses.push(Prisma.sql`a.confidence = ${options.confidence}`);
+  }
+
+  // Apply restricted-tag scope filtering
+  if (options.allowedScopes !== undefined) {
+    if (options.allowedScopes.length === 0) {
+      // No scopes — only unrestricted articles
+      clauses.push(Prisma.sql`coalesce(a."restrictedTags", '{}') = '{}'`);
+    } else if (!options.allowedScopes.includes("*")) {
+      // Non-admin: must have at least one matching scope
+      clauses.push(
+        Prisma.sql`(coalesce(a."restrictedTags", '{}') = '{}' OR a."restrictedTags" && ${options.allowedScopes})`,
+      );
+    }
+    // If "*" is in allowedScopes, skip scope filter (admin can see all restricted articles)
   }
 
   return clauses;

--- a/src/lib/memory/noosphere.ts
+++ b/src/lib/memory/noosphere.ts
@@ -86,6 +86,25 @@ export class NoosphereProvider implements MemoryProvider {
     };
   }
 
+  /**
+   * Build a Prisma scope-filter fragment for article queries.
+   * Returns undefined if admin (*) — meaning no filter needed.
+   */
+  private buildScopeWhere(): Record<string, unknown> | undefined {
+    if (this.allowedScopes?.includes("*")) {
+      return undefined; // admin: no filter
+    }
+    if (!this.allowedScopes || this.allowedScopes.length === 0) {
+      return { restrictedTags: { isEmpty: true } }; // no scopes: unrestricted only
+    }
+    return {
+      OR: [
+        { restrictedTags: { isEmpty: true } },
+        { restrictedTags: { hasSome: this.allowedScopes } },
+      ],
+    };
+  }
+
   async search(
     query: string,
     options: MemoryProviderSearchOptions = {},
@@ -131,10 +150,12 @@ export class NoosphereProvider implements MemoryProvider {
     }
 
     const articleId = parseNoosphereArticleId(id);
+    const scopeWhere = this.buildScopeWhere();
     const article = await this.prisma.article.findFirst({
       where: {
         id: articleId,
         deletedAt: null,
+        ...(scopeWhere ?? {}),
       },
       include: {
         topic: true,

--- a/src/lib/memory/noosphere.ts
+++ b/src/lib/memory/noosphere.ts
@@ -30,6 +30,9 @@ export interface NoosphereProviderSettings {
 
   /** Base provider config consumed by orchestrators. */
   providerConfig?: Partial<MemoryProviderConfig>;
+
+  /** Scopes for restricted-article filtering. */
+  allowedScopes?: string[];
 }
 
 export interface NoosphereSearchOptionsMetadata extends MemoryProviderMetadata {
@@ -66,9 +69,11 @@ export class NoosphereProvider implements MemoryProvider {
   readonly descriptor: MemoryProviderDescriptor;
 
   private readonly prisma: PrismaClient;
+  private readonly allowedScopes?: string[];
 
   constructor(settings: NoosphereProviderSettings = {}) {
     this.prisma = settings.prisma ?? defaultPrisma;
+    this.allowedScopes = settings.allowedScopes;
 
     this.descriptor = {
       ...NOOSPHERE_PROVIDER_DESCRIPTOR,
@@ -107,6 +112,7 @@ export class NoosphereProvider implements MemoryProvider {
       tagSlug: metadata.tagSlug,
       status: metadata.status,
       confidence: metadata.confidence,
+      allowedScopes: this.allowedScopes,
     });
 
     return articles;
@@ -204,6 +210,7 @@ export class NoosphereProvider implements MemoryProvider {
       confidence?: string;
       limit?: number;
       offset: number;
+      allowedScopes?: string[];
     },
   ): Promise<MemoryResult[]> {
     const filters = buildArticleSearchFilters(options);

--- a/src/lib/wiki.ts
+++ b/src/lib/wiki.ts
@@ -50,6 +50,8 @@ export async function buildTagConnections(tagNames: string[]) {
 export interface SearchArticlesOptions extends ArticleSearchFilters {
   limit?: number;
   offset?: number;
+  /** Scopes for restricted-article filtering. */
+  allowedScopes?: string[];
 }
 
 // Use PostgreSQL full-text search so article search ranks meaningful matches
@@ -67,7 +69,13 @@ export async function searchArticleIds(
 
   const limit = options.limit ?? 50;
   const offset = options.offset ?? 0;
-  const filters = buildArticleSearchFilters(options);
+  const filters = buildArticleSearchFilters({
+    topicSlug: options.topicSlug,
+    tagSlug: options.tagSlug,
+    status: options.status,
+    confidence: options.confidence,
+    allowedScopes: options.allowedScopes,
+  });
   const cte = buildSearchableCTE(filters);
   const tsQuery = buildSearchTsQuery(query);
 
@@ -93,7 +101,13 @@ export async function countSearchArticles(
   const query = rawQuery.trim();
   if (!query) return 0;
 
-  const filters = buildArticleSearchFilters(options);
+  const filters = buildArticleSearchFilters({
+    topicSlug: options.topicSlug,
+    tagSlug: options.tagSlug,
+    status: options.status,
+    confidence: options.confidence,
+    allowedScopes: options.allowedScopes,
+  });
   const cte = buildSearchableCTE(filters);
   const tsQuery = buildSearchTsQuery(query);
 


### PR DESCRIPTION
## Restricted Tags — Per-Article Access Control

Implements the access control system from `docs/RESTRICTED-TAGS-SPEC.md`.

### What this does

Every article can now carry **restricted tags** (e.g. `health`, `intimate`, `company-x`). An API key can be granted **allowed scopes**. An article is only accessible if at least one of its restricted tags matches a scope on the key.

Unrestricted articles (`restrictedTags: []`) remain visible to all keys — fully backward compatible.

### Schema changes

| Model | Change |
|---|---|
| `Article` | + `restrictedTags String[]` |
| `ApiKey` | + `allowedScopes String[]` |
| `RestrictedScope` | new — registry of valid scope tags |

Seeded system scopes: `health`, `intimate`, `identity`, `financial`, `social`

### New API routes

| Route | Auth | Description |
|---|---|---|
| `GET /api/scopes` | any key | List all available scope tags |
| `POST /api/scopes` | ADMIN | Create a custom scope |
| `GET /api/keys` | ADMIN | List all API keys (metadata only) |
| `POST /api/keys` | ADMIN | Create a new API key |
| `GET /api/keys/:id` | ADMIN | Get single key metadata |
| `PATCH /api/keys/:id` | ADMIN | Update key name, permissions, scopes |
| `DELETE /api/keys/:id` | ADMIN | Revoke a key |

### Modified routes

- `GET /api/articles` — filtered by key scopes (restricted articles without matching scope return 404)
- `POST /api/articles` — `restrictedTags` field accepted; validated against RestrictedScope registry
- `PATCH /api/articles/:id` — `restrictedTags` field updatable
- `DELETE /api/articles/:id` — 404 if no scope access
- `POST /api/memory/recall` — restricted articles filtered by key scopes

### Access rule

```
article.restrictedTags = []         → accessible to ALL keys
article.restrictedTags = ["health"] → only keys where allowedScopes includes "health"
No match                                → 404 (article invisible, not just forbidden)
```

### Phase 2 (follow-up PR)

GUI admin panel for managing keys and scopes in the web UI.

### Phase 3 (follow-up)

OpenCode CLI integration, CLI key management commands, activity log entries for scope changes.

## Summary by Sourcery

Introduce per-article restricted tag access control enforced by API key scopes across articles and memory recall, plus admin APIs for managing scopes and API keys.

New Features:
- Add restricted tag support on articles and allowed scope lists on API keys to control which keys can access restricted content.
- Expose new admin APIs to list, create, update, and revoke API keys, including their allowed scopes.
- Expose APIs to list and register restricted scopes used for tagging sensitive articles.

Enhancements:
- Propagate scope-based filtering through article listing, article mutation, and memory recall search so restricted articles are only visible to keys with matching scopes.
- Treat human session users as having full (“*”) scope access while enforcing fine-grained scope checks for API keys.
- Validate restrictedTags and allowedScopes against a RestrictedScope registry when creating or updating articles and API keys.