### PR TITLE
feat: centralize Noosphere markdown codec

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,10 @@ POST /api/import
 # multipart form fields: file, defaultTopicSlug?, overwrite?
 ```
 
+Export, import, and Obsidian sync share the same versioned frontmatter codec in
+`src/lib/markdown/noosphere-markdown.ts`, including `noosphere.schemaVersion`,
+`noosphere.contentHash`, topic metadata, tags, and restricted scopes.
+
 ## Memory Module API
 
 The memory layer is exposed in two ways:

--- a/docs/OBSIDIAN-SYNC-SPEC.md
+++ b/docs/OBSIDIAN-SYNC-SPEC.md
@@ -203,6 +203,7 @@ createdAt: 2026-04-01T10:00:00.000Z
 updatedAt: 2026-04-15T14:32:11.000Z
 noosphere:
   entity: article
+  schemaVersion: 1
   syncedAt: 2026-04-15T14:35:00.000Z
   contentHash: sha256:...
   sourceOfTruth: database
@@ -236,7 +237,14 @@ noosphere:
 2. Add `topicPath` because the filesystem mirrors full hierarchy and Obsidian users may want the full context in metadata.
 3. `noosphere.contentHash` is the hash of the fully rendered markdown payload or article body plus canonical metadata fields.
 4. `noosphere.syncedAt` is sync-time metadata, not article update time.
-5. Frontmatter order should be stable for clean diffs.
+5. `noosphere.schemaVersion` is the shared markdown codec version used by sync, export, and import.
+6. Frontmatter order should be stable for clean diffs.
+
+### Shared codec
+The canonical implementation lives in `src/lib/markdown/noosphere-markdown.ts`.
+Obsidian sync, ZIP export, and ZIP import should all use this module instead of
+hand-rolled YAML parsing/rendering so reverse import work can rely on one
+frontmatter contract.
 
 ### Body content
 After frontmatter, write the raw article markdown body exactly as stored in DB.

--- a/src/__tests__/api/noosphere-markdown.test.ts
+++ b/src/__tests__/api/noosphere-markdown.test.ts
@@ -95,11 +95,13 @@ test("parseNoosphereMarkdown reports missing and invalid frontmatter distinctly"
 test("readMarkdownString helpers normalize imported metadata", () => {
   const frontmatter = {
     title: "  Title  ",
+    slug: "   ",
     tags: [" alpha ", "beta", "alpha", 42, true, { bad: "value" }],
     restrictedTags: "not-an-array",
   };
 
   assert.equal(readMarkdownString(frontmatter, "title"), "Title");
+  assert.equal(readMarkdownString(frontmatter, "slug"), undefined);
   assert.deepEqual(readMarkdownStringArray(frontmatter, "tags"), ["alpha", "beta", "42", "true"]);
   assert.deepEqual(readMarkdownStringArray(frontmatter, "restrictedTags"), []);
 });

--- a/src/__tests__/api/noosphere-markdown.test.ts
+++ b/src/__tests__/api/noosphere-markdown.test.ts
@@ -95,11 +95,11 @@ test("parseNoosphereMarkdown reports missing and invalid frontmatter distinctly"
 test("readMarkdownString helpers normalize imported metadata", () => {
   const frontmatter = {
     title: "  Title  ",
-    tags: [" alpha ", "beta", "alpha", 42],
+    tags: [" alpha ", "beta", "alpha", 42, true, { bad: "value" }],
     restrictedTags: "not-an-array",
   };
 
   assert.equal(readMarkdownString(frontmatter, "title"), "Title");
-  assert.deepEqual(readMarkdownStringArray(frontmatter, "tags"), ["alpha", "beta"]);
+  assert.deepEqual(readMarkdownStringArray(frontmatter, "tags"), ["alpha", "beta", "42", "true"]);
   assert.deepEqual(readMarkdownStringArray(frontmatter, "restrictedTags"), []);
 });

--- a/src/__tests__/api/noosphere-markdown.test.ts
+++ b/src/__tests__/api/noosphere-markdown.test.ts
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import yaml from "js-yaml";
+import {
+  computeNoosphereContentHash,
+  parseNoosphereMarkdown,
+  readMarkdownString,
+  readMarkdownStringArray,
+  renderNoosphereMarkdown,
+} from "@/lib/markdown/noosphere-markdown";
+
+const article = {
+  id: "article-1",
+  slug: "connection-pooling",
+  title: "Connection Pooling",
+  topic: "prisma",
+  topicPath: ["engineering", "backend", "prisma"],
+  content: "# Connection Pooling\n\nUse bounded pools for database clients.",
+  tags: ["postgresql", "performance", "postgresql"],
+  restrictedTags: ["serianis-project"],
+  confidence: "high",
+  status: "published",
+  authorName: "Cylena",
+  sourceUrl: "https://example.com/docs",
+  sourceType: "url",
+  createdAt: new Date("2026-04-01T10:00:00Z"),
+  updatedAt: new Date("2026-04-15T14:32:11Z"),
+};
+
+test("renderNoosphereMarkdown emits parseable versioned frontmatter", () => {
+  const markdown = renderNoosphereMarkdown(article, {
+    contentHash: "abc123",
+    syncedAt: "2026-04-15T14:35:00.000Z",
+    publish: true,
+  });
+
+  const parsed = parseNoosphereMarkdown(markdown);
+  assert.equal(parsed.ok, true);
+  if (!parsed.ok) return;
+
+  const fm = parsed.markdown.frontmatter;
+  assert.equal(fm["id"], "article-1");
+  assert.equal(fm["slug"], "connection-pooling");
+  assert.deepEqual(fm["topicPath"], ["engineering", "backend", "prisma"]);
+  assert.deepEqual(fm["tags"], ["postgresql", "performance"]);
+  assert.deepEqual(fm["restrictedTags"], ["serianis-project"]);
+  assert.equal(fm["publish"], true);
+  assert.equal(parsed.markdown.content, article.content);
+
+  const noosphere = fm["noosphere"] as Record<string, unknown>;
+  assert.equal(noosphere["entity"], "article");
+  assert.equal(noosphere["schemaVersion"], 1);
+  assert.equal(noosphere["contentHash"], "sha256:abc123");
+  assert.equal(noosphere["sourceOfTruth"], "database");
+  assert.equal(noosphere["url"], "/wiki/engineering/backend/prisma/connection-pooling");
+});
+
+test("renderNoosphereMarkdown uses stable key order", () => {
+  const markdown = renderNoosphereMarkdown(article, {
+    contentHash: "abc123",
+    syncedAt: "2026-04-15T14:35:00.000Z",
+  });
+  const frontmatter = markdown.slice(4, markdown.indexOf("\n---\n"));
+  const idIndex = frontmatter.indexOf("id:");
+  const slugIndex = frontmatter.indexOf("slug:");
+  const titleIndex = frontmatter.indexOf("title:");
+  const noosphereIndex = frontmatter.indexOf("noosphere:");
+
+  assert.ok(idIndex < slugIndex);
+  assert.ok(slugIndex < titleIndex);
+  assert.ok(titleIndex < noosphereIndex);
+  assert.doesNotThrow(() => yaml.load(frontmatter));
+});
+
+test("computeNoosphereContentHash ignores syncedAt but tracks content", () => {
+  const hashA = computeNoosphereContentHash(article);
+  const hashB = computeNoosphereContentHash({ ...article });
+  const hashC = computeNoosphereContentHash({ ...article, content: `${article.content}\n\nUpdated.` });
+
+  assert.equal(hashA, hashB);
+  assert.notEqual(hashA, hashC);
+});
+
+test("parseNoosphereMarkdown reports missing and invalid frontmatter distinctly", () => {
+  assert.deepEqual(parseNoosphereMarkdown("# Missing frontmatter"), {
+    ok: false,
+    error: "No YAML frontmatter found",
+  });
+  assert.deepEqual(parseNoosphereMarkdown("---\n:\n---\nBody"), {
+    ok: false,
+    error: "Invalid YAML frontmatter",
+  });
+});
+
+test("readMarkdownString helpers normalize imported metadata", () => {
+  const frontmatter = {
+    title: "  Title  ",
+    tags: [" alpha ", "beta", "alpha", 42],
+    restrictedTags: "not-an-array",
+  };
+
+  assert.equal(readMarkdownString(frontmatter, "title"), "Title");
+  assert.deepEqual(readMarkdownStringArray(frontmatter, "tags"), ["alpha", "beta"]);
+  assert.deepEqual(readMarkdownStringArray(frontmatter, "restrictedTags"), []);
+});

--- a/src/app/api/export/route.ts
+++ b/src/app/api/export/route.ts
@@ -6,6 +6,26 @@ import JSZip from "jszip";
 import { rateLimit } from "@/lib/rate-limit";
 import { renderNoosphereMarkdown } from "@/lib/markdown/noosphere-markdown";
 
+interface ExportTopicNode {
+  id: string;
+  slug: string;
+  parentId: string | null;
+}
+
+function buildExportTopicPath(topicMap: Map<string, ExportTopicNode>, topicId: string): string[] {
+  const path: string[] = [];
+  let current = topicMap.get(topicId);
+  const seen = new Set<string>();
+
+  while (current && !seen.has(current.id)) {
+    seen.add(current.id);
+    path.unshift(current.slug);
+    current = current.parentId ? topicMap.get(current.parentId) : undefined;
+  }
+
+  return path;
+}
+
 // GET /api/export — Export all articles as a zip of markdown files
 // Auth: API key (READ/WRITE/ADMIN) or session (human)
 export async function GET(request: NextRequest) {
@@ -32,19 +52,25 @@ export async function GET(request: NextRequest) {
     const zip = new JSZip();
     const folder = zip.folder("noosphere-export");
     const exportedAt = new Date().toISOString();
+    const topics = await prisma.topic.findMany({
+      select: { id: true, slug: true, parentId: true },
+    });
+    const topicMap = new Map<string, ExportTopicNode>(topics.map((topic) => [topic.id, topic]));
 
     if (!folder) {
       return NextResponse.json({ error: "Failed to create zip folder" }, { status: 500 });
     }
 
     for (const article of articles) {
+      const topicPath = buildExportTopicPath(topicMap, article.topicId);
+      const topicSlug = topicPath.at(-1) ?? article.topic.slug;
       const mdContent = renderNoosphereMarkdown(
         {
           id: article.id,
           slug: article.slug,
           title: article.title,
-          topic: article.topic.slug,
-          topicPath: [article.topic.slug],
+          topic: topicSlug,
+          topicPath: topicPath.length > 0 ? topicPath : [article.topic.slug],
           content: article.content,
           tags: article.tags.map((t) => t.tag.slug),
           restrictedTags: article.restrictedTags,
@@ -66,7 +92,7 @@ export async function GET(request: NextRequest) {
     // Add a README
     folder.file(
       "README.md",
-      `# Noosphere Export\n\nExported ${articles.length} article(s).\n\n## Format\n\nEach .md file has YAML frontmatter rendered by the shared Noosphere markdown codec:\n\n\`\`\`yaml\n---\nid: article-id\nslug: article-slug\ntitle: Article Title\ntopic: topic-slug\ntopicPath: [topic-slug]\ntags: [tag1, tag2]\nrestrictedTags: [health, intimate]  # optional — controls access\ncreatedAt: 2024-01-01T00:00:00Z\nupdatedAt: 2024-01-02T00:00:00Z\nnoosphere:\n  entity: article\n  schemaVersion: 1\n  syncedAt: 2024-01-02T00:00:00Z\n  contentHash: sha256:...\n  sourceOfTruth: database\n---\n\n# Article Title\n\nContent here...\n\`\`\`\n\n## Topics\n\n${[...new Map(articles.map((a) => [a.topic.slug, a.topic.name])).entries()].map(([slug, name]) => `- ${name} (${slug})`).join("\n")}\n`
+      `# Noosphere Export\n\nExported ${articles.length} article(s).\n\n## Format\n\nEach .md file has YAML frontmatter rendered by the shared Noosphere markdown codec:\n\n\`\`\`yaml\n---\nid: article-id\nslug: article-slug\ntitle: Article Title\ntopic: topic-slug\ntopicPath: [parent-topic, topic-slug]\ntags: [tag1, tag2]\nrestrictedTags: [health, intimate]  # optional — controls access\ncreatedAt: 2024-01-01T00:00:00Z\nupdatedAt: 2024-01-02T00:00:00Z\nnoosphere:\n  entity: article\n  schemaVersion: 1\n  syncedAt: 2024-01-02T00:00:00Z\n  contentHash: sha256:...\n  sourceOfTruth: database\n---\n\n# Article Title\n\nContent here...\n\`\`\`\n\n## Topics\n\n${[...new Map(articles.map((a) => [a.topic.slug, a.topic.name])).entries()].map(([slug, name]) => `- ${name} (${slug})`).join("\n")}\n`
     );
 
     const buffer = await zip.generateAsync({ type: "uint8array", compression: "DEFLATE" });

