### PR TITLE
fix: harden Hermes Noosphere memory provider

### DIFF
--- a/hermes-noosphere-memory/README.md
+++ b/hermes-noosphere-memory/README.md
@@ -35,7 +35,9 @@ Implemented:
 - standard-library HTTP client with redacted errors
 - `noosphere_status`, `noosphere_recall`, `noosphere_get`, `noosphere_topics`, and `noosphere_save` tools
 - auto-recall prefetch through Noosphere's prompt-ready recall API
+- fail-fast prompt/status timeouts separate from explicit API tool timeouts
 - explicit Hermes memory-write mirroring through draft memory candidates
+- optional `restrictedTags` pass-through for scoped draft saves
 - optional `sync_turn` capture when `auto_capture=true` and `topic_id` is configured
 - Hermes setup skill installed to `$HERMES_HOME/skills/noosphere-memory-hermes`
 
@@ -75,7 +77,9 @@ Example:
       "token_budget": 1200,
       "topic_id": "",
       "author_name_template": "Hermes:{identity}",
-      "api_timeout": 15.0
+      "api_timeout": 15.0,
+      "auto_recall_timeout": 4.0,
+      "status_timeout": 5.0
     }
 
 Use scoped Noosphere API keys for each Hermes profile when you want different agents to see or write different knowledge areas.
@@ -115,12 +119,23 @@ PY
   "token_budget": 1200,
   "topic_id": "",
   "author_name_template": "Hermes:{identity}",
-  "api_timeout": 15.0
+  "api_timeout": 15.0,
+  "auto_recall_timeout": 4.0,
+  "status_timeout": 5.0
 }
 JSON
 ```
 
 Do not commit real API keys.
+
+`base_url` is validated before use. The provider rejects malformed URLs,
+credential-embedded URLs, non-loopback `http://` URLs, and literal private,
+reserved, link-local, multicast, documentation, or unspecified IPv4/IPv6
+targets for both HTTP and HTTPS. Query strings and fragments are stripped.
+
+`noosphere_save` accepts optional `restrictedTags` with up to 16 non-empty
+strings of at most 64 characters each. Noosphere enforces whether the API key
+may use those scopes.
 
 ## Verification
 

--- a/hermes-noosphere-memory/install-hermes.sh
+++ b/hermes-noosphere-memory/install-hermes.sh
@@ -124,7 +124,9 @@ PY
   "token_budget": 1200,
   "topic_id": "",
   "author_name_template": "Hermes:{identity}",
-  "api_timeout": 15.0
+  "api_timeout": 15.0,
+  "auto_recall_timeout": 4.0,
+  "status_timeout": 5.0
 }
 JSON
 

--- a/hermes-noosphere-memory/plugins/memory/noosphere/README.md
+++ b/hermes-noosphere-memory/plugins/memory/noosphere/README.md
@@ -11,6 +11,8 @@ This provider is currently in Phase 4:
 - it exposes status, recall, get, and topics tools
 - it uses Noosphere's prompt-ready recall API for `prefetch()`
 - it saves explicit durable memories as draft candidates
+- it supports scoped draft saves through optional `restrictedTags`
+- it validates `base_url` before sending authenticated requests
 - it can mirror explicit Hermes memory writes when `topic_id` is configured
 
 Direct article publication is intentionally added in later phases.
@@ -61,7 +63,9 @@ PY
   "token_budget": 1200,
   "topic_id": "",
   "author_name_template": "Hermes:{identity}",
-  "api_timeout": 15.0
+  "api_timeout": 15.0,
+  "auto_recall_timeout": 4.0,
+  "status_timeout": 5.0
 }
 JSON
 ```
@@ -80,7 +84,9 @@ Config file: `$HERMES_HOME/noosphere.json`
 | `token_budget` | `1200` | Prompt-ready recall token budget. |
 | `topic_id` | `""` | Default topic for draft saves and optional turn capture. |
 | `author_name_template` | `Hermes:{identity}` | Author name template for draft memory candidates. |
-| `api_timeout` | `15.0` | HTTP timeout in seconds. |
+| `api_timeout` | `15.0` | HTTP timeout in seconds for explicit tools and saves. |
+| `auto_recall_timeout` | `4.0` | Fail-fast HTTP timeout in seconds for prompt-time prefetch. |
+| `status_timeout` | `5.0` | Fail-fast HTTP timeout in seconds for status and health probes. |
 
 Secrets:
 
@@ -93,6 +99,10 @@ Secrets:
 
 `is_available()` checks only local environment. It does not make network calls during Hermes startup.
 
+`base_url` rejects malformed URLs, embedded credentials, non-loopback
+`http://` URLs, and literal private/reserved/link-local/multicast IPv4 or IPv6
+targets. Local loopback installs such as `http://127.0.0.1:6578` remain allowed.
+
 Writes are disabled during `cron`, `flush`, and `subagent` contexts.
 
 ## Tools
@@ -104,3 +114,7 @@ Writes are disabled during `cron`, `flush`, and `subagent` contexts.
 | `noosphere_get` | Calls `POST /api/memory/get` by canonical ref or provider/id. |
 | `noosphere_topics` | Calls `GET /api/topics` for topic selection. |
 | `noosphere_save` | Calls `POST /api/memory/save` and creates a draft memory candidate. |
+
+`noosphere_save` accepts optional `restrictedTags` for explicit scoped saves.
+The provider validates the shape only; the Noosphere API enforces whether the
+key may assign the requested scopes.

--- a/hermes-noosphere-memory/plugins/memory/noosphere/__init__.py
+++ b/hermes-noosphere-memory/plugins/memory/noosphere/__init__.py
@@ -104,9 +104,8 @@ def _sanitize_config(raw: Dict[str, Any]) -> Dict[str, Any]:
     config = dict(_DEFAULT_CONFIG)
     config.update({key: value for key, value in raw.items() if value is not None})
 
-    config["base_url"] = normalize_base_url(
-        _as_string(config.get("base_url"), _DEFAULT_CONFIG["base_url"])
-    )
+    base_url = _as_string(config.get("base_url")) or str(_DEFAULT_CONFIG["base_url"])
+    config["base_url"] = normalize_base_url(base_url)
     config["auto_recall"] = _as_bool(config.get("auto_recall"), True)
     config["auto_capture"] = _as_bool(config.get("auto_capture"), False)
 
