### PR TITLE
chore: remove unused uuid dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,8 +24,7 @@
         "react-syntax-highlighter": "^16.1.1",
         "rehype-highlight": "^7.0.2",
         "rehype-sanitize": "^6.0.0",
-        "remark-gfm": "^4.0.1",
-        "uuid": "^13.0.2"
+        "remark-gfm": "^4.0.1"
       },
       "devDependencies": {
         "@types/bcryptjs": "^2.4.6",
@@ -34,7 +33,6 @@
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "@types/react-syntax-highlighter": "^15.5.13",
-        "@types/uuid": "^10.0.0",
         "dotenv": "^17.4.2",
         "eslint": "^9",
         "eslint-config-next": "16.2.6",
@@ -2264,13 +2262,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
-      "license": "MIT"
-    },
-    "node_modules/@types/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -9459,19 +9450,6 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
-    },
-    "node_modules/uuid": {
-      "version": "13.0.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.2.tgz",
-      "integrity": "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist-node/bin/uuid"
-      }
     },
     "node_modules/valibot": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -34,8 +34,7 @@
     "react-syntax-highlighter": "^16.1.1",
     "rehype-highlight": "^7.0.2",
     "rehype-sanitize": "^6.0.0",
-    "remark-gfm": "^4.0.1",
-    "uuid": "^13.0.2"
+    "remark-gfm": "^4.0.1"
   },
   "devDependencies": {
     "@types/bcryptjs": "^2.4.6",
@@ -44,7 +43,6 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@types/react-syntax-highlighter": "^15.5.13",
-    "@types/uuid": "^10.0.0",
     "dotenv": "^17.4.2",
     "eslint": "^9",
     "eslint-config-next": "16.2.6",


### PR DESCRIPTION
## Summary
Removes `uuid` and `@types/uuid` from dependencies since the `uuid` npm package is not used in the codebase. The code uses the built-in Node.js `crypto.randomUUID()` function instead.

## Changes
- Removed `uuid` from `dependencies`
- Removed `@types/uuid` from `devDependencies`
- Updated `package-lock.json` (24 lines removed)

## Why
1. The `uuid` npm package is not imported or used anywhere in the codebase
2. The code uses `crypto.randomUUID()` which is a built-in Node.js function (available since Node.js 19)
3. Removing unused dependencies reduces supply chain attack surface and install time

## Fixes
- LOW-4 from security audit

## Verification
- Searched codebase for `require('uuid')`, `import.*uuid`, `from 'uuid'` - no matches found
- Code uses `crypto.randomUUID()` in `src/lib/memory/api/save.ts`

## Summary by Sourcery

Remove unused UUID-related dependencies from the project configuration.

Build:
- Remove the unused `uuid` runtime dependency from package.json.
- Remove the unused `@types/uuid` development dependency from package.json.