### PR TITLE
Fix Hermes Noosphere provider reliability issues

### DIFF
--- a/docs/HERMES-NOOSPHERE-MEMORY-PLUGIN-PLAN.md
+++ b/docs/HERMES-NOOSPHERE-MEMORY-PLUGIN-PLAN.md
@@ -59,7 +59,9 @@ hermes-noosphere-memory/
   README.md
   install-hermes.sh
   plugins/
+    __init__.py
     memory/
+      __init__.py
       noosphere/
         __init__.py
         plugin.yaml
@@ -71,11 +73,10 @@ hermes-noosphere-memory/
           noosphere/
             SKILL.md
   tests/
-    test_noosphere_memory_provider.py
     test_noosphere_client.py
-    fixtures/
-      recall.json
-      topics.json
+    test_noosphere_provider_phase1.py
+    test_noosphere_recall_phase3.py
+    test_noosphere_save_phase4.py
 ```
 
 Rationale:

--- a/hermes-noosphere-memory/README.md
+++ b/hermes-noosphere-memory/README.md
@@ -14,12 +14,15 @@ plugins/memory/noosphere/
   plugin.yaml
   README.md
   schemas.py
+  skills/noosphere/SKILL.md
 tests/
   test_noosphere_client.py
   test_noosphere_provider_phase1.py
+  test_noosphere_recall_phase3.py
+  test_noosphere_save_phase4.py
 ```
 
-## Phase 1 Scope
+## Phase 4 Scope
 
 Implemented:
 
@@ -37,7 +40,6 @@ Implemented:
 Not implemented yet:
 
 - direct article publication tools
-- installer script
 
 Those are intentionally left for later PRs so each step stays reviewable.
 

--- a/hermes-noosphere-memory/install-hermes.sh
+++ b/hermes-noosphere-memory/install-hermes.sh
@@ -44,6 +44,12 @@ need tar
 mkdir -p "$TARGET_DIR"
 tar -C "$SOURCE_DIR" -cf - . | tar -C "$TARGET_DIR" -xf -
 
+if command -v python3 >/dev/null 2>&1; then
+  if ! python3 -m compileall -q "$TARGET_DIR"; then
+    echo "Warning: installed plugin has Python syntax errors. Check $TARGET_DIR." >&2
+  fi
+fi
+
 echo ""
 echo "Noosphere Hermes memory provider installed."
 echo ""

--- a/hermes-noosphere-memory/plugins/__init__.py
+++ b/hermes-noosphere-memory/plugins/__init__.py
@@ -1,0 +1,2 @@
+"""Hermes plugin namespace for the Noosphere memory provider."""
+

--- a/hermes-noosphere-memory/plugins/memory/__init__.py
+++ b/hermes-noosphere-memory/plugins/memory/__init__.py
@@ -1,0 +1,2 @@
+"""Hermes memory-provider plugin namespace."""
+

--- a/hermes-noosphere-memory/plugins/memory/noosphere/README.md
+++ b/hermes-noosphere-memory/plugins/memory/noosphere/README.md
@@ -53,14 +53,14 @@ Config file: `$HERMES_HOME/noosphere.json`
 | Key | Default | Description |
 | --- | --- | --- |
 | `base_url` | `http://127.0.0.1:6578` | Noosphere deployment URL. |
-| `auto_recall` | `true` | Enable prompt-time recall once Phase 3 lands. |
+| `auto_recall` | `true` | Enable prompt-time recall through Noosphere's prompt-ready recall API. |
 | `auto_capture` | `false` | Keep broad turn capture disabled by default. |
