### PR TITLE
feat(hermes): add Noosphere draft save support

### DIFF
--- a/hermes-noosphere-memory/README.md
+++ b/hermes-noosphere-memory/README.md
@@ -2,7 +2,7 @@
 
 This package contains the Hermes Agent memory-provider integration for Noosphere.
 
-Current implementation status: Phase 3 recall/get/topics and auto-recall prefetch.
+Current implementation status: Phase 4 draft save and explicit memory mirroring.
 
 ## Layout
 
@@ -29,13 +29,14 @@ Implemented:
 - environment-based secret lookup through `NOOSPHERE_API_KEY`
 - safe initialization without network calls
 - standard-library HTTP client with redacted errors
-- `noosphere_status`, `noosphere_recall`, `noosphere_get`, and `noosphere_topics` tools
+- `noosphere_status`, `noosphere_recall`, `noosphere_get`, `noosphere_topics`, and `noosphere_save` tools
 - auto-recall prefetch through Noosphere's prompt-ready recall API
+- explicit Hermes memory-write mirroring through draft memory candidates
+- optional `sync_turn` capture when `auto_capture=true` and `topic_id` is configured
 
 Not implemented yet:
 
-- explicit save/article tools
-- explicit memory write mirroring
+- direct article publication tools
 - installer script
 
 Those are intentionally left for later PRs so each step stays reviewable.

--- a/hermes-noosphere-memory/plugins/memory/noosphere/README.md
+++ b/hermes-noosphere-memory/plugins/memory/noosphere/README.md
@@ -2,7 +2,7 @@
 
 Noosphere gives Hermes Agent access to durable, scoped, human-readable memory.
 
-This provider is currently in Phase 3:
+This provider is currently in Phase 4:
 
 - it registers with Hermes as a memory provider
 - it exposes setup fields for the Noosphere API key and base URL
@@ -10,8 +10,10 @@ This provider is currently in Phase 3:
 - it reads the secret API key from `NOOSPHERE_API_KEY`
 - it exposes status, recall, get, and topics tools
 - it uses Noosphere's prompt-ready recall API for `prefetch()`
+- it saves explicit durable memories as draft candidates
+- it can mirror explicit Hermes memory writes when `topic_id` is configured
 
-Save tools are intentionally added in later phases.
+Direct article publication is intentionally added in later phases.
 
 ## Setup
 
@@ -83,3 +85,4 @@ Writes are disabled during `cron`, `flush`, and `subagent` contexts.
 | `noosphere_recall` | Calls `POST /api/memory/recall` in inspection mode. |
 | `noosphere_get` | Calls `POST /api/memory/get` by canonical ref or provider/id. |
 | `noosphere_topics` | Calls `GET /api/topics` for topic selection. |
+| `noosphere_save` | Calls `POST /api/memory/save` and creates a draft memory candidate. |

--- a/hermes-noosphere-memory/plugins/memory/noosphere/__init__.py
+++ b/hermes-noosphere-memory/plugins/memory/noosphere/__init__.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
+import threading
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -35,6 +37,11 @@ _DEFAULT_CONFIG: Dict[str, Any] = {
     "api_timeout": 5.0,
 }
 _NON_WRITING_CONTEXTS = {"cron", "flush", "subagent"}
+_MIN_CAPTURE_LENGTH = 10
+_TRIVIAL_RE = re.compile(
+    r"^(ok|okay|thanks|thank you|got it|sure|yes|no|yep|nope|k|ty|thx|np)\.?$",
+    re.IGNORECASE,
+)
 
 
 def _config_path(hermes_home: str) -> Path:
@@ -178,6 +185,7 @@ class NoosphereMemoryProvider(MemoryProvider):
         self._write_enabled = True
         self._active = False
         self._client: Optional[NoosphereClient] = None
+        self._write_thread: Optional[threading.Thread] = None
 
     @property
     def name(self) -> str:
@@ -278,13 +286,85 @@ class NoosphereMemoryProvider(MemoryProvider):
                 return json.dumps(self._client.recall(_read_recall_args(args, self._config)))
             if tool_name == "noosphere_get":
                 return json.dumps(self._client.get(_read_get_args(args)))
+            if tool_name == "noosphere_save":
+                return json.dumps(
+                    self._client.save(_read_save_args(args, self._config, self._agent_identity))
+                )
             return json.dumps({"error": f"Unknown Noosphere memory tool: {tool_name}"})
         except (NoosphereClientError, ValueError) as error:
             if isinstance(error, ValueError):
                 return json.dumps({"error": str(error)})
             return error.to_json()
 
