### PR TITLE
fix: add explicit Prisma connection pool settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,17 @@ NEXTAUTH_URL="http://localhost:4400"
 APP_URL="http://localhost:4400"
 
 # ────────────────────────────────────────────
+# Database Connection Pool
+# ────────────────────────────────────────────
+# Tune these for your expected concurrent load.
+# PG_POOL_MAX: max connections in the pool (default: 20)
+# PG_IDLE_TIMEOUT_MS: close idle connections after this many ms (default: 30000)
+# PG_CONN_TIMEOUT_MS: abort connection attempts after this many ms (default: 5000)
+PG_POOL_MAX="20"
+PG_IDLE_TIMEOUT_MS="30000"
+PG_CONN_TIMEOUT_MS="5000"
+
+# ────────────────────────────────────────────
 # Security
 # ────────────────────────────────────────────
 # Generate with: openssl rand -hex 32

--- a/docker-compose.noosphere.yml
+++ b/docker-compose.noosphere.yml
@@ -13,6 +13,9 @@ services:
       NEXTAUTH_URL: ${APP_URL:-http://127.0.0.1:6578}
       APP_URL: ${APP_URL:-http://127.0.0.1:6578}
       UPLOAD_DIR: /app/uploads
+      PG_POOL_MAX: ${PG_POOL_MAX:-20}
+      PG_IDLE_TIMEOUT_MS: ${PG_IDLE_TIMEOUT_MS:-30000}
+      PG_CONN_TIMEOUT_MS: ${PG_CONN_TIMEOUT_MS:-5000}
     command: ["sh", "-c", "node docker/migrate-or-baseline.mjs && node docker/bootstrap.mjs"]
     volumes:
       - noosphere_uploads:/app/uploads:rw
@@ -32,6 +35,9 @@ services:
       NEXTAUTH_URL: ${APP_URL:-http://127.0.0.1:6578}
       APP_URL: ${APP_URL:-http://127.0.0.1:6578}
       UPLOAD_DIR: /app/uploads
+      PG_POOL_MAX: ${PG_POOL_MAX:-20}
+      PG_IDLE_TIMEOUT_MS: ${PG_IDLE_TIMEOUT_MS:-30000}
+      PG_CONN_TIMEOUT_MS: ${PG_CONN_TIMEOUT_MS:-5000}
     volumes:
       - noosphere_uploads:/app/uploads:rw
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,9 @@ services:
       UPLOAD_DIR: /app/uploads
       OBSIDIAN_SYNC_ENABLED: ${OBSIDIAN_SYNC_ENABLED:-true}
       OBSIDIAN_SYNC_VAULT_PATH: ${OBSIDIAN_SYNC_VAULT_PATH:-/app/obsidian-vault}
+      PG_POOL_MAX: ${PG_POOL_MAX:-20}
+      PG_IDLE_TIMEOUT_MS: ${PG_IDLE_TIMEOUT_MS:-30000}
+      PG_CONN_TIMEOUT_MS: ${PG_CONN_TIMEOUT_MS:-5000}
     volumes:
       - ./uploads:/app/uploads:rw
       - ./uploads/images:/app/uploads/images:rw

--- a/scripts/_prisma.ts
+++ b/scripts/_prisma.ts
@@ -2,12 +2,26 @@ import { PrismaClient } from "@prisma/client";
 import { PrismaPg } from "@prisma/adapter-pg";
 import { Pool } from "pg";
 
+/**
+ * Parse a positive integer from an environment variable, falling back to a default.
+ * Handles empty strings, non-numeric values, and NaN gracefully.
+ */
+function parsePositiveInt(envVar: string | undefined, defaultValue: number): number {
+  const parsed = parseInt(envVar || "", 10);
+  return isNaN(parsed) || parsed <= 0 ? defaultValue : parsed;
+}
+
 const connectionString = process.env.DATABASE_URL;
 if (!connectionString) {
   throw new Error("DATABASE_URL must be set before running scripts.");
 }
 
-const pool = new Pool({ connectionString });
+const pool = new Pool({
+  connectionString,
+  max: parsePositiveInt(process.env.PG_POOL_MAX, 20),
+  idleTimeoutMillis: parsePositiveInt(process.env.PG_IDLE_TIMEOUT_MS, 30000),
+  connectionTimeoutMillis: parsePositiveInt(process.env.PG_CONN_TIMEOUT_MS, 5000),
+});
 const adapter = new PrismaPg(pool);
 
 export const prisma = new PrismaClient({ adapter });

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -13,7 +13,12 @@ function createPrismaClient() {
     throw new Error("DATABASE_URL environment variable is not set");
   }
 
-  const pool = globalForPrisma.pool ?? new Pool({ connectionString });
+  const pool = globalForPrisma.pool ?? new Pool({
+    connectionString,
+    max: Number(process.env.PG_POOL_MAX ?? 20),
+    idleTimeoutMillis: Number(process.env.PG_IDLE_TIMEOUT_MS ?? 30000),
+    connectionTimeoutMillis: Number(process.env.PG_CONN_TIMEOUT_MS ?? 5000),
+  });
   if (process.env.NODE_ENV !== "production") {
     globalForPrisma.pool = pool;
   }

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -7,6 +7,15 @@ const globalForPrisma = globalThis as unknown as {
   pool: Pool | undefined;
 };
 
+/**
+ * Parse a positive integer from an environment variable, falling back to a default.
+ * Handles empty strings, non-numeric values, and NaN gracefully.
+ */
+function parsePositiveInt(envVar: string | undefined, defaultValue: number): number {
+  const parsed = parseInt(envVar || "", 10);
+  return isNaN(parsed) || parsed <= 0 ? defaultValue : parsed;
+}
+
 function createPrismaClient() {
   const connectionString = process.env.DATABASE_URL;
   if (!connectionString) {
@@ -15,9 +24,9 @@ function createPrismaClient() {
 
   const pool = globalForPrisma.pool ?? new Pool({
     connectionString,
-    max: Number(process.env.PG_POOL_MAX ?? 20),
-    idleTimeoutMillis: Number(process.env.PG_IDLE_TIMEOUT_MS ?? 30000),
-    connectionTimeoutMillis: Number(process.env.PG_CONN_TIMEOUT_MS ?? 5000),
+    max: parsePositiveInt(process.env.PG_POOL_MAX, 20),
+    idleTimeoutMillis: parsePositiveInt(process.env.PG_IDLE_TIMEOUT_MS, 30000),
+    connectionTimeoutMillis: parsePositiveInt(process.env.PG_CONN_TIMEOUT_MS, 5000),
   });
   if (process.env.NODE_ENV !== "production") {
     globalForPrisma.pool = pool;


### PR DESCRIPTION
## Summary
Adds explicit connection pool configuration to the PostgreSQL `pg.Pool` instance used by Prisma.

## New environment variables
| Variable | Default | Description |
|----------|---------|-------------|
| `PG_POOL_MAX` | 20 | Max connections in the pool |
| `PG_IDLE_TIMEOUT_MS` | 30000 | Close idle connections after this ms |
| `PG_CONN_TIMEOUT_MS` | 5000 | Abort connection attempts after this ms |

## Changes
- `src/lib/prisma.ts`: passes explicit pool options to `new Pool({...})`
- `.env.example`: documents the new variables

## Fixes
- **HIGH-4** from security audit: implicit connection pool settings could cause connection exhaustion under load