-| `capture_mode` | `explicit` | Capture policy. Phase 1 stores only config. |
-| `max_recall_results` | `5` | Future recall result cap. |
-| `token_budget` | `1200` | Future recall token budget. |
-| `topic_id` | `""` | Default save topic for later write phases. |
-| `author_name_template` | `Hermes:{identity}` | Future author name template. |
-| `api_timeout` | `5.0` | Future HTTP timeout in seconds. |
+| `capture_mode` | `explicit` | Capture policy; broad turn capture only runs when set up explicitly. |
+| `max_recall_results` | `5` | Maximum results requested during prefetch and recall. |
+| `token_budget` | `1200` | Prompt-ready recall token budget. |
+| `topic_id` | `""` | Default topic for draft saves and optional turn capture. |
+| `author_name_template` | `Hermes:{identity}` | Author name template for draft memory candidates. |
+| `api_timeout` | `5.0` | HTTP timeout in seconds. |
 
 Secrets:
 

--- a/hermes-noosphere-memory/plugins/memory/noosphere/__init__.py
+++ b/hermes-noosphere-memory/plugins/memory/noosphere/__init__.py
@@ -10,9 +10,11 @@ from __future__ import annotations
 import json
 import logging
 import os
+import queue
 import re
 import tempfile
 import threading
+import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -39,6 +41,8 @@ _DEFAULT_CONFIG: Dict[str, Any] = {
 _NON_WRITING_CONTEXTS = {"cron", "flush", "subagent"}
 _SECRET_CONFIG_KEYS = {"api_key"}
 _MIN_CAPTURE_LENGTH = 40  # Noosphere API durable content minimum
+_SAVE_QUEUE_MAXSIZE = 100
+_VALID_CONFIDENCE = {"low", "medium", "high"}
 _TRIVIAL_RE = re.compile(
     r"^(ok|okay|thanks|thank you|got it|sure|yes|no|yep|nope|k|ty|thx|np)\.?$",
     re.IGNORECASE,
@@ -131,11 +135,11 @@ def _sanitize_config(raw: Dict[str, Any]) -> Dict[str, Any]:
 
 def _load_noosphere_config(hermes_home: str) -> Dict[str, Any]:
     path = _config_path(hermes_home)
-    if not path.exists():
-        return dict(_DEFAULT_CONFIG)
     try:
         raw = json.loads(path.read_text(encoding="utf-8"))
-    except Exception:
+    except FileNotFoundError:
+        return dict(_DEFAULT_CONFIG)
+    except (json.JSONDecodeError, OSError):
         logger.warning("Failed to parse %s; using defaults", path, exc_info=True)
         return dict(_DEFAULT_CONFIG)
     if not isinstance(raw, dict):
@@ -147,18 +151,19 @@ def _load_noosphere_config(hermes_home: str) -> Dict[str, Any]:
 def _save_noosphere_config(values: Dict[str, Any], hermes_home: str) -> None:
     path = _config_path(hermes_home)
     existing: Dict[str, Any] = {}
-    if path.exists():
-        try:
-            raw = json.loads(path.read_text(encoding="utf-8"))
-            if isinstance(raw, dict):
-                existing = raw
-        except Exception:
-            logger.warning(
-                "Failed to parse existing Noosphere config at %s; ignoring",
-                path,
-                exc_info=True,
-            )
-            existing = {}
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+        if isinstance(raw, dict):
+            existing = raw
+    except FileNotFoundError:
+        existing = {}
+    except (json.JSONDecodeError, OSError):
+        logger.warning(
+            "Failed to parse existing Noosphere config at %s; ignoring",
+            path,
+            exc_info=True,
+        )
+        existing = {}
 
     sanitized_values = dict(values or {})
     for key in _SECRET_CONFIG_KEYS:
@@ -204,7 +209,9 @@ class NoosphereMemoryProvider(MemoryProvider):
         self._write_enabled = True
         self._active = False
         self._client: Optional[NoosphereClient] = None
-        self._write_thread: Optional[threading.Thread] = None
+        self._save_queue: queue.Queue[Dict[str, Any]] = queue.Queue(maxsize=_SAVE_QUEUE_MAXSIZE)
+        self._save_worker: Optional[threading.Thread] = None
+        self._save_worker_lock = threading.Lock()
 
     @property
     def name(self) -> str:
@@ -286,7 +293,7 @@ class NoosphereMemoryProvider(MemoryProvider):
                     "tokenBudget": self._config["token_budget"],
                 }
             )
