### PR TITLE
fix: limit graph API cross-reference parsing to prevent CPU exhaustion

### DIFF
--- a/src/__tests__/api/graph.test.ts
+++ b/src/__tests__/api/graph.test.ts
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  buildArticleLookupMaps,
+  GRAPH_CONTENT_MAX_BYTES_DEFAULT,
+  GRAPH_CONTENT_MAX_BYTES_MAX,
+  isContentWithinByteLimit,
+  parseGraphQueryParams,
+} from "@/lib/graph";
+
+test.describe("parseGraphQueryParams", () => {
+  test("uses safe defaults", () => {
+    assert.deepEqual(parseGraphQueryParams(new URLSearchParams()), {
+      limit: 100,
+      contentLimit: 100,
+      contentMaxBytes: GRAPH_CONTENT_MAX_BYTES_DEFAULT,
+    });
+  });
+
+  test("preserves explicit zero values for content parsing controls", () => {
+    const params = new URLSearchParams({
+      contentLimit: "0",
+      contentMaxBytes: "0",
+    });
+
+    assert.deepEqual(parseGraphQueryParams(params), {
+      limit: 100,
+      contentLimit: 0,
+      contentMaxBytes: 0,
+    });
+  });
+
+  test("clamps client-provided limits to server-side ceilings", () => {
+    const params = new URLSearchParams({
+      limit: "999",
+      contentLimit: "999",
+      contentMaxBytes: "999999999",
+    });
+
+    assert.deepEqual(parseGraphQueryParams(params), {
+      limit: 500,
+      contentLimit: 500,
+      contentMaxBytes: GRAPH_CONTENT_MAX_BYTES_MAX,
+    });
+  });
+
+  test("falls back only for invalid numeric values", () => {
+    const params = new URLSearchParams({
+      limit: "not-a-number",
+      contentLimit: "also-bad",
+      contentMaxBytes: "bad",
+    });
+
+    assert.deepEqual(parseGraphQueryParams(params), {
+      limit: 100,
+      contentLimit: 100,
+      contentMaxBytes: GRAPH_CONTENT_MAX_BYTES_DEFAULT,
+    });
+  });
+});
+
+test.describe("isContentWithinByteLimit", () => {
+  test("rejects zero-byte limits", () => {
+    assert.equal(isContentWithinByteLimit("", 0), false);
+    assert.equal(isContentWithinByteLimit("a", 0), false);
+  });
+
+  test("uses a cheap character-length rejection before byte measurement", () => {
+    assert.equal(isContentWithinByteLimit("a".repeat(11), 10), false);
+  });
+
+  test("checks UTF-8 byte length for short content", () => {
+    assert.equal(isContentWithinByteLimit("\u00e9", 1), false);
+    assert.equal(isContentWithinByteLimit("\u00e9", 2), true);
+  });
+});
+
+test("buildArticleLookupMaps creates slug and topic-scoped lookup maps", () => {
+  const first = { slug: "shared", topic: { slug: "alpha" }, id: "first" };
+  const second = { slug: "shared", topic: { slug: "beta" }, id: "second" };
+  const { articleBySlug, articleByTopicSlug } = buildArticleLookupMaps([
+    first,
+    second,
+  ]);
+
+  assert.equal(articleBySlug.get("shared"), first);
+  assert.equal(articleByTopicSlug.get("alpha:shared"), first);
+  assert.equal(articleByTopicSlug.get("beta:shared"), second);
+});

--- a/src/app/api/graph/route.ts
+++ b/src/app/api/graph/route.ts
@@ -1,7 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
+import { Prisma } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
 import { requirePermission, buildScopeFilter } from "@/lib/api/auth";
 import { rateLimit } from "@/lib/rate-limit";
+import {
+  buildArticleLookupMaps,
+  isContentWithinByteLimit,
+  parseGraphQueryParams,
+} from "@/lib/graph";
 
 // GET /api/graph — Wiki knowledge graph
 //