@@ -167,11 +166,11 @@ def _load_noosphere_config(hermes_home: str) -> Dict[str, Any]:
         return _sanitize_config(raw)
     except ValueError:
         logger.warning(
-            "Ignoring unsafe Noosphere config at %s; using defaults",
+            "Unsafe Noosphere config at %s; disabling provider",
             path,
             exc_info=True,
         )
-        return dict(_DEFAULT_CONFIG)
+        raise
 
 
 def _save_noosphere_config(values: Dict[str, Any], hermes_home: str) -> None:
@@ -278,7 +277,12 @@ class NoosphereMemoryProvider(MemoryProvider):
         self._agent_identity = _as_string(kwargs.get("agent_identity"), "default") or "default"
         self._agent_context = _as_string(kwargs.get("agent_context"))
 
-        self._config = _load_noosphere_config(self._hermes_home)
+        try:
+            self._config = _load_noosphere_config(self._hermes_home)
+        except ValueError:
+            self._active = False
+            self._client = None
+            return
         env_base_url = os.environ.get("NOOSPHERE_BASE_URL", "").strip()
         if env_base_url:
             try:

--- a/hermes-noosphere-memory/plugins/memory/noosphere/__init__.py
+++ b/hermes-noosphere-memory/plugins/memory/noosphere/__init__.py
@@ -20,7 +20,7 @@ from typing import Any, Dict, List, Optional
 
 from agent.memory_provider import MemoryProvider
 
-from .client import NoosphereClient, NoosphereClientError
+from .client import NoosphereClient, NoosphereClientError, normalize_base_url
 from .formatting import strip_context_fences
 from .schemas import TOOL_SCHEMAS
 
@@ -37,6 +37,8 @@ _DEFAULT_CONFIG: Dict[str, Any] = {
     "topic_id": "",
     "author_name_template": "Hermes:{identity}",
     "api_timeout": 15.0,
+    "auto_recall_timeout": 4.0,
+    "status_timeout": 5.0,
 }
 _NON_WRITING_CONTEXTS = {"cron", "flush", "subagent"}
 _SECRET_CONFIG_KEYS = {"api_key"}
@@ -55,7 +57,10 @@ def _config_path(hermes_home: str) -> Path:
 
 def _setup_key_url() -> str:
     base_url = os.environ.get("NOOSPHERE_BASE_URL", _DEFAULT_CONFIG["base_url"])
-    base_url = _as_string(base_url, _DEFAULT_CONFIG["base_url"]).rstrip("/")
+    try:
+        base_url = normalize_base_url(_as_string(base_url, _DEFAULT_CONFIG["base_url"]))
+    except ValueError:
+        base_url = str(_DEFAULT_CONFIG["base_url"])
     return f"{base_url}/wiki/admin/keys"
 
 
@@ -99,8 +104,9 @@ def _sanitize_config(raw: Dict[str, Any]) -> Dict[str, Any]:
     config = dict(_DEFAULT_CONFIG)
     config.update({key: value for key, value in raw.items() if value is not None})
 
-    base_url = _as_string(config.get("base_url"), _DEFAULT_CONFIG["base_url"]).rstrip("/")
-    config["base_url"] = base_url or _DEFAULT_CONFIG["base_url"]
+    config["base_url"] = normalize_base_url(
+        _as_string(config.get("base_url"), _DEFAULT_CONFIG["base_url"])
+    )
     config["auto_recall"] = _as_bool(config.get("auto_recall"), True)
     config["auto_capture"] = _as_bool(config.get("auto_capture"), False)
 
@@ -130,6 +136,18 @@ def _sanitize_config(raw: Dict[str, Any]) -> Dict[str, Any]:
         minimum=0.5,
         maximum=30.0,
     )
+    config["auto_recall_timeout"] = _as_float(
+        config.get("auto_recall_timeout"),
+        float(_DEFAULT_CONFIG["auto_recall_timeout"]),
+        minimum=0.5,
+        maximum=10.0,
+    )
+    config["status_timeout"] = _as_float(
+        config.get("status_timeout"),
+        float(_DEFAULT_CONFIG["status_timeout"]),
+        minimum=0.5,
+        maximum=10.0,
+    )
     return config
 
 
@@ -145,7 +163,15 @@ def _load_noosphere_config(hermes_home: str) -> Dict[str, Any]:
     if not isinstance(raw, dict):
         logger.warning("Ignoring non-object Noosphere config at %s", path)
         return dict(_DEFAULT_CONFIG)
-    return _sanitize_config(raw)
+    try:
+        return _sanitize_config(raw)
+    except ValueError:
+        logger.warning(
+            "Ignoring unsafe Noosphere config at %s; using defaults",
+            path,
+            exc_info=True,
+        )
+        return dict(_DEFAULT_CONFIG)
 
 
 def _save_noosphere_config(values: Dict[str, Any], hermes_home: str) -> None:
@@ -253,9 +279,18 @@ class NoosphereMemoryProvider(MemoryProvider):
         self._agent_context = _as_string(kwargs.get("agent_context"))
 
         self._config = _load_noosphere_config(self._hermes_home)
-        env_base_url = os.environ.get("NOOSPHERE_BASE_URL", "").strip().rstrip("/")
+        env_base_url = os.environ.get("NOOSPHERE_BASE_URL", "").strip()
         if env_base_url:
-            self._config["base_url"] = env_base_url
+            try:
+                self._config["base_url"] = normalize_base_url(env_base_url)
+            except ValueError:
+                logger.warning(
+                    "Unsafe NOOSPHERE_BASE_URL ignored; Noosphere disabled",
+                    exc_info=True,
+                )
+                self._active = False
+                self._client = None
+                return
 
         self._api_key = os.environ.get("NOOSPHERE_API_KEY", "").strip()
         self._write_enabled = self._agent_context not in _NON_WRITING_CONTEXTS
@@ -266,6 +301,8 @@ class NoosphereMemoryProvider(MemoryProvider):
                 base_url=str(self._config["base_url"]),
                 api_key=self._api_key,
                 timeout=float(self._config["api_timeout"]),
+                auto_recall_timeout=float(self._config["auto_recall_timeout"]),
+                status_timeout=float(self._config["status_timeout"]),
             )
 
     def system_prompt_block(self) -> str:
@@ -291,7 +328,8 @@ class NoosphereMemoryProvider(MemoryProvider):
                     "mode": "auto",
                     "resultCap": self._config["max_recall_results"],
                     "tokenBudget": self._config["token_budget"],
-                }
+                },
+                timeout=float(self._config["auto_recall_timeout"]),
             )
         except Exception:
             logger.debug("Noosphere prefetch failed", exc_info=True)
@@ -514,7 +552,34 @@ def _read_save_args(
         clean_tags = [tag for tag in clean_tags if tag]
         if clean_tags:
             request["tags"] = clean_tags[:20]
+    restricted_tags = _read_restricted_tags(args.get("restrictedTags"))
+    if restricted_tags:
+        request["restrictedTags"] = restricted_tags
     return request
+
+
+def _read_restricted_tags(value: Any) -> List[str]:
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise ValueError("restrictedTags must be an array of non-empty strings")
+    if len(value) > 16:
+        raise ValueError("restrictedTags must contain at most 16 items")
+
+    seen = set()
+    tags: List[str] = []
+    for item in value:
+        if not isinstance(item, str):
+            raise ValueError("restrictedTags must be an array of non-empty strings")
+        tag = item.strip()
+        if not tag:
+            raise ValueError("restrictedTags must be an array of non-empty strings")
+        if len(tag) > 64:
+            raise ValueError("restrictedTags entries must be at most 64 characters")
+        if tag not in seen:
+            seen.add(tag)
+            tags.append(tag)
+    return tags
 
 
 def _clean_capture_text(text: Any) -> str:

--- a/hermes-noosphere-memory/plugins/memory/noosphere/client.py
+++ b/hermes-noosphere-memory/plugins/memory/noosphere/client.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import http.client
+import ipaddress
 import json
 import re
 import urllib.error
+import urllib.parse
 import urllib.request
 from typing import Any, Dict, Optional
 
@@ -22,6 +24,115 @@ _SENSITIVE_FIELD_NAMES = {
 _SENSITIVE_VALUE_RE = re.compile(
     r"(?:noo_[A-Za-z0-9_-]+|Bearer\s+[A-Za-z0-9._~+/=-]{8,}|(?:sk|pk|tok|key)_[A-Za-z0-9_-]{16,})"
 )
+_ALLOWED_SCHEMES = {"http", "https"}
+
+
+def normalize_base_url(value: Any) -> str:
+    """Return a normalized Noosphere base URL or raise for unsafe egress targets."""
+
+    raw = str(value or "").strip()
+    if not raw:
+        raise ValueError("Noosphere base_url is required")
+    parsed = urllib.parse.urlsplit(raw)
+    if parsed.scheme not in _ALLOWED_SCHEMES:
+        raise ValueError("Noosphere base_url must use http or https")
+    if not parsed.hostname:
+        raise ValueError("Noosphere base_url must include a host")
+    if parsed.username or parsed.password:
+        raise ValueError("Noosphere base_url must not include credentials")
+
+    host = parsed.hostname
+    if _parse_ip_literal(host) is not None:
+        try:
+            ipaddress.ip_address(_normalized_host(host))
+        except ValueError as error:
+            raise ValueError("Noosphere base_url must use standard IP literal notation") from error
+    if parsed.scheme == "http" and not _is_loopback_host(host):
+        raise ValueError("Noosphere http base_url is allowed only for loopback hosts")
+    if _is_blocked_network_host(host):
+        raise ValueError("Noosphere base_url must not target private or reserved networks")
+
+    netloc = host
+    ip_literal = _parse_ip_literal(host)
+    if (
+        ip_literal is not None
+        and ip_literal.version == 6
+        and ":" in host
+        and not host.startswith("[")
+    ):
+        netloc = f"[{host}]"
+    try:
+        port = parsed.port
+    except ValueError as error:
+        raise ValueError("Noosphere base_url port is invalid") from error
+    if port is not None:
+        netloc = f"{netloc}:{port}"
+
+    path = parsed.path.rstrip("/")
+    return urllib.parse.urlunsplit((parsed.scheme, netloc, path, "", ""))
+
+
+def _is_loopback_host(host: str) -> bool:
+    normalized = _normalized_host(host)
+    if normalized == "localhost":
+        return True
+    ip = _parse_ip_literal(normalized)
+    return bool(ip and ip.is_loopback)
+
+
+def _is_blocked_network_host(host: str) -> bool:
+    ip = _parse_ip_literal(host)
+    if ip is None:
+        return False
+    if ip.is_loopback:
+        return False
+    mapped = getattr(ip, "ipv4_mapped", None)
+    if mapped is not None:
+        ip = mapped
+    return any(
+        (
+            ip.is_private,
+            ip.is_link_local,
+            ip.is_multicast,
+            ip.is_reserved,
+            ip.is_unspecified,
+        )
+    )
+
+
+def _normalized_host(host: str) -> str:
+    return host.strip().lower().strip("[]").split("%", 1)[0]
+
+
+def _parse_ip_literal(host: str) -> Optional[Any]:
+    normalized = _normalized_host(host)
+    try:
+        return ipaddress.ip_address(normalized)
+    except ValueError:
+        pass
+
+    try:
+        if re.fullmatch(r"(?:0x[0-9a-f]+|\d+)", normalized):
+            return ipaddress.ip_address(int(normalized, 0))
+        if "." in normalized and re.fullmatch(r"[0-9a-fx.]+", normalized):
+            parts = normalized.split(".")
+            if len(parts) == 4:
+                octets = [_parse_ipv4_component(part) for part in parts]
+                if all(octet is not None and 0 <= octet <= 255 for octet in octets):
+                    return ipaddress.ip_address(".".join(str(octet) for octet in octets))
+    except ValueError:
+        return None
+    return None
+
+
+def _parse_ipv4_component(value: str) -> Optional[int]:
+    if not value:
+        return None
+    if value.startswith("0x"):
+        return int(value, 16)
+    if len(value) > 1 and value.startswith("0"):
+        return int(value, 8)
+    return int(value, 10)
 
 
 class NoosphereClientError(Exception):
@@ -40,18 +151,30 @@ class NoosphereClientError(Exception):
 
 
 class NoosphereClient:
-    def __init__(self, *, base_url: str, api_key: str, timeout: float) -> None:
-        self._base_url = base_url.rstrip("/")
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        api_key: str,
+        timeout: float,
+        auto_recall_timeout: Optional[float] = None,
+        status_timeout: Optional[float] = None,
+    ) -> None:
+        self._base_url = normalize_base_url(base_url)
         self._api_key = api_key
         self._timeout = timeout
+        self._auto_recall_timeout = (
+            auto_recall_timeout if auto_recall_timeout is not None else min(timeout, 4.0)
+        )
+        self._status_timeout = status_timeout if status_timeout is not None else min(timeout, 5.0)
 
     def status(self) -> Dict[str, Any]:
         try:
-            return self._request_json("GET", "/api/memory/status")
+            return self._request_json("GET", "/api/memory/status", timeout=self._status_timeout)
         except NoosphereClientError as error:
             if error.status not in {401, 403}:
                 raise
-            health = self._request_json("GET", "/api/health")
+            health = self._request_json("GET", "/api/health", timeout=self._status_timeout)
             health["memoryStatusAvailable"] = False
             health["memoryStatusError"] = {
                 "status": error.status,
@@ -59,8 +182,13 @@ class NoosphereClient:
             }
             return health
 
-    def recall(self, request: Dict[str, Any]) -> Dict[str, Any]:
-        return self._request_json("POST", "/api/memory/recall", request)
+    def recall(
+        self,
+        request: Dict[str, Any],
+        *,
+        timeout: Optional[float] = None,
+    ) -> Dict[str, Any]:
+        return self._request_json("POST", "/api/memory/recall", request, timeout=timeout)
 
     def get(self, request: Dict[str, Any]) -> Dict[str, Any]:
         return self._request_json("POST", "/api/memory/get", request)
@@ -76,6 +204,8 @@ class NoosphereClient:
         method: str,
         path: str,
         body: Optional[Dict[str, Any]] = None,
+        *,
+        timeout: Optional[float] = None,
     ) -> Dict[str, Any]:
         url = f"{self._base_url}{path if path.startswith('/') else '/' + path}"
         data = None