-        except NoosphereClientError:
+        except Exception:
             logger.debug("Noosphere prefetch failed", exc_info=True)
             return ""
         prompt_text = result.get("promptInjectionText")
@@ -319,6 +326,9 @@ class NoosphereMemoryProvider(MemoryProvider):
             if isinstance(error, ValueError):
                 return json.dumps({"error": str(error)})
             return error.to_json()
+        except Exception:
+            logger.warning("Noosphere tool call failed: %s", tool_name, exc_info=True)
+            return json.dumps({"error": f"Noosphere {tool_name} failed"})
 
     def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
         if not self._active or not self._client or not self._write_enabled:
@@ -327,9 +337,11 @@ class NoosphereMemoryProvider(MemoryProvider):
             return
         clean_user = _clean_capture_text(user_content)
         clean_assistant = _clean_capture_text(assistant_content)
-        if not _should_capture(clean_user) or not _should_capture(clean_assistant):
+        combined = f"{clean_user}\n{clean_assistant}".strip()
+        if not _should_capture(combined):
             return
-        title = _truncate_title(f"Hermes turn: {clean_user}", 120)
+        title_seed = clean_user if _should_capture(clean_user) else clean_assistant
+        title = _truncate_title(f"Hermes turn: {title_seed}", 120)
         content = (
             f"[role: user]\n{clean_user}\n[user:end]\n\n"
             f"[role: assistant]\n{clean_assistant}\n[assistant:end]"
@@ -373,22 +385,51 @@ class NoosphereMemoryProvider(MemoryProvider):
     def _save_async(self, request: Dict[str, Any]) -> None:
         if not self._client:
             return
+        try:
+            self._save_queue.put_nowait(request)
+        except queue.Full:
+            logger.warning("Noosphere save queue full; dropping write")
+            return
+        self._ensure_save_worker()
 
-        def _run() -> None:
+    def _ensure_save_worker(self) -> None:
+        with self._save_worker_lock:
+            if self._save_worker and self._save_worker.is_alive():
+                return
+            self._save_worker = threading.Thread(
+                target=self._save_worker_loop,
+                daemon=True,
+                name="noosphere-save-worker",
+            )
+            self._save_worker.start()
+
+    def _save_worker_loop(self) -> None:
+        while True:
             try:
-                assert self._client is not None
-                self._client.save(request)
+                request = self._save_queue.get(timeout=1.0)
+            except queue.Empty:
+                continue
+            try:
+                client = self._client
+                if client:
+                    client.save(request)
             except Exception:
                 logger.debug("Noosphere async save failed", exc_info=True)
-
-        if self._write_thread and self._write_thread.is_alive():
-            self._write_thread.join(timeout=2.0)
-        self._write_thread = threading.Thread(target=_run, daemon=True, name="noosphere-save")
-        self._write_thread.start()
+            finally:
+                self._save_queue.task_done()
 
     def shutdown(self) -> None:
-        if self._write_thread and self._write_thread.is_alive():
-            self._write_thread.join(timeout=5.0)
+        deadline = time.monotonic() + 5.0
+        with self._save_queue.all_tasks_done:
+            while self._save_queue.unfinished_tasks:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    logger.warning(
+                        "Noosphere shutdown timed out with %s pending save(s)",
+                        self._save_queue.unfinished_tasks,
+                    )
+                    break
+                self._save_queue.all_tasks_done.wait(timeout=remaining)
         return None
 
 
@@ -442,7 +483,7 @@ def _read_save_args(
     config: Dict[str, Any],
     agent_identity: str,
 ) -> Dict[str, Any]:
-    title = _as_string(args.get("title"))
+    title = _clean_capture_text(args.get("title"))
     content = _clean_capture_text(args.get("content", ""))
     topic_id = _as_string(args.get("topicId")) or _as_string(config.get("topic_id"))
     if not title:
@@ -458,10 +499,15 @@ def _read_save_args(
         "topicId": topic_id,
         "authorName": _resolve_author_name(config, agent_identity),
     }
-    for key in ("excerpt", "source", "confidence"):
-        value = _as_string(args.get(key))
+    for key in ("excerpt", "source"):
+        value = _clean_capture_text(args.get(key))
         if value:
             request[key] = value
+    confidence = _as_string(args.get("confidence")).lower()
+    if confidence:
+        if confidence not in _VALID_CONFIDENCE:
+            raise ValueError("confidence must be low, medium, or high")
+        request["confidence"] = confidence
     tags = args.get("tags")
     if isinstance(tags, list):
         clean_tags = [_as_string(tag) for tag in tags]

--- a/hermes-noosphere-memory/plugins/memory/noosphere/client.py
+++ b/hermes-noosphere-memory/plugins/memory/noosphere/client.py
@@ -2,12 +2,26 @@
 
 from __future__ import annotations
 
+import http.client
 import json
+import re
 import urllib.error
 import urllib.request
 from typing import Any, Dict, Optional
 
 _MAX_RESPONSE_BYTES = 1_000_000
+_SENSITIVE_FIELD_NAMES = {
+    "api_key",
+    "apikey",
+    "key",
+    "token",
+    "authorization",
+    "access_token",
+    "refresh_token",
+}
+_SENSITIVE_VALUE_RE = re.compile(
+    r"(?:noo_[A-Za-z0-9_-]+|Bearer\s+[A-Za-z0-9._~+/=-]{8,}|(?:sk|pk|tok|key)_[A-Za-z0-9_-]{16,})"
+)
 
 
 class NoosphereClientError(Exception):
@@ -78,6 +92,10 @@ class NoosphereClient:
             ):
                 raise NoosphereClientError("Noosphere request timed out") from None
             raise NoosphereClientError(f"Noosphere request failed: {reason}") from None