+    def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
+        if not self._active or not self._client or not self._write_enabled:
+            return
+        if not self._config.get("auto_capture") or not self._config.get("topic_id"):
+            return
+        clean_user = _clean_capture_text(user_content)
+        clean_assistant = _clean_capture_text(assistant_content)
+        if not _should_capture(clean_user) or not _should_capture(clean_assistant):
+            return
+        title = _truncate_title(f"Hermes turn: {clean_user}", 120)
+        content = (
+            f"[role: user]\n{clean_user}\n[user:end]\n\n"
+            f"[role: assistant]\n{clean_assistant}\n[assistant:end]"
+        )
+        self._save_async(
+            {
+                "title": title,
+                "content": content,
+                "topicId": self._config["topic_id"],
+                "source": f"hermes:session:{session_id or self._session_id}",
+                "authorName": _resolve_author_name(self._config, self._agent_identity),
+                "confidence": "medium",
+                "tags": ["hermes", "conversation-turn"],
+            }
+        )
+
+    def on_memory_write(
+        self,
+        action: str,
+        target: str,
+        content: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        if action != "add" or not self._active or not self._client or not self._write_enabled:
+            return
+        clean = _clean_capture_text(content)
+        if not _should_capture(clean) or not self._config.get("topic_id"):
+            return
+        self._save_async(
+            {
+                "title": _truncate_title(f"Hermes memory: {target}", 120),
+                "content": clean,
+                "topicId": self._config["topic_id"],
+                "source": str((metadata or {}).get("source") or f"hermes:memory:{target}"),
+                "authorName": _resolve_author_name(self._config, self._agent_identity),
+                "confidence": "medium",
+                "tags": ["hermes", "explicit-memory", target],
+            }
+        )
+
+    def _save_async(self, request: Dict[str, Any]) -> None:
+        if not self._client:
+            return
+
+        def _run() -> None:
+            try:
+                assert self._client is not None
+                self._client.save(request)
+            except Exception:
+                logger.debug("Noosphere async save failed", exc_info=True)
+
+        if self._write_thread and self._write_thread.is_alive():
+            self._write_thread.join(timeout=2.0)
+        self._write_thread = threading.Thread(target=_run, daemon=True, name="noosphere-save")
+        self._write_thread.start()
+
     def shutdown(self) -> None:
+        if self._write_thread and self._write_thread.is_alive():
+            self._write_thread.join(timeout=5.0)
         return None
 
 
@@ -332,3 +412,57 @@ def _read_get_args(args: Dict[str, Any]) -> Dict[str, Any]:
     if provider and memory_id:
         return {"provider": provider, "id": memory_id}
     raise ValueError("Provide canonicalRef or provider+id")
+
+
+def _read_save_args(
+    args: Dict[str, Any],
+    config: Dict[str, Any],
+    agent_identity: str,
+) -> Dict[str, Any]:
+    title = _as_string(args.get("title"))
+    content = _clean_capture_text(args.get("content", ""))
+    topic_id = _as_string(args.get("topicId")) or _as_string(config.get("topic_id"))
+    if not title:
+        raise ValueError("title is required")
+    if not content:
+        raise ValueError("content is required")
+    if not topic_id:
+        raise ValueError("topicId is required unless noosphere.json defines topic_id")
+
+    request: Dict[str, Any] = {
+        "title": _truncate_title(title, 160),
+        "content": content,
+        "topicId": topic_id,
+        "authorName": _resolve_author_name(config, agent_identity),
+    }
+    for key in ("excerpt", "source", "confidence"):
+        value = _as_string(args.get(key))
+        if value:
+            request[key] = value
+    tags = args.get("tags")
+    if isinstance(tags, list):
+        clean_tags = [_as_string(tag) for tag in tags]
+        clean_tags = [tag for tag in clean_tags if tag]
+        if clean_tags:
+            request["tags"] = clean_tags[:20]
+    return request
+
+
+def _clean_capture_text(text: Any) -> str:
+    return strip_context_fences(str(text or "")).strip()
+
+
+def _should_capture(text: str) -> bool:
+    return len(text) >= _MIN_CAPTURE_LENGTH and not _TRIVIAL_RE.match(text)
+
+
+def _truncate_title(text: str, limit: int) -> str:
+    clean = " ".join((text or "").split())
+    if len(clean) <= limit:
+        return clean
+    return clean[: limit - 1].rstrip() + "..."
+
+
+def _resolve_author_name(config: Dict[str, Any], agent_identity: str) -> str:
+    template = _as_string(config.get("author_name_template"), "Hermes:{identity}")
+    return template.replace("{identity}", agent_identity or "default")

--- a/hermes-noosphere-memory/plugins/memory/noosphere/client.py
+++ b/hermes-noosphere-memory/plugins/memory/noosphere/client.py
@@ -40,6 +40,9 @@ class NoosphereClient:
     def get(self, request: Dict[str, Any]) -> Dict[str, Any]:
         return self._request_json("POST", "/api/memory/get", request)
 
+    def save(self, request: Dict[str, Any]) -> Dict[str, Any]:
+        return self._request_json("POST", "/api/memory/save", request)
+
     def topics(self) -> Dict[str, Any]:
         return self._request_json("GET", "/api/topics")
 

--- a/hermes-noosphere-memory/plugins/memory/noosphere/schemas.py
+++ b/hermes-noosphere-memory/plugins/memory/noosphere/schemas.py
@@ -74,9 +74,43 @@ NOOSPHERE_TOPICS_SCHEMA = {
     },
 }
 
