### PR TITLE
feat(hermes): add Noosphere status client

### DIFF
--- a/hermes-noosphere-memory/README.md
+++ b/hermes-noosphere-memory/README.md
@@ -2,16 +2,19 @@
 
 This package contains the Hermes Agent memory-provider integration for Noosphere.
 
-Current implementation status: Phase 1 skeleton and configuration lifecycle.
+Current implementation status: Phase 2 client and status tool.
 
 ## Layout
 
 ```text
 plugins/memory/noosphere/
   __init__.py
+  client.py
   plugin.yaml
   README.md
+  schemas.py
 tests/
+  test_noosphere_client.py
   test_noosphere_provider_phase1.py
 ```
 
@@ -24,11 +27,12 @@ Implemented:
 - profile-scoped `$HERMES_HOME/noosphere.json` config persistence
 - environment-based secret lookup through `NOOSPHERE_API_KEY`
 - safe initialization without network calls
+- standard-library HTTP client with redacted errors
+- `noosphere_status` tool
 
 Not implemented yet:
 
-- Noosphere HTTP client
-- explicit recall/save/status tools
+- explicit recall/save/get/topics tools
 - automatic recall
 - explicit memory write mirroring
 - installer script

--- a/hermes-noosphere-memory/plugins/memory/noosphere/README.md
+++ b/hermes-noosphere-memory/plugins/memory/noosphere/README.md
@@ -2,12 +2,13 @@
 
 Noosphere gives Hermes Agent access to durable, scoped, human-readable memory.
 
-This provider is currently in Phase 1:
+This provider is currently in Phase 2:
 
 - it registers with Hermes as a memory provider
 - it exposes setup fields for the Noosphere API key and base URL
 - it stores non-secret configuration in `$HERMES_HOME/noosphere.json`
 - it reads the secret API key from `NOOSPHERE_API_KEY`
+- it exposes `noosphere_status` for Noosphere memory status checks
 
 Recall and save tools are intentionally added in later phases.
 
@@ -72,3 +73,9 @@ Secrets:
 `is_available()` checks only local environment. It does not make network calls during Hermes startup.
 
 Writes are disabled during `cron`, `flush`, and `subagent` contexts.
+
+## Tools
+
+| Tool | Description |
+| --- | --- |
+| `noosphere_status` | Calls `GET /api/memory/status` and returns Noosphere memory status JSON. |

--- a/hermes-noosphere-memory/plugins/memory/noosphere/__init__.py
+++ b/hermes-noosphere-memory/plugins/memory/noosphere/__init__.py
@@ -11,9 +11,12 @@ import json
 import logging
 import os
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from agent.memory_provider import MemoryProvider
+
+from .client import NoosphereClient, NoosphereClientError
+from .schemas import NOOSPHERE_STATUS_SCHEMA
 
 logger = logging.getLogger(__name__)
 
@@ -173,6 +176,7 @@ class NoosphereMemoryProvider(MemoryProvider):
         self._agent_context = ""
         self._write_enabled = True
         self._active = False
+        self._client: Optional[NoosphereClient] = None
 
     @property
     def name(self) -> str:
@@ -217,6 +221,13 @@ class NoosphereMemoryProvider(MemoryProvider):
         self._api_key = os.environ.get("NOOSPHERE_API_KEY", "").strip()
         self._write_enabled = self._agent_context not in _NON_WRITING_CONTEXTS
         self._active = bool(self._api_key)
+        self._client = None
+        if self._active:
+            self._client = NoosphereClient(
+                base_url=str(self._config["base_url"]),
+                api_key=self._api_key,
+                timeout=float(self._config["api_timeout"]),
+            )
 
     def system_prompt_block(self) -> str:
         if not self._active:
@@ -229,15 +240,17 @@ class NoosphereMemoryProvider(MemoryProvider):
         )
 
     def get_tool_schemas(self) -> List[Dict[str, Any]]:
