### PR TITLE
fix(noosphere): allow READ keys to fetch memory settings

### DIFF
--- a/src/app/api/memory/settings/route.ts
+++ b/src/app/api/memory/settings/route.ts
@@ -15,7 +15,8 @@ const SETTINGS_MAX_BODY_BYTES = 64 * 1024; // 64 KiB
  * Merges with defaults for any missing fields.
  */
 export async function GET(request: NextRequest) {
-  const auth = await requirePermission(request, [Permissions.ADMIN]);
+  // Read-only endpoint — READ is sufficient.
+  const auth = await requirePermission(request, [Permissions.READ]);
   if (!auth.success) {
     return auth.response;
   }


### PR DESCRIPTION
## Summary
Change the permission check for `GET /api/memory/settings` from `ADMIN` to `READ`. This is a read-only operation that should not require ADMIN-level access.

## Problem
The `noosphere-memory` plugin uses a WRITE-scoped API key. When `autoRecall` is enabled, the plugin calls `GET /api/memory/settings` to fetch recall settings, but this endpoint requires `ADMIN` permissions, resulting in `Insufficient permissions` errors.

## Fix
- `GET /api/memory/settings` → requires `READ` (was `ADMIN`)
- `POST /api/memory/settings` → still requires `ADMIN` (mutation, needs higher privilege)

## Testing
- Build succeeds with the change
- Unit tests pass (see CI)