+NOOSPHERE_SAVE_SCHEMA = {
+    "name": "noosphere_save",
+    "description": (
+        "Save durable, reusable knowledge to Noosphere as a draft memory candidate. "
+        "Use only for information likely to matter in future sessions."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "title": {"type": "string", "description": "Short title for the memory candidate."},
+            "content": {"type": "string", "description": "Durable memory content to save."},
+            "topicId": {
+                "type": "string",
+                "description": "Noosphere topic id. Uses configured default topic_id if omitted.",
+            },
+            "excerpt": {"type": "string", "description": "Optional short summary."},
+            "tags": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Optional tags.",
+            },
+            "source": {"type": "string", "description": "Optional source pointer."},
+            "confidence": {
+                "type": "string",
+                "enum": ["low", "medium", "high"],
+                "description": "Initial confidence for the draft candidate.",
+            },
+        },
+        "required": ["title", "content"],
+        "additionalProperties": False,
+    },
+}
+
 TOOL_SCHEMAS = [
     NOOSPHERE_STATUS_SCHEMA,
     NOOSPHERE_RECALL_SCHEMA,
     NOOSPHERE_GET_SCHEMA,
     NOOSPHERE_TOPICS_SCHEMA,
+    NOOSPHERE_SAVE_SCHEMA,
 ]

--- a/hermes-noosphere-memory/tests/test_noosphere_provider_phase1.py
+++ b/hermes-noosphere-memory/tests/test_noosphere_provider_phase1.py
@@ -137,7 +137,13 @@ class NoosphereProviderPhase1Test(unittest.TestCase):
 
         self.assertEqual(
             [schema["name"] for schema in schemas],
-            ["noosphere_status", "noosphere_recall", "noosphere_get", "noosphere_topics"],
+            [
+                "noosphere_status",
+                "noosphere_recall",
+                "noosphere_get",
+                "noosphere_topics",
+                "noosphere_save",
+            ],
         )
 
 

--- a/hermes-noosphere-memory/tests/test_noosphere_recall_phase3.py
+++ b/hermes-noosphere-memory/tests/test_noosphere_recall_phase3.py
@@ -72,6 +72,10 @@ class _FakeClient:
         self.calls.append(("get", request))
         return {"result": {"id": request.get("canonicalRef") or request.get("id")}}
 
+    def save(self, request):
+        self.calls.append(("save", request))
+        return {"success": True, "candidate": {"title": request["title"]}}
+
 
 class NoosphereRecallPhase3Test(unittest.TestCase):
     def initialized_provider(self):