-        return []
+        return [NOOSPHERE_STATUS_SCHEMA]
 
     def handle_tool_call(self, tool_name: str, args: Dict[str, Any], **kwargs: Any) -> str:
-        return json.dumps(
-            {
-                "error": "Noosphere memory tools are not implemented in Phase 1.",
-                "tool": tool_name,
-            }
-        )
+        if tool_name != "noosphere_status":
+            return json.dumps({"error": f"Unknown Noosphere memory tool: {tool_name}"})
+        if not self._active or not self._client:
+            return json.dumps({"error": "Noosphere is not configured. Set NOOSPHERE_API_KEY."})
+        try:
+            return json.dumps(self._client.status())
+        except NoosphereClientError as error:
+            return error.to_json()
 
     def shutdown(self) -> None:
         return None

--- a/hermes-noosphere-memory/plugins/memory/noosphere/client.py
+++ b/hermes-noosphere-memory/plugins/memory/noosphere/client.py
@@ -1,0 +1,115 @@
+"""HTTP client for the Hermes Noosphere memory provider."""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+from typing import Any, Dict, Optional
+
+_MAX_RESPONSE_BYTES = 1_000_000
+
+
+class NoosphereClientError(Exception):
+    def __init__(self, message: str, *, status: Optional[int] = None, details: Any = None):
+        super().__init__(message)
+        self.status = status
+        self.details = details
+
+    def to_json(self) -> str:
+        payload: Dict[str, Any] = {"error": str(self)}
+        if self.status is not None:
+            payload["status"] = self.status
+        if self.details is not None:
+            payload["details"] = self.details
+        return json.dumps(payload)
+
+
+class NoosphereClient:
+    def __init__(self, *, base_url: str, api_key: str, timeout: float) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._api_key = api_key
+        self._timeout = timeout
+
+    def status(self) -> Dict[str, Any]:
+        return self._request_json("GET", "/api/memory/status")
+
+    def _request_json(
+        self,
+        method: str,
+        path: str,
+        body: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        url = f"{self._base_url}{path if path.startswith('/') else '/' + path}"
+        data = None
+        headers = {
+            "Authorization": f"Bearer {self._api_key}",
+            "Accept": "application/json",
+        }
+        if body is not None:
+            data = json.dumps(body).encode("utf-8")
+            headers["Content-Type"] = "application/json"
+
+        request = urllib.request.Request(url, data=data, headers=headers, method=method)
+        try:
+            with urllib.request.urlopen(request, timeout=self._timeout) as response:
+                return _parse_json_response(response.read(_MAX_RESPONSE_BYTES + 1))
+        except urllib.error.HTTPError as error:
+            details = _safe_error_body(error)
+            message = _message_from_error_details(details) or f"Noosphere HTTP {error.code}"
+            raise NoosphereClientError(message, status=error.code, details=details) from None
+        except urllib.error.URLError as error:
+            raise NoosphereClientError(f"Noosphere request failed: {error.reason}") from None
+        except TimeoutError:
+            raise NoosphereClientError("Noosphere request timed out") from None
+
+
+def _parse_json_response(raw: bytes) -> Dict[str, Any]:
+    if len(raw) > _MAX_RESPONSE_BYTES:
+        raise NoosphereClientError("Noosphere response exceeded size limit")
+    try:
+        parsed = json.loads(raw.decode("utf-8"))
+    except Exception as error:
+        raise NoosphereClientError("Noosphere returned invalid JSON") from error
+    if not isinstance(parsed, dict):
+        raise NoosphereClientError("Noosphere returned non-object JSON")
+    return parsed
+
+
+def _safe_error_body(error: urllib.error.HTTPError) -> Any:
+    try:
+        raw = error.read(_MAX_RESPONSE_BYTES + 1)
+    except Exception:
+        return None
+    if not raw or len(raw) > _MAX_RESPONSE_BYTES:
+        return None
+    try:
+        parsed = json.loads(raw.decode("utf-8"))
+    except Exception:
+        return None
+    return _redact(parsed)
+
+
+def _message_from_error_details(details: Any) -> str:
+    if isinstance(details, dict):
+        message = details.get("error") or details.get("message")
+        if isinstance(message, str):
+            return message
+    return ""
+
+
+def _redact(value: Any) -> Any:
+    if isinstance(value, dict):
+        redacted: Dict[str, Any] = {}
+        for key, item in value.items():
+            lowered = str(key).lower()
+            if "key" in lowered or "token" in lowered or "authorization" in lowered:
+                redacted[key] = "[redacted]"
+            else:
+                redacted[key] = _redact(item)
+        return redacted
+    if isinstance(value, list):
+        return [_redact(item) for item in value]
+    if isinstance(value, str) and value.startswith("noo_"):
+        return "[redacted]"
+    return value

--- a/hermes-noosphere-memory/plugins/memory/noosphere/schemas.py
+++ b/hermes-noosphere-memory/plugins/memory/noosphere/schemas.py
@@ -1,0 +1,14 @@
+"""Tool schemas for the Hermes Noosphere memory provider."""
+
+NOOSPHERE_STATUS_SCHEMA = {
+    "name": "noosphere_status",
+    "description": (
+        "Check Noosphere memory provider connectivity and status. Use this when "
+        "the user asks whether Noosphere memory is configured or available."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {},
+        "additionalProperties": False,
+    },
+}

--- a/hermes-noosphere-memory/tests/test_noosphere_client.py
+++ b/hermes-noosphere-memory/tests/test_noosphere_client.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import threading
+import types
+import unittest
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from unittest import mock
+
+
+PLUGIN_DIR = (
+    Path(__file__).resolve().parents[1]
+    / "plugins"
+    / "memory"
+    / "noosphere"
+)
+
+
+class _FakeMemoryProvider:
+    pass
+
+
+def load_plugin_package():
+    agent_module = types.ModuleType("agent")
+    memory_provider_module = types.ModuleType("agent.memory_provider")
+    memory_provider_module.MemoryProvider = _FakeMemoryProvider
+    with mock.patch.dict(
+        sys.modules,
+        {
+            "agent": agent_module,
+            "agent.memory_provider": memory_provider_module,
+        },
+    ):
+        spec = importlib.util.spec_from_file_location(
+            "noosphere_memory_plugin",
+            PLUGIN_DIR / "__init__.py",
+            submodule_search_locations=[str(PLUGIN_DIR)],
+        )
+        module = importlib.util.module_from_spec(spec)
+        assert spec and spec.loader
+        with mock.patch.dict(sys.modules, {"noosphere_memory_plugin": module}):
+            spec.loader.exec_module(module)
+            return module
+
+
+class _StatusHandler(BaseHTTPRequestHandler):
+    response_status = 200
+    response_body = {"ok": True, "providers": [], "settings": {}}
+    seen_authorization = ""
+
+    def do_GET(self):
+        if self.path != "/api/memory/status":
+            self.send_response(404)
+            self.end_headers()
+            return
+        type(self).seen_authorization = self.headers.get("Authorization", "")
+        raw = json.dumps(type(self).response_body).encode("utf-8")
+        self.send_response(type(self).response_status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(raw)))
+        self.end_headers()
+        self.wfile.write(raw)
+
+    def log_message(self, format, *args):
+        return
+
+
+class NoosphereClientTest(unittest.TestCase):
+    def setUp(self):
+        _StatusHandler.response_status = 200
+        _StatusHandler.response_body = {"ok": True, "providers": [], "settings": {}}
+        _StatusHandler.seen_authorization = ""
+        self.server = ThreadingHTTPServer(("127.0.0.1", 0), _StatusHandler)
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+        self.thread.start()
+        self.base_url = f"http://127.0.0.1:{self.server.server_port}"
+
+    def tearDown(self):
+        self.server.shutdown()
+        self.thread.join(timeout=2)
+        self.server.server_close()
+
+    def test_status_sends_bearer_key_and_returns_json(self):
+        module = load_plugin_package()
+        client = module.NoosphereClient(
+            base_url=self.base_url,
+            api_key="noo_test",
+            timeout=2.0,
+        )
+
+        result = client.status()
+
+        self.assertTrue(result["ok"])
+        self.assertEqual(_StatusHandler.seen_authorization, "Bearer noo_test")
+
+    def test_http_error_is_redacted_json(self):
+        module = load_plugin_package()
+        _StatusHandler.response_status = 401
+        _StatusHandler.response_body = {
+            "error": "Unauthorized",
+            "apiKey": "noo_secret",
+            "nested": {"authorization": "Bearer noo_secret"},
+        }
+        client = module.NoosphereClient(
+            base_url=self.base_url,
+            api_key="noo_secret",
+            timeout=2.0,
+        )
+
+        with self.assertRaises(module.NoosphereClientError) as caught:
+            client.status()
+
+        payload = json.loads(caught.exception.to_json())
+        self.assertEqual(payload["status"], 401)
+        self.assertEqual(payload["details"]["apiKey"], "[redacted]")
+        self.assertEqual(payload["details"]["nested"]["authorization"], "[redacted]")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/hermes-noosphere-memory/tests/test_noosphere_provider_phase1.py
+++ b/hermes-noosphere-memory/tests/test_noosphere_provider_phase1.py
@@ -36,11 +36,16 @@ def load_plugin():
             "agent.memory_provider": memory_provider_module,
         },
     ):