+        except TimeoutError:
+            raise NoosphereClientError("Noosphere request timed out") from None
+        except (http.client.HTTPException, OSError):
+            raise NoosphereClientError("Noosphere request failed") from None
 
 
 def _parse_json_response(raw: bytes) -> Dict[str, Any]:
@@ -119,13 +137,17 @@ def _redact(value: Any) -> Any:
         redacted: Dict[str, Any] = {}
         for key, item in value.items():
             lowered = str(key).lower()
-            if "key" in lowered or "token" in lowered or "authorization" in lowered:
+            if (
+                lowered in _SENSITIVE_FIELD_NAMES
+                or lowered.endswith("_key")
+                or lowered.endswith("_token")
+            ):
                 redacted[key] = "[redacted]"
             else:
                 redacted[key] = _redact(item)
         return redacted
     if isinstance(value, list):
         return [_redact(item) for item in value]
-    if isinstance(value, str) and value.startswith("noo_"):
+    if isinstance(value, str) and _SENSITIVE_VALUE_RE.search(value):
         return "[redacted]"
     return value

--- a/hermes-noosphere-memory/plugins/memory/noosphere/plugin.yaml
+++ b/hermes-noosphere-memory/plugins/memory/noosphere/plugin.yaml
@@ -1,3 +1,3 @@
 name: noosphere
-version: 0.1.0
+version: 0.4.1
 description: "Noosphere durable memory provider with scoped recall and draft memory capture."

--- a/hermes-noosphere-memory/tests/test_noosphere_client.py
+++ b/hermes-noosphere-memory/tests/test_noosphere_client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import http.client
 import json
 import sys
 import threading
@@ -150,6 +151,42 @@ class NoosphereClientTest(unittest.TestCase):
         self.assertEqual(payload["status"], 401)
         self.assertEqual(payload["details"]["apiKey"], "[redacted]")
         self.assertEqual(payload["details"]["nested"]["authorization"], "[redacted]")