@@ -14,7 +20,7 @@ import { rateLimit } from "@/lib/rate-limit";
 //   contentLimit — max articles to parse for cross-references (default 100)
 //                    Articles beyond this get topic/tag edges only.
 //   contentMaxBytes — skip cross-ref parsing for articles larger than this
-//                       (default 50KB) to prevent CPU exhaustion.
+//                       (default 50KB, max 50KB) to prevent CPU exhaustion.
 //
 // Response:
 //   {
@@ -36,15 +42,15 @@ export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url);
     const topicSlug = searchParams.get("topic");
-    const rawLimit = parseInt(searchParams.get("limit") ?? "100", 10);
-    const limit = Math.max(1, Math.min(rawLimit || 100, 500));
-    const contentLimit = Math.max(0, Math.min(parseInt(searchParams.get("contentLimit") ?? "100", 10) || 100, limit));
-    const contentMaxBytes = Math.max(0, parseInt(searchParams.get("contentMaxBytes") ?? "51200", 10) || 51200);
+    const { limit, contentLimit, contentMaxBytes } =
+      parseGraphQueryParams(searchParams);
 
     // Build scope-filtered where clause — restricts articles based on key scopes
     const scopeWhere = buildScopeFilter(auth.auth.allowedScopes, { deletedAt: null });
 
