### PR TITLE
test: harden recall alias assertions

### DIFF
--- a/src/__tests__/api/recall-alias-routes.test.ts
+++ b/src/__tests__/api/recall-alias-routes.test.ts
@@ -7,6 +7,7 @@ test("legacy recall route aliases the canonical memory recall handler", async ()
   const { POST: canonicalRecallPost } = await import("@/app/api/memory/recall/route");
   const { POST: legacyRecallPost } = await import("@/app/api/recall/route");
 
+  assert.equal(typeof canonicalRecallPost, "function");
   assert.equal(legacyRecallPost, canonicalRecallPost);
 });
 
@@ -14,5 +15,6 @@ test("plural memories recall route aliases the canonical memory recall handler",
   const { POST: canonicalRecallPost } = await import("@/app/api/memory/recall/route");
   const { POST: pluralRecallPost } = await import("@/app/api/memories/recall/route");
 
+  assert.equal(typeof canonicalRecallPost, "function");
   assert.equal(pluralRecallPost, canonicalRecallPost);
 });


### PR DESCRIPTION
## Summary
- assert the canonical recall POST export is a function in both alias route regression tests
- prevent the tests from passing if the handler export disappears and both imports resolve to undefined

## Verification
- DATABASE_URL constructed from /home/niya/.noosphere/.env: npm run test:api
- npm run lint

Follow-up to Gemini review on PR #125: https://github.com/SweetSophia/noosphere/pull/125#pullrequestreview-4359216778

## Summary by Sourcery

Tests:
- Add explicit assertions that the canonical recall POST handler is a function in both recall alias route tests to prevent false positives when the handler export is undefined.