### PR TITLE
fix: restore recall endpoint aliases

### DIFF
--- a/src/__tests__/api/recall-alias-routes.test.ts
+++ b/src/__tests__/api/recall-alias-routes.test.ts
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+process.env.DATABASE_URL ??= "postgresql://noosphere:noosphere@localhost:5432/noosphere";
+
+test("legacy recall route aliases the canonical memory recall handler", async () => {
+  const { POST: canonicalRecallPost } = await import("@/app/api/memory/recall/route");
+  const { POST: legacyRecallPost } = await import("@/app/api/recall/route");
+
+  assert.equal(legacyRecallPost, canonicalRecallPost);
+});
+
+test("plural memories recall route aliases the canonical memory recall handler", async () => {
+  const { POST: canonicalRecallPost } = await import("@/app/api/memory/recall/route");
+  const { POST: pluralRecallPost } = await import("@/app/api/memories/recall/route");
+
+  assert.equal(pluralRecallPost, canonicalRecallPost);
+});

--- a/src/app/api/memories/recall/route.ts
+++ b/src/app/api/memories/recall/route.ts
@@ -1,0 +1,1 @@
+export { POST } from "@/app/api/memory/recall/route";

--- a/src/app/api/recall/route.ts
+++ b/src/app/api/recall/route.ts
@@ -1,0 +1,1 @@
+export { POST } from "@/app/api/memory/recall/route";


### PR DESCRIPTION
## Summary
- add compatibility routes for POST /api/recall and POST /api/memories/recall
- route both aliases through the canonical POST /api/memory/recall handler
- add regression tests to keep the aliases wired to the canonical handler

## Verification
- npm test
- npm run lint
- npm run build

## Summary by Sourcery

Restore compatibility recall API endpoints by routing legacy paths through the canonical memory recall handler.

New Features:
- Expose POST /api/recall as an alias of the canonical memory recall endpoint.
- Expose POST /api/memories/recall as an alias of the canonical memory recall endpoint.

Tests:
- Add regression tests to ensure recall alias routes continue to invoke the canonical handler.