@@ -89,7 +219,7 @@ class NoosphereClient:
 
         request = urllib.request.Request(url, data=data, headers=headers, method=method)
         try:
-            with urllib.request.urlopen(request, timeout=self._timeout) as response:
+            with urllib.request.urlopen(request, timeout=timeout or self._timeout) as response:
                 return _parse_json_response(response.read(_MAX_RESPONSE_BYTES + 1))
         except urllib.error.HTTPError as error:
             details = _safe_error_body(error)

--- a/hermes-noosphere-memory/plugins/memory/noosphere/client.py
+++ b/hermes-noosphere-memory/plugins/memory/noosphere/client.py
@@ -42,18 +42,20 @@ def normalize_base_url(value: Any) -> str:
         raise ValueError("Noosphere base_url must not include credentials")
 
     host = parsed.hostname
-    if _parse_ip_literal(host) is not None:
+    ip_literal = _parse_ip_literal(host)
+    if ip_literal is not None:
         try:
             ipaddress.ip_address(_normalized_host(host))
         except ValueError as error:
             raise ValueError("Noosphere base_url must use standard IP literal notation") from error
+    elif _looks_like_ipv4_literal(host):
+        raise ValueError("Noosphere base_url must use standard IP literal notation")
     if parsed.scheme == "http" and not _is_loopback_host(host):
         raise ValueError("Noosphere http base_url is allowed only for loopback hosts")
     if _is_blocked_network_host(host):
         raise ValueError("Noosphere base_url must not target private or reserved networks")
 
     netloc = host
