### PR TITLE
feat(hermes): add Noosphere memory provider skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@
 
 # testing
 /coverage
+__pycache__/
+*.py[cod]
 
 # next.js
 /.next/

--- a/hermes-noosphere-memory/README.md
+++ b/hermes-noosphere-memory/README.md
@@ -1,0 +1,74 @@
+# Noosphere Memory Provider for Hermes Agent
+
+This package contains the Hermes Agent memory-provider integration for Noosphere.
+
+Current implementation status: Phase 1 skeleton and configuration lifecycle.
+
+## Layout
+
+```text
+plugins/memory/noosphere/
+  __init__.py
+  plugin.yaml
+  README.md
+tests/
+  test_noosphere_provider_phase1.py
+```
+
+## Phase 1 Scope
+
+Implemented:
+
+- Hermes `MemoryProvider` registration entry point
+- `hermes memory setup` config schema
+- profile-scoped `$HERMES_HOME/noosphere.json` config persistence
+- environment-based secret lookup through `NOOSPHERE_API_KEY`
+- safe initialization without network calls
+
+Not implemented yet:
+
+- Noosphere HTTP client
+- explicit recall/save/status tools
+- automatic recall
+- explicit memory write mirroring
+- installer script
+
+Those are intentionally left for later PRs so each step stays reviewable.
+
+## Manual Install During Development
+
+```bash
+mkdir -p "$HERMES_HOME/plugins/memory"
+cp -R hermes-noosphere-memory/plugins/memory/noosphere "$HERMES_HOME/plugins/memory/noosphere"
+hermes memory setup
+```
+
+Manual fallback:
+
+```bash
+hermes config set memory.provider noosphere
+printf '%s\n' 'NOOSPHERE_API_KEY=noo_...' >> "$HERMES_HOME/.env"
+cat > "$HERMES_HOME/noosphere.json" <<'JSON'
+{
+  "base_url": "http://127.0.0.1:6578",
+  "auto_recall": true,
+  "auto_capture": false,
+  "capture_mode": "explicit",
+  "max_recall_results": 5,
+  "token_budget": 1200,
+  "providers": ["noosphere"],
+  "topic_id": "",
+  "author_name_template": "Hermes:{identity}",
+  "api_timeout": 5.0
+}
+JSON
+```
+
+Do not commit real API keys.
+
+## Verification
+
+```bash
+python3 -m unittest discover -s hermes-noosphere-memory/tests
+python3 -m compileall hermes-noosphere-memory/plugins/memory/noosphere
+```