+
+    def test_http_exception_is_wrapped(self):
+        module = load_plugin_package()
+        client = module.NoosphereClient(
+            base_url=self.base_url,
+            api_key="noo_test",
+            timeout=2.0,
+        )
+
+        client_globals = module.NoosphereClient._request_json.__globals__
+        with mock.patch.object(
+            client_globals["urllib"].request,
+            "urlopen",
+            side_effect=http.client.HTTPException("bad status line"),
+        ):
+            with self.assertRaises(module.NoosphereClientError) as caught:
+                client.status()
+
+        self.assertEqual(str(caught.exception), "Noosphere request failed")
+
+    def test_redact_preserves_non_secret_key_substrings(self):
+        module = load_plugin_package()
+
+        redacted = module.NoosphereClient._request_json.__globals__["_redact"](
+            {
+                "monkey": "visible",
+                "keywords": ["search", "terms"],
+                "access_token": "tok_1234567890abcdef",
+                "message": "Bearer secretbearertoken",
+            }
+        )
+
+        self.assertEqual(redacted["monkey"], "visible")
+        self.assertEqual(redacted["keywords"], ["search", "terms"])
+        self.assertEqual(redacted["access_token"], "[redacted]")
+        self.assertEqual(redacted["message"], "[redacted]")
 
 
 if __name__ == "__main__":

--- a/hermes-noosphere-memory/tests/test_noosphere_recall_phase3.py
+++ b/hermes-noosphere-memory/tests/test_noosphere_recall_phase3.py
@@ -77,6 +77,14 @@ class _FakeClient:
         return {"success": True, "candidate": {"title": request["title"]}}
 
 
+class _ExplodingClient:
+    def recall(self, request):
+        raise RuntimeError("boom")
+
+    def topics(self):
+        raise RuntimeError("boom")
+
+
 class NoosphereRecallPhase3Test(unittest.TestCase):
     def initialized_provider(self):
         module = load_plugin()
@@ -95,6 +103,19 @@ class NoosphereRecallPhase3Test(unittest.TestCase):
         self.assertEqual(result, "Remember the Serianis deploy path.")
         self.assertEqual(provider._client.calls[0][0], "recall")
         self.assertEqual(provider._client.calls[0][1]["mode"], "auto")
+
+    def test_prefetch_suppresses_unexpected_client_errors(self):
+        provider = self.initialized_provider()
+        provider._client = _ExplodingClient()
+
+        self.assertEqual(provider.prefetch("Serianis deploy?"), "")
+
+    def test_prefetch_respects_auto_recall_false(self):
+        provider = self.initialized_provider()
+        provider._config["auto_recall"] = False
+
+        self.assertEqual(provider.prefetch("Serianis deploy?"), "")
+        self.assertEqual(provider._client.calls, [])
 
     def test_recall_tool_uses_inspection_mode(self):
         provider = self.initialized_provider()
@@ -122,6 +143,16 @@ class NoosphereRecallPhase3Test(unittest.TestCase):
 
         self.assertIn("not both", error["error"])
         self.assertEqual(success["result"]["id"], "noosphere:article:1")
+
+    def test_tool_call_returns_generic_error_for_unexpected_exception(self):
+        provider = self.initialized_provider()
+        provider._client = _ExplodingClient()
+
+        logger = provider.__class__.handle_tool_call.__globals__["logger"]
+        with mock.patch.object(logger, "warning"):
+            payload = json.loads(provider.handle_tool_call("noosphere_topics", {}))
+
+        self.assertEqual(payload["error"], "Noosphere noosphere_topics failed")
 
 
 if __name__ == "__main__":

--- a/hermes-noosphere-memory/tests/test_noosphere_save_phase4.py
+++ b/hermes-noosphere-memory/tests/test_noosphere_save_phase4.py
@@ -5,8 +5,10 @@ import json
 import os
 import sys
 import tempfile
+import time
 import types
 import unittest
+import threading
 from pathlib import Path
 from unittest import mock
 
@@ -55,6 +57,19 @@ class _FakeClient:
         return {"success": True, "candidate": {"title": request["title"]}}
 
 
+class _BlockingClient:
+    def __init__(self):
+        self.entered = threading.Event()
+        self.release = threading.Event()
+        self.saved = []
+
+    def save(self, request):
+        self.entered.set()
+        self.release.wait(timeout=2)
+        self.saved.append(request)
+        return {"success": True}
+
+
 class NoosphereSavePhase4Test(unittest.TestCase):
     def initialized_provider(self, *, topic_id="topic-1", auto_capture=False, context="primary"):
         module = load_plugin()
