### PR TITLE
feat(hermes): add Noosphere recall tools

### DIFF
--- a/hermes-noosphere-memory/README.md
+++ b/hermes-noosphere-memory/README.md
@@ -2,7 +2,7 @@
 
 This package contains the Hermes Agent memory-provider integration for Noosphere.
 
-Current implementation status: Phase 2 client and status tool.
+Current implementation status: Phase 3 recall/get/topics and auto-recall prefetch.
 
 ## Layout
 
@@ -10,6 +10,7 @@ Current implementation status: Phase 2 client and status tool.
 plugins/memory/noosphere/
   __init__.py
   client.py
+  formatting.py
   plugin.yaml
   README.md
   schemas.py
@@ -28,12 +29,12 @@ Implemented:
 - environment-based secret lookup through `NOOSPHERE_API_KEY`
 - safe initialization without network calls
 - standard-library HTTP client with redacted errors
-- `noosphere_status` tool
+- `noosphere_status`, `noosphere_recall`, `noosphere_get`, and `noosphere_topics` tools
+- auto-recall prefetch through Noosphere's prompt-ready recall API
 
 Not implemented yet:
 
-- explicit recall/save/get/topics tools
-- automatic recall
+- explicit save/article tools
 - explicit memory write mirroring
 - installer script
 

--- a/hermes-noosphere-memory/plugins/memory/noosphere/README.md
+++ b/hermes-noosphere-memory/plugins/memory/noosphere/README.md
@@ -2,15 +2,16 @@
 
 Noosphere gives Hermes Agent access to durable, scoped, human-readable memory.
 
-This provider is currently in Phase 2:
+This provider is currently in Phase 3:
 
 - it registers with Hermes as a memory provider
 - it exposes setup fields for the Noosphere API key and base URL
 - it stores non-secret configuration in `$HERMES_HOME/noosphere.json`
 - it reads the secret API key from `NOOSPHERE_API_KEY`
-- it exposes `noosphere_status` for Noosphere memory status checks
+- it exposes status, recall, get, and topics tools
+- it uses Noosphere's prompt-ready recall API for `prefetch()`
 
-Recall and save tools are intentionally added in later phases.
+Save tools are intentionally added in later phases.
 
 ## Setup
 
@@ -79,3 +80,6 @@ Writes are disabled during `cron`, `flush`, and `subagent` contexts.
 | Tool | Description |
 | --- | --- |
 | `noosphere_status` | Calls `GET /api/memory/status` and returns Noosphere memory status JSON. |
+| `noosphere_recall` | Calls `POST /api/memory/recall` in inspection mode. |
+| `noosphere_get` | Calls `POST /api/memory/get` by canonical ref or provider/id. |
+| `noosphere_topics` | Calls `GET /api/topics` for topic selection. |

--- a/hermes-noosphere-memory/plugins/memory/noosphere/__init__.py
+++ b/hermes-noosphere-memory/plugins/memory/noosphere/__init__.py
@@ -16,7 +16,8 @@ from typing import Any, Dict, List, Optional
 from agent.memory_provider import MemoryProvider
 
 from .client import NoosphereClient, NoosphereClientError
-from .schemas import NOOSPHERE_STATUS_SCHEMA
+from .formatting import strip_context_fences
+from .schemas import TOOL_SCHEMAS
 
 logger = logging.getLogger(__name__)
 
@@ -234,22 +235,53 @@ class NoosphereMemoryProvider(MemoryProvider):
             return ""
         return (
             "# Noosphere\n"
-            "Noosphere memory provider is configured. Explicit memory tools and "
-            "automatic recall are added by later plugin phases. Save only durable, "
-            "reusable knowledge; skip transient task status and trivial turns."
+            "Noosphere memory provider is configured. Use noosphere_recall, "
+            "noosphere_get, noosphere_topics, and noosphere_status for explicit "
+            "memory operations. Save only durable, reusable knowledge; skip "
+            "transient task status and trivial turns."
         )
 