-    // Fetch all non-deleted articles with their tags and topic
+    // Fetch graph metadata first. Article content is loaded separately for the
+    // small cross-reference candidate set so large bodies are not returned just
+    // to build topic/tag edges.
     const articles = await prisma.article.findMany({
       where: {
         ...scopeWhere,
@@ -55,7 +61,6 @@ export async function GET(request: NextRequest) {
         title: true,
         slug: true,
         excerpt: true,
-        content: true,
         createdAt: true,
         topic: { select: { slug: true } },
         tags: { select: { tag: { select: { id: true, name: true, slug: true } } } },
@@ -64,11 +69,36 @@ export async function GET(request: NextRequest) {
       orderBy: { updatedAt: "desc" },
     });
 
-    // Determine which articles are eligible for cross-reference parsing.
-    // Parsing large content with regex is O(n) and can exhaust CPU/memory.
-    const articlesToParse = articles.filter((a, i) =>
-      i < contentLimit && new TextEncoder().encode(a.content).length <= contentMaxBytes
+    // Load content only for candidate articles. PostgreSQL enforces the byte
+    // ceiling before returning content, so oversized bodies become NULL instead
+    // of being transferred to Node just to be skipped.
+    const candidateArticleIds = articles.slice(0, contentLimit).map((a) => a.id);
+    const articleContents =
+      candidateArticleIds.length > 0 && contentMaxBytes > 0
+        ? await prisma.$queryRaw<Array<{ id: string; content: string | null }>>`
+            SELECT id,
+                   CASE
+                     WHEN octet_length(content) <= ${contentMaxBytes} THEN content
+                     ELSE NULL
+                   END AS content
+            FROM "Article"
+            WHERE id IN (${Prisma.join(candidateArticleIds)})
+          `
+        : [];
+    const contentByArticleId = new Map(
+      articleContents
+        .filter((row): row is { id: string; content: string } => row.content !== null)
+        .map((row) => [row.id, row.content])
     );
+    const articlesToParse = articles.slice(0, contentLimit).flatMap((article) => {
+      const content = contentByArticleId.get(article.id);
+      if (!content || !isContentWithinByteLimit(content, contentMaxBytes)) {
+        return [];
+      }
+
+      return [{ ...article, content }];
+    });
+    const { articleBySlug, articleByTopicSlug } = buildArticleLookupMaps(articles);
 
   // Build nodes
   const nodes = articles.map((a) => ({
@@ -131,15 +161,16 @@ export async function GET(request: NextRequest) {
   // Cross-reference edges: articles that explicitly link to other articles in the wiki
   // Detect wikilink-style references: [[slug]] or [text](/wiki/topic/slug)
   // Only parsed for articles within contentLimit and contentMaxBytes to prevent
-  // CPU exhaustion on large wikis. For full accuracy, cross-references should be
-  // pre-computed at write time and stored in the ArticleRelation table.
+  // CPU exhaustion on large wikis. contentMaxBytes is capped server-side even
+  // when the query string asks for more. For full accuracy, cross-references
+  // should be pre-computed at write time and stored in the ArticleRelation table.
   for (const article of articlesToParse) {
     // Match [[slug]] patterns (wikilinks to other wiki pages)
     const wikiLinkRegex = /\[\[([a-z0-9-]+)\]\]/gi;
     let match;
     while ((match = wikiLinkRegex.exec(article.content)) !== null) {
       const targetSlug = match[1].toLowerCase();
-      const target = articles.find((a) => a.slug === targetSlug);
+      const target = articleBySlug.get(targetSlug);
       if (target) {
         addEdge(article.id, target.id, "cross_ref");
       }
@@ -150,9 +181,7 @@ export async function GET(request: NextRequest) {
     while ((match = hrefRegex.exec(article.content)) !== null) {
       const refTopic = match[1].toLowerCase();
       const refSlug = match[2].toLowerCase();
-      const target = articles.find(
-        (a) => a.topic.slug === refTopic && a.slug === refSlug
-      );
+      const target = articleByTopicSlug.get(`${refTopic}:${refSlug}`);
       if (target) {
         addEdge(article.id, target.id, "cross_ref");
       }

--- a/src/app/api/graph/route.ts
+++ b/src/app/api/graph/route.ts
@@ -10,7 +10,11 @@ import { rateLimit } from "@/lib/rate-limit";
 //
 // Query params:
 //   topic    — filter to a specific topic slug
-//   limit    — max articles to include per topic (default 100)
+//   limit    — max articles to include per topic (default 100, max 500)
+//   contentLimit — max articles to parse for cross-references (default 100)
+//                    Articles beyond this get topic/tag edges only.
+//   contentMaxBytes — skip cross-ref parsing for articles larger than this
+//                       (default 50KB) to prevent CPU exhaustion.
 //
 // Response:
 //   {
@@ -34,6 +38,8 @@ export async function GET(request: NextRequest) {
     const topicSlug = searchParams.get("topic");
     const rawLimit = parseInt(searchParams.get("limit") ?? "100", 10);
     const limit = Math.max(1, Math.min(rawLimit || 100, 500));
+    const contentLimit = Math.max(0, Math.min(parseInt(searchParams.get("contentLimit") ?? "100", 10) || 100, limit));
+    const contentMaxBytes = Math.max(0, parseInt(searchParams.get("contentMaxBytes") ?? "51200", 10) || 51200);
 
     // Build scope-filtered where clause — restricts articles based on key scopes
     const scopeWhere = buildScopeFilter(auth.auth.allowedScopes, { deletedAt: null });
@@ -57,6 +63,12 @@ export async function GET(request: NextRequest) {
       take: limit,
       orderBy: { updatedAt: "desc" },
     });
+
+    // Determine which articles are eligible for cross-reference parsing.
+    // Parsing large content with regex is O(n) and can exhaust CPU/memory.
+    const articlesToParse = articles.filter((a, i) =>
+      i < contentLimit && new TextEncoder().encode(a.content).length <= contentMaxBytes
+    );
 
   // Build nodes
   const nodes = articles.map((a) => ({
@@ -118,7 +130,10 @@ export async function GET(request: NextRequest) {
 
   // Cross-reference edges: articles that explicitly link to other articles in the wiki
   // Detect wikilink-style references: [[slug]] or [text](/wiki/topic/slug)
-  for (const article of articles) {
+  // Only parsed for articles within contentLimit and contentMaxBytes to prevent
+  // CPU exhaustion on large wikis. For full accuracy, cross-references should be
+  // pre-computed at write time and stored in the ArticleRelation table.
+  for (const article of articlesToParse) {
     // Match [[slug]] patterns (wikilinks to other wiki pages)
     const wikiLinkRegex = /\[\[([a-z0-9-]+)\]\]/gi;
     let match;

--- a/src/lib/graph.ts
+++ b/src/lib/graph.ts
@@ -1,0 +1,76 @@
+import { Buffer } from "node:buffer";
+
+export const GRAPH_ARTICLE_LIMIT_DEFAULT = 100;
+export const GRAPH_ARTICLE_LIMIT_MAX = 500;
+export const GRAPH_CONTENT_LIMIT_DEFAULT = 100;
+export const GRAPH_CONTENT_MAX_BYTES_DEFAULT = 50 * 1024;
+export const GRAPH_CONTENT_MAX_BYTES_MAX = 50 * 1024;
+
+function parseIntegerParam(
+  searchParams: URLSearchParams,
+  name: string,
+  fallback: number
+) {
+  const value = searchParams.get(name);
+  if (value === null) return fallback;
+
+  const parsed = Number.parseInt(value, 10);
+  return Number.isNaN(parsed) ? fallback : parsed;
+}
+
+function clamp(value: number, min: number, max: number) {
+  return Math.max(min, Math.min(value, max));
+}
+
+export function parseGraphQueryParams(searchParams: URLSearchParams) {
+  const limit = clamp(
+    parseIntegerParam(searchParams, "limit", GRAPH_ARTICLE_LIMIT_DEFAULT),
+    1,
+    GRAPH_ARTICLE_LIMIT_MAX
+  );
+
+  const contentLimit = clamp(
+    parseIntegerParam(searchParams, "contentLimit", GRAPH_CONTENT_LIMIT_DEFAULT),
+    0,
+    limit
+  );
+
+  const contentMaxBytes = clamp(
+    parseIntegerParam(
+      searchParams,
+      "contentMaxBytes",
+      GRAPH_CONTENT_MAX_BYTES_DEFAULT
+    ),
+    0,
+    GRAPH_CONTENT_MAX_BYTES_MAX
+  );
+
+  return { limit, contentLimit, contentMaxBytes };
+}
+
+export function isContentWithinByteLimit(content: string, maxBytes: number) {
+  if (maxBytes <= 0) return false;
+  if (content.length > maxBytes) return false;
+
+  return Buffer.byteLength(content, "utf8") <= maxBytes;
+}
+
+export function buildArticleLookupMaps<
+  TArticle extends { slug: string; topic: { slug: string } },
+>(articles: TArticle[]) {
+  const articleBySlug = new Map<string, TArticle>();
+  const articleByTopicSlug = new Map<string, TArticle>();
+
+  for (const article of articles) {
+    const slug = article.slug.toLowerCase();
+    const topicSlug = article.topic.slug.toLowerCase();
+
+    if (!articleBySlug.has(slug)) {
+      articleBySlug.set(slug, article);
+    }
+
+    articleByTopicSlug.set(`${topicSlug}:${slug}`, article);
+  }
+
+  return { articleBySlug, articleByTopicSlug };
+}


### PR DESCRIPTION
## Summary
The `/api/graph` endpoint previously regex-parsed returned article content to detect cross-references, which made large wiki graphs vulnerable to unnecessary CPU and memory pressure.

## Changes
- Added `contentLimit` query param (default 100): only the first N articles are candidates for cross-reference parsing
- Added `contentMaxBytes` query param (default 50KB, max 50KB): larger article bodies are not returned to Node for cross-reference parsing
- Articles outside these limits still receive **topic** and **tag** edges
- Rebased onto current `master` so rate limiting and unified route auth are preserved
- Replaced repeated `articles.find(...)` cross-reference lookups with precomputed maps
- Added focused tests for graph query parsing, byte-limit behavior, and lookup maps

## Query params updated
| Param | Default | Max | Description |
|-------|---------|-----|-------------|
| `limit` | 100 | 500 | Max articles returned |
| `contentLimit` | 100 | `limit` | Max articles considered for cross-refs |
| `contentMaxBytes` | 51200 | 51200 | Skip parsing articles larger than this |

## Fixes
- **HIGH-1** from security audit: unbounded memory/CPU usage on graph endpoint

## Future work
- Pre-compute cross-reference edges at write time and query `ArticleRelation` directly