### PR TITLE
fix: standardize all API routes on requirePermission() helper

### DIFF
--- a/src/app/api/articles/[id]/route.ts
+++ b/src/app/api/articles/[id]/route.ts
@@ -1,6 +1,4 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getServerSession } from "next-auth";
-import { authOptions } from "@/lib/auth";
 import { Permissions } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
 import { requirePermission, canAccessScopes } from "@/lib/api/auth";
@@ -340,8 +338,7 @@ export async function DELETE(request: NextRequest, { params }: { params: Promise
   }
 
   // Log the deletion for audit trail
-  const session = await getServerSession(authOptions);
-  const authorName = session?.user?.name ?? auth.auth.name ?? "API";
+  const authorName = auth.auth.name ?? "API";
   try {
     await prisma.activityLog.create({
       data: {

--- a/src/app/api/export/route.ts
+++ b/src/app/api/export/route.ts
@@ -1,9 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
+import { Permissions } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
-import { requireApiKey } from "@/lib/api/keys";
-import { buildScopeFilter } from "@/lib/api/auth";
-import { getServerSession } from "next-auth";
-import { authOptions } from "@/lib/auth";
+import { requirePermission, buildScopeFilter } from "@/lib/api/auth";
 import JSZip from "jszip";
 import yaml from "js-yaml";
 import { rateLimit } from "@/lib/rate-limit";
@@ -14,19 +12,12 @@ export async function GET(request: NextRequest) {
   const rl = rateLimit(request, { windowMs: 60_000, maxRequests: 10, keyPrefix: "export" });
   if (!rl.allowed) return rl.response;
 
-  const apiAuth = await requireApiKey(request);
-  const session = await getServerSession(authOptions);
-
-  if (!apiAuth.authorized && !session?.user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const auth = await requirePermission(request, [Permissions.READ]);
+  if (!auth.success) {
+    return auth.response;
   }
 
-  // Determine effective scopes for export filtering
-  const allowedScopes = apiAuth.authorized
-    ? apiAuth.allowedScopes
-    : ["*"]; // Sessions get full access
-
-  const scopeWhere = buildScopeFilter(allowedScopes, { deletedAt: null });
+  const scopeWhere = buildScopeFilter(auth.auth.allowedScopes, { deletedAt: null });
 
   try {
     const articles = await prisma.article.findMany({

--- a/src/app/api/import/route.ts
+++ b/src/app/api/import/route.ts
@@ -1,9 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
+import { Permissions } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
-import { requireApiKey } from "@/lib/api/keys";
-import { canAccessScopes } from "@/lib/api/auth";
-import { getServerSession } from "next-auth";
-import { authOptions } from "@/lib/auth";
+import { requirePermission, canAccessScopes } from "@/lib/api/auth";
 import JSZip from "jszip";
 import yaml from "js-yaml";
 import { isValidConfidence, isValidStatus } from "@/lib/validation";
@@ -80,28 +78,12 @@ export async function POST(request: NextRequest) {
   const rl = rateLimit(request, { windowMs: 60_000, maxRequests: 10, keyPrefix: "import" });
   if (!rl.allowed) return rl.response;
 
-  const apiAuth = await requireApiKey(request);
-  const session = await getServerSession(authOptions);
-
-  if (!apiAuth.authorized && !session?.user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const auth = await requirePermission(request, [Permissions.WRITE]);
+  if (!auth.success) {
+    return auth.response;
   }
 
-  if (apiAuth.authorized) {
-    if (apiAuth.permissions !== "WRITE" && apiAuth.permissions !== "ADMIN") {
-      return NextResponse.json({ error: "Insufficient permissions" }, { status: 403 });
-    }
-  } else {
-    const role = session?.user?.role;
-    if (role !== "EDITOR" && role !== "ADMIN") {
-      return NextResponse.json({ error: "Insufficient permissions" }, { status: 403 });
-    }
-  }
-
-  // Determine effective allowedScopes for scope-based article filtering
-  const allowedScopes = apiAuth.authorized
-    ? apiAuth.allowedScopes
-    : ["*"]; // Sessions get admin-level access
+  const allowedScopes = auth.auth.allowedScopes;
 
   // Parse multipart form using Web API
   let formData: FormData;
@@ -260,9 +242,8 @@ export async function POST(request: NextRequest) {
   }
 
   // Process imports
-  const sessionUser = session?.user as ({ id?: string } | null) | undefined;
-  const userId = sessionUser?.id ?? null;
-  const userName = session?.user?.name ?? "Importer";
+  const userId = auth.auth.userId ?? null;
+  const userName = auth.auth.name ?? "Importer";
 
   const results = { imported: 0, skipped: 0, errors: 0 };
 

--- a/src/app/api/lint/route.ts
+++ b/src/app/api/lint/route.ts
@@ -1,9 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
+import { Permissions } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
-import { requireApiKey } from "@/lib/api/keys";
-import { buildScopeFilter } from "@/lib/api/auth";
-import { getServerSession } from "next-auth";
-import { authOptions } from "@/lib/auth";
+import { requirePermission, buildScopeFilter } from "@/lib/api/auth";
 import { rateLimit } from "@/lib/rate-limit";
 
 const LINT_MAX_ARTICLES_DEFAULT = 500;
@@ -39,30 +37,12 @@ export async function POST(request: NextRequest) {
   const rl = rateLimit(request, { windowMs: 60_000, maxRequests: 10, keyPrefix: "lint" });
   if (!rl.allowed) return rl.response;
 
-  // --- Auth ---
-  const apiAuth = await requireApiKey(request);
-  const session = await getServerSession(authOptions);
-
-  if (!apiAuth.authorized && !session?.user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const auth = await requirePermission(request, [Permissions.WRITE]);
+  if (!auth.success) {
+    return auth.response;
   }
 
-  if (apiAuth.authorized) {
-    if (apiAuth.permissions !== "WRITE" && apiAuth.permissions !== "ADMIN") {
-      return NextResponse.json({ error: "Insufficient permissions" }, { status: 403 });
-    }
-  } else {
-    const role = session?.user?.role;
-    if (role !== "EDITOR" && role !== "ADMIN") {
-      return NextResponse.json({ error: "Insufficient permissions" }, { status: 403 });
-    }
-  }
-
-  // Determine effective scopes for lint filtering
-  const allowedScopes = apiAuth.authorized
-    ? apiAuth.allowedScopes
-    : ["*"]; // Sessions get full access
-  const scopeWhere = buildScopeFilter(allowedScopes, { deletedAt: null });
+  const scopeWhere = buildScopeFilter(auth.auth.allowedScopes, { deletedAt: null });
 
   // --- Parse options ---
   let body: { staleDays?: number; tagMin?: number; maxArticles?: unknown } = {};
@@ -285,7 +265,7 @@ export async function POST(request: NextRequest) {
   };
 
   // ── Log the lint run ──
-  const authorName = session?.user?.name || "API";
+  const authorName = auth.auth.name || "API";
 
   await prisma.activityLog.create({
     data: {

--- a/src/app/api/log/route.ts
+++ b/src/app/api/log/route.ts
@@ -1,9 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { Prisma } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
-import { requireApiKey } from "@/lib/api/keys";
-import { getServerSession } from "next-auth";
-import { authOptions } from "@/lib/auth";
+import { requirePermission } from "@/lib/api/auth";
 import { rateLimit } from "@/lib/rate-limit";
 
 // GET /api/log — Query the activity log
@@ -24,10 +22,9 @@ export async function GET(request: NextRequest) {
   if (!rl.allowed) return rl.response;
 
   // Auth: API key (any permission) or session
-  const apiAuth = await requireApiKey(request);
-  const session = await getServerSession(authOptions);
-  if (!apiAuth.authorized && !session?.user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const auth = await requirePermission(request, []);
+  if (!auth.success) {
+    return auth.response;
   }
 
   const { searchParams } = new URL(request.url);

--- a/src/app/api/sync/obsidian/route.ts
+++ b/src/app/api/sync/obsidian/route.ts
@@ -8,9 +8,8 @@
 export const dynamic = "force-dynamic";
 
 import { NextRequest, NextResponse } from "next/server";
-import { requireApiKey } from "@/lib/api/keys";
-import { getServerSession } from "next-auth";
-import { authOptions } from "@/lib/auth";
+import { Permissions } from "@prisma/client";
+import { requirePermission } from "@/lib/api/auth";
 import { getObsidianSyncConfig } from "@/lib/obsidian-sync/config";
 import { runObsidianSync, SyncConflictError } from "@/lib/obsidian-sync";
 import type { SyncOptions } from "@/lib/obsidian-sync";
@@ -21,23 +20,9 @@ export async function GET(request: NextRequest) {
   const rl = rateLimit(request, { windowMs: 60_000, maxRequests: 10, keyPrefix: "obsidian-get" });
   if (!rl.allowed) return rl.response;
 
-  const apiAuth = await requireApiKey(request);
-  const session = await getServerSession(authOptions);
-
-  if (!apiAuth.authorized && !session?.user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
-  // Require ADMIN for config visibility (vaultPath is server filesystem info)
-  if (apiAuth.authorized) {
-    if (apiAuth.permissions !== "ADMIN") {
-      return NextResponse.json({ error: "Insufficient permissions" }, { status: 403 });
-    }
-  } else {
-    const role = session?.user?.role;
-    if (role !== "ADMIN") {
-      return NextResponse.json({ error: "Insufficient permissions" }, { status: 403 });
-    }
+  const auth = await requirePermission(request, [Permissions.ADMIN]);
+  if (!auth.success) {
+    return auth.response;
   }
 
   try {
@@ -68,23 +53,9 @@ export async function POST(request: NextRequest) {
   const rl = rateLimit(request, { windowMs: 60_000, maxRequests: 5, keyPrefix: "obsidian-post" });
   if (!rl.allowed) return rl.response;
 
-  const apiAuth = await requireApiKey(request);
-  const session = await getServerSession(authOptions);
-
-  if (!apiAuth.authorized && !session?.user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
-  // Require ADMIN for production use; allow WRITE for development
-  if (apiAuth.authorized) {
-    if (apiAuth.permissions !== "ADMIN" && apiAuth.permissions !== "WRITE") {
-      return NextResponse.json({ error: "Insufficient permissions" }, { status: 403 });
-    }
-  } else {
-    const role = session?.user?.role;
-    if (role !== "ADMIN") {
-      return NextResponse.json({ error: "Insufficient permissions" }, { status: 403 });
-    }
+  const auth = await requirePermission(request, [Permissions.ADMIN]);
+  if (!auth.success) {
+    return auth.response;
   }
 
   // Check feature flag
@@ -133,7 +104,7 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  const callerName = session?.user?.name ?? (apiAuth.authorized ? "API Key" : undefined);
+  const callerName = auth.auth.name ?? (auth.auth.keyId ? "API Key" : "Session User");
 
   const options: SyncOptions = {
     mode,

--- a/src/app/api/uploads/image/route.ts
+++ b/src/app/api/uploads/image/route.ts
@@ -1,8 +1,7 @@
 import path from "path";
 import { NextRequest, NextResponse } from "next/server";
-import { getServerSession } from "next-auth";
-import { authOptions } from "@/lib/auth";
-import { requireApiKey } from "@/lib/api/keys";
+import { Permissions } from "@prisma/client";
+import { requirePermission } from "@/lib/api/auth";
 import { saveUploadedImage } from "@/lib/uploads";
 import { rateLimit } from "@/lib/rate-limit";
 
@@ -12,19 +11,9 @@ export async function POST(request: NextRequest) {
   const rl = rateLimit(request, { windowMs: 60_000, maxRequests: 10, keyPrefix: "upload" });
   if (!rl.allowed) return rl.response;
 
-  const apiAuth = await requireApiKey(request);
-  const session = await getServerSession(authOptions);
-
-  if (!apiAuth.authorized && !session?.user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
-  if (apiAuth.authorized && !["WRITE", "ADMIN"].includes(apiAuth.permissions)) {
-    return NextResponse.json({ error: "Insufficient permissions" }, { status: 403 });
-  }
-
-  if (session?.user && !["EDITOR", "ADMIN"].includes(session.user.role)) {
-    return NextResponse.json({ error: "Insufficient permissions" }, { status: 403 });
+  const auth = await requirePermission(request, [Permissions.WRITE]);
+  if (!auth.success) {
+    return auth.response;
   }
 
   try {


### PR DESCRIPTION
## Summary
Replaces manual `requireApiKey()` + `getServerSession()` pairs with the unified `requirePermission()` helper across all API routes that were still using the legacy pattern.

This branch has been rebased onto the rate-limited API route changes from `master`, so the refactor now preserves the route-specific `rateLimit(...)` calls added in PR #97.

## Routes refactored
| Route | Before | After |
|-------|--------|-------|
| `GET /api/export` | manual auth | rate limit + `requirePermission([READ])` |
| `POST /api/import` | manual auth | rate limit + `requirePermission([WRITE])` |
| `POST /api/lint` | manual auth | rate limit + `requirePermission([WRITE])` |
| `POST /api/uploads/image` | manual auth | rate limit + `requirePermission([WRITE])` |
| `GET /api/sync/obsidian` | manual auth | rate limit + `requirePermission([ADMIN])` |
| `POST /api/sync/obsidian` | manual auth | rate limit + `requirePermission([ADMIN])` |
| `GET /api/log` | manual auth | rate limit + `requirePermission([])` |
| `DELETE /api/articles/[id]` | extra `getServerSession` call | uses `auth.auth.name` |

## Obsidian sync security note
`POST /api/sync/obsidian` now requires ADMIN for API keys and human sessions. This directly addresses the review comments about avoiding WRITE/EDITOR access to a filesystem-writing sync operation.

Nameless session callers now fall back to `Session User` instead of being mislabeled as `API Key` in sync audit metadata.

## Benefits
- **Eliminates auth logic duplication** — one helper, one behavior
- **Fixes CRIT-2** from the security audit (inconsistent auth patterns)
- **Preserves PR #97 rate limits** after rebase
- **Consistent error responses** — all routes now return identical 401/403 shapes
- **Single source of truth** for permission hierarchy (READ < WRITE < ADMIN)

## Testing
- [x] `git diff --check`
- [x] `npm run lint` (passes with 3 pre-existing warnings)
- [x] `npm run test:security` (7/7 passing)
- [x] `npm run test:api` (38/38 passing, with local DATABASE_URL)
- [x] `npm run build` (passes; existing Turbopack NFT warning for Obsidian sync import trace)
- [ ] `npm run test:memory` has pre-existing timing-sensitive failures unrelated to this PR (`recency > 0.9`, provider duration >=10ms)