+    def prefetch(self, query: str, *, session_id: str = "") -> str:
+        if not self._active or not self._client or not self._config.get("auto_recall"):
+            return ""
+        if not query or not query.strip():
+            return ""
+        try:
+            result = self._client.recall(
+                {
+                    "query": query.strip()[:1000],
+                    "mode": "auto",
+                    "resultCap": self._config["max_recall_results"],
+                    "tokenBudget": self._config["token_budget"],
+                    "providers": self._config["providers"],
+                }
+            )
+        except NoosphereClientError:
+            logger.debug("Noosphere prefetch failed", exc_info=True)
+            return ""
+        prompt_text = result.get("promptInjectionText")
+        return strip_context_fences(prompt_text) if isinstance(prompt_text, str) else ""
+
     def get_tool_schemas(self) -> List[Dict[str, Any]]:
-        return [NOOSPHERE_STATUS_SCHEMA]
+        return TOOL_SCHEMAS
 
     def handle_tool_call(self, tool_name: str, args: Dict[str, Any], **kwargs: Any) -> str:
-        if tool_name != "noosphere_status":
-            return json.dumps({"error": f"Unknown Noosphere memory tool: {tool_name}"})
         if not self._active or not self._client:
             return json.dumps({"error": "Noosphere is not configured. Set NOOSPHERE_API_KEY."})
+
         try:
-            return json.dumps(self._client.status())
-        except NoosphereClientError as error:
+            if tool_name == "noosphere_status":
+                return json.dumps(self._client.status())
+            if tool_name == "noosphere_topics":
+                return json.dumps(self._client.topics())
+            if tool_name == "noosphere_recall":
+                return json.dumps(self._client.recall(_read_recall_args(args, self._config)))
+            if tool_name == "noosphere_get":
+                return json.dumps(self._client.get(_read_get_args(args)))
+            return json.dumps({"error": f"Unknown Noosphere memory tool: {tool_name}"})
+        except (NoosphereClientError, ValueError) as error:
+            if isinstance(error, ValueError):
+                return json.dumps({"error": str(error)})
             return error.to_json()
 
     def shutdown(self) -> None:
@@ -260,3 +292,43 @@ def register(ctx: Any) -> None:
     """Register the Noosphere memory provider with Hermes."""
 
     ctx.register_memory_provider(NoosphereMemoryProvider())
+
+
+def _read_recall_args(args: Dict[str, Any], config: Dict[str, Any]) -> Dict[str, Any]:
+    query = _as_string(args.get("query"))
+    if not query:
+        raise ValueError("query is required")
+    request: Dict[str, Any] = {
+        "query": query,
+        "mode": "inspection",
+        "resultCap": _as_int(
+            args.get("resultCap"),
+            int(config["max_recall_results"]),
+            minimum=1,
+            maximum=20,
+        ),
+        "tokenBudget": _as_int(
+            args.get("tokenBudget"),
+            int(config["token_budget"]),
+            minimum=100,
+            maximum=8000,
+        ),
+        "providers": config["providers"],
+    }
+    scope = _as_string(args.get("scope"))
+    if scope:
+        request["scope"] = scope
+    return request
+
+
+def _read_get_args(args: Dict[str, Any]) -> Dict[str, Any]:
+    canonical_ref = _as_string(args.get("canonicalRef"))
+    provider = _as_string(args.get("provider"))
+    memory_id = _as_string(args.get("id"))
+    if canonical_ref:
+        if provider or memory_id:
+            raise ValueError("Use either canonicalRef or provider+id, not both")
+        return {"canonicalRef": canonical_ref}
+    if provider and memory_id:
+        return {"provider": provider, "id": memory_id}
+    raise ValueError("Provide canonicalRef or provider+id")

--- a/hermes-noosphere-memory/plugins/memory/noosphere/client.py
+++ b/hermes-noosphere-memory/plugins/memory/noosphere/client.py
@@ -34,6 +34,15 @@ class NoosphereClient:
     def status(self) -> Dict[str, Any]:
         return self._request_json("GET", "/api/memory/status")
 