--- a/hermes-noosphere-memory/tests/test_noosphere_save_phase4.py
+++ b/hermes-noosphere-memory/tests/test_noosphere_save_phase4.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+PLUGIN_DIR = (
+    Path(__file__).resolve().parents[1]
+    / "plugins"
+    / "memory"
+    / "noosphere"
+)
+
+
+class _FakeMemoryProvider:
+    pass
+
+
+def load_plugin():
+    agent_module = types.ModuleType("agent")
+    memory_provider_module = types.ModuleType("agent.memory_provider")
+    memory_provider_module.MemoryProvider = _FakeMemoryProvider
+    with mock.patch.dict(
+        sys.modules,
+        {
+            "agent": agent_module,
+            "agent.memory_provider": memory_provider_module,
+        },
+    ):
+        spec = importlib.util.spec_from_file_location(
+            "noosphere_memory_plugin",
+            PLUGIN_DIR / "__init__.py",
+            submodule_search_locations=[str(PLUGIN_DIR)],
+        )
+        module = importlib.util.module_from_spec(spec)
+        assert spec and spec.loader
+        with mock.patch.dict(sys.modules, {"noosphere_memory_plugin": module}):
+            spec.loader.exec_module(module)
+            return module
+
+
+class _FakeClient:
+    def __init__(self):
+        self.saved = []
+
+    def save(self, request):
+        self.saved.append(request)
+        return {"success": True, "candidate": {"title": request["title"]}}
+
+
+class NoosphereSavePhase4Test(unittest.TestCase):
+    def initialized_provider(self, *, topic_id="topic-1", auto_capture=False, context="primary"):
+        module = load_plugin()
+        provider = module.NoosphereMemoryProvider()
+        with tempfile.TemporaryDirectory() as hermes_home:
+            Path(hermes_home, "noosphere.json").write_text(
+                json.dumps({"topic_id": topic_id, "auto_capture": auto_capture}),
+                encoding="utf-8",
+            )
+            with mock.patch.dict(os.environ, {"NOOSPHERE_API_KEY": "noo_test"}, clear=True):
+                provider.initialize(
+                    "session-1",
+                    hermes_home=hermes_home,
+                    agent_identity="coder",
+                    agent_context=context,
+                )
+        provider._client = _FakeClient()
+        return provider
+
+    def test_save_tool_uses_default_topic_and_author_template(self):
+        provider = self.initialized_provider(topic_id="topic-1")
+
+        result = json.loads(
+            provider.handle_tool_call(
+                "noosphere_save",
+                {
+                    "title": "Deployment rule",
+                    "content": "<memory-context>Use pkapp PM2.</memory-context>",
+                    "tags": ["ops", ""],
+                },
+            )
+        )
+
+        self.assertTrue(result["success"])
+        saved = provider._client.saved[0]
+        self.assertEqual(saved["topicId"], "topic-1")
+        self.assertEqual(saved["authorName"], "Hermes:coder")
+        self.assertEqual(saved["content"], "Use pkapp PM2.")
+        self.assertEqual(saved["tags"], ["ops"])
+
+    def test_memory_write_mirror_runs_async_when_topic_is_configured(self):
+        provider = self.initialized_provider(topic_id="topic-1")
+
+        provider.on_memory_write("add", "memory", "Remember this durable operating fact.")
+        provider.shutdown()
+
+        self.assertEqual(len(provider._client.saved), 1)
+        self.assertEqual(provider._client.saved[0]["tags"], ["hermes", "explicit-memory", "memory"])
+
+    def test_memory_write_mirror_skips_subagent_context(self):
+        provider = self.initialized_provider(topic_id="topic-1", context="subagent")
+
+        provider.on_memory_write("add", "memory", "Remember this durable operating fact.")
+        provider.shutdown()
+
+        self.assertEqual(provider._client.saved, [])
+
+    def test_sync_turn_requires_auto_capture_and_topic(self):
+        provider = self.initialized_provider(topic_id="topic-1", auto_capture=True)
+
+        provider.sync_turn("The user selected option B.", "I implemented option B.")
+        provider.shutdown()
+
+        self.assertEqual(len(provider._client.saved), 1)
+        self.assertIn("[role: user]", provider._client.saved[0]["content"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds Phase 4 noosphere_save support through Noosphere's draft memory candidate API.
- Mirrors explicit Hermes memory writes into Noosphere when topic_id is configured.
- Adds conservative optional sync_turn capture behind auto_capture=true and topic_id.

## Verification
- python3 -m unittest discover -s hermes-noosphere-memory/tests
- python3 -m compileall hermes-noosphere-memory/plugins/memory/noosphere
- git diff --check

## Stack
- Base PR: #87
- This PR intentionally keeps direct article publication and installer work out of scope.

## Summary by Sourcery

Add Phase 4 Noosphere draft save support, including a new save tool and automatic mirroring of Hermes memories into Noosphere when configured.

New Features:
- Introduce a noosphere_save tool and corresponding client API for creating draft memory candidates in Noosphere.
- Add optional sync_turn-based conversational capture to save selected user/assistant turns as draft memories when auto_capture and topic_id are configured.
- Mirror explicit Hermes memory writes into Noosphere as draft memory candidates when a topic_id is set.

Enhancements:
- Add filtering and normalization utilities to clean, de-duplicate, and title memory content before saving, including trivial-response suppression and title truncation.
- Extend provider shutdown to wait for in-flight asynchronous save operations to complete.
- Document Phase 4 capabilities and the new save tool in the project and plugin READMEs.

Tests:
- Add Phase 4 tests covering the save tool behavior, memory mirroring, and sync_turn capture, and update existing tests to include the new tool schema.