-    ip_literal = _parse_ip_literal(host)
     if (
         ip_literal is not None
         and ip_literal.version == 6
@@ -77,6 +79,9 @@ def _is_loopback_host(host: str) -> bool:
     if normalized == "localhost":
         return True
     ip = _parse_ip_literal(normalized)
+    mapped = getattr(ip, "ipv4_mapped", None) if ip is not None else None
+    if mapped is not None:
+        ip = mapped
     return bool(ip and ip.is_loopback)
 
 
@@ -84,13 +89,14 @@ def _is_blocked_network_host(host: str) -> bool:
     ip = _parse_ip_literal(host)
     if ip is None:
         return False
-    if ip.is_loopback:
-        return False
     mapped = getattr(ip, "ipv4_mapped", None)
     if mapped is not None:
         ip = mapped
+    if ip.is_loopback:
+        return False
     return any(
         (
+            not ip.is_global,
             ip.is_private,
             ip.is_link_local,
             ip.is_multicast,
@@ -111,23 +117,54 @@ def _parse_ip_literal(host: str) -> Optional[Any]:
     except ValueError:
         pass
 
+    candidate = normalized[:-1] if normalized.endswith(".") else normalized
     try:
-        if re.fullmatch(r"(?:0x[0-9a-f]+|\d+)", normalized):
-            return ipaddress.ip_address(int(normalized, 0))
-        if "." in normalized and re.fullmatch(r"[0-9a-fx.]+", normalized):
-            parts = normalized.split(".")
-            if len(parts) == 4:
-                octets = [_parse_ipv4_component(part) for part in parts]
-                if all(octet is not None and 0 <= octet <= 255 for octet in octets):
-                    return ipaddress.ip_address(".".join(str(octet) for octet in octets))
+        return _parse_legacy_ipv4_literal(candidate)
     except ValueError:
         return None
-    return None
+
+
+def _looks_like_ipv4_literal(host: str) -> bool:
+    candidate = _normalized_host(host)
+    candidate = candidate[:-1] if candidate.endswith(".") else candidate
+    return bool(re.fullmatch(r"(?:0x[0-9a-f]+|[0-9]+)(?:\.(?:0x[0-9a-f]+|[0-9]+)){0,3}", candidate))
+
+
+def _parse_legacy_ipv4_literal(value: str) -> Optional[Any]:
+    """Recognize inet_aton-style IPv4 forms so non-standard literals can be rejected."""
+
+    if not _looks_like_ipv4_literal(value):
+        return None
+    parts = [_parse_ipv4_component(part) for part in value.split(".")]
+    if any(part is None for part in parts):
+        return None
+
+    if len(parts) == 1:
+        number = parts[0]
+    elif len(parts) == 2:
+        if parts[0] > 0xFF or parts[1] > 0xFFFFFF:
+            return None
+        number = (parts[0] << 24) | parts[1]
+    elif len(parts) == 3:
+        if parts[0] > 0xFF or parts[1] > 0xFF or parts[2] > 0xFFFF:
+            return None
+        number = (parts[0] << 24) | (parts[1] << 16) | parts[2]
+    elif len(parts) == 4:
+        if any(part > 0xFF for part in parts):
+            return None
+        number = (parts[0] << 24) | (parts[1] << 16) | (parts[2] << 8) | parts[3]
+    else:
+        return None
+
+    if number > 0xFFFFFFFF:
+        return None
+    return ipaddress.ip_address(number)
 
 
 def _parse_ipv4_component(value: str) -> Optional[int]:
     if not value:
         return None
+    value = value.lower()
     if value.startswith("0x"):
         return int(value, 16)
     if len(value) > 1 and value.startswith("0"):
@@ -188,7 +225,12 @@ class NoosphereClient:
         *,
         timeout: Optional[float] = None,
     ) -> Dict[str, Any]:
-        return self._request_json("POST", "/api/memory/recall", request, timeout=timeout)
+        effective_timeout = (
+            self._auto_recall_timeout
+            if timeout is None and request.get("mode") == "auto"
+            else timeout
+        )
+        return self._request_json("POST", "/api/memory/recall", request, timeout=effective_timeout)
 
     def get(self, request: Dict[str, Any]) -> Dict[str, Any]:
         return self._request_json("POST", "/api/memory/get", request)

--- a/hermes-noosphere-memory/plugins/memory/noosphere/plugin.yaml
+++ b/hermes-noosphere-memory/plugins/memory/noosphere/plugin.yaml
@@ -1,3 +1,3 @@
 name: noosphere
-version: 0.4.1
+version: 0.4.2
 description: "Noosphere durable memory provider with scoped recall and draft memory capture."

--- a/hermes-noosphere-memory/plugins/memory/noosphere/schemas.py
+++ b/hermes-noosphere-memory/plugins/memory/noosphere/schemas.py
@@ -95,6 +95,15 @@ NOOSPHERE_SAVE_SCHEMA = {
                 "items": {"type": "string"},
                 "description": "Optional tags.",
             },
+            "restrictedTags": {
+                "type": "array",
+                "items": {"type": "string", "minLength": 1, "maxLength": 64},
+                "maxItems": 16,
+                "description": (
+                    "Optional Noosphere restricted scope tags. The server rejects "
+                    "scopes not allowed for the API key."
+                ),
+            },
             "source": {"type": "string", "description": "Optional source pointer."},
             "confidence": {
                 "type": "string",

--- a/hermes-noosphere-memory/plugins/memory/noosphere/skills/noosphere/SKILL.md
+++ b/hermes-noosphere-memory/plugins/memory/noosphere/skills/noosphere/SKILL.md
@@ -15,6 +15,7 @@ Use this skill when Hermes has the Noosphere memory provider enabled and the tas
 - Save decisions, stable project facts, runbooks, recurring failure fixes, and explicit "remember this" requests.
 - Do not save transient task status, greetings, tiny confirmations, secrets, or raw prompt/context dumps.
 - Prefer draft candidates; humans or review workflows can promote them later.
+- Use `restrictedTags` only for known Noosphere scopes when a draft memory candidate must be explicitly narrowed. The Noosphere API rejects scopes the key cannot use.
 
 ## Topics
 
@@ -27,3 +28,4 @@ Use this skill when Hermes has the Noosphere memory provider enabled and the tas
 - API-key scopes control what Hermes can read and write.
 - Do not assume a memory is absent just because a scoped key cannot see it.
 - Never include API keys in saved memory content, logs, or user-visible output.
+- The provider validates `base_url` before egress and only allows HTTP for loopback installs.

--- a/hermes-noosphere-memory/skills/noosphere-memory-hermes/SKILL.md
+++ b/hermes-noosphere-memory/skills/noosphere-memory-hermes/SKILL.md
@@ -134,6 +134,8 @@ config.update({
     "topic_id": os.environ.get("NOOSPHERE_TOPIC_ID") or config.get("topic_id") or "",
     "author_name_template": config.get("author_name_template") or "Hermes:{identity}",
     "api_timeout": as_float(config.get("api_timeout"), 15.0, 0.5, 30.0),
+    "auto_recall_timeout": as_float(config.get("auto_recall_timeout"), 4.0, 0.5, 10.0),
+    "status_timeout": as_float(config.get("status_timeout"), 5.0, 0.5, 10.0),
 })
 
 path.write_text(json.dumps(config, indent=2, sort_keys=True) + "\n", encoding="utf-8")
@@ -161,6 +163,14 @@ For live smoke testing, use the provider tools:
 - `READ`: recall and get only.
 - `WRITE`: recall, get, and draft saves. Recommended default.
 - `ADMIN`: only needed for admin endpoints, not normal Hermes memory use.
+
+## Safety Defaults
+
+- Keep `base_url` on HTTPS for remote Noosphere deployments.
+- HTTP is only allowed for local loopback installs such as `http://127.0.0.1:6578`.
+- Do not use URLs with credentials, query strings, fragments, private network IPs, or metadata IPs.
+- Use `auto_recall_timeout` for prompt-time recall; keep it lower than `api_timeout` so turn construction fails open quickly.
+- Use `restrictedTags` on `noosphere_save` only when the memory should be narrowed to a known Noosphere scope. The server still enforces key permissions.
 
 ## Memory Use
 

--- a/hermes-noosphere-memory/tests/test_noosphere_client.py
+++ b/hermes-noosphere-memory/tests/test_noosphere_client.py
@@ -231,7 +231,7 @@ class NoosphereClientTest(unittest.TestCase):
 
     def test_normalize_base_url_accepts_safe_targets_and_strips_fragments(self):
         module = load_plugin_package()
-        normalize = module.NoosphereClient.__init__.__globals__["normalize_base_url"]
+        normalize = module.normalize_base_url
 
         cases = {
             "http://127.0.0.1:6578/path/?x=1#frag": "http://127.0.0.1:6578/path",
@@ -245,7 +245,7 @@ class NoosphereClientTest(unittest.TestCase):
 
     def test_normalize_base_url_rejects_unsafe_targets(self):
         module = load_plugin_package()
-        normalize = module.NoosphereClient.__init__.__globals__["normalize_base_url"]
+        normalize = module.normalize_base_url
 
         cases = [
             "file:///tmp/noosphere.sock",
@@ -254,8 +254,12 @@ class NoosphereClientTest(unittest.TestCase):
             "https://10.0.0.5",
             "https://172.16.0.5",
             "https://192.168.1.5",
+            "https://100.64.0.1",
             "https://169.254.169.254",
             "https://2130706433",
+            "https://127.1",
+            "https://192.168.1",
+            "https://127.0.0.1.",
             "https://0177.0.0.1",
             "https://0x7f.0.0.1",
             "https://[fc00::1]",
@@ -288,10 +292,14 @@ class NoosphereClientTest(unittest.TestCase):
             return_value=_JsonResponse({"ok": True}),
         ) as urlopen:
             client.status()
-            client.recall({"query": "deploy"}, timeout=1.25)
+            client.recall({"query": "deploy", "mode": "auto"})
+            client.recall({"query": "deploy", "mode": "inspection"})
+            client.recall({"query": "deploy", "mode": "inspection"}, timeout=2.5)
 
         self.assertEqual(urlopen.call_args_list[0].kwargs["timeout"], 0.75)
         self.assertEqual(urlopen.call_args_list[1].kwargs["timeout"], 1.25)
+        self.assertEqual(urlopen.call_args_list[2].kwargs["timeout"], 15.0)
+        self.assertEqual(urlopen.call_args_list[3].kwargs["timeout"], 2.5)
 
 
 if __name__ == "__main__":

--- a/hermes-noosphere-memory/tests/test_noosphere_client.py
+++ b/hermes-noosphere-memory/tests/test_noosphere_client.py
@@ -95,6 +95,20 @@ class _StatusHandler(BaseHTTPRequestHandler):
         return
 
 
+class _JsonResponse:
+    def __init__(self, body):
+        self.body = json.dumps(body).encode("utf-8")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, traceback):
+        return False
+
+    def read(self, size=-1):
+        return self.body
+
+
 class NoosphereClientTest(unittest.TestCase):
     def setUp(self):
         _StatusHandler.response_status = 200
@@ -214,6 +228,70 @@ class NoosphereClientTest(unittest.TestCase):
         self.assertEqual(redacted["keywords"], ["search", "terms"])
         self.assertEqual(redacted["access_token"], "[redacted]")
         self.assertEqual(redacted["message"], "[redacted]")
+
+    def test_normalize_base_url_accepts_safe_targets_and_strips_fragments(self):
+        module = load_plugin_package()
+        normalize = module.NoosphereClient.__init__.__globals__["normalize_base_url"]
+
+        cases = {
+            "http://127.0.0.1:6578/path/?x=1#frag": "http://127.0.0.1:6578/path",
+            "http://localhost:6578/": "http://localhost:6578",
+            "http://[::1]:6578/": "http://[::1]:6578",
+            "https://noosphere.example.test/base/": "https://noosphere.example.test/base",
+        }
+        for raw, expected in cases.items():
+            with self.subTest(raw=raw):
+                self.assertEqual(normalize(raw), expected)
+
+    def test_normalize_base_url_rejects_unsafe_targets(self):
+        module = load_plugin_package()
+        normalize = module.NoosphereClient.__init__.__globals__["normalize_base_url"]
+
+        cases = [
+            "file:///tmp/noosphere.sock",
+            "https://user:pass@noosphere.example.test",
+            "http://noosphere.example.test",
+            "https://10.0.0.5",
+            "https://172.16.0.5",
+            "https://192.168.1.5",
+            "https://169.254.169.254",
+            "https://2130706433",
+            "https://0177.0.0.1",
+            "https://0x7f.0.0.1",
+            "https://[fc00::1]",
+            "https://[fd00::1]",
+            "https://[fe80::1]",
+            "https://[fe80::1%25eth0]",
+            "https://[ff02::1]",
+            "https://[::ffff:192.168.1.5]",
+            "https://[2001:db8::1]",
+        ]
+        for raw in cases:
+            with self.subTest(raw=raw):
+                with self.assertRaises(ValueError):
+                    normalize(raw)
+
+    def test_status_and_recall_allow_call_specific_timeouts(self):
+        module = load_plugin_package()
+        client = module.NoosphereClient(
+            base_url=self.base_url,
+            api_key="noo_test",
+            timeout=15.0,
+            auto_recall_timeout=1.25,
+            status_timeout=0.75,
+        )
+
+        client_globals = module.NoosphereClient._request_json.__globals__
+        with mock.patch.object(
+            client_globals["urllib"].request,
+            "urlopen",
+            return_value=_JsonResponse({"ok": True}),
+        ) as urlopen:
+            client.status()
+            client.recall({"query": "deploy"}, timeout=1.25)
+
+        self.assertEqual(urlopen.call_args_list[0].kwargs["timeout"], 0.75)
+        self.assertEqual(urlopen.call_args_list[1].kwargs["timeout"], 1.25)
 
 
 if __name__ == "__main__":

--- a/hermes-noosphere-memory/tests/test_noosphere_provider_phase1.py
+++ b/hermes-noosphere-memory/tests/test_noosphere_provider_phase1.py
@@ -99,6 +99,19 @@ class NoosphereProviderPhase1Test(unittest.TestCase):
         self.assertEqual(data["max_recall_results"], 20)
         self.assertNotIn("providers", data)
 
+    def test_save_config_treats_blank_base_url_as_default(self):
+        module = load_plugin()
+        provider = module.NoosphereMemoryProvider()
+
+        with tempfile.TemporaryDirectory() as hermes_home:
+            provider.save_config({"base_url": "", "auto_recall": False}, hermes_home)
+
+            path = Path(hermes_home) / "noosphere.json"
+            data = json.loads(path.read_text(encoding="utf-8"))
+
+        self.assertEqual(data["base_url"], "http://127.0.0.1:6578")
+        self.assertFalse(data["auto_recall"])
+
     def test_save_config_removes_legacy_secret_from_existing_file(self):
         module = load_plugin()
         provider = module.NoosphereMemoryProvider()
@@ -203,6 +216,22 @@ class NoosphereProviderPhase1Test(unittest.TestCase):
         self.assertFalse(provider._active)
         self.assertIsNone(provider._client)
         self.assertIn("Unsafe NOOSPHERE_BASE_URL ignored", "\n".join(logs.output))
+
+    def test_initialize_disables_provider_for_unsafe_stored_base_url(self):
+        module = load_plugin()
+        provider = module.NoosphereMemoryProvider()
+
+        with tempfile.TemporaryDirectory() as hermes_home:
+            path = Path(hermes_home) / "noosphere.json"
+            path.write_text(json.dumps({"base_url": "https://169.254.169.254"}), encoding="utf-8")
+
+            with mock.patch.dict(os.environ, {"NOOSPHERE_API_KEY": "noo_test"}, clear=True):
+                with self.assertLogs(module.logger, level="WARNING") as logs:
+                    provider.initialize("session-1", hermes_home=hermes_home)
+
+        self.assertFalse(provider._active)
+        self.assertIsNone(provider._client)
+        self.assertIn("Unsafe Noosphere config", "\n".join(logs.output))
 
     def test_register_adds_memory_provider(self):
         module = load_plugin()

--- a/hermes-noosphere-memory/tests/test_noosphere_provider_phase1.py
+++ b/hermes-noosphere-memory/tests/test_noosphere_provider_phase1.py
@@ -66,10 +66,10 @@ class NoosphereProviderPhase1Test(unittest.TestCase):
         module = load_plugin()
         provider = module.NoosphereMemoryProvider()
 
-        with mock.patch.dict(os.environ, {"NOOSPHERE_BASE_URL": "http://noosphere.test/"}, clear=True):
+        with mock.patch.dict(os.environ, {"NOOSPHERE_BASE_URL": "https://noosphere.test/"}, clear=True):
             schema = provider.get_config_schema()
 
-        self.assertEqual(schema[0]["url"], "http://noosphere.test/wiki/admin/keys")
+        self.assertEqual(schema[0]["url"], "https://noosphere.test/wiki/admin/keys")
 
     def test_save_config_persists_non_secret_values(self):
         module = load_plugin()
@@ -79,8 +79,10 @@ class NoosphereProviderPhase1Test(unittest.TestCase):
             provider.save_config(
                 {
                     "api_key": "noo_secret",
-                    "base_url": "http://example.test:6578/",
+                    "base_url": "https://example.test:6578/",
                     "auto_capture": "true",
+                    "auto_recall_timeout": 99,
+                    "status_timeout": 99,
                     "max_recall_results": 99,
                 },
                 hermes_home,
@@ -90,8 +92,10 @@ class NoosphereProviderPhase1Test(unittest.TestCase):
             data = json.loads(path.read_text(encoding="utf-8"))
 
         self.assertNotIn("api_key", data)
-        self.assertEqual(data["base_url"], "http://example.test:6578")
+        self.assertEqual(data["base_url"], "https://example.test:6578")
         self.assertTrue(data["auto_capture"])
+        self.assertEqual(data["auto_recall_timeout"], 10.0)
+        self.assertEqual(data["status_timeout"], 10.0)
         self.assertEqual(data["max_recall_results"], 20)
         self.assertNotIn("providers", data)
 
@@ -102,7 +106,7 @@ class NoosphereProviderPhase1Test(unittest.TestCase):
         with tempfile.TemporaryDirectory() as hermes_home:
             path = Path(hermes_home) / "noosphere.json"
             path.write_text(
-                json.dumps({"api_key": "noo_legacy", "base_url": "http://stored.test"}),
+                json.dumps({"api_key": "noo_legacy", "base_url": "https://stored.test"}),
                 encoding="utf-8",
             )
 
@@ -111,7 +115,7 @@ class NoosphereProviderPhase1Test(unittest.TestCase):
             data = json.loads(path.read_text(encoding="utf-8"))
 
         self.assertNotIn("api_key", data)
-        self.assertEqual(data["base_url"], "http://stored.test")
+        self.assertEqual(data["base_url"], "https://stored.test")
         self.assertTrue(data["auto_capture"])
 
     def test_save_config_logs_and_rebuilds_corrupt_existing_file(self):
@@ -123,12 +127,12 @@ class NoosphereProviderPhase1Test(unittest.TestCase):
             path.write_text("{not-json", encoding="utf-8")
 
             with self.assertLogs(module.logger, level="WARNING") as logs:
-                provider.save_config({"base_url": "http://rebuilt.test"}, hermes_home)
+                provider.save_config({"base_url": "https://rebuilt.test"}, hermes_home)
 
             data = json.loads(path.read_text(encoding="utf-8"))
 
         self.assertIn("Failed to parse existing Noosphere config", "\n".join(logs.output))
-        self.assertEqual(data["base_url"], "http://rebuilt.test")
+        self.assertEqual(data["base_url"], "https://rebuilt.test")
 
     def test_initialize_loads_context_and_disables_writes_for_subagents(self):
         module = load_plugin()
@@ -137,7 +141,7 @@ class NoosphereProviderPhase1Test(unittest.TestCase):
         with tempfile.TemporaryDirectory() as hermes_home:
             path = Path(hermes_home) / "noosphere.json"
             path.write_text(
-                json.dumps({"base_url": "http://stored.test", "auto_recall": False}),
+                json.dumps({"base_url": "https://stored.test", "auto_recall": False}),
                 encoding="utf-8",
             )
 
@@ -145,7 +149,7 @@ class NoosphereProviderPhase1Test(unittest.TestCase):
                 os.environ,
                 {
                     "NOOSPHERE_API_KEY": "noo_test",
-                    "NOOSPHERE_BASE_URL": "http://env.test/",
+                    "NOOSPHERE_BASE_URL": "https://env.test/",
                 },
                 clear=True,
             ):
@@ -159,7 +163,7 @@ class NoosphereProviderPhase1Test(unittest.TestCase):
 
         self.assertTrue(provider._active)
         self.assertFalse(provider._write_enabled)
-        self.assertEqual(provider._config["base_url"], "http://env.test")
+        self.assertEqual(provider._config["base_url"], "https://env.test")
         self.assertEqual(provider._agent_identity, "coder")
 
     def test_initialize_uses_hermes_home_env_when_kwarg_missing(self):
@@ -168,7 +172,7 @@ class NoosphereProviderPhase1Test(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as hermes_home:
             path = Path(hermes_home) / "noosphere.json"
-            path.write_text(json.dumps({"base_url": "http://env-home.test"}), encoding="utf-8")
+            path.write_text(json.dumps({"base_url": "https://env-home.test"}), encoding="utf-8")
 
             with mock.patch.dict(
                 os.environ,
@@ -178,7 +182,27 @@ class NoosphereProviderPhase1Test(unittest.TestCase):
                 provider.initialize("session-1")
 
         self.assertEqual(provider._hermes_home, hermes_home)
-        self.assertEqual(provider._config["base_url"], "http://env-home.test")
+        self.assertEqual(provider._config["base_url"], "https://env-home.test")
+
+    def test_initialize_disables_provider_for_unsafe_env_base_url(self):
+        module = load_plugin()
+        provider = module.NoosphereMemoryProvider()
+
+        with tempfile.TemporaryDirectory() as hermes_home:
+            with mock.patch.dict(
+                os.environ,
+                {
+                    "NOOSPHERE_API_KEY": "noo_test",
+                    "NOOSPHERE_BASE_URL": "https://169.254.169.254",
+                },
+                clear=True,
+            ):
+                with self.assertLogs(module.logger, level="WARNING") as logs:
+                    provider.initialize("session-1", hermes_home=hermes_home)
+
+        self.assertFalse(provider._active)
+        self.assertIsNone(provider._client)
+        self.assertIn("Unsafe NOOSPHERE_BASE_URL ignored", "\n".join(logs.output))
 
     def test_register_adds_memory_provider(self):
         module = load_plugin()

--- a/hermes-noosphere-memory/tests/test_noosphere_recall_phase3.py
+++ b/hermes-noosphere-memory/tests/test_noosphere_recall_phase3.py
@@ -56,8 +56,8 @@ class _FakeClient:
     def topics(self):
         return {"topics": []}
 
-    def recall(self, request):
-        self.calls.append(("recall", request))
+    def recall(self, request, *, timeout=None):
+        self.calls.append(("recall", request, timeout))
         return {
             "results": [{"id": "one"}],
             "promptInjectionText": (
@@ -78,7 +78,7 @@ class _FakeClient:
 
 
 class _ExplodingClient:
-    def recall(self, request):
+    def recall(self, request, *, timeout=None):
         raise RuntimeError("boom")
 
     def topics(self):
@@ -103,6 +103,7 @@ class NoosphereRecallPhase3Test(unittest.TestCase):
         self.assertEqual(result, "Remember the Serianis deploy path.")
         self.assertEqual(provider._client.calls[0][0], "recall")
         self.assertEqual(provider._client.calls[0][1]["mode"], "auto")
+        self.assertEqual(provider._client.calls[0][2], provider._config["auto_recall_timeout"])
 
     def test_prefetch_suppresses_unexpected_client_errors(self):
         provider = self.initialized_provider()

--- a/hermes-noosphere-memory/tests/test_noosphere_save_phase4.py
+++ b/hermes-noosphere-memory/tests/test_noosphere_save_phase4.py
@@ -110,6 +110,49 @@ class NoosphereSavePhase4Test(unittest.TestCase):
         self.assertEqual(saved["content"], "Use pkapp PM2.")
         self.assertEqual(saved["tags"], ["ops"])
 
+    def test_save_tool_passes_bounded_restricted_tags(self):
+        provider = self.initialized_provider(topic_id="topic-1")
+
+        result = json.loads(
+            provider.handle_tool_call(
+                "noosphere_save",
+                {
+                    "title": "Deployment rule",
+                    "content": "Use this durable deployment rule for the configured system.",
+                    "restrictedTags": ["serianis", " cylena ", "serianis"],
+                },
+            )
+        )
+
+        self.assertTrue(result["success"])
+        self.assertEqual(provider._client.saved[0]["restrictedTags"], ["serianis", "cylena"])
+
+    def test_save_tool_rejects_malformed_restricted_tags(self):
+        provider = self.initialized_provider(topic_id="topic-1")
+
+        cases = [
+            "serianis",
+            [""],
+            ["x" * 65],
+            [str(index) for index in range(17)],
+            ["serianis", 42],
+        ]
+        for restricted_tags in cases:
+            with self.subTest(restricted_tags=restricted_tags):
+                error = json.loads(
+                    provider.handle_tool_call(
+                        "noosphere_save",
+                        {
+                            "title": "Deployment rule",
+                            "content": "Use this durable deployment rule for the configured system.",
+                            "restrictedTags": restricted_tags,
+                        },
+                    )
+                )
+
+                self.assertIn("restrictedTags", error["error"])
+        self.assertEqual(provider._client.saved, [])
+
     def test_save_tool_validates_confidence(self):
         provider = self.initialized_provider(topic_id="topic-1")
 


### PR DESCRIPTION
## Summary
- harden Hermes Noosphere base_url handling against SSRF-style egress targets
- add restrictedTags schema validation and pass-through for noosphere_save
- split prompt/status fail-fast timeouts from the shared API timeout
- update Hermes docs, setup skill, installer template, and regression tests

## Verification
- python3 -m unittest discover -s hermes-noosphere-memory/tests -p 'test_*.py'
- bash -n hermes-noosphere-memory/install-hermes.sh
- python3 -m compileall -q hermes-noosphere-memory/plugins/memory/noosphere
- DATABASE_URL=postgresql://test:test@localhost:5432/test npm run test:memory
- npm run lint
- npm run test:security
- git diff --check

Closes #109

## Summary by Sourcery

Harden the Hermes Noosphere memory provider’s network egress and configuration while adding scoped save support and finer-grained timeouts.

New Features:
- Support optional restrictedTags on noosphere_save for scoped draft memory saves.
- Expose separate auto_recall_timeout and status_timeout settings distinct from the general API timeout.

Bug Fixes:
- Validate and normalize base_url to reject malformed, credentialed, or private/reserved-network targets and to constrain HTTP usage to loopback hosts.

Enhancements:
- Allow per-call timeouts for client status and recall operations to enable fail-fast behavior during prompts and health checks.
- Treat unsafe or invalid Noosphere configuration or environment base URLs as disabled, falling back to safe defaults.
- Normalize and persist Noosphere base_url consistently across configuration loading and saving.

Documentation:
- Update provider and skill documentation, examples, and safety guidance to cover base_url validation rules, timeout options, and restrictedTags behavior.

Tests:
- Extend and adjust unit tests for base_url normalization, restrictedTags validation and pass-through, timeout handling, and provider initialization behavior.

Chores:
- Bump the Noosphere plugin version to 0.4.2 and update installer defaults to include the new timeout settings.