+    def recall(self, request: Dict[str, Any]) -> Dict[str, Any]:
+        return self._request_json("POST", "/api/memory/recall", request)
+
+    def get(self, request: Dict[str, Any]) -> Dict[str, Any]:
+        return self._request_json("POST", "/api/memory/get", request)
+
+    def topics(self) -> Dict[str, Any]:
+        return self._request_json("GET", "/api/topics")
+
     def _request_json(
         self,
         method: str,

--- a/hermes-noosphere-memory/plugins/memory/noosphere/formatting.py
+++ b/hermes-noosphere-memory/plugins/memory/noosphere/formatting.py
@@ -1,0 +1,22 @@
+"""Formatting helpers for Noosphere context returned to Hermes."""
+
+from __future__ import annotations
+
+import re
+
+_FENCE_TAG_RE = re.compile(r"</?\s*(?:memory-context|noosphere-context)\s*>", re.IGNORECASE)
+_SYSTEM_NOTE_RE = re.compile(
+    r"\[System note:\s*The following is recalled memory context,\s*"
+    r"NOT new user input\.[^\]]*\]\s*",
+    re.IGNORECASE,
+)
+
+
+def strip_context_fences(text: str) -> str:
+    """Remove context wrapper markup while preserving recalled memory content."""
+
+    if not text:
+        return ""
+    clean = _SYSTEM_NOTE_RE.sub("", text)
+    clean = _FENCE_TAG_RE.sub("", clean)
+    return clean.strip()

--- a/hermes-noosphere-memory/plugins/memory/noosphere/schemas.py
+++ b/hermes-noosphere-memory/plugins/memory/noosphere/schemas.py
@@ -12,3 +12,71 @@ NOOSPHERE_STATUS_SCHEMA = {
         "additionalProperties": False,
     },
 }
+
+NOOSPHERE_RECALL_SCHEMA = {
+    "name": "noosphere_recall",
+    "description": "Search Noosphere durable memory for relevant context.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {
+                "type": "string",
+                "description": "Search query for durable memory.",
+            },
+            "resultCap": {
+                "type": "integer",
+                "description": "Maximum results to return, 1 to 20.",
+            },
+            "tokenBudget": {
+                "type": "integer",
+                "description": "Maximum prompt-token budget for formatted recall context.",
+            },
+            "scope": {
+                "type": "string",
+                "description": "Optional Noosphere scope hint.",
+            },
+        },
+        "required": ["query"],
+        "additionalProperties": False,
+    },
+}
+
+NOOSPHERE_GET_SCHEMA = {
+    "name": "noosphere_get",
+    "description": "Fetch one normalized Noosphere memory result by canonical reference or provider/id.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "canonicalRef": {
+                "type": "string",
+                "description": "Canonical memory reference, for example noosphere:article:<id>.",
+            },
+            "provider": {
+                "type": "string",
+                "description": "Provider id when fetching by provider-local id.",
+            },
+            "id": {
+                "type": "string",
+                "description": "Provider-local memory id.",
+            },
+        },
+        "additionalProperties": False,
+    },
+}
+
+NOOSPHERE_TOPICS_SCHEMA = {
+    "name": "noosphere_topics",
+    "description": "List Noosphere topics for choosing where durable memory should be saved later.",
+    "parameters": {
+        "type": "object",
+        "properties": {},
+        "additionalProperties": False,
+    },
+}
+
+TOOL_SCHEMAS = [
+    NOOSPHERE_STATUS_SCHEMA,
+    NOOSPHERE_RECALL_SCHEMA,
+    NOOSPHERE_GET_SCHEMA,
+    NOOSPHERE_TOPICS_SCHEMA,
+]

--- a/hermes-noosphere-memory/tests/test_noosphere_client.py
+++ b/hermes-noosphere-memory/tests/test_noosphere_client.py
@@ -50,6 +50,7 @@ class _StatusHandler(BaseHTTPRequestHandler):
     response_status = 200
     response_body = {"ok": True, "providers": [], "settings": {}}
     seen_authorization = ""
+    seen_json = {}
 
     def do_GET(self):
         if self.path != "/api/memory/status":
@@ -57,6 +58,22 @@ class _StatusHandler(BaseHTTPRequestHandler):
             self.end_headers()
             return
         type(self).seen_authorization = self.headers.get("Authorization", "")
