### PR TITLE
fix(hermes): install Noosphere provider in discoverable path

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,10 +534,30 @@ cd hermes-noosphere-memory
 Manual setup:
 
 ```bash
-mkdir -p "$HERMES_HOME/plugins/memory"
-cp -R plugins/memory/noosphere "$HERMES_HOME/plugins/memory/noosphere"
+mkdir -p "$HERMES_HOME/plugins"
+cp -R plugins/memory/noosphere "$HERMES_HOME/plugins/noosphere"
 hermes config set memory.provider noosphere
-printf '%s\n' 'NOOSPHERE_API_KEY=noo_...' >> "$HERMES_HOME/.env"
+python3 - <<'PY'
+import os
+from pathlib import Path
+
+hermes_home = Path(os.environ.get("HERMES_HOME", str(Path.home() / ".hermes"))).expanduser()
+env_path = hermes_home / ".env"
+env_path.parent.mkdir(parents=True, exist_ok=True)
+lines = env_path.read_text(encoding="utf-8").splitlines() if env_path.exists() else []
+key = "NOOSPHERE_API_KEY"
+value = "noo_..."
+updated = False
+for index, line in enumerate(lines):
+    if line.split("=", 1)[0].strip() == key:
+        lines[index] = f"{key}={value}"
+        updated = True
+        break
+if not updated:
+    lines.append(f"{key}={value}")
+env_path.write_text("\\n".join(lines) + "\\n", encoding="utf-8")
+env_path.chmod(0o600)
+PY
 ```
 
 Then create or edit `$HERMES_HOME/noosphere.json`:
@@ -550,10 +570,9 @@ Then create or edit `$HERMES_HOME/noosphere.json`:
   "capture_mode": "explicit",
   "max_recall_results": 5,
   "token_budget": 1200,
-  "providers": ["noosphere"],
   "topic_id": "",
   "author_name_template": "Hermes:{identity}",
-  "api_timeout": 5.0
+  "api_timeout": 15.0
 }
 ```
 
@@ -561,7 +580,7 @@ Then create or edit `$HERMES_HOME/noosphere.json`:
 
 | Capability | Status | Description |
 | --- | --- | --- |
-| `noosphere_status` | Implemented | Checks `GET /api/memory/status`. |
+| `noosphere_status` | Implemented | Checks `GET /api/memory/status`, with `/api/health` fallback for scoped non-admin keys. |
 | `noosphere_recall` | Implemented | Calls Noosphere recall in inspection mode. |
 | `noosphere_get` | Implemented | Fetches one memory by canonical ref or provider/id. |
 | `noosphere_topics` | Implemented | Lists topics for save target selection. |

--- a/docs/HERMES-NOOSPHERE-MEMORY-PLUGIN-PLAN.md
+++ b/docs/HERMES-NOOSPHERE-MEMORY-PLUGIN-PLAN.md
@@ -81,9 +81,9 @@ hermes-noosphere-memory/
 
 Rationale:
 
-- The `plugins/memory/noosphere/` shape matches Hermes' provider discovery model.
+- The source `plugins/memory/noosphere/` shape matches Hermes' bundled provider layout.
 - Keeping it under `hermes-noosphere-memory/` avoids mixing Python Hermes code with the TypeScript OpenClaw plugin.
-- The install script can copy or sync `plugins/memory/noosphere` into `$HERMES_HOME/plugins/memory/noosphere`.
+- Hermes 0.14 discovers user-installed providers at `$HERMES_HOME/plugins/<name>`, so the install script copies `plugins/memory/noosphere` into `$HERMES_HOME/plugins/noosphere`.
 
 ## Configuration Design
 
@@ -128,7 +128,7 @@ Suggested defaults:
   "token_budget": 1200,
   "topic_id": "",
   "author_name_template": "Hermes:{identity}",
-  "api_timeout": 5.0
+  "api_timeout": 15.0
 }
 ```
 
@@ -250,21 +250,44 @@ Add `hermes-noosphere-memory/install-hermes.sh`.
 Installer responsibilities:
 
 1. detect `HERMES_HOME`, defaulting to `$HOME/.hermes`