@@ -95,6 +110,64 @@ class NoosphereSavePhase4Test(unittest.TestCase):
         self.assertEqual(saved["content"], "Use pkapp PM2.")
         self.assertEqual(saved["tags"], ["ops"])
 
+    def test_save_tool_validates_confidence(self):
+        provider = self.initialized_provider(topic_id="topic-1")
+
+        error = json.loads(
+            provider.handle_tool_call(
+                "noosphere_save",
+                {
+                    "title": "Deployment rule",
+                    "content": "Use this durable deployment rule for the configured system.",
+                    "confidence": "very high",
+                },
+            )
+        )
+
+        self.assertEqual(error["error"], "confidence must be low, medium, or high")
+        self.assertEqual(provider._client.saved, [])
+
+    def test_save_tool_strips_context_fences_from_metadata(self):
+        provider = self.initialized_provider(topic_id="topic-1")
+
+        result = json.loads(
+            provider.handle_tool_call(
+                "noosphere_save",
+                {
+                    "title": "<memory-context>Deployment rule</memory-context>",
+                    "content": "Use this durable deployment rule for the configured system.",
+                    "excerpt": "<memory-context>PM2 restart rule</memory-context>",
+                    "source": "<memory-context>hermes:test</memory-context>",
+                    "confidence": "HIGH",
+                },
+            )
+        )
+
+        self.assertTrue(result["success"])
+        saved = provider._client.saved[0]
+        self.assertEqual(saved["title"], "Deployment rule")
+        self.assertEqual(saved["excerpt"], "PM2 restart rule")
+        self.assertEqual(saved["source"], "hermes:test")
+        self.assertEqual(saved["confidence"], "high")
+
+    def test_save_async_does_not_block_behind_in_flight_write(self):
+        provider = self.initialized_provider(topic_id="topic-1")
+        client = _BlockingClient()
+        provider._client = client
+
+        provider._save_async({"title": "one"})
+        self.assertTrue(client.entered.wait(timeout=1))
+
+        started = time.monotonic()
+        provider._save_async({"title": "two"})
+        elapsed = time.monotonic() - started
+
+        client.release.set()
+        provider.shutdown()
+
+        self.assertLess(elapsed, 0.25)
+        self.assertEqual([item["title"] for item in client.saved], ["one", "two"])
+
     def test_memory_write_mirror_runs_async_when_topic_is_configured(self):
         provider = self.initialized_provider(topic_id="topic-1")
 
@@ -120,6 +193,18 @@ class NoosphereSavePhase4Test(unittest.TestCase):
 
         self.assertEqual(len(provider._client.saved), 1)
         self.assertIn("[role: user]", provider._client.saved[0]["content"])
+
+    def test_sync_turn_captures_when_assistant_side_is_substantial(self):
+        provider = self.initialized_provider(topic_id="topic-1", auto_capture=True)
+
+        provider.sync_turn(
+            "ok",
+            "I documented the deployment rule, including the PM2 process name and verification command.",
+        )
+        provider.shutdown()
+
+        self.assertEqual(len(provider._client.saved), 1)
+        self.assertIn("I documented the deployment rule", provider._client.saved[0]["title"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Replace one-thread-per-save behavior with a bounded async save queue and single worker so sync_turn/on_memory_write do not block behind in-flight writes.
- Harden prefetch/tool-call exception boundaries, client HTTP exception handling, and secret redaction.
- Fix config load/save TOCTOU handling, save argument cleanup/validation, stale docs, package markers, installer compile check, and plugin version metadata.
- Add regression coverage for async save concurrency, partial-trivial sync_turn capture, malformed confidence, context-fence stripping, broad exception handling, and redaction behavior.

## Verification
- python3 -m unittest discover -s hermes-noosphere-memory/tests
- python3 -m compileall hermes-noosphere-memory/plugins hermes-noosphere-memory/tests
- git diff --check