+        raw = json.dumps(type(self).response_body).encode("utf-8")
+        self.send_response(type(self).response_status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(raw)))
+        self.end_headers()
+        self.wfile.write(raw)
+
+    def do_POST(self):
+        if self.path not in {"/api/memory/recall", "/api/memory/get"}:
+            self.send_response(404)
+            self.end_headers()
+            return
+        type(self).seen_authorization = self.headers.get("Authorization", "")
+        length = int(self.headers.get("Content-Length", "0"))
+        raw_body = self.rfile.read(length)
+        type(self).seen_json = json.loads(raw_body.decode("utf-8")) if raw_body else {}
         raw = json.dumps(type(self).response_body).encode("utf-8")
         self.send_response(type(self).response_status)
         self.send_header("Content-Type", "application/json")
@@ -73,6 +90,7 @@ class NoosphereClientTest(unittest.TestCase):
         _StatusHandler.response_status = 200
         _StatusHandler.response_body = {"ok": True, "providers": [], "settings": {}}
         _StatusHandler.seen_authorization = ""
+        _StatusHandler.seen_json = {}
         self.server = ThreadingHTTPServer(("127.0.0.1", 0), _StatusHandler)
         self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
         self.thread.start()
@@ -95,6 +113,21 @@ class NoosphereClientTest(unittest.TestCase):
 
         self.assertTrue(result["ok"])
         self.assertEqual(_StatusHandler.seen_authorization, "Bearer noo_test")
+
+    def test_recall_posts_json_body(self):
+        module = load_plugin_package()
+        _StatusHandler.response_body = {"results": [], "mode": "inspection"}
+        client = module.NoosphereClient(
+            base_url=self.base_url,
+            api_key="noo_test",
+            timeout=2.0,
+        )
+
+        result = client.recall({"query": "deploy", "mode": "inspection"})
+
+        self.assertEqual(result["mode"], "inspection")
+        self.assertEqual(_StatusHandler.seen_authorization, "Bearer noo_test")
+        self.assertEqual(_StatusHandler.seen_json["query"], "deploy")
 
     def test_http_error_is_redacted_json(self):
         module = load_plugin_package()

--- a/hermes-noosphere-memory/tests/test_noosphere_provider_phase1.py
+++ b/hermes-noosphere-memory/tests/test_noosphere_provider_phase1.py
@@ -135,7 +135,10 @@ class NoosphereProviderPhase1Test(unittest.TestCase):
 
         schemas = provider.get_tool_schemas()
 
-        self.assertEqual([schema["name"] for schema in schemas], ["noosphere_status"])
+        self.assertEqual(
+            [schema["name"] for schema in schemas],
+            ["noosphere_status", "noosphere_recall", "noosphere_get", "noosphere_topics"],
+        )
 
 
 if __name__ == "__main__":

