### PR TITLE
Fix OpenClaw plugin npm release version guard

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -41,6 +41,23 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Validate package metadata
+        run: |
+          node - <<'NODE'
+          const fs = require("node:fs");
+
+          const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
+          const lock = JSON.parse(fs.readFileSync("package-lock.json", "utf8"));
+          const lockVersion = lock.packages?.[""]?.version ?? lock.version;
+
+          if (lockVersion !== pkg.version) {
+            console.error(
+              `package-lock.json version (${lockVersion}) does not match package.json version (${pkg.version})`
+            );
+            process.exit(1);
+          }
+          NODE
+
       - name: Build package
         run: npm run build
 
@@ -71,6 +88,41 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Validate package metadata
+        run: |
+          node - <<'NODE'
+          const fs = require("node:fs");
+
+          const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
+          const lock = JSON.parse(fs.readFileSync("package-lock.json", "utf8"));
+          const lockVersion = lock.packages?.[""]?.version ?? lock.version;
+
+          if (lockVersion !== pkg.version) {
+            console.error(
+              `package-lock.json version (${lockVersion}) does not match package.json version (${pkg.version})`
+            );
+            process.exit(1);
+          }
+          NODE
+
+      - name: Validate release tag
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          node - <<'NODE'
+          const fs = require("node:fs");
+
+          const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
+          const tag = process.env.GITHUB_REF_NAME ?? "";
+          const tagVersion = tag.replace(/^v/, "");
+
+          if (tagVersion !== pkg.version) {
+            console.error(
+              `Release tag ${tag} does not match package.json version ${pkg.version}`
+            );
+            process.exit(1);
+          }
+          NODE
 
       - name: Build package
         run: npm run build

--- a/openclaw-noosphere-memory/package-lock.json
+++ b/openclaw-noosphere-memory/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sweetsophia/openclaw-noosphere-memory",
-  "version": "1.3.0",
+  "version": "1.5.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sweetsophia/openclaw-noosphere-memory",
-      "version": "1.3.0",
+      "version": "1.5.6",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20",

--- a/openclaw-noosphere-memory/package.json
+++ b/openclaw-noosphere-memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sweetsophia/openclaw-noosphere-memory",
-  "version": "1.3.1",
+  "version": "1.5.6",
   "private": false,
   "description": "OpenClaw plugin for Noosphere: agent memory tools, Noosphere recall, draft memory saving, and automatic prompt-time memory injection.",
   "type": "module",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "noosphere",
-  "version": "1.3.0",
+  "version": "1.5.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "noosphere",
-      "version": "1.3.0",
+      "version": "1.5.6",
       "dependencies": {
         "@prisma/adapter-pg": "^7.7.0",
         "@prisma/client": "^7.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "noosphere",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary
- bump Noosphere and OpenClaw plugin package metadata to 1.5.6 for a fresh release after the stale v1.5.5 tag
- keep root and plugin package-lock metadata aligned with package.json
- add npm publish workflow checks for package-lock/package.json version consistency and tag/package version consistency

## Verification
- cd openclaw-noosphere-memory && npm ci
- cd openclaw-noosphere-memory && npm run build
- cd openclaw-noosphere-memory && git diff --exit-code -- dist
- cd openclaw-noosphere-memory && npm pack --dry-run
- root npm ci --ignore-scripts
- root/package-lock metadata check
- git diff --check
- npm view @sweetsophia/openclaw-noosphere-memory@1.5.6 version returns 404, confirming 1.5.6 is not already published