### PR TITLE
fix: apply rate limiting to all API routes

### DIFF
--- a/src/app/api/answer/route.ts
+++ b/src/app/api/answer/route.ts
@@ -10,6 +10,7 @@ import {
   sanitizeAuthorName,
   validateSlug,
 } from "@/lib/validation";
+import { rateLimit } from "@/lib/rate-limit";
 
 // POST /api/answer — Save a synthesized answer as a new wiki article
 // Auth: API key (WRITE/ADMIN) or session (EDITOR/ADMIN)
@@ -32,6 +33,9 @@ import {
 //   { article: {id, title, slug, topic, tags}, answerId }
 
 export async function POST(request: NextRequest) {
+  const rl = rateLimit(request, { windowMs: 60_000, maxRequests: 30, keyPrefix: "answer" });
+  if (!rl.allowed) return rl.response;
+
   const auth = await requirePermission(request, [Permissions.WRITE]);
   if (!auth.success) {
     return auth.response;

--- a/src/app/api/articles/[id]/route.ts
+++ b/src/app/api/articles/[id]/route.ts
@@ -12,10 +12,14 @@ import {
   isValidStatus,
   validateSlug,
 } from "@/lib/validation";
+import { rateLimit } from "@/lib/rate-limit";
 
 // PATCH /api/articles/[id] — Update article
 // Auth: API key (WRITE/ADMIN) or session (EDITOR/ADMIN)
 export async function PATCH(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const rl = rateLimit(request, { windowMs: 60_000, maxRequests: 30, keyPrefix: "articles-patch" });
+  if (!rl.allowed) return rl.response;
+
   const { id } = await params;
 
   const auth = await requirePermission(request, [Permissions.WRITE]);
@@ -302,6 +306,9 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
 // DELETE /api/articles/[id] — Soft-delete article
 // Auth: API key (ADMIN) or session (ADMIN)
 export async function DELETE(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const rl = rateLimit(request, { windowMs: 60_000, maxRequests: 30, keyPrefix: "articles-delete" });
+  if (!rl.allowed) return rl.response;
+
   const { id } = await params;
 
   const auth = await requirePermission(request, [Permissions.ADMIN]);

--- a/src/app/api/articles/route.ts
+++ b/src/app/api/articles/route.ts
@@ -12,10 +12,14 @@ import {
   validateSlug,
 } from "@/lib/validation";
 import { parsePagination } from "@/lib/pagination";
+import { rateLimit } from "@/lib/rate-limit";
 
 // GET /api/articles — List articles (with filters)
 // Auth: API key (READ/WRITE/ADMIN) or session (human)
 export async function GET(request: NextRequest) {
+  const rl = rateLimit(request, { windowMs: 60_000, maxRequests: 60, keyPrefix: "articles-get" });
+  if (!rl.allowed) return rl.response;
+
   const auth = await requirePermission(request, [Permissions.READ]);
   if (!auth.success) {
     return auth.response;
@@ -155,6 +159,9 @@ export async function GET(request: NextRequest) {
 // POST /api/articles — Create article
 // Auth: API key (WRITE/ADMIN) or session (EDITOR/ADMIN)
 export async function POST(request: NextRequest) {
+  const rl = rateLimit(request, { windowMs: 60_000, maxRequests: 30, keyPrefix: "articles-post" });
+  if (!rl.allowed) return rl.response;
+
   const auth = await requirePermission(request, [Permissions.WRITE]);
   if (!auth.success) {
     return auth.response;

--- a/src/app/api/export/route.ts
+++ b/src/app/api/export/route.ts
@@ -6,10 +6,14 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import JSZip from "jszip";
 import yaml from "js-yaml";
+import { rateLimit } from "@/lib/rate-limit";
 
 // GET /api/export — Export all articles as a zip of markdown files
 // Auth: API key (READ/WRITE/ADMIN) or session (human)
 export async function GET(request: NextRequest) {
+  const rl = rateLimit(request, { windowMs: 60_000, maxRequests: 10, keyPrefix: "export" });
+  if (!rl.allowed) return rl.response;
+
   const apiAuth = await requireApiKey(request);
   const session = await getServerSession(authOptions);
 

--- a/src/app/api/graph/route.ts
+++ b/src/app/api/graph/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { requirePermission, buildScopeFilter } from "@/lib/api/auth";
+import { rateLimit } from "@/lib/rate-limit";
 
 // GET /api/graph — Wiki knowledge graph
 //
@@ -19,6 +20,9 @@ import { requirePermission, buildScopeFilter } from "@/lib/api/auth";
 //   }
 
 export async function GET(request: NextRequest) {
+  const rl = rateLimit(request, { windowMs: 60_000, maxRequests: 10, keyPrefix: "graph" });
+  if (!rl.allowed) return rl.response;
+
   // Auth: API key (any permission) or session — empty array = any authenticated caller
   const auth = await requirePermission(request, []);
   if (!auth.success) {

--- a/src/app/api/import/route.ts
+++ b/src/app/api/import/route.ts
@@ -7,6 +7,7 @@ import { authOptions } from "@/lib/auth";
 import JSZip from "jszip";
 import yaml from "js-yaml";
 import { isValidConfidence, isValidStatus } from "@/lib/validation";
+import { rateLimit } from "@/lib/rate-limit";
 
 // Disable Next.js body parsing for file uploads
 export const dynamic = "force-dynamic";
@@ -38,7 +39,10 @@ interface ImportArticle {
 }
 
 // GET /api/import — Return import format documentation
-export async function GET() {
+export async function GET(request: NextRequest) {
+  const rl = rateLimit(request, { windowMs: 60_000, maxRequests: 60, keyPrefix: "import-get" });
+  if (!rl.allowed) return rl.response;
+
   return NextResponse.json({
     endpoint: "POST /api/import",
     description: "Import articles from a markdown zip export",
@@ -73,6 +77,9 @@ status: published
 
 // POST /api/import — Import articles from a markdown zip
 export async function POST(request: NextRequest) {
+  const rl = rateLimit(request, { windowMs: 60_000, maxRequests: 10, keyPrefix: "import" });
+  if (!rl.allowed) return rl.response;
+
   const apiAuth = await requireApiKey(request);
   const session = await getServerSession(authOptions);
 

--- a/src/app/api/ingest/route.ts
+++ b/src/app/api/ingest/route.ts
@@ -4,6 +4,7 @@ import { prisma } from "@/lib/prisma";
 import { requirePermission } from "@/lib/api/auth";
 import { apiError } from "@/lib/api/errors";
 import { ARTICLE_LIMITS, deriveExcerpt, sanitizeAuthorName } from "@/lib/validation";
+import { rateLimit } from "@/lib/rate-limit";
 
 // POST /api/ingest — Process a source into multiple wiki articles
 // Auth: API key (WRITE/ADMIN) or session (EDITOR/ADMIN)
@@ -42,6 +43,9 @@ interface IngestArticle {
 }
 
 export async function POST(request: NextRequest) {
+  const rl = rateLimit(request, { windowMs: 60_000, maxRequests: 10, keyPrefix: "ingest" });
+  if (!rl.allowed) return rl.response;
+
   // --- Auth ---
   const auth = await requirePermission(request, [Permissions.WRITE]);
   if (!auth.success) {

--- a/src/app/api/keys/[id]/route.ts
+++ b/src/app/api/keys/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { Permissions } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
 import { requirePermission } from "@/lib/api/auth";
+import { rateLimit } from "@/lib/rate-limit";
 
 // GET /api/keys/[id] — Get a single key's metadata
 // Auth: ADMIN only
@@ -9,6 +10,9 @@ export async function GET(
   _request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  const rl = rateLimit(_request, { windowMs: 60_000, maxRequests: 30, keyPrefix: "keys-get-id" });
+  if (!rl.allowed) return rl.response;
+
   const { id } = await params;
   const auth = await requirePermission(_request, [Permissions.ADMIN]);
   if (!auth.success) {
@@ -41,6 +45,9 @@ export async function PATCH(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  const rl = rateLimit(request, { windowMs: 60_000, maxRequests: 30, keyPrefix: "keys-patch" });
+  if (!rl.allowed) return rl.response;
+
   const { id } = await params;
   const auth = await requirePermission(request, [Permissions.ADMIN]);
   if (!auth.success) {
@@ -130,6 +137,9 @@ export async function DELETE(
   _request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  const rl = rateLimit(_request, { windowMs: 60_000, maxRequests: 30, keyPrefix: "keys-delete" });
+  if (!rl.allowed) return rl.response;
+
   const { id } = await params;
   const auth = await requirePermission(_request, [Permissions.ADMIN]);
   if (!auth.success) {

--- a/src/app/api/keys/route.ts
+++ b/src/app/api/keys/route.ts
@@ -3,10 +3,14 @@ import { Permissions } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
 import { requirePermission } from "@/lib/api/auth";
 import { generateApiKey } from "@/lib/api/keys";
+import { rateLimit } from "@/lib/rate-limit";
 
 // GET /api/keys — List all API keys (metadata only)
 // Auth: ADMIN only
 export async function GET(_request: NextRequest) {
+  const rl = rateLimit(_request, { windowMs: 60_000, maxRequests: 30, keyPrefix: "keys-get" });
+  if (!rl.allowed) return rl.response;
+
   const auth = await requirePermission(_request, [Permissions.ADMIN]);
   if (!auth.success) {
     return auth.response;
@@ -32,6 +36,9 @@ export async function GET(_request: NextRequest) {
 // POST /api/keys — Create a new API key
 // Auth: ADMIN only
 export async function POST(request: NextRequest) {
+  const rl = rateLimit(request, { windowMs: 60_000, maxRequests: 30, keyPrefix: "keys-post" });
+  if (!rl.allowed) return rl.response;
+
   const auth = await requirePermission(request, [Permissions.ADMIN]);
   if (!auth.success) {
     return auth.response;

--- a/src/app/api/lint/route.ts
+++ b/src/app/api/lint/route.ts
@@ -4,6 +4,7 @@ import { requireApiKey } from "@/lib/api/keys";
 import { buildScopeFilter } from "@/lib/api/auth";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
+import { rateLimit } from "@/lib/rate-limit";
 
 const LINT_MAX_ARTICLES_DEFAULT = 500;
 const LINT_MAX_ARTICLES_HARD_LIMIT = 2000;
@@ -35,6 +36,9 @@ interface LintIssue {
 }
 
 export async function POST(request: NextRequest) {
+  const rl = rateLimit(request, { windowMs: 60_000, maxRequests: 10, keyPrefix: "lint" });
+  if (!rl.allowed) return rl.response;
+
   // --- Auth ---
   const apiAuth = await requireApiKey(request);
   const session = await getServerSession(authOptions);

--- a/src/app/api/log/route.ts
+++ b/src/app/api/log/route.ts
@@ -4,6 +4,7 @@ import { prisma } from "@/lib/prisma";
 import { requireApiKey } from "@/lib/api/keys";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
+import { rateLimit } from "@/lib/rate-limit";
 
 // GET /api/log — Query the activity log
 //
@@ -19,6 +20,9 @@ import { authOptions } from "@/lib/auth";
 //   { entries: [{id, type, title, details, sourceUrl, authorName, createdAt}], total, limit, offset }
 
 export async function GET(request: NextRequest) {
+  const rl = rateLimit(request, { windowMs: 60_000, maxRequests: 30, keyPrefix: "log-get" });
+  if (!rl.allowed) return rl.response;
+
   // Auth: API key (any permission) or session
   const apiAuth = await requireApiKey(request);
   const session = await getServerSession(authOptions);

--- a/src/app/api/memory/get/route.ts
+++ b/src/app/api/memory/get/route.ts
@@ -3,8 +3,12 @@ import { Permissions } from "@prisma/client";
 import { requirePermission } from "@/lib/api/auth";
 import { readBoundedJson, RequestBodyTooLargeError, JsonDepthExceededError } from "@/lib/api/body";
 import { executeMemoryGetRequest } from "@/lib/memory/api/get";
+import { rateLimit } from "@/lib/rate-limit";
 
 export async function POST(request: NextRequest) {
+  const rl = rateLimit(request, { windowMs: 60_000, maxRequests: 30, keyPrefix: "memory-get" });
+  if (!rl.allowed) return rl.response;
+
   const auth = await requirePermission(request, [Permissions.READ]);
   if (!auth.success) {
     return auth.response;

--- a/src/app/api/memory/recall/route.ts
+++ b/src/app/api/memory/recall/route.ts
@@ -3,8 +3,12 @@ import { Permissions } from "@prisma/client";
 import { requirePermission } from "@/lib/api/auth";
 import { readBoundedJson, RequestBodyTooLargeError, JsonDepthExceededError } from "@/lib/api/body";
 import { executeMemoryRecallRequest } from "@/lib/memory/api/recall";
+import { rateLimit } from "@/lib/rate-limit";
 
 export async function POST(request: NextRequest) {
+  const rl = rateLimit(request, { windowMs: 60_000, maxRequests: 10, keyPrefix: "memory-recall" });
+  if (!rl.allowed) return rl.response;
+
   const auth = await requirePermission(request, [Permissions.READ]);
   if (!auth.success) {
     return auth.response;

--- a/src/app/api/memory/save/route.ts
+++ b/src/app/api/memory/save/route.ts
@@ -6,8 +6,12 @@ import {
   executeMemorySaveRequest,
   MemorySaveError,
 } from "@/lib/memory/api/save";
+import { rateLimit } from "@/lib/rate-limit";
 
 export async function POST(request: NextRequest) {
+  const rl = rateLimit(request, { windowMs: 60_000, maxRequests: 30, keyPrefix: "memory-save" });
+  if (!rl.allowed) return rl.response;
+
   const auth = await requirePermission(request, [Permissions.WRITE]);
   if (!auth.success) {
     return auth.response;

--- a/src/app/api/memory/settings/route.ts
+++ b/src/app/api/memory/settings/route.ts
@@ -3,6 +3,7 @@ import { Permissions } from "@prisma/client";
 import { requirePermission } from "@/lib/api/auth";
 import { getRecallSettingsFromDB, upsertRecallSettings } from "@/lib/memory/api/settings";
 import type { RecallSettings } from "@/lib/memory/settings";
+import { rateLimit } from "@/lib/rate-limit";
 
 // ─── Constants ───────────────────────────────────────────────────────────────
 
@@ -15,6 +16,9 @@ const SETTINGS_MAX_BODY_BYTES = 64 * 1024; // 64 KiB
  * Merges with defaults for any missing fields.
  */
 export async function GET(request: NextRequest) {
+  const rl = rateLimit(request, { windowMs: 60_000, maxRequests: 60, keyPrefix: "memory-settings-get" });
+  if (!rl.allowed) return rl.response;
+
   // Read-only endpoint — READ is sufficient.
   const auth = await requirePermission(request, [Permissions.READ]);
   if (!auth.success) {
@@ -40,6 +44,9 @@ export async function GET(request: NextRequest) {
  * Accepts partial settings and merges with existing values.
  */
 export async function POST(request: NextRequest) {
+  const rl = rateLimit(request, { windowMs: 60_000, maxRequests: 30, keyPrefix: "memory-settings-post" });
+  if (!rl.allowed) return rl.response;
+
   const auth = await requirePermission(request, [Permissions.ADMIN]);
   if (!auth.success) {
     return auth.response;

--- a/src/app/api/memory/status/route.ts
+++ b/src/app/api/memory/status/route.ts
@@ -3,8 +3,11 @@ import { Permissions } from "@prisma/client";
 import { requirePermission } from "@/lib/api/auth";
 import { getMemoryStatusSnapshot } from "@/lib/memory/api/providers";
 import { getRecallSettingsFromDB } from "@/lib/memory/api/settings";
+import { rateLimit } from "@/lib/rate-limit";
 
 export async function GET(request: NextRequest) {
+  const rl = rateLimit(request, { windowMs: 60_000, maxRequests: 60, keyPrefix: "memory-status" });
+  if (!rl.allowed) return rl.response;
   // ADMIN required: status exposes internal provider configuration
   // (priority weights, capabilities, max results) — operational data,
   // not article content, so WRITE is insufficient.

--- a/src/app/api/scopes/route.ts
+++ b/src/app/api/scopes/route.ts
@@ -2,10 +2,14 @@ import { NextRequest, NextResponse } from "next/server";
 import { Permissions } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
 import { requirePermission } from "@/lib/api/auth";
+import { rateLimit } from "@/lib/rate-limit";
 
 // GET /api/scopes — List all available restricted scopes
 // Auth: Any valid API key (READ minimum)
 export async function GET(request: NextRequest) {
+  const rl = rateLimit(request, { windowMs: 60_000, maxRequests: 60, keyPrefix: "scopes-get" });
+  if (!rl.allowed) return rl.response;
+
   const auth = await requirePermission(request, [Permissions.READ]);
   if (!auth.success) {
     return auth.response;
@@ -22,6 +26,9 @@ export async function GET(request: NextRequest) {
 // POST /api/scopes — Register a new custom scope
 // Auth: ADMIN only
 export async function POST(request: NextRequest) {
+  const rl = rateLimit(request, { windowMs: 60_000, maxRequests: 30, keyPrefix: "scopes-post" });
+  if (!rl.allowed) return rl.response;
+
   const auth = await requirePermission(request, [Permissions.ADMIN]);
   if (!auth.success) {
     return auth.response;

--- a/src/app/api/sync/obsidian/route.ts
+++ b/src/app/api/sync/obsidian/route.ts
@@ -14,9 +14,13 @@ import { authOptions } from "@/lib/auth";
 import { getObsidianSyncConfig } from "@/lib/obsidian-sync/config";
 import { runObsidianSync, SyncConflictError } from "@/lib/obsidian-sync";
 import type { SyncOptions } from "@/lib/obsidian-sync";
+import { rateLimit } from "@/lib/rate-limit";
 
 // GET /api/sync/obsidian — return status / config visibility
 export async function GET(request: NextRequest) {
+  const rl = rateLimit(request, { windowMs: 60_000, maxRequests: 10, keyPrefix: "obsidian-get" });
+  if (!rl.allowed) return rl.response;
+
   const apiAuth = await requireApiKey(request);
   const session = await getServerSession(authOptions);
 
@@ -61,6 +65,9 @@ export async function GET(request: NextRequest) {
 
 // POST /api/sync/obsidian — trigger a sync run
 export async function POST(request: NextRequest) {
+  const rl = rateLimit(request, { windowMs: 60_000, maxRequests: 5, keyPrefix: "obsidian-post" });
+  if (!rl.allowed) return rl.response;
+
   const apiAuth = await requireApiKey(request);
   const session = await getServerSession(authOptions);
 

--- a/src/app/api/tags/[id]/route.ts
+++ b/src/app/api/tags/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { slugify } from "@/lib/wiki";
 import { checkRouteAuth } from "@/lib/api/auth";
+import { rateLimit } from "@/lib/rate-limit";
 
 interface Props {
   params: Promise<{ id: string }>;
@@ -9,6 +10,9 @@ interface Props {
 
 // PATCH /api/tags/[id] — Rename a tag
 export async function PATCH(request: NextRequest, { params }: Props) {
+  const rl = rateLimit(request, { windowMs: 60_000, maxRequests: 30, keyPrefix: "tags-patch" });
+  if (!rl.allowed) return rl.response;
+
   const auth = await checkRouteAuth(request);
   if (!auth.authorized) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
@@ -59,6 +63,9 @@ export async function PATCH(request: NextRequest, { params }: Props) {
 
 // DELETE /api/tags/[id] — Delete a tag
 export async function DELETE(request: NextRequest, { params }: Props) {
+  const rl = rateLimit(request, { windowMs: 60_000, maxRequests: 30, keyPrefix: "tags-delete" });
+  if (!rl.allowed) return rl.response;
+
   const auth = await checkRouteAuth(request);
   if (!auth.authorized) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });

--- a/src/app/api/tags/route.ts
+++ b/src/app/api/tags/route.ts
@@ -2,9 +2,13 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { slugify } from "@/lib/wiki";
 import { checkRouteAuth } from "@/lib/api/auth";
+import { rateLimit } from "@/lib/rate-limit";
 
 // GET /api/tags — List all tags with article counts
-export async function GET() {
+export async function GET(request: NextRequest) {
+  const rl = rateLimit(request, { windowMs: 60_000, maxRequests: 60, keyPrefix: "tags-get" });
+  if (!rl.allowed) return rl.response;
+
   try {
     const tags = await prisma.tag.findMany({
       include: {
@@ -30,6 +34,9 @@ export async function GET() {
 
 // POST /api/tags — Create a tag
 export async function POST(request: NextRequest) {
+  const rl = rateLimit(request, { windowMs: 60_000, maxRequests: 30, keyPrefix: "tags-post" });
+  if (!rl.allowed) return rl.response;
+
   const auth = await checkRouteAuth(request);
   if (!auth.authorized) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });

--- a/src/app/api/topics/[id]/route.ts
+++ b/src/app/api/topics/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { slugify } from "@/lib/wiki";
 import { checkRouteAuth } from "@/lib/api/auth";
+import { rateLimit } from "@/lib/rate-limit";
 
 interface Props {
   params: Promise<{ id: string }>;
@@ -24,6 +25,9 @@ async function getDescendantIds(topicId: string): Promise<string[]> {
 
 // PATCH /api/topics/[id] — Update a topic
 export async function PATCH(request: NextRequest, { params }: Props) {
+  const rl = rateLimit(request, { windowMs: 60_000, maxRequests: 30, keyPrefix: "topics-patch" });
+  if (!rl.allowed) return rl.response;
+
   const auth = await checkRouteAuth(request);
   if (!auth.authorized) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
@@ -99,6 +103,9 @@ export async function PATCH(request: NextRequest, { params }: Props) {
 
 // DELETE /api/topics/[id] — Delete a topic
 export async function DELETE(request: NextRequest, { params }: Props) {
+  const rl = rateLimit(request, { windowMs: 60_000, maxRequests: 30, keyPrefix: "topics-delete" });
+  if (!rl.allowed) return rl.response;
+
   const auth = await checkRouteAuth(request);
   if (!auth.authorized) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });

--- a/src/app/api/topics/route.ts
+++ b/src/app/api/topics/route.ts
@@ -2,9 +2,12 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { slugify } from "@/lib/wiki";
 import { checkRouteAuth } from "@/lib/api/auth";
+import { rateLimit } from "@/lib/rate-limit";
 
 // GET /api/topics — List all topics (existing)
-export async function GET() {
+export async function GET(request: NextRequest) {
+  const rl = rateLimit(request, { windowMs: 60_000, maxRequests: 60, keyPrefix: "topics-get" });
+  if (!rl.allowed) return rl.response;
   try {
     const allTopics = await prisma.topic.findMany({
       include: {
@@ -61,6 +64,9 @@ export async function GET() {
 
 // POST /api/topics — Create a topic or subtopic
 export async function POST(request: NextRequest) {
+  const rl = rateLimit(request, { windowMs: 60_000, maxRequests: 30, keyPrefix: "topics-post" });
+  if (!rl.allowed) return rl.response;
+
   const auth = await checkRouteAuth(request);
   if (!auth.authorized) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });

--- a/src/app/api/uploads/image/route.ts
+++ b/src/app/api/uploads/image/route.ts
@@ -4,10 +4,14 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { requireApiKey } from "@/lib/api/keys";
 import { saveUploadedImage } from "@/lib/uploads";
+import { rateLimit } from "@/lib/rate-limit";
 
 const MAX_FILE_SIZE = 5 * 1024 * 1024;
 
 export async function POST(request: NextRequest) {
+  const rl = rateLimit(request, { windowMs: 60_000, maxRequests: 10, keyPrefix: "upload" });
+  if (!rl.allowed) return rl.response;
+
   const apiAuth = await requireApiKey(request);
   const session = await getServerSession(authOptions);
 


### PR DESCRIPTION
## Summary
Applies the existing in-memory fixed-window rate limiter (`src/lib/rate-limit.ts`) to **all API routes**.

## Changes
- **Read endpoints** (articles list, tags, topics, scopes, memory settings/status, import docs): `60 req/min`
- **Standard write endpoints** (POST/PATCH/DELETE articles, tags, topics, scopes, keys, memory/save, answer): `30 req/min`
- **Expensive endpoints** (graph, export, ingest, import, lint, memory/recall, obsidian GET): `10 req/min`
- **Image uploads**: `10 req/min` (stricter than standard writes because uploads are file I/O and storage-heavy)
- **Obsidian sync POST**: `5 req/min` (filesystem-heavy operation)

## Why
- Fixes **CRIT-1** from the security audit
- Mitigates DoS attacks on CPU/DB-heavy endpoints
- Prevents brute-force API key guessing
- Protects against accidental agent retry storms

## Testing
- [x] Verify 429 responses on rapid requests
- [x] Verify different limits per endpoint class
- [x] Route coverage scan confirms every API handler is rate-limited except `GET /api/health`
- [x] `npm run lint`
- [x] `npm run test:security`

## Future work
- Replace in-memory Map with Redis for multi-replica deployments