--- a/src/app/api/export/route.ts
+++ b/src/app/api/export/route.ts
@@ -3,8 +3,8 @@ import { Permissions } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
 import { requirePermission, buildScopeFilter } from "@/lib/api/auth";
 import JSZip from "jszip";
-import yaml from "js-yaml";
 import { rateLimit } from "@/lib/rate-limit";
+import { renderNoosphereMarkdown } from "@/lib/markdown/noosphere-markdown";
 
 // GET /api/export — Export all articles as a zip of markdown files
 // Auth: API key (READ/WRITE/ADMIN) or session (human)
@@ -31,33 +31,34 @@ export async function GET(request: NextRequest) {
 
     const zip = new JSZip();
     const folder = zip.folder("noosphere-export");
+    const exportedAt = new Date().toISOString();
 
     if (!folder) {
       return NextResponse.json({ error: "Failed to create zip folder" }, { status: 500 });
     }
 
     for (const article of articles) {
-      const frontmatter: Record<string, unknown> = {
-        title: article.title,
-        topic: article.topic.slug,
-        tags: article.tags.map((t) => t.tag.slug),
-        createdAt: article.createdAt.toISOString(),
-        updatedAt: article.updatedAt.toISOString(),
-      };
-
-      if (article.restrictedTags && article.restrictedTags.length > 0) {
-        frontmatter.restrictedTags = article.restrictedTags;
-      }
-
-      if (article.confidence) frontmatter.confidence = article.confidence;
-      if (article.status) frontmatter.status = article.status;
-      if (article.lastReviewed) frontmatter.lastReviewed = article.lastReviewed.toISOString();
-      if (article.sourceUrl) frontmatter.sourceUrl = article.sourceUrl;
-      if (article.sourceType) frontmatter.sourceType = article.sourceType;
-      if (article.excerpt) frontmatter.excerpt = article.excerpt;
-
-      const fm = yaml.dump(frontmatter, { indent: 2, lineWidth: -1, quotingType: '"' });
-      const mdContent = `---\n${fm}---\n\n${article.content}`;
+      const mdContent = renderNoosphereMarkdown(
+        {
+          id: article.id,
+          slug: article.slug,
+          title: article.title,
+          topic: article.topic.slug,
+          topicPath: [article.topic.slug],
+          content: article.content,
+          tags: article.tags.map((t) => t.tag.slug),
+          restrictedTags: article.restrictedTags,
+          excerpt: article.excerpt,
+          confidence: article.confidence,
+          status: article.status,
+          sourceUrl: article.sourceUrl,
+          sourceType: article.sourceType,
+          lastReviewed: article.lastReviewed,
+          createdAt: article.createdAt,
+          updatedAt: article.updatedAt,
+        },
+        { syncedAt: exportedAt }
+      );
       const filename = `${article.slug}.md`;
       folder.file(filename, mdContent);
     }
@@ -65,7 +66,7 @@ export async function GET(request: NextRequest) {
     // Add a README
     folder.file(
       "README.md",
-      `# Noosphere Export\n\nExported ${articles.length} article(s).\n\n## Format\n\nEach .md file has YAML frontmatter:\n\n\`\`\`yaml\n---\ntitle: Article Title\ntopic: topic-slug\ntags: [tag1, tag2]\nrestrictedTags: [health, intimate]  # optional — controls access\ncreatedAt: 2024-01-01T00:00:00Z\n---\n\n# Article Title\n\nContent here...\n\`\`\`\n\n## Topics\n\n${[...new Map(articles.map((a) => [a.topic.slug, a.topic.name])).entries()].map(([slug, name]) => `- ${name} (${slug})`).join("\n")}\n`
+      `# Noosphere Export\n\nExported ${articles.length} article(s).\n\n## Format\n\nEach .md file has YAML frontmatter rendered by the shared Noosphere markdown codec:\n\n\`\`\`yaml\n---\nid: article-id\nslug: article-slug\ntitle: Article Title\ntopic: topic-slug\ntopicPath: [topic-slug]\ntags: [tag1, tag2]\nrestrictedTags: [health, intimate]  # optional — controls access\ncreatedAt: 2024-01-01T00:00:00Z\nupdatedAt: 2024-01-02T00:00:00Z\nnoosphere:\n  entity: article\n  schemaVersion: 1\n  syncedAt: 2024-01-02T00:00:00Z\n  contentHash: sha256:...\n  sourceOfTruth: database\n---\n\n# Article Title\n\nContent here...\n\`\`\`\n\n## Topics\n\n${[...new Map(articles.map((a) => [a.topic.slug, a.topic.name])).entries()].map(([slug, name]) => `- ${name} (${slug})`).join("\n")}\n`
     );
 
     const buffer = await zip.generateAsync({ type: "uint8array", compression: "DEFLATE" });

--- a/src/app/api/import/route.ts
+++ b/src/app/api/import/route.ts
@@ -60,8 +60,13 @@ export async function GET(request: NextRequest) {
       required: ["title", "topic", "content"],
       optional: ["id", "slug", "topicPath", "tags", "excerpt", "confidence", "status", "sourceUrl", "sourceType", "lastReviewed", "restrictedTags", "noosphere"],
     },
+    notes: {
+      id: "preserved as exported metadata; this importer matches existing articles by topic+slug",
+      slug: "optional; blank or missing values fall back to the markdown filename",
+      topicPath: "optional hierarchy; when topic is missing, the last topicPath entry is used",
+    },
     exampleFrontmatter: `---
-id: optional-existing-article-id
+id: exported-article-id
 slug: my-article-title
 title: My Article Title
 topic: engineering

--- a/src/app/api/import/route.ts
+++ b/src/app/api/import/route.ts
@@ -3,10 +3,14 @@ import { Permissions } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
 import { requirePermission, canAccessScopes } from "@/lib/api/auth";
 import JSZip from "jszip";
-import yaml from "js-yaml";
 import { isValidConfidence, isValidStatus } from "@/lib/validation";
 import { rateLimit } from "@/lib/rate-limit";
 import { invalidateSearchCache } from "@/lib/cache/search-cache";
+import {
+  parseNoosphereMarkdown,
+  readMarkdownString,
+  readMarkdownStringArray,
+} from "@/lib/markdown/noosphere-markdown";
 
 // Disable Next.js body parsing for file uploads
 export const dynamic = "force-dynamic";
@@ -54,16 +58,24 @@ export async function GET(request: NextRequest) {
     },
     frontmatterFields: {
       required: ["title", "topic", "content"],
-      optional: ["tags", "excerpt", "confidence", "status", "sourceUrl", "sourceType", "lastReviewed", "restrictedTags"],
+      optional: ["id", "slug", "topicPath", "tags", "excerpt", "confidence", "status", "sourceUrl", "sourceType", "lastReviewed", "restrictedTags", "noosphere"],
     },
     exampleFrontmatter: `---
+id: optional-existing-article-id
+slug: my-article-title
 title: My Article Title
 topic: engineering
+topicPath: [engineering]
 tags: [python, backend]
 restrictedTags: [health, intimate]  # optional — controls access
 createdAt: 2024-01-01T00:00:00Z
+updatedAt: 2024-01-02T00:00:00Z
 confidence: high
 status: published
+noosphere:
+  entity: article
+  schemaVersion: 1
+  sourceOfTruth: database
 ---`,
     response: {
       success: true,
@@ -170,24 +182,16 @@ export async function POST(request: NextRequest) {
     // Update cumulative size after successful decompression
     totalUncompressed += entrySize;
 
-    // Parse frontmatter (handles both \n and \r\n)
-    const fmMatch = content.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n([\s\S]*)$/);
-    if (!fmMatch) {
-      toImport.push({ filename: entry.name, title: "", slug: "", topicSlug: "", content: "", tags: [], error: "No YAML frontmatter found" });
+    const parsed = parseNoosphereMarkdown(content);
+    if (!parsed.ok) {
+      toImport.push({ filename: entry.name, title: "", slug: "", topicSlug: "", content: "", tags: [], error: parsed.error });
       continue;
     }
 
-    let frontmatter: Record<string, unknown>;
-    try {
-      frontmatter = yaml.load(fmMatch[1]) as Record<string, unknown>;
-    } catch {
-      toImport.push({ filename: entry.name, title: "", slug: "", topicSlug: "", content: "", tags: [], error: "Invalid YAML frontmatter" });
-      continue;
-    }
-
-    const title = typeof frontmatter.title === "string" ? frontmatter.title.trim() : "";
-    const topicSlug = (typeof frontmatter.topic === "string" ? frontmatter.topic : defaultTopicSlug ?? "") as string;
-    const articleContent = fmMatch[2];
+    const { frontmatter, content: articleContent } = parsed.markdown;
+    const title = readMarkdownString(frontmatter, "title") ?? "";
+    const topicPath = readMarkdownStringArray(frontmatter, "topicPath");
+    const topicSlug = readMarkdownString(frontmatter, "topic") ?? topicPath.at(-1) ?? defaultTopicSlug ?? "";
 
     if (!title || !articleContent.trim()) {
       toImport.push({ filename: entry.name, title, slug: "", topicSlug, content: articleContent, tags: [], error: "Missing required field: title or content" });
@@ -199,10 +203,9 @@ export async function POST(request: NextRequest) {
       continue;
     }
 
-    // Derive slug from filename (strip path and .md)
-    const slug = entry.name
-      .replace(/\.md$/i, "")
-      .replace(/.*\//, "")
+    // Prefer the shared frontmatter slug. Fall back to filename for legacy imports.
+    const slugSource = readMarkdownString(frontmatter, "slug") ?? entry.name.replace(/\.md$/i, "").replace(/.*\//, "");
+    const slug = slugSource
       .toLowerCase()
       .replace(/[^a-z0-9-]/g, "-")
       .replace(/-+/g, "-")
@@ -214,10 +217,8 @@ export async function POST(request: NextRequest) {
       continue;
     }
 
-    const tags = Array.isArray(frontmatter.tags) ? (frontmatter.tags as string[]).map(String) : [];
-    const restrictedTags = Array.isArray(frontmatter.restrictedTags)
-      ? (frontmatter.restrictedTags as string[]).filter((t) => typeof t === "string" && t.length > 0)
-      : undefined;
+    const tags = readMarkdownStringArray(frontmatter, "tags");
+    const restrictedTags = readMarkdownStringArray(frontmatter, "restrictedTags");
 
     toImport.push({
       filename: entry.name,
@@ -226,12 +227,12 @@ export async function POST(request: NextRequest) {
       slug,
       content: articleContent,
       tags,
-      excerpt: typeof frontmatter.excerpt === "string" ? frontmatter.excerpt : undefined,
-      confidence: typeof frontmatter.confidence === "string" ? frontmatter.confidence : undefined,
-      status: typeof frontmatter.status === "string" ? frontmatter.status : undefined,
-      sourceUrl: typeof frontmatter.sourceUrl === "string" ? frontmatter.sourceUrl : undefined,
-      sourceType: typeof frontmatter.sourceType === "string" ? frontmatter.sourceType : undefined,
-      restrictedTags,
+      excerpt: readMarkdownString(frontmatter, "excerpt"),
+      confidence: readMarkdownString(frontmatter, "confidence"),
+      status: readMarkdownString(frontmatter, "status"),
+      sourceUrl: readMarkdownString(frontmatter, "sourceUrl"),
+      sourceType: readMarkdownString(frontmatter, "sourceType"),
+      restrictedTags: restrictedTags.length > 0 ? restrictedTags : undefined,
     });
   }
 

--- a/src/lib/markdown/noosphere-markdown.ts
+++ b/src/lib/markdown/noosphere-markdown.ts
@@ -1,0 +1,182 @@
+import { createHash } from "crypto";
+import yaml from "js-yaml";
+
+export const NOOSPHERE_MARKDOWN_SCHEMA_VERSION = 1;
+
+export interface NoosphereMarkdownArticle {
+  id?: string;
+  slug?: string;
+  title: string;
+  topic: string;
+  topicPath?: string[];
+  content: string;
+  tags?: string[];
+  restrictedTags?: string[];
+  excerpt?: string | null;
+  confidence?: string | null;
+  status?: string | null;
+  authorName?: string | null;
+  sourceUrl?: string | null;
+  sourceType?: string | null;
+  lastReviewed?: Date | string | null;
+  createdAt?: Date | string | null;
+  updatedAt?: Date | string | null;
+}
+
+export interface RenderNoosphereMarkdownOptions {
+  contentHash?: string;
+  syncedAt?: string;
+  publish?: boolean;
+  sourceOfTruth?: "database" | "markdown";
+}
+
+export interface ParsedNoosphereMarkdown {
+  frontmatter: Record<string, unknown>;
+  content: string;
+}
+
+export type NoosphereMarkdownParseResult =
+  | { ok: true; markdown: ParsedNoosphereMarkdown }
+  | { ok: false; error: "No YAML frontmatter found" | "Invalid YAML frontmatter" };
+
+const FRONTMATTER_KEYS = [
+  "id", "slug", "title", "topic", "topicPath",
+  "confidence", "status", "tags", "restrictedTags", "excerpt",
+  "authorName", "sourceUrl", "sourceType", "lastReviewed",
+  "createdAt", "updatedAt", "noosphere", "publish",
+] as const;
+
+function isoString(value: Date | string | null | undefined): string | undefined {
+  if (!value) return undefined;
+  return value instanceof Date ? value.toISOString() : value;
+}
+
+function normalizeStringArray(values: string[] | undefined): string[] {
+  if (!values) return [];
+  return Array.from(new Set(values.map((value) => value.trim()).filter(Boolean)));
+}
+
+export function buildNoosphereFrontmatter(
+  article: NoosphereMarkdownArticle,
+  options: RenderNoosphereMarkdownOptions = {}
+): string {
+  const topicPath = article.topicPath && article.topicPath.length > 0
+    ? article.topicPath
+    : [article.topic];
+  const syncedAt = options.syncedAt ?? new Date().toISOString();
+  const sourceOfTruth = options.sourceOfTruth ?? "database";
+  const contentHash = options.contentHash ?? computeNoosphereContentHash(article, { sourceOfTruth });
+
+  const fm: Record<string, unknown> = {
+    title: article.title,
+    topic: article.topic,
+    topicPath,
+    noosphere: {
+      entity: "article",
+      schemaVersion: NOOSPHERE_MARKDOWN_SCHEMA_VERSION,
+      syncedAt,
+      contentHash: `sha256:${contentHash}`,
+      sourceOfTruth,
+    },
+  };
+
+  if (article.id) fm.id = article.id;
+  if (article.slug) fm.slug = article.slug;
+  if (article.confidence) fm.confidence = article.confidence;
+  if (article.status) fm.status = article.status;
+
+  const tags = normalizeStringArray(article.tags);
+  if (tags.length > 0) fm.tags = tags;
+
+  const restrictedTags = normalizeStringArray(article.restrictedTags);
+  if (restrictedTags.length > 0) fm.restrictedTags = restrictedTags;
+
+  if (article.excerpt) fm.excerpt = article.excerpt;
+  if (article.authorName) fm.authorName = article.authorName;
+  if (article.sourceUrl) fm.sourceUrl = article.sourceUrl;
+  if (article.sourceType) fm.sourceType = article.sourceType;
+
+  const lastReviewed = isoString(article.lastReviewed);
+  if (lastReviewed) fm.lastReviewed = lastReviewed;
+
+  const createdAt = isoString(article.createdAt);
+  if (createdAt) fm.createdAt = createdAt;
+
+  const updatedAt = isoString(article.updatedAt);
+  if (updatedAt) fm.updatedAt = updatedAt;
+
+  if (article.slug) {
+    (fm.noosphere as Record<string, unknown>).url = `/wiki/${[...topicPath, article.slug].join("/")}`;
+  }
+  if (options.publish) fm.publish = true;
+
+  const ordered: Record<string, unknown> = {};
+  for (const key of FRONTMATTER_KEYS) {
+    if (fm[key] !== undefined) ordered[key] = fm[key];
+  }
+
+  const yamlStr = yaml.dump(ordered, {
+    indent: 2,
+    lineWidth: -1,
+    quotingType: '"',
+    forceQuotes: false,
+    noRefs: true,
+    sortKeys: false,
+  });
+
+  return `---\n${yamlStr.trim()}\n---\n`;
+}
+
+export function renderNoosphereMarkdown(
+  article: NoosphereMarkdownArticle,
+  options: RenderNoosphereMarkdownOptions = {}
+): string {
+  return `${buildNoosphereFrontmatter(article, options)}\n${article.content}`;
+}
+
+export function computeNoosphereContentHash(
+  article: NoosphereMarkdownArticle,
+  options: Pick<RenderNoosphereMarkdownOptions, "sourceOfTruth"> = {}
+): string {
+  const stableFrontmatter = buildNoosphereFrontmatter(article, {
+    contentHash: "STABLE_HASH",
+    syncedAt: "1970-01-01T00:00:00.000Z",
+    publish: false,
+    sourceOfTruth: options.sourceOfTruth,
+  });
+  return createHash("sha256").update(`${stableFrontmatter}\n${article.content}`).digest("hex");
+}
+
+export function parseNoosphereMarkdown(content: string): NoosphereMarkdownParseResult {
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n([\s\S]*)$/);
+  if (!match) {
+    return { ok: false, error: "No YAML frontmatter found" };
+  }
+
+  try {
+    const parsed = yaml.load(match[1]);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return { ok: false, error: "Invalid YAML frontmatter" };
+    }
+    return {
+      ok: true,
+      markdown: {
+        frontmatter: parsed as Record<string, unknown>,
+        content: match[2].replace(/^\r?\n/, ""),
+      },
+    };
+  } catch {
+    return { ok: false, error: "Invalid YAML frontmatter" };
+  }
+}
+
+export function readMarkdownString(frontmatter: Record<string, unknown>, key: string): string | undefined {
+  const value = frontmatter[key];
+  return typeof value === "string" ? value.trim() : undefined;
+}
+
+export function readMarkdownStringArray(frontmatter: Record<string, unknown>, key: string): string[] {
+  const value = frontmatter[key];
+  if (!Array.isArray(value)) return [];
+  return normalizeStringArray(value.filter((item): item is string => typeof item === "string"));
+}

--- a/src/lib/markdown/noosphere-markdown.ts
+++ b/src/lib/markdown/noosphere-markdown.ts
@@ -201,7 +201,9 @@ export function parseNoosphereMarkdown(content: string): NoosphereMarkdownParseR
 
 export function readMarkdownString(frontmatter: Record<string, unknown>, key: string): string | undefined {
   const value = frontmatter[key];
-  return typeof value === "string" ? value.trim() : undefined;
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed || undefined;
 }
 
 export function readMarkdownStringArray(frontmatter: Record<string, unknown>, key: string): string[] {

--- a/src/lib/markdown/noosphere-markdown.ts
+++ b/src/lib/markdown/noosphere-markdown.ts
@@ -56,16 +56,25 @@ function normalizeStringArray(values: string[] | undefined): string[] {
   return Array.from(new Set(values.map((value) => value.trim()).filter(Boolean)));
 }
 
-export function buildNoosphereFrontmatter(
+function normalizeMarkdownArrayValue(value: unknown): string | null {
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  return null;
+}
+
+type BuildFrontmatterRecordOptions = Omit<RenderNoosphereMarkdownOptions, "contentHash"> & {
+  contentHash?: string | null;
+};
+
+function buildFrontmatterRecord(
   article: NoosphereMarkdownArticle,
-  options: RenderNoosphereMarkdownOptions = {}
-): string {
+  options: BuildFrontmatterRecordOptions = {}
+): Record<string, unknown> {
   const topicPath = article.topicPath && article.topicPath.length > 0
     ? article.topicPath
     : [article.topic];
   const syncedAt = options.syncedAt ?? new Date().toISOString();
   const sourceOfTruth = options.sourceOfTruth ?? "database";
-  const contentHash = options.contentHash ?? computeNoosphereContentHash(article, { sourceOfTruth });
 
   const fm: Record<string, unknown> = {
     title: article.title,
@@ -75,10 +84,13 @@ export function buildNoosphereFrontmatter(
       entity: "article",
       schemaVersion: NOOSPHERE_MARKDOWN_SCHEMA_VERSION,
       syncedAt,
-      contentHash: `sha256:${contentHash}`,
       sourceOfTruth,
     },
   };
+
+  if (options.contentHash) {
+    (fm.noosphere as Record<string, unknown>).contentHash = `sha256:${options.contentHash}`;
+  }
 
   if (article.id) fm.id = article.id;
   if (article.slug) fm.slug = article.slug;
@@ -115,7 +127,11 @@ export function buildNoosphereFrontmatter(
     if (fm[key] !== undefined) ordered[key] = fm[key];
   }
 
-  const yamlStr = yaml.dump(ordered, {
+  return ordered;
+}
+
+function dumpFrontmatter(record: Record<string, unknown>): string {
+  const yamlStr = yaml.dump(record, {
     indent: 2,
     lineWidth: -1,
     quotingType: '"',
@@ -125,6 +141,15 @@ export function buildNoosphereFrontmatter(
   });
 
   return `---\n${yamlStr.trim()}\n---\n`;
+}
+
+export function buildNoosphereFrontmatter(
+  article: NoosphereMarkdownArticle,
+  options: RenderNoosphereMarkdownOptions = {}
+): string {
+  const sourceOfTruth = options.sourceOfTruth ?? "database";
+  const contentHash = options.contentHash ?? computeNoosphereContentHash(article, { sourceOfTruth });
+  return dumpFrontmatter(buildFrontmatterRecord(article, { ...options, contentHash, sourceOfTruth }));
 }
 
 export function renderNoosphereMarkdown(
@@ -138,13 +163,17 @@ export function computeNoosphereContentHash(
   article: NoosphereMarkdownArticle,
   options: Pick<RenderNoosphereMarkdownOptions, "sourceOfTruth"> = {}
 ): string {
-  const stableFrontmatter = buildNoosphereFrontmatter(article, {
-    contentHash: "STABLE_HASH",
+  const stableFrontmatter = dumpFrontmatter(buildFrontmatterRecord(article, {
     syncedAt: "1970-01-01T00:00:00.000Z",
     publish: false,
     sourceOfTruth: options.sourceOfTruth,
-  });
-  return createHash("sha256").update(`${stableFrontmatter}\n${article.content}`).digest("hex");
+    contentHash: null,
+  }));
+  return createHash("sha256")
+    .update(stableFrontmatter)
+    .update("\n")
+    .update(article.content)
+    .digest("hex");
 }
 
 export function parseNoosphereMarkdown(content: string): NoosphereMarkdownParseResult {
@@ -178,5 +207,9 @@ export function readMarkdownString(frontmatter: Record<string, unknown>, key: st
 export function readMarkdownStringArray(frontmatter: Record<string, unknown>, key: string): string[] {
   const value = frontmatter[key];
   if (!Array.isArray(value)) return [];
-  return normalizeStringArray(value.filter((item): item is string => typeof item === "string"));
+  return normalizeStringArray(
+    value
+      .map(normalizeMarkdownArrayValue)
+      .filter((item): item is string => item !== null)
+  );
 }

--- a/src/lib/obsidian-sync/index.ts
+++ b/src/lib/obsidian-sync/index.ts
@@ -9,11 +9,15 @@ import { createHash } from "crypto";
 import { existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "fs";
 import { join, resolve, relative as pathRelative } from "path";
 import { spawn } from "child_process";
-import yaml from "js-yaml";
 import type { ObsidianSyncConfig } from "./config";
 import { getObsidianSyncConfig } from "./config";
 import { prisma } from "@/lib/prisma";
 import type { Prisma } from "@prisma/client";
+import {
+  computeNoosphereContentHash,
+  renderNoosphereMarkdown,
+  type NoosphereMarkdownArticle,
+} from "@/lib/markdown/noosphere-markdown";
 
 // ─────────────────────────────────────────────
 // Types
@@ -251,75 +255,41 @@ interface ArticleForSync {
   lastReviewed: Date | null;
   createdAt: Date;
   updatedAt: Date;
+  restrictedTags: string[];
   authorName: string | null;
   topicId: string;
   tags: Array<{ tag: { name: string; slug: string } }>;
   topic: { id: string; slug: string; name: string };
 }
 
-// Ordered frontmatter keys for deterministic output (consistent with export route)
-const FM_KEYS = [
-  "id", "slug", "title", "topic", "topicPath",
-  "confidence", "status", "tags", "excerpt",
-  "authorName", "sourceUrl", "sourceType", "lastReviewed",
-  "createdAt", "updatedAt", "noosphere", "publish",
-] as const;
-
-function buildFrontmatter(
-  article: ArticleForSync,
-  topicPath: string[],
-  contentHash: string,
-  syncedAt: string,
-  publish: boolean
-): string {
-  const fm: Record<string, unknown> = {
+function toMarkdownArticle(article: ArticleForSync, topicPath: string[]): NoosphereMarkdownArticle {
+  return {
     id: article.id,
     slug: article.slug,
     title: article.title,
     topic: article.topic.slug,
     topicPath,
-    noosphere: {
-      entity: "article",
-      syncedAt,
-      contentHash: `sha256:${contentHash}`,
-      sourceOfTruth: "database",
-      url: `/wiki/${[...topicPath, article.slug].join("/")}`,
-    },
-    createdAt: article.createdAt.toISOString(),
-    updatedAt: article.updatedAt.toISOString(),
+    content: article.content,
+    confidence: article.confidence,
+    status: article.status,
+    tags: article.tags.map((t) => t.tag.slug),
+    restrictedTags: article.restrictedTags,
+    excerpt: article.excerpt,
+    authorName: article.authorName,
+    sourceUrl: article.sourceUrl,
+    sourceType: article.sourceType,
+    lastReviewed: article.lastReviewed,
+    createdAt: article.createdAt,
+    updatedAt: article.updatedAt,
   };
-
-  if (article.confidence) fm.confidence = article.confidence;
-  if (article.status) fm.status = article.status;
-  if (article.tags.length > 0) fm.tags = article.tags.map((t) => t.tag.slug);
-  if (article.excerpt) fm.excerpt = article.excerpt;
-  if (article.authorName) fm.authorName = article.authorName;
-  if (article.sourceUrl) fm.sourceUrl = article.sourceUrl;
-  if (article.sourceType) fm.sourceType = article.sourceType;
-  if (article.lastReviewed) fm.lastReviewed = article.lastReviewed.toISOString();
-  if (publish) fm.publish = true;
-
-  // Build ordered object matching FM_KEYS for stable serialization
-  const ordered: Record<string, unknown> = {};
-  for (const key of FM_KEYS) {
-    if (fm[key] !== undefined) ordered[key] = fm[key];
-  }
-
-  // js-yaml.dump for proper YAML (not JSON.stringify per-field — breaks on colons/quotes)
-  const yamlStr = yaml.dump(ordered, {
-    indent: 2,
-    lineWidth: -1,
-    quotingType: '"',
-    forceQuotes: false,
-    noRefs: true,
-    sortKeys: false,
-  });
-
-  return `---\n${yamlStr.trim()}\n---\n`;
 }
 
 function renderMarkdown(article: ArticleForSync, topicPath: string[], contentHash: string, syncedAt: string, publish: boolean): string {
-  return buildFrontmatter(article, topicPath, contentHash, syncedAt, publish) + "\n" + article.content;
+  return renderNoosphereMarkdown(toMarkdownArticle(article, topicPath), {
+    contentHash,
+    syncedAt,
+    publish,
+  });
 }
 
 /**
@@ -328,15 +298,7 @@ function renderMarkdown(article: ArticleForSync, topicPath: string[], contentHas
  * regardless of when the sync runs.
  */
 function computeContentHash(article: ArticleForSync, topicPath: string[]): string {
-  // Use false for publish so the hash is stable regardless of the publish setting
-  const stable = buildFrontmatter(
-    article,
-    topicPath,
-    "STABLE_HASH",
-    "1970-01-01T00:00:00.000Z",
-    false
-  ) + "\n" + article.content;
-  return createHash("sha256").update(stable).digest("hex");
+  return computeNoosphereContentHash(toMarkdownArticle(article, topicPath));
 }
 
 // ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Add a shared Noosphere markdown codec for versioned YAML frontmatter rendering, parsing, metadata normalization, and stable content hashes.
- Refactor Obsidian sync, markdown ZIP export, and markdown ZIP import to use the shared codec.
- Document the shared schema and add API tests for parser/render/hash behavior.

## Notes
- Exported/imported markdown now carries the versioned `noosphere.schemaVersion` block and consistent `noosphere.contentHash` metadata.
- Import still supports legacy markdown with only `title` and `topic`; it now prefers frontmatter `slug` when present and falls back to filename.

## Verification
- `DATABASE_URL='postgresql://noosphere:test@localhost:5432/noosphere' npm test`
- `DATABASE_URL='postgresql://noosphere:test@localhost:5432/noosphere' npm run build`
- `npm run lint` (0 errors, 3 pre-existing warnings)
- `node --import tsx --test src/__tests__/obsidian-sync/index.test.ts`