### PR TITLE
fix: polish API key admin review feedback

### DIFF
--- a/src/app/wiki/admin/keys/page.tsx
+++ b/src/app/wiki/admin/keys/page.tsx
@@ -158,7 +158,7 @@ export default async function ApiKeysPage({ searchParams }: Props) {
                     <td data-label="Created">{new Date(key.createdAt).toLocaleDateString()}</td>
                     <td data-label="Last Used">{key.lastUsedAt ? new Date(key.lastUsedAt).toLocaleDateString() : "Never"}</td>
                     <td data-label="Status">{key.revokedAt ? "Revoked" : "Active"}</td>
-                    <td data-label="Actions" className="api-key-action-cell">
+                    <td data-label="Action" className="api-key-action-cell">
                       <div className="api-key-actions">
                         {!key.revokedAt && (
                           <details className="scope-edit-dropdown">

--- a/src/components/wiki/CopyButton.tsx
+++ b/src/components/wiki/CopyButton.tsx
@@ -1,11 +1,14 @@
 "use client";
 
-import { useState } from "react";
+import { useState, type CSSProperties } from "react";
 
 interface CopyButtonProps {
   text: string;
   label?: string;
   copiedLabel?: string;
+  failedLabel?: string;
+  copiedStatusLabel?: string;
+  failedStatusLabel?: string;
   className?: string;
 }
 
@@ -13,10 +16,14 @@ export function CopyButton({
   text,
   label = "Copy",
   copiedLabel = "Copied",
+  failedLabel = "Copy failed",
+  copiedStatusLabel = "Copied to clipboard.",
+  failedStatusLabel = "Copy failed. The text was not copied.",
   className = "btn btn-secondary btn-sm",
 }: CopyButtonProps) {
   const [copied, setCopied] = useState(false);
   const [failed, setFailed] = useState(false);
+  const statusText = failed ? failedStatusLabel : copied ? copiedStatusLabel : "";
 
   async function handleCopy() {
     try {
@@ -35,11 +42,28 @@ export function CopyButton({
   }
 
   return (
-    <button type="button" className={className} onClick={handleCopy} aria-live="polite">
-      {failed ? "Copy failed" : copied ? copiedLabel : label}
-    </button>
+    <>
+      <button type="button" className={className} onClick={handleCopy}>
+        {failed ? failedLabel : copied ? copiedLabel : label}
+      </button>
+      <span aria-live="polite" aria-atomic="true" style={visuallyHiddenStyle}>
+        {statusText}
+      </span>
+    </>
   );
 }
+
+const visuallyHiddenStyle = {
+  border: 0,
+  clip: "rect(0 0 0 0)",
+  height: "1px",
+  margin: "-1px",
+  overflow: "hidden",
+  padding: 0,
+  position: "absolute",
+  whiteSpace: "nowrap",
+  width: "1px",
+} satisfies CSSProperties;
 
 function copyWithTextareaFallback(text: string) {
   const textarea = document.createElement("textarea");


### PR DESCRIPTION
## Summary
- align the API key action cell responsive label with the desktop header
- move CopyButton status announcements into a separate polite live region instead of placing aria-live on the button

## Verification
- npm run lint
- DATABASE_URL='postgresql://test:test@localhost:5432/test' npm run build
- DATABASE_URL='postgresql://test:test@localhost:5432/test' npm run test:memory

## Summary by Sourcery

Improve accessibility and labeling for the API key admin interface and copy button feedback.

Enhancements:
- Align the API key table action column responsive label with the desktop header naming.
- Announce copy status messages via a separate visually hidden polite live region instead of the button element.