### PR TITLE
feat: protect admin routes in proxy

### DIFF
--- a/src/__tests__/security/proxy.test.ts
+++ b/src/__tests__/security/proxy.test.ts
@@ -5,17 +5,19 @@ import { NextRequest } from "next/server";
 import { proxy } from "@/proxy";
 
 function request(path: string, init: RequestInit = {}) {
+  const headers = new Headers(init.headers);
+  headers.set("x-real-ip", headers.get("x-real-ip") ?? `test-${crypto.randomUUID()}`);
+  const { headers: _headers, signal, ...requestInit } = init;
+
   return new NextRequest(`http://localhost${path}`, {
-    ...init,
-    headers: {
-      "x-real-ip": `test-${crypto.randomUUID()}`,
-      ...(init.headers ?? {}),
-    },
+    ...requestInit,
+    signal: signal ?? undefined,
+    headers,
   });
 }
 
-test("proxy adds security headers to wiki pages", () => {
-  const response = proxy(request("/wiki/projects/example"));
+test("proxy adds security headers to wiki pages", async () => {
+  const response = await proxy(request("/wiki/projects/example"));
 
   assert.equal(response.headers.get("X-Content-Type-Options"), "nosniff");
   assert.equal(response.headers.get("X-Frame-Options"), "DENY");
@@ -23,27 +25,46 @@ test("proxy adds security headers to wiki pages", () => {
   assert.match(response.headers.get("Content-Security-Policy") ?? "", /frame-ancestors 'none'/);
 });
 
-test("proxy rate-limits article mutation routes", () => {
+test("proxy rate-limits article mutation routes", async () => {
   const headers = { "x-real-ip": `patch-${crypto.randomUUID()}` };
-  let response = proxy(request("/api/articles/article-1", { method: "PATCH", headers }));
+  let response = await proxy(request("/api/articles/article-1", { method: "PATCH", headers }));
 
   for (let i = 1; i < 30; i += 1) {
-    response = proxy(request("/api/articles/article-1", { method: "PATCH", headers }));
+    response = await proxy(request("/api/articles/article-1", { method: "PATCH", headers }));
   }
 
   assert.notEqual(response.status, 429);
 
-  const blocked = proxy(request("/api/articles/article-1", { method: "PATCH", headers }));
+  const blocked = await proxy(request("/api/articles/article-1", { method: "PATCH", headers }));
   assert.equal(blocked.status, 429);
 });
 
-test("proxy does not rate-limit article reads", () => {
+test("proxy does not rate-limit article reads", async () => {
   const headers = { "x-real-ip": `get-${crypto.randomUUID()}` };
-  let response = proxy(request("/api/articles/article-1", { method: "GET", headers }));
+  let response = await proxy(request("/api/articles/article-1", { method: "GET", headers }));
 
   for (let i = 0; i < 35; i += 1) {
-    response = proxy(request("/api/articles/article-1", { method: "GET", headers }));
+    response = await proxy(request("/api/articles/article-1", { method: "GET", headers }));
   }
 
   assert.notEqual(response.status, 429);
+});
+
+test("proxy redirects unauthenticated admin pages to login with callback", async () => {
+  const response = await proxy(request("/wiki/admin/keys?tab=active"));
+  const location = response.headers.get("location");
+
+  assert.equal(response.status, 307);
+  assert.ok(location);
+
+  const redirect = new URL(location);
+  assert.equal(redirect.pathname, "/wiki/login");
+  assert.equal(redirect.searchParams.get("callbackUrl"), "/wiki/admin/keys?tab=active");
+});
+
+test("proxy does not treat similarly named wiki paths as admin pages", async () => {
+  const response = await proxy(request("/wiki/administrator"));
+
+  assert.equal(response.headers.get("location"), null);
+  assert.equal(response.headers.get("X-Frame-Options"), "DENY");
 });

--- a/src/app/wiki/login/page.tsx
+++ b/src/app/wiki/login/page.tsx
@@ -4,6 +4,26 @@ import { useState } from "react";
 import { signIn } from "next-auth/react";
 import { useRouter } from "next/navigation";
 
+function getSafeCallbackUrl(rawCallbackUrl: string | null) {
+  if (!rawCallbackUrl) return "/wiki";
+
+  try {
+    const callbackUrl = new URL(rawCallbackUrl, window.location.origin);
+    const isWikiPath =
+      callbackUrl.pathname === "/wiki" || callbackUrl.pathname.startsWith("/wiki/");
+    const isLoginPath = callbackUrl.pathname === "/wiki/login";
+
+    // Only redirect after login to local wiki pages to avoid open redirects.
+    if (callbackUrl.origin !== window.location.origin || !isWikiPath || isLoginPath) {
+      return "/wiki";
+    }
+
+    return `${callbackUrl.pathname}${callbackUrl.search}${callbackUrl.hash}`;
+  } catch {
+    return "/wiki";
+  }
+}
+
 export default function LoginPage() {
   const router = useRouter();
   const [email, setEmail] = useState("");
@@ -27,7 +47,10 @@ export default function LoginPage() {
     if (result?.error) {
       setError("Invalid email or password.");
     } else {
-      router.push("/wiki");
+      const callbackUrl = getSafeCallbackUrl(
+        new URLSearchParams(window.location.search).get("callbackUrl")
+      );
+      router.push(callbackUrl);
       router.refresh();
     }
   }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,7 +1,37 @@
 import { NextRequest, NextResponse } from "next/server";
+import { getToken } from "next-auth/jwt";
 import { rateLimit } from "@/lib/rate-limit";
 
-export function proxy(request: NextRequest) {
+function isAdminPath(path: string) {
+  return path === "/wiki/admin" || path.startsWith("/wiki/admin/");
+}
+
+function addSecurityHeaders(response: NextResponse) {
+  // NOTE: Using 'unsafe-inline' for scripts is pragmatic for Next.js hydration.
+  // A production-hardened setup should use nonce-based CSP instead:
+  // generate a random nonce per request, add it to script-src, and pass it
+  // through NextScript / inline script tags. That requires a custom _document.tsx.
+  const csp = [
+    "default-src 'self'",
+    "script-src 'self' 'unsafe-inline'", // Next.js needs inline scripts for hydration
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data: blob:",
+    "font-src 'self'",
+    "connect-src 'self'",
+    "frame-ancestors 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+  ].join("; ");
+
+  response.headers.set("Content-Security-Policy", csp);
+  response.headers.set("X-Content-Type-Options", "nosniff");
+  response.headers.set("X-Frame-Options", "DENY");
+  response.headers.set("Referrer-Policy", "strict-origin-when-cross-origin");
+
+  return response;
+}
+
+export async function proxy(request: NextRequest) {
   const path = request.nextUrl.pathname;
 
   // Rate-limit authentication endpoints
@@ -11,7 +41,7 @@ export function proxy(request: NextRequest) {
       maxRequests: 10,
       keyPrefix: "auth",
     });
-    if (!result.allowed) return result.response;
+    if (!result.allowed) return addSecurityHeaders(result.response);
   }
 
   // Rate-limit write-heavy API endpoints. Keep this broad enough to cover
@@ -35,34 +65,27 @@ export function proxy(request: NextRequest) {
       maxRequests: 30,
       keyPrefix: "api-write",
     });
-    if (!result.allowed) return result.response;
+    if (!result.allowed) return addSecurityHeaders(result.response);
   }
 
-  // Add security headers to all responses
-  const response = NextResponse.next();
+  if (isAdminPath(path)) {
+    const token = await getToken({
+      req: request,
+      secret: process.env.NEXTAUTH_SECRET,
+    });
 
-  // NOTE: Using 'unsafe-inline' for scripts is pragmatic for Next.js hydration.
-  // A production-hardened setup should use nonce-based CSP instead:
-  // generate a random nonce per request, add it to script-src, and pass it
-  // through NextScript / inline script tags. That requires a custom _document.tsx.
-  const csp = [
-    "default-src 'self'",
-    "script-src 'self' 'unsafe-inline'", // Next.js needs inline scripts for hydration
-    "style-src 'self' 'unsafe-inline'",
-    "img-src 'self' data: blob:",
-    "font-src 'self'",
-    "connect-src 'self'",
-    "frame-ancestors 'none'",
-    "base-uri 'self'",
-    "form-action 'self'",
-  ].join("; ");
+    if (!token) {
+      const loginUrl = new URL("/wiki/login", request.url);
+      loginUrl.searchParams.set("callbackUrl", `${path}${request.nextUrl.search}`);
+      return addSecurityHeaders(NextResponse.redirect(loginUrl));
+    }
 
-  response.headers.set("Content-Security-Policy", csp);
-  response.headers.set("X-Content-Type-Options", "nosniff");
-  response.headers.set("X-Frame-Options", "DENY");
-  response.headers.set("Referrer-Policy", "strict-origin-when-cross-origin");
+    if (token.role !== "ADMIN") {
+      return addSecurityHeaders(NextResponse.redirect(new URL("/wiki", request.url)));
+    }
+  }
 
-  return response;
+  return addSecurityHeaders(NextResponse.next());
 }
 
 export const config = {

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -13,3 +13,10 @@ declare module "next-auth" {
     role: Role;
   }
 }
+
+declare module "next-auth/jwt" {
+  interface JWT {
+    id?: string;
+    role?: Role;
+  }
+}


### PR DESCRIPTION
## Summary
Adds route-level defense-in-depth for wiki admin pages through the existing Next.js 16 `src/proxy.ts` route proxy.

## Behavior
| Path | Unauthenticated | Non-ADMIN |
|------|-----------------|-----------|
| `/wiki/admin/*` | Redirect to `/wiki/login?callbackUrl=...` | Redirect to `/wiki` |
| All other paths | No change | No change |

## Why
- Fixes **CRIT-3** from the security audit.
- Prevents accidental exposure if a future admin page forgets the per-page auth check.
- Keeps API routes excluded from page-level auth decisions; they continue to use `requirePermission()`.

## Implementation notes
- Integrates admin protection into `src/proxy.ts` instead of adding a separate `middleware.ts`.
- Preserves and validates internal wiki `callbackUrl` values after login.
- Adds `next-auth/jwt` type augmentation for the JWT `role`.
- Extends proxy security tests for admin redirects and similarly named non-admin wiki paths.