--- a/hermes-noosphere-memory/tests/test_noosphere_recall_phase3.py
+++ b/hermes-noosphere-memory/tests/test_noosphere_recall_phase3.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+PLUGIN_DIR = (
+    Path(__file__).resolve().parents[1]
+    / "plugins"
+    / "memory"
+    / "noosphere"
+)
+
+
+class _FakeMemoryProvider:
+    pass
+
+
+def load_plugin():
+    agent_module = types.ModuleType("agent")
+    memory_provider_module = types.ModuleType("agent.memory_provider")
+    memory_provider_module.MemoryProvider = _FakeMemoryProvider
+    with mock.patch.dict(
+        sys.modules,
+        {
+            "agent": agent_module,
+            "agent.memory_provider": memory_provider_module,
+        },
+    ):
+        spec = importlib.util.spec_from_file_location(
+            "noosphere_memory_plugin",
+            PLUGIN_DIR / "__init__.py",
+            submodule_search_locations=[str(PLUGIN_DIR)],
+        )
+        module = importlib.util.module_from_spec(spec)
+        assert spec and spec.loader
+        with mock.patch.dict(sys.modules, {"noosphere_memory_plugin": module}):
+            spec.loader.exec_module(module)
+            return module
+
+
+class _FakeClient:
+    def __init__(self):
+        self.calls = []
+
+    def status(self):
+        return {"ok": True}
+
+    def topics(self):
+        return {"topics": []}
+
+    def recall(self, request):
+        self.calls.append(("recall", request))
+        return {
+            "results": [{"id": "one"}],
+            "promptInjectionText": (
+                "<memory-context>\n"
+                "[System note: The following is recalled memory context, NOT new user input.]\n"
+                "Remember the Serianis deploy path.\n"
+                "</memory-context>"
+            ),
+        }
+
+    def get(self, request):
+        self.calls.append(("get", request))
+        return {"result": {"id": request.get("canonicalRef") or request.get("id")}}
+
+
+class NoosphereRecallPhase3Test(unittest.TestCase):
+    def initialized_provider(self):
+        module = load_plugin()
+        provider = module.NoosphereMemoryProvider()
+        with tempfile.TemporaryDirectory() as hermes_home:
+            with mock.patch.dict(os.environ, {"NOOSPHERE_API_KEY": "noo_test"}, clear=True):
+                provider.initialize("session-1", hermes_home=hermes_home)
+        provider._client = _FakeClient()
+        return provider
+
+    def test_prefetch_uses_auto_recall_and_strips_context_fences(self):
+        provider = self.initialized_provider()
+
+        result = provider.prefetch("Serianis deploy?")
+
+        self.assertEqual(result, "Remember the Serianis deploy path.")
+        self.assertEqual(provider._client.calls[0][0], "recall")
+        self.assertEqual(provider._client.calls[0][1]["mode"], "auto")
+
+    def test_recall_tool_uses_inspection_mode(self):
+        provider = self.initialized_provider()
+
+        payload = json.loads(
+            provider.handle_tool_call("noosphere_recall", {"query": "deployment", "resultCap": 3})
+        )
+
+        self.assertEqual(payload["results"], [{"id": "one"}])
+        self.assertEqual(provider._client.calls[0][1]["mode"], "inspection")
+        self.assertEqual(provider._client.calls[0][1]["resultCap"], 3)
+
+    def test_get_tool_validates_exclusive_lookup_forms(self):
+        provider = self.initialized_provider()
+
+        error = json.loads(
+            provider.handle_tool_call(
+                "noosphere_get",
+                {"canonicalRef": "noosphere:article:1", "provider": "noosphere", "id": "1"},
+            )
+        )
+        success = json.loads(
+            provider.handle_tool_call("noosphere_get", {"canonicalRef": "noosphere:article:1"})
+        )
+
+        self.assertIn("not both", error["error"])
+        self.assertEqual(success["result"]["id"], "noosphere:article:1")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds Phase 3 explicit Noosphere memory tools: noosphere_recall, noosphere_get, and noosphere_topics.
- Implements prefetch() auto recall through Noosphere's prompt-ready /api/memory/recall response.
- Adds context-fence stripping and tests for recall/get validation and client POST bodies.

## Verification
- python3 -m unittest discover -s hermes-noosphere-memory/tests
- python3 -m compileall hermes-noosphere-memory/plugins/memory/noosphere
- git diff --check

## Stack
- Base PR: #86
- This PR intentionally excludes save/write behavior; that comes in the next step.

## Summary by Sourcery

Add Phase 3 Noosphere memory integration with explicit recall/get/topics tools and auto-recall prefetch support.

New Features:
- Expose noosphere_recall, noosphere_get, and noosphere_topics tools alongside the existing noosphere_status tool for explicit Noosphere memory operations.
- Add a prefetch() method that uses Noosphere's prompt-ready recall API to automatically retrieve relevant memory context.
- Introduce formatting utilities to strip Noosphere context fences and system notes from recalled memory text before returning it to Hermes.

Enhancements:
- Extend the Noosphere client with recall, get, and topics HTTP methods for interacting with the memory and topics APIs.
- Validate and normalize recall and get tool arguments, including enforcing mutually exclusive lookup forms and bounded result/token limits.

Documentation:
- Update Noosphere plugin documentation to describe Phase 3 capabilities, including new tools, auto-recall prefetch, and current implementation status.

Tests:
- Add client tests to verify recall requests send JSON POST bodies and authorization headers correctly.
- Add Phase 3 provider tests covering auto-recall prefetch behavior, recall/get tool modes and validation, and context-fence stripping logic.