-        spec = importlib.util.spec_from_file_location("noosphere_memory_plugin", PLUGIN_PATH)
+        spec = importlib.util.spec_from_file_location(
+            "noosphere_memory_plugin",
+            PLUGIN_PATH,
+            submodule_search_locations=[str(PLUGIN_PATH.parent)],
+        )
         module = importlib.util.module_from_spec(spec)
         assert spec and spec.loader
-        spec.loader.exec_module(module)
-        return module
+        with mock.patch.dict(sys.modules, {"noosphere_memory_plugin": module}):
+            spec.loader.exec_module(module)
+            return module
 
 
 class NoosphereProviderPhase1Test(unittest.TestCase):
@@ -123,6 +128,14 @@ class NoosphereProviderPhase1Test(unittest.TestCase):
 
         self.assertEqual(len(registered), 1)
         self.assertEqual(registered[0].name, "noosphere")
+
+    def test_status_tool_schema_is_registered(self):
+        module = load_plugin()
+        provider = module.NoosphereMemoryProvider()
+
+        schemas = provider.get_tool_schemas()
+
+        self.assertEqual([schema["name"] for schema in schemas], ["noosphere_status"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Adds Phase 2 HTTP client for the Hermes Noosphere memory provider.
- Adds the noosphere_status tool schema and handler.
- Adds local HTTP-server tests for bearer auth, JSON status responses, and redacted error output.

## Verification
- python3 -m unittest discover -s hermes-noosphere-memory/tests
- python3 -m compileall hermes-noosphere-memory/plugins/memory/noosphere
- git diff --check

## Stack
- Base PR: #85
- This PR intentionally excludes recall/save behavior; that comes in the next step.

## Summary by Sourcery

Introduce a Phase 2 HTTP status client for the Hermes Noosphere memory provider and wire it into the provider as a callable tool.

New Features:
- Add a standard-library-based NoosphereClient with a status endpoint for querying Noosphere memory status over HTTP.
- Expose a noosphere_status tool schema from the Noosphere memory provider for checking configuration and connectivity.

Enhancements:
- Initialize and cache a NoosphereClient instance inside the memory provider when configured and active.
- Improve plugin loading in tests by registering the plugin module in sys.modules to support submodule imports.
- Redact sensitive API key and authorization data from HTTP error payloads returned by the Noosphere client.

Documentation:
- Update package and plugin documentation to describe Phase 2 capabilities and the noosphere_status tool.

Tests:
- Add HTTP server–backed tests for NoosphereClient status behavior, bearer auth handling, and redacted error output.
- Extend provider tests to verify that the noosphere_status tool schema is registered.