--- a/hermes-noosphere-memory/plugins/memory/noosphere/README.md
+++ b/hermes-noosphere-memory/plugins/memory/noosphere/README.md
@@ -1,0 +1,74 @@
+# Noosphere Memory Provider
+
+Noosphere gives Hermes Agent access to durable, scoped, human-readable memory.
+
+This provider is currently in Phase 1:
+
+- it registers with Hermes as a memory provider
+- it exposes setup fields for the Noosphere API key and base URL
+- it stores non-secret configuration in `$HERMES_HOME/noosphere.json`
+- it reads the secret API key from `NOOSPHERE_API_KEY`
+
+Recall and save tools are intentionally added in later phases.
+
+## Setup
+
+```bash
+hermes memory setup
+```
+
+Select `noosphere`, then provide:
+
+- Noosphere API key from `/wiki/admin/keys`
+- Noosphere base URL, for example `http://127.0.0.1:6578`
+
+Manual setup:
+
+```bash
+hermes config set memory.provider noosphere
+printf '%s\n' 'NOOSPHERE_API_KEY=noo_...' >> "$HERMES_HOME/.env"
+cat > "$HERMES_HOME/noosphere.json" <<'JSON'
+{
+  "base_url": "http://127.0.0.1:6578",
+  "auto_recall": true,
+  "auto_capture": false,
+  "capture_mode": "explicit",
+  "max_recall_results": 5,
+  "token_budget": 1200,
+  "providers": ["noosphere"],
+  "topic_id": "",
+  "author_name_template": "Hermes:{identity}",
+  "api_timeout": 5.0
+}
+JSON
+```
+
+## Config
+
+Config file: `$HERMES_HOME/noosphere.json`
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `base_url` | `http://127.0.0.1:6578` | Noosphere deployment URL. |
+| `auto_recall` | `true` | Enable prompt-time recall once Phase 3 lands. |
+| `auto_capture` | `false` | Keep broad turn capture disabled by default. |
+| `capture_mode` | `explicit` | Capture policy. Phase 1 stores only config. |
+| `max_recall_results` | `5` | Future recall result cap. |
+| `token_budget` | `1200` | Future recall token budget. |
+| `providers` | `["noosphere"]` | Noosphere recall providers to query. |
+| `topic_id` | `""` | Default save topic for later write phases. |
+| `author_name_template` | `Hermes:{identity}` | Future author name template. |
+| `api_timeout` | `5.0` | Future HTTP timeout in seconds. |
+
+Secrets:
+
+| Variable | Description |
+| --- | --- |
+| `NOOSPHERE_API_KEY` | Required Noosphere API key. |
+| `NOOSPHERE_BASE_URL` | Optional environment override for `base_url`. |
+
+## Safety
+
+`is_available()` checks only local environment. It does not make network calls during Hermes startup.
+
+Writes are disabled during `cron`, `flush`, and `subagent` contexts.

--- a/hermes-noosphere-memory/plugins/memory/noosphere/__init__.py
+++ b/hermes-noosphere-memory/plugins/memory/noosphere/__init__.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import tempfile
 from pathlib import Path
 from typing import Any, Dict, List
 
@@ -31,10 +32,17 @@ _DEFAULT_CONFIG: Dict[str, Any] = {
     "api_timeout": 5.0,
 }
 _NON_WRITING_CONTEXTS = {"cron", "flush", "subagent"}
+_SECRET_CONFIG_KEYS = {"api_key"}
 
 
 def _config_path(hermes_home: str) -> Path:
     return Path(hermes_home).expanduser() / _CONFIG_FILENAME
+
+
+def _setup_key_url() -> str:
+    base_url = os.environ.get("NOOSPHERE_BASE_URL", _DEFAULT_CONFIG["base_url"])
+    base_url = _as_string(base_url, _DEFAULT_CONFIG["base_url"]).rstrip("/")
+    return f"{base_url}/wiki/admin/keys"
 
 
 def _as_bool(value: Any, default: bool) -> bool:
@@ -147,15 +155,39 @@ def _save_noosphere_config(values: Dict[str, Any], hermes_home: str) -> None:
             if isinstance(raw, dict):
                 existing = raw
         except Exception:
+            logger.warning(
+                "Failed to parse existing Noosphere config at %s; ignoring",
+                path,
+                exc_info=True,
+            )
             existing = {}
 
     sanitized_values = dict(values or {})
-    sanitized_values.pop("api_key", None)
+    for key in _SECRET_CONFIG_KEYS:
+        existing.pop(key, None)
+        sanitized_values.pop(key, None)
     existing.update(sanitized_values)
     config = _sanitize_config(existing)
 
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(config, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=path.parent)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as tmp:
+            json.dump(config, tmp, indent=2, sort_keys=True)
+            tmp.write("\n")
+            tmp.flush()
+            os.fsync(tmp.fileno())
+        try:
+            os.chmod(tmp_name, 0o600)
+        except OSError:
+            logger.debug("Could not chmod temporary config %s", tmp_name, exc_info=True)
+        os.replace(tmp_name, path)
+    finally:
+        try:
+            if os.path.exists(tmp_name):
+                os.unlink(tmp_name)
+        except OSError:
+            logger.debug("Could not remove temporary config %s", tmp_name, exc_info=True)
     try:
         path.chmod(0o600)
     except OSError:
@@ -189,7 +221,7 @@ class NoosphereMemoryProvider(MemoryProvider):
                 "secret": True,
                 "required": True,
                 "env_var": "NOOSPHERE_API_KEY",
-                "url": "http://127.0.0.1:6578/wiki/admin/keys",
+                "url": _setup_key_url(),
             },
             {
                 "key": "base_url",
@@ -204,7 +236,11 @@ class NoosphereMemoryProvider(MemoryProvider):
 
     def initialize(self, session_id: str, **kwargs: Any) -> None:
         self._session_id = session_id
-        self._hermes_home = kwargs.get("hermes_home") or str(Path.home() / ".hermes")
+        self._hermes_home = (
+            kwargs.get("hermes_home")
+            or os.environ.get("HERMES_HOME")
+            or str(Path.home() / ".hermes")
+        )
         self._platform = _as_string(kwargs.get("platform"))
         self._agent_identity = _as_string(kwargs.get("agent_identity"), "default") or "default"
         self._agent_context = _as_string(kwargs.get("agent_context"))
@@ -232,6 +268,7 @@ class NoosphereMemoryProvider(MemoryProvider):
         return []
 
     def handle_tool_call(self, tool_name: str, args: Dict[str, Any], **kwargs: Any) -> str:
+        logger.warning("Noosphere memory tool called before Phase 2 implementation: %s", tool_name)
         return json.dumps(
             {
                 "error": "Noosphere memory tools are not implemented in Phase 1.",

--- a/hermes-noosphere-memory/plugins/memory/noosphere/__init__.py
+++ b/hermes-noosphere-memory/plugins/memory/noosphere/__init__.py
@@ -1,0 +1,249 @@
+"""Noosphere memory provider for Hermes Agent.
+
+Phase 1 implements provider discovery, setup schema, config persistence, and
+safe lifecycle initialization. HTTP tools and recall hooks are added in later
+phases.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any, Dict, List
+
+from agent.memory_provider import MemoryProvider
+
+logger = logging.getLogger(__name__)
+
+_CONFIG_FILENAME = "noosphere.json"
+_DEFAULT_CONFIG: Dict[str, Any] = {
+    "base_url": "http://127.0.0.1:6578",
+    "auto_recall": True,
+    "auto_capture": False,
+    "capture_mode": "explicit",
+    "max_recall_results": 5,
+    "token_budget": 1200,
+    "providers": ["noosphere"],
+    "topic_id": "",
+    "author_name_template": "Hermes:{identity}",
+    "api_timeout": 5.0,
+}
+_NON_WRITING_CONTEXTS = {"cron", "flush", "subagent"}
+
+
+def _config_path(hermes_home: str) -> Path:
+    return Path(hermes_home).expanduser() / _CONFIG_FILENAME
+
+
+def _as_bool(value: Any, default: bool) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"true", "1", "yes", "y", "on"}:
+            return True
+        if lowered in {"false", "0", "no", "n", "off"}:
+            return False
+    return default
+
+
+def _as_int(value: Any, default: int, *, minimum: int, maximum: int) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return max(minimum, min(maximum, parsed))
+
+
+def _as_float(value: Any, default: float, *, minimum: float, maximum: float) -> float:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return default
+    return max(minimum, min(maximum, parsed))
+
+
+def _as_string(value: Any, default: str = "") -> str:
+    if value is None:
+        return default
+    return str(value).strip()
+
+
+def _as_provider_list(value: Any) -> List[str]:
+    if not isinstance(value, list):
+        return list(_DEFAULT_CONFIG["providers"])
+    providers = []
+    for item in value:
+        provider = _as_string(item)
+        if provider and provider not in providers:
+            providers.append(provider)
+    return providers or list(_DEFAULT_CONFIG["providers"])
+
+
+def _sanitize_config(raw: Dict[str, Any]) -> Dict[str, Any]:
+    """Normalize config loaded from Hermes setup or noosphere.json."""
+
+    config = dict(_DEFAULT_CONFIG)
+    config.update({key: value for key, value in raw.items() if value is not None})
+
+    base_url = _as_string(config.get("base_url"), _DEFAULT_CONFIG["base_url"]).rstrip("/")
+    config["base_url"] = base_url or _DEFAULT_CONFIG["base_url"]
+    config["auto_recall"] = _as_bool(config.get("auto_recall"), True)
+    config["auto_capture"] = _as_bool(config.get("auto_capture"), False)
+
+    capture_mode = _as_string(config.get("capture_mode"), "explicit").lower()
+    config["capture_mode"] = capture_mode if capture_mode in {"explicit", "all"} else "explicit"
+
+    config["max_recall_results"] = _as_int(
+        config.get("max_recall_results"),
+        int(_DEFAULT_CONFIG["max_recall_results"]),
+        minimum=1,
+        maximum=20,
+    )
+    config["token_budget"] = _as_int(
+        config.get("token_budget"),
+        int(_DEFAULT_CONFIG["token_budget"]),
+        minimum=100,
+        maximum=8000,
+    )
+    config["providers"] = _as_provider_list(config.get("providers"))
+    config["topic_id"] = _as_string(config.get("topic_id"))
+    config["author_name_template"] = _as_string(
+        config.get("author_name_template"),
+        _DEFAULT_CONFIG["author_name_template"],
+    )
+    config["api_timeout"] = _as_float(
+        config.get("api_timeout"),
+        float(_DEFAULT_CONFIG["api_timeout"]),
+        minimum=0.5,
+        maximum=30.0,
+    )
+    return config
+
+
+def _load_noosphere_config(hermes_home: str) -> Dict[str, Any]:
+    path = _config_path(hermes_home)
+    if not path.exists():
+        return dict(_DEFAULT_CONFIG)
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        logger.warning("Failed to parse %s; using defaults", path, exc_info=True)
+        return dict(_DEFAULT_CONFIG)
+    if not isinstance(raw, dict):
+        logger.warning("Ignoring non-object Noosphere config at %s", path)
+        return dict(_DEFAULT_CONFIG)
+    return _sanitize_config(raw)
+
+
+def _save_noosphere_config(values: Dict[str, Any], hermes_home: str) -> None:
+    path = _config_path(hermes_home)
+    existing: Dict[str, Any] = {}
+    if path.exists():
+        try:
+            raw = json.loads(path.read_text(encoding="utf-8"))
+            if isinstance(raw, dict):
+                existing = raw
+        except Exception:
+            existing = {}
+
+    sanitized_values = dict(values or {})
+    sanitized_values.pop("api_key", None)
+    existing.update(sanitized_values)
+    config = _sanitize_config(existing)
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(config, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    try:
+        path.chmod(0o600)
+    except OSError:
+        logger.debug("Could not chmod %s", path, exc_info=True)
+
+
+class NoosphereMemoryProvider(MemoryProvider):
+    def __init__(self) -> None:
+        self._config: Dict[str, Any] = dict(_DEFAULT_CONFIG)
+        self._api_key = ""
+        self._session_id = ""
+        self._hermes_home = ""
+        self._platform = ""
+        self._agent_identity = "default"
+        self._agent_context = ""
+        self._write_enabled = True
+        self._active = False
+
+    @property
+    def name(self) -> str:
+        return "noosphere"
+
+    def is_available(self) -> bool:
+        return bool(os.environ.get("NOOSPHERE_API_KEY", "").strip())
+
+    def get_config_schema(self) -> List[Dict[str, Any]]:
+        return [
+            {
+                "key": "api_key",
+                "description": "Noosphere API key",
+                "secret": True,
+                "required": True,
+                "env_var": "NOOSPHERE_API_KEY",
+                "url": "http://127.0.0.1:6578/wiki/admin/keys",
+            },
+            {
+                "key": "base_url",
+                "description": "Noosphere base URL",
+                "required": True,
+                "default": _DEFAULT_CONFIG["base_url"],
+            },
+        ]
+
+    def save_config(self, values: Dict[str, Any], hermes_home: str) -> None:
+        _save_noosphere_config(values, hermes_home)
+
+    def initialize(self, session_id: str, **kwargs: Any) -> None:
+        self._session_id = session_id
+        self._hermes_home = kwargs.get("hermes_home") or str(Path.home() / ".hermes")
+        self._platform = _as_string(kwargs.get("platform"))
+        self._agent_identity = _as_string(kwargs.get("agent_identity"), "default") or "default"
+        self._agent_context = _as_string(kwargs.get("agent_context"))
+
+        self._config = _load_noosphere_config(self._hermes_home)
+        env_base_url = os.environ.get("NOOSPHERE_BASE_URL", "").strip().rstrip("/")
+        if env_base_url:
+            self._config["base_url"] = env_base_url
+
+        self._api_key = os.environ.get("NOOSPHERE_API_KEY", "").strip()
+        self._write_enabled = self._agent_context not in _NON_WRITING_CONTEXTS
+        self._active = bool(self._api_key)
+
+    def system_prompt_block(self) -> str:
+        if not self._active:
+            return ""
+        return (
+            "# Noosphere\n"
+            "Noosphere memory provider is configured. Explicit memory tools and "
+            "automatic recall are added by later plugin phases. Save only durable, "
+            "reusable knowledge; skip transient task status and trivial turns."
+        )
+
+    def get_tool_schemas(self) -> List[Dict[str, Any]]:
+        return []
+
+    def handle_tool_call(self, tool_name: str, args: Dict[str, Any], **kwargs: Any) -> str:
+        return json.dumps(
+            {
+                "error": "Noosphere memory tools are not implemented in Phase 1.",
+                "tool": tool_name,
+            }
+        )
+
+    def shutdown(self) -> None:
+        return None
+
+
+def register(ctx: Any) -> None:
+    """Register the Noosphere memory provider with Hermes."""
+
+    ctx.register_memory_provider(NoosphereMemoryProvider())

--- a/hermes-noosphere-memory/plugins/memory/noosphere/plugin.yaml
+++ b/hermes-noosphere-memory/plugins/memory/noosphere/plugin.yaml
@@ -1,0 +1,3 @@
+name: noosphere
+version: 0.1.0
+description: "Noosphere durable memory provider with scoped recall and draft memory capture."

--- a/hermes-noosphere-memory/tests/test_noosphere_provider_phase1.py
+++ b/hermes-noosphere-memory/tests/test_noosphere_provider_phase1.py
@@ -51,8 +51,20 @@ class NoosphereProviderPhase1Test(unittest.TestCase):
         with mock.patch.dict(os.environ, {}, clear=True):
             self.assertFalse(provider.is_available())
 
+        with mock.patch.dict(os.environ, {"NOOSPHERE_API_KEY": "   \t  "}, clear=True):
+            self.assertFalse(provider.is_available())
+
         with mock.patch.dict(os.environ, {"NOOSPHERE_API_KEY": "noo_test"}, clear=True):
             self.assertTrue(provider.is_available())
+
+    def test_config_schema_uses_base_url_env_for_key_help(self):
+        module = load_plugin()
+        provider = module.NoosphereMemoryProvider()
+
+        with mock.patch.dict(os.environ, {"NOOSPHERE_BASE_URL": "http://noosphere.test/"}, clear=True):
+            schema = provider.get_config_schema()
+
+        self.assertEqual(schema[0]["url"], "http://noosphere.test/wiki/admin/keys")
 
     def test_save_config_persists_non_secret_values(self):
         module = load_plugin()
@@ -78,6 +90,41 @@ class NoosphereProviderPhase1Test(unittest.TestCase):
         self.assertTrue(data["auto_capture"])
         self.assertEqual(data["max_recall_results"], 20)
         self.assertEqual(data["providers"], ["noosphere", "hindsight"])
+
+    def test_save_config_removes_legacy_secret_from_existing_file(self):
+        module = load_plugin()
+        provider = module.NoosphereMemoryProvider()
+
+        with tempfile.TemporaryDirectory() as hermes_home:
+            path = Path(hermes_home) / "noosphere.json"
+            path.write_text(
+                json.dumps({"api_key": "noo_legacy", "base_url": "http://stored.test"}),
+                encoding="utf-8",
+            )
+
+            provider.save_config({"auto_capture": True}, hermes_home)
+
+            data = json.loads(path.read_text(encoding="utf-8"))
+
+        self.assertNotIn("api_key", data)
+        self.assertEqual(data["base_url"], "http://stored.test")
+        self.assertTrue(data["auto_capture"])
+
+    def test_save_config_logs_and_rebuilds_corrupt_existing_file(self):
+        module = load_plugin()
+        provider = module.NoosphereMemoryProvider()
+
+        with tempfile.TemporaryDirectory() as hermes_home:
+            path = Path(hermes_home) / "noosphere.json"
+            path.write_text("{not-json", encoding="utf-8")
+
+            with self.assertLogs(module.logger, level="WARNING") as logs:
+                provider.save_config({"base_url": "http://rebuilt.test"}, hermes_home)
+
+            data = json.loads(path.read_text(encoding="utf-8"))
+
+        self.assertIn("Failed to parse existing Noosphere config", "\n".join(logs.output))
+        self.assertEqual(data["base_url"], "http://rebuilt.test")
 
     def test_initialize_loads_context_and_disables_writes_for_subagents(self):
         module = load_plugin()
@@ -110,6 +157,24 @@ class NoosphereProviderPhase1Test(unittest.TestCase):
         self.assertFalse(provider._write_enabled)
         self.assertEqual(provider._config["base_url"], "http://env.test")
         self.assertEqual(provider._agent_identity, "coder")
+
+    def test_initialize_uses_hermes_home_env_when_kwarg_missing(self):
+        module = load_plugin()
+        provider = module.NoosphereMemoryProvider()
+
+        with tempfile.TemporaryDirectory() as hermes_home:
+            path = Path(hermes_home) / "noosphere.json"
+            path.write_text(json.dumps({"base_url": "http://env-home.test"}), encoding="utf-8")
+
+            with mock.patch.dict(
+                os.environ,
+                {"NOOSPHERE_API_KEY": "noo_test", "HERMES_HOME": hermes_home},
+                clear=True,
+            ):
+                provider.initialize("session-1")
+
+        self.assertEqual(provider._hermes_home, hermes_home)
+        self.assertEqual(provider._config["base_url"], "http://env-home.test")
 
     def test_register_adds_memory_provider(self):
         module = load_plugin()

--- a/hermes-noosphere-memory/tests/test_noosphere_provider_phase1.py
+++ b/hermes-noosphere-memory/tests/test_noosphere_provider_phase1.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+PLUGIN_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "plugins"
+    / "memory"
+    / "noosphere"
+    / "__init__.py"
+)
+
+
+class _FakeMemoryProvider:
+    pass
+
+
+def load_plugin():
+    agent_module = types.ModuleType("agent")
+    memory_provider_module = types.ModuleType("agent.memory_provider")
+    memory_provider_module.MemoryProvider = _FakeMemoryProvider
+
+    with mock.patch.dict(
+        sys.modules,
+        {
+            "agent": agent_module,
+            "agent.memory_provider": memory_provider_module,
+        },
+    ):
+        spec = importlib.util.spec_from_file_location("noosphere_memory_plugin", PLUGIN_PATH)
+        module = importlib.util.module_from_spec(spec)
+        assert spec and spec.loader
+        spec.loader.exec_module(module)
+        return module
+
+
+class NoosphereProviderPhase1Test(unittest.TestCase):
+    def test_is_available_checks_only_api_key_env(self):
+        module = load_plugin()
+        provider = module.NoosphereMemoryProvider()
+
+        with mock.patch.dict(os.environ, {}, clear=True):
+            self.assertFalse(provider.is_available())
+
+        with mock.patch.dict(os.environ, {"NOOSPHERE_API_KEY": "noo_test"}, clear=True):
+            self.assertTrue(provider.is_available())
+
+    def test_save_config_persists_non_secret_values(self):
+        module = load_plugin()
+        provider = module.NoosphereMemoryProvider()
+
+        with tempfile.TemporaryDirectory() as hermes_home:
+            provider.save_config(
+                {
+                    "api_key": "noo_secret",
+                    "base_url": "http://example.test:6578/",
+                    "auto_capture": "true",
+                    "max_recall_results": 99,
+                    "providers": ["noosphere", "noosphere", "hindsight"],
+                },
+                hermes_home,
+            )
+
+            path = Path(hermes_home) / "noosphere.json"
+            data = json.loads(path.read_text(encoding="utf-8"))
+
+        self.assertNotIn("api_key", data)
+        self.assertEqual(data["base_url"], "http://example.test:6578")
+        self.assertTrue(data["auto_capture"])
+        self.assertEqual(data["max_recall_results"], 20)
+        self.assertEqual(data["providers"], ["noosphere", "hindsight"])
+
+    def test_initialize_loads_context_and_disables_writes_for_subagents(self):
+        module = load_plugin()
+        provider = module.NoosphereMemoryProvider()
+
+        with tempfile.TemporaryDirectory() as hermes_home:
+            path = Path(hermes_home) / "noosphere.json"
+            path.write_text(
+                json.dumps({"base_url": "http://stored.test", "auto_recall": False}),
+                encoding="utf-8",
+            )
+
+            with mock.patch.dict(
+                os.environ,
+                {
+                    "NOOSPHERE_API_KEY": "noo_test",
+                    "NOOSPHERE_BASE_URL": "http://env.test/",
+                },
+                clear=True,
+            ):
+                provider.initialize(
+                    "session-1",
+                    hermes_home=hermes_home,
+                    platform="cli",
+                    agent_identity="coder",
+                    agent_context="subagent",
+                )
+
+        self.assertTrue(provider._active)
+        self.assertFalse(provider._write_enabled)
+        self.assertEqual(provider._config["base_url"], "http://env.test")
+        self.assertEqual(provider._agent_identity, "coder")
+
+    def test_register_adds_memory_provider(self):
+        module = load_plugin()
+        registered = []
+
+        class Ctx:
+            def register_memory_provider(self, provider):
+                registered.append(provider)
+
+        module.register(Ctx())
+
+        self.assertEqual(len(registered), 1)
+        self.assertEqual(registered[0].name, "noosphere")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary\n- Adds Phase 1 Hermes Noosphere memory-provider skeleton under .\n- Implements Hermes  registration, setup schema, config load/save, env-based secret lookup, and safe initialization.\n- Adds local unit tests for availability, config persistence, context initialization, and provider registration.\n\n## Verification\n- \n- Listing 'hermes-noosphere-memory/plugins/memory/noosphere'...\n- \n\n## Notes\n- Recall/save/status HTTP behavior is intentionally deferred to the next PR.

## Summary by Sourcery

Introduce an initial Noosphere memory provider plugin for Hermes focused on configuration and registration lifecycle, without implementing HTTP-based recall or save behavior yet.

New Features:
- Add a Noosphere-based MemoryProvider implementation that can be registered by Hermes and participate in the memory provider lifecycle.
- Provide configuration schema, environment-based secret lookup, and profile-scoped JSON config persistence for the Noosphere provider.

Documentation:
- Document the Noosphere memory provider layout, configuration, setup instructions, and current phase-1 limitations in top-level and plugin-specific READMEs.

Tests:
- Add unit tests covering provider availability via environment variables, config persistence and sanitization, initialization behavior, and registration wiring.