### PR TITLE
chore: release Noosphere v1.6.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
         DATABASE_URL: postgresql://noosphere:buildtime@db:5432/noosphere
     container_name: noosphere-app
     restart: unless-stopped
+    labels:
+      org.opencontainers.image.version: "1.6.0"
     ports:
       - "6578:3000"
     environment:

--- a/hermes-noosphere-memory/plugins/memory/noosphere/plugin.yaml
+++ b/hermes-noosphere-memory/plugins/memory/noosphere/plugin.yaml
@@ -1,3 +1,3 @@
 name: noosphere
-version: 0.4.2
+version: 1.6.0
 description: "Noosphere durable memory provider with scoped recall and draft memory capture."

--- a/kilocode-noosphere-memory/package-lock.json
+++ b/kilocode-noosphere-memory/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sweetsophia/kilocode-noosphere-memory",
-  "version": "0.1.0",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sweetsophia/kilocode-noosphere-memory",
-      "version": "0.1.0",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "@kilocode/plugin": "^7.3.1",

--- a/kilocode-noosphere-memory/package.json
+++ b/kilocode-noosphere-memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sweetsophia/kilocode-noosphere-memory",
-  "version": "0.1.0",
+  "version": "1.6.0",
   "private": false,
   "description": "Kilo Code plugin for Noosphere memory: prompt-time auto-recall, optional idle auto-save, and explicit memory tools.",
   "type": "module",

--- a/openclaw-noosphere-memory/package-lock.json
+++ b/openclaw-noosphere-memory/package-lock.json
@@ -1,17 +1,20 @@
 {
   "name": "@sweetsophia/openclaw-noosphere-memory",
-  "version": "1.5.7",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sweetsophia/openclaw-noosphere-memory",
-      "version": "1.5.7",
+      "version": "1.6.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20",
         "tsx": "^4.21.0",
         "typescript": "^5"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/openclaw-noosphere-memory/package.json
+++ b/openclaw-noosphere-memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sweetsophia/openclaw-noosphere-memory",
-  "version": "1.5.7",
+  "version": "1.6.0",
   "private": false,
   "description": "OpenClaw plugin for Noosphere: agent memory tools, Noosphere recall, draft memory saving, and automatic prompt-time memory injection.",
   "type": "module",

--- a/opencode-noosphere-memory/package-lock.json
+++ b/opencode-noosphere-memory/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sweetsophia/opencode-noosphere-memory",
-  "version": "0.1.0",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sweetsophia/opencode-noosphere-memory",
-      "version": "0.1.0",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "@opencode-ai/plugin": "^1.14.18",

--- a/opencode-noosphere-memory/package.json
+++ b/opencode-noosphere-memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sweetsophia/opencode-noosphere-memory",
-  "version": "0.1.0",
+  "version": "1.6.0",
   "private": false,
   "description": "Opencode plugin for Noosphere memory: prompt-time auto-recall, optional idle auto-save, and explicit memory tools.",
   "type": "module",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "noosphere",
-  "version": "1.5.6",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "noosphere",
-      "version": "1.5.6",
+      "version": "1.6.0",
       "dependencies": {
         "@prisma/adapter-pg": "^7.7.0",
         "@prisma/client": "^7.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "noosphere",
-  "version": "1.5.6",
+  "version": "1.6.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,5 +30,10 @@
     ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
-  "exclude": ["node_modules", "opencode-noosphere-memory", "hermes-noosphere-memory"]
+  "exclude": [
+    "node_modules",
+    "opencode-noosphere-memory",
+    "kilocode-noosphere-memory",
+    "hermes-noosphere-memory"
+  ]
 }


### PR DESCRIPTION
## Summary
- Bump Noosphere app/container metadata to v1.6.0.
- Bump OpenClaw, Opencode, Kilo Code, and Hermes plugin versions to v1.6.0.
- Update npm lockfiles for all npm-distributed plugin packages.

## Verification
- OpenClaw: npm ci, npm run build, git diff --exit-code -- dist, npm pack --dry-run.
- Opencode: npm ci, npm run typecheck, npm run build, git diff --exit-code -- dist, npm pack --dry-run.
- Kilo Code: npm ci, npm run typecheck, npm run build, git diff --exit-code -- dist, npm pack --dry-run.

## Summary by Sourcery

Release Noosphere v1.6.0 across the app and associated memory plugins.

Enhancements:
- Bump Noosphere core app version and container metadata to 1.6.0.
- Align Hermes, OpenClaw, Opencode, and Kilo Code Noosphere memory plugin versions to 1.6.0.
- Regenerate npm lockfiles for the main app and all Noosphere memory plugins to match the new release versions.