-2. copy `plugins/memory/noosphere` to `$HERMES_HOME/plugins/memory/noosphere`
+2. copy `plugins/memory/noosphere` to `$HERMES_HOME/plugins/noosphere`
 3. offer to run `hermes memory setup`
 4. print exact manual fallback commands:
 
 ```bash
 hermes config set memory.provider noosphere
-echo 'NOOSPHERE_API_KEY=noo_...' >> "$HERMES_HOME/.env"
-cat > "$HERMES_HOME/noosphere.json" <<'JSON'
+python3 - <<'PY'
+import os
+from pathlib import Path
+
+hermes_home = Path(os.environ.get("HERMES_HOME", str(Path.home() / ".hermes"))).expanduser()
+env_path = hermes_home / ".env"
+env_path.parent.mkdir(parents=True, exist_ok=True)
+lines = env_path.read_text(encoding="utf-8").splitlines() if env_path.exists() else []
+key = "NOOSPHERE_API_KEY"
+value = "noo_..."
+updated = False
+for index, line in enumerate(lines):
+    if line.split("=", 1)[0].strip() == key:
+        lines[index] = f"{key}={value}"
+        updated = True
+        break
+if not updated:
+    lines.append(f"{key}={value}")
+env_path.write_text("\\n".join(lines) + "\\n", encoding="utf-8")
+env_path.chmod(0o600)
+PY
+[ ! -f "$HERMES_HOME/noosphere.json" ] && cat > "$HERMES_HOME/noosphere.json" <<'JSON'
 {
   "base_url": "http://127.0.0.1:6578",
   "auto_recall": true,
   "auto_capture": false,
   "capture_mode": "explicit",
   "max_recall_results": 5,
-  "token_budget": 1200
+  "token_budget": 1200,
+  "topic_id": "",
+  "author_name_template": "Hermes:{identity}",
+  "api_timeout": 15.0
 }
 JSON
 ```

--- a/hermes-noosphere-memory/README.md
+++ b/hermes-noosphere-memory/README.md
@@ -46,8 +46,8 @@ Those are intentionally left for later PRs so each step stays reviewable.
 ## Manual Install During Development
 
 ```bash
-mkdir -p "$HERMES_HOME/plugins/memory"
-cp -R hermes-noosphere-memory/plugins/memory/noosphere "$HERMES_HOME/plugins/memory/noosphere"
+mkdir -p "$HERMES_HOME/plugins"
+cp -R hermes-noosphere-memory/plugins/memory/noosphere "$HERMES_HOME/plugins/noosphere"
 hermes memory setup
 ```
 
@@ -55,8 +55,28 @@ Manual fallback:
 
 ```bash
 hermes config set memory.provider noosphere
-printf '%s\n' 'NOOSPHERE_API_KEY=noo_...' >> "$HERMES_HOME/.env"
-cat > "$HERMES_HOME/noosphere.json" <<'JSON'
+python3 - <<'PY'
+import os
+from pathlib import Path
+
+hermes_home = Path(os.environ.get("HERMES_HOME", str(Path.home() / ".hermes"))).expanduser()
+env_path = hermes_home / ".env"
+env_path.parent.mkdir(parents=True, exist_ok=True)
+lines = env_path.read_text(encoding="utf-8").splitlines() if env_path.exists() else []
+key = "NOOSPHERE_API_KEY"
+value = "noo_..."
+updated = False
+for index, line in enumerate(lines):
+    if line.split("=", 1)[0].strip() == key:
+        lines[index] = f"{key}={value}"
+        updated = True
+        break
+if not updated:
+    lines.append(f"{key}={value}")
+env_path.write_text("\\n".join(lines) + "\\n", encoding="utf-8")
+env_path.chmod(0o600)
+PY
+[ ! -f "$HERMES_HOME/noosphere.json" ] && cat > "$HERMES_HOME/noosphere.json" <<'JSON'
 {
   "base_url": "http://127.0.0.1:6578",
   "auto_recall": true,
@@ -66,7 +86,7 @@ cat > "$HERMES_HOME/noosphere.json" <<'JSON'
   "token_budget": 1200,
   "topic_id": "",
   "author_name_template": "Hermes:{identity}",
-  "api_timeout": 5.0
+  "api_timeout": 15.0
 }
 JSON
 ```

--- a/hermes-noosphere-memory/install-hermes.sh
+++ b/hermes-noosphere-memory/install-hermes.sh
@@ -5,7 +5,7 @@ trap 'echo "Installer failed near line ${LINENO}: ${BASH_COMMAND}" >&2' ERR
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 SOURCE_DIR="${SCRIPT_DIR}/plugins/memory/noosphere"
 HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
