### PR TITLE
fix: return 'untitled' for empty slugify output

### DIFF
--- a/src/lib/wiki.ts
+++ b/src/lib/wiki.ts
@@ -9,13 +9,15 @@ import {
 } from "@/lib/memory/article-search";
 
 export function slugify(text: string): string {
-  return text
-    .toLowerCase()
-    .replace(/[^a-z0-9 -]/g, "")
-    .replace(/\s+/g, "-")
-    .replace(/-+/g, "-")
-    .replace(/^-+|-+$/g, "")
-    .trim();
+  return (
+    text
+      .toLowerCase()
+      .replace(/[^a-z0-9 -]/g, "")
+      .replace(/\s+/g, "-")
+      .replace(/-+/g, "-")
+      .replace(/^-+|-+$/g, "")
+      .trim() || "untitled"
+  );
 }
 
 export function parseTagInput(raw: string | null | undefined): string[] {


### PR DESCRIPTION
## Summary
The `slugify()` function in `src/lib/wiki.ts` could return an empty string for inputs like `'@@@'` or emoji-only strings, which would fail database `UNIQUE` constraints or create invalid URLs.

## Change
Added `|| "untitled"` fallback to match the behavior of `slugify()` in `src/lib/memory/backfill.ts`.

## Before
```ts
slugify(🚀🚀🚀) // → 
slugify(@@@)   // → 
```

## After
```ts
slugify(🚀🚀🚀) // → untitled
slugify(@@@)   // → untitled
```

## Fixes
- **MED-7** from security audit: empty slugify output could cause DB constraint failures