-TARGET_DIR="${HERMES_HOME}/plugins/memory/noosphere"
+TARGET_DIR="${HERMES_HOME}/plugins/noosphere"
 
 need() {
   if ! command -v "$1" >/dev/null 2>&1; then
@@ -82,8 +82,28 @@ cat <<EOF
 Manual setup:
 
   hermes config set memory.provider noosphere
-  printf '%s\n' 'NOOSPHERE_API_KEY=noo_...' >> "\$HERMES_HOME/.env"
-  cat > "\$HERMES_HOME/noosphere.json" <<'JSON'
+  python3 - <<'PY'
+import os
+from pathlib import Path
+
+hermes_home = Path(os.environ.get("HERMES_HOME", str(Path.home() / ".hermes"))).expanduser()
+env_path = hermes_home / ".env"
+env_path.parent.mkdir(parents=True, exist_ok=True)
+lines = env_path.read_text(encoding="utf-8").splitlines() if env_path.exists() else []
+key = "NOOSPHERE_API_KEY"
+value = "noo_..."
+updated = False
+for index, line in enumerate(lines):
+    if line.split("=", 1)[0].strip() == key:
+        lines[index] = f"{key}={value}"
+        updated = True
+        break
+if not updated:
+    lines.append(f"{key}={value}")
+env_path.write_text("\\n".join(lines) + "\\n", encoding="utf-8")
+env_path.chmod(0o600)
+PY
+  [ ! -f "\$HERMES_HOME/noosphere.json" ] && cat > "\$HERMES_HOME/noosphere.json" <<'JSON'
 {
   "base_url": "http://127.0.0.1:6578",
   "auto_recall": true,
@@ -93,7 +113,7 @@ Manual setup:
   "token_budget": 1200,
   "topic_id": "",
   "author_name_template": "Hermes:{identity}",
-  "api_timeout": 5.0
+  "api_timeout": 15.0
 }
 JSON
 

--- a/hermes-noosphere-memory/plugins/memory/noosphere/README.md
+++ b/hermes-noosphere-memory/plugins/memory/noosphere/README.md
@@ -30,8 +30,28 @@ Manual setup:
 
 ```bash
 hermes config set memory.provider noosphere
-printf '%s\n' 'NOOSPHERE_API_KEY=noo_...' >> "$HERMES_HOME/.env"
-cat > "$HERMES_HOME/noosphere.json" <<'JSON'
+python3 - <<'PY'
+import os
+from pathlib import Path
+
+hermes_home = Path(os.environ.get("HERMES_HOME", str(Path.home() / ".hermes"))).expanduser()
+env_path = hermes_home / ".env"
+env_path.parent.mkdir(parents=True, exist_ok=True)
+lines = env_path.read_text(encoding="utf-8").splitlines() if env_path.exists() else []
+key = "NOOSPHERE_API_KEY"
+value = "noo_..."
+updated = False
+for index, line in enumerate(lines):
+    if line.split("=", 1)[0].strip() == key:
+        lines[index] = f"{key}={value}"
+        updated = True
+        break
+if not updated:
+    lines.append(f"{key}={value}")
+env_path.write_text("\\n".join(lines) + "\\n", encoding="utf-8")
+env_path.chmod(0o600)
+PY
+[ ! -f "$HERMES_HOME/noosphere.json" ] && cat > "$HERMES_HOME/noosphere.json" <<'JSON'
 {
   "base_url": "http://127.0.0.1:6578",
   "auto_recall": true,
@@ -41,7 +61,7 @@ cat > "$HERMES_HOME/noosphere.json" <<'JSON'
   "token_budget": 1200,
   "topic_id": "",
   "author_name_template": "Hermes:{identity}",
-  "api_timeout": 5.0
+  "api_timeout": 15.0
 }
 JSON
 ```
@@ -60,7 +80,7 @@ Config file: `$HERMES_HOME/noosphere.json`
 | `token_budget` | `1200` | Prompt-ready recall token budget. |
 | `topic_id` | `""` | Default topic for draft saves and optional turn capture. |
 | `author_name_template` | `Hermes:{identity}` | Author name template for draft memory candidates. |
-| `api_timeout` | `5.0` | HTTP timeout in seconds. |
+| `api_timeout` | `15.0` | HTTP timeout in seconds. |
 
 Secrets:
 

--- a/hermes-noosphere-memory/plugins/memory/noosphere/__init__.py
+++ b/hermes-noosphere-memory/plugins/memory/noosphere/__init__.py
@@ -36,7 +36,7 @@ _DEFAULT_CONFIG: Dict[str, Any] = {
     "token_budget": 1200,
     "topic_id": "",
     "author_name_template": "Hermes:{identity}",
-    "api_timeout": 5.0,
+    "api_timeout": 15.0,
 }
 _NON_WRITING_CONTEXTS = {"cron", "flush", "subagent"}
 _SECRET_CONFIG_KEYS = {"api_key"}

--- a/hermes-noosphere-memory/plugins/memory/noosphere/client.py
+++ b/hermes-noosphere-memory/plugins/memory/noosphere/client.py
@@ -46,7 +46,18 @@ class NoosphereClient:
         self._timeout = timeout
 
     def status(self) -> Dict[str, Any]:
-        return self._request_json("GET", "/api/memory/status")
+        try:
+            return self._request_json("GET", "/api/memory/status")
+        except NoosphereClientError as error:
+            if error.status not in {401, 403}:
+                raise
+            health = self._request_json("GET", "/api/health")
+            health["memoryStatusAvailable"] = False
+            health["memoryStatusError"] = {
+                "status": error.status,
+                "error": str(error),
+            }
+            return health
 
     def recall(self, request: Dict[str, Any]) -> Dict[str, Any]:
         return self._request_json("POST", "/api/memory/recall", request)

--- a/hermes-noosphere-memory/tests/test_noosphere_client.py
+++ b/hermes-noosphere-memory/tests/test_noosphere_client.py
@@ -50,10 +50,19 @@ def load_plugin_package():
 class _StatusHandler(BaseHTTPRequestHandler):
     response_status = 200
     response_body = {"ok": True, "providers": [], "settings": {}}
+    health_body = {"status": "ok"}
     seen_authorization = ""
     seen_json = {}
 
     def do_GET(self):
+        if self.path == "/api/health":
+            raw = json.dumps(type(self).health_body).encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(raw)))
+            self.end_headers()
+            self.wfile.write(raw)
+            return
         if self.path != "/api/memory/status":
             self.send_response(404)
             self.end_headers()
@@ -90,6 +99,7 @@ class NoosphereClientTest(unittest.TestCase):
     def setUp(self):
         _StatusHandler.response_status = 200
         _StatusHandler.response_body = {"ok": True, "providers": [], "settings": {}}
+        _StatusHandler.health_body = {"status": "ok"}
         _StatusHandler.seen_authorization = ""
         _StatusHandler.seen_json = {}
         self.server = ThreadingHTTPServer(("127.0.0.1", 0), _StatusHandler)
@@ -114,6 +124,23 @@ class NoosphereClientTest(unittest.TestCase):
 
         self.assertTrue(result["ok"])
         self.assertEqual(_StatusHandler.seen_authorization, "Bearer noo_test")
+
+    def test_status_falls_back_to_health_for_scoped_key(self):
+        module = load_plugin_package()
+        _StatusHandler.response_status = 403
+        _StatusHandler.response_body = {"error": "Insufficient permissions"}
+        _StatusHandler.health_body = {"status": "ok", "timestamp": "test"}
+        client = module.NoosphereClient(
+            base_url=self.base_url,
+            api_key="noo_test",
+            timeout=2.0,
+        )
+
+        result = client.status()
+
+        self.assertEqual(result["status"], "ok")
+        self.assertFalse(result["memoryStatusAvailable"])
+        self.assertEqual(result["memoryStatusError"]["status"], 403)
 
     def test_recall_posts_json_body(self):
         module = load_plugin_package()
@@ -145,7 +172,7 @@ class NoosphereClientTest(unittest.TestCase):
         )
 
         with self.assertRaises(module.NoosphereClientError) as caught:
-            client.status()
+            client.recall({"query": "deploy", "mode": "inspection"})
 
         payload = json.loads(caught.exception.to_json())
         self.assertEqual(payload["status"], 401)


### PR DESCRIPTION
## Summary
- Install the Hermes Noosphere memory provider to `$HERMES_HOME/plugins/noosphere`, which Hermes 0.14 discovers for user-installed memory providers.
- Update install docs/manual fallback commands to avoid duplicate `.env` writes and avoid overwriting existing `noosphere.json`.
- Add `/api/health` fallback for `noosphere_status` when scoped non-admin keys cannot access `/api/memory/status`.
- Raise the default Hermes Noosphere HTTP timeout to 15 seconds.

## Verification
- `bash -n hermes-noosphere-memory/install-hermes.sh`
- `python3 -m unittest discover -s hermes-noosphere-memory/tests`
- `python3 -m compileall hermes-noosphere-memory/plugins/memory/noosphere`
- `git diff --check`
- Live Hermes 0.14 integration smoke against `/home/niya/.hermes`: discovery/load, status health fallback, topics, recall, explicit save, invalid confidence rejection, async memory write shutdown flush.