### PR TITLE
feat: add sync conflict preferences API

### DIFF
--- a/prisma/migrations/20260526172000_add_sync_conflict_preferences/migration.sql
+++ b/prisma/migrations/20260526172000_add_sync_conflict_preferences/migration.sql
@@ -1,0 +1,17 @@
+-- CreateTable
+CREATE TABLE "SyncConflictPreferences" (
+    "id" TEXT NOT NULL DEFAULT 'singleton',
+    "defaultBehavior" TEXT NOT NULL DEFAULT 'manual-review',
+    "noosphereToVault" TEXT NOT NULL DEFAULT 'manual-review',
+    "vaultToNoosphere" TEXT NOT NULL DEFAULT 'manual-review',
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "SyncConflictPreferences_pkey" PRIMARY KEY ("id")
+);
+
+ALTER TABLE "SyncConflictPreferences" ADD CONSTRAINT "SyncConflictPreferences_defaultBehavior_check" CHECK ("defaultBehavior" IN ('preserve', 'overwrite', 'manual-review'));
+ALTER TABLE "SyncConflictPreferences" ADD CONSTRAINT "SyncConflictPreferences_noosphereToVault_check" CHECK ("noosphereToVault" IN ('preserve', 'overwrite', 'manual-review'));
+ALTER TABLE "SyncConflictPreferences" ADD CONSTRAINT "SyncConflictPreferences_vaultToNoosphere_check" CHECK ("vaultToNoosphere" IN ('preserve', 'overwrite', 'manual-review'));
+
+-- CreateIndex
+CREATE UNIQUE INDEX "SyncConflictPreferences_id_key" ON "SyncConflictPreferences"("id");

--- a/prisma/migrations/20260526174500_drop_redundant_sync_conflict_preferences_index/migration.sql
+++ b/prisma/migrations/20260526174500_drop_redundant_sync_conflict_preferences_index/migration.sql
@@ -1,0 +1,3 @@
+-- Drop redundant unique index created by @@unique([id]); the primary key
+-- already enforces uniqueness for the singleton row id.
+DROP INDEX IF EXISTS "SyncConflictPreferences_id_key";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -278,3 +278,22 @@ model RecallSettings {
 
   @@unique([id])
 }
+
+// ─────────────────────────────────────────────
+// Sync Conflict Preferences — singleton config for markdown sync conflicts
+// ─────────────────────────────────────────────
+model SyncConflictPreferences {
+  id        String   @id @default("singleton")
+
+  // Conflict behavior values: "preserve" | "overwrite" | "manual-review"
+  defaultBehavior String @default("manual-review")
+
+  // Per-direction preferences. Direction names match the public API keys:
+  // "noosphere-to-vault" and "vault-to-noosphere".
+  noosphereToVault String @default("manual-review")
+  vaultToNoosphere String @default("manual-review")
+
+  updatedAt DateTime @updatedAt
+
+  @@unique([id])
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -294,6 +294,4 @@ model SyncConflictPreferences {
   vaultToNoosphere String @default("manual-review")
 
   updatedAt DateTime @updatedAt
-
-  @@unique([id])
 }

--- a/src/__tests__/api/sync-conflict-preferences.test.ts
+++ b/src/__tests__/api/sync-conflict-preferences.test.ts
@@ -69,6 +69,12 @@ test("validateSyncConflictPreferencesUpdate rejects invalid behaviors and direct
   assert.ok(result.errors.some((error) => error.includes("extra")));
 });
 
+test("validateSyncConflictPreferencesUpdate returns structural body errors verbatim", () => {
+  const result = validateSyncConflictPreferencesUpdate([]);
+
+  assert.deepEqual(result, { ok: false, errors: ["Body must be a JSON object"] });
+});
+
 test("validateSyncConflictPreferencesUpdate returns normalized partial updates", () => {
   const result = validateSyncConflictPreferencesUpdate({
     defaultBehavior: "overwrite",

--- a/src/__tests__/api/sync-conflict-preferences.test.ts
+++ b/src/__tests__/api/sync-conflict-preferences.test.ts
@@ -1,0 +1,121 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  DEFAULT_SYNC_CONFLICT_PREFERENCES,
+  SYNC_CONFLICT_PREFERENCES_READ_PERMISSIONS,
+  SYNC_CONFLICT_PREFERENCES_WRITE_PERMISSIONS,
+  mergeSyncConflictPreferences,
+  normalizeSyncConflictPreferences,
+  toPublicSyncConflictPreferences,
+  validateSyncConflictPreferencesContentLength,
+  validateSyncConflictPreferencesUpdate,
+} from "@/lib/markdown-sync/conflict-preferences";
+
+test("sync conflict preferences API policy allows READ gets and ADMIN writes", () => {
+  assert.deepEqual(SYNC_CONFLICT_PREFERENCES_READ_PERMISSIONS, ["READ"]);
+  assert.deepEqual(SYNC_CONFLICT_PREFERENCES_WRITE_PERMISSIONS, ["ADMIN"]);
+});
+
+test("sync conflict preferences default to manual review for both directions", () => {
+  const preferences = normalizeSyncConflictPreferences();
+
+  assert.equal(preferences.defaultBehavior, "manual-review");
+  assert.equal(preferences.directionPreferences["noosphere-to-vault"], "manual-review");
+  assert.equal(preferences.directionPreferences["vault-to-noosphere"], "manual-review");
+});
+
+test("sync conflict preferences accept all supported behaviors per direction", () => {
+  const preferences = normalizeSyncConflictPreferences({
+    defaultBehavior: "preserve",
+    directionPreferences: {
+      "noosphere-to-vault": "overwrite",
+      "vault-to-noosphere": "manual-review",
+    },
+  });
+
+  assert.equal(preferences.defaultBehavior, "preserve");
+  assert.equal(preferences.directionPreferences["noosphere-to-vault"], "overwrite");
+  assert.equal(preferences.directionPreferences["vault-to-noosphere"], "manual-review");
+});
+
+test("mergeSyncConflictPreferences applies partial direction updates", () => {
+  const merged = mergeSyncConflictPreferences(DEFAULT_SYNC_CONFLICT_PREFERENCES, {
+    directionPreferences: {
+      "vault-to-noosphere": "preserve",
+    },
+  });
+
+  assert.equal(merged.defaultBehavior, "manual-review");
+  assert.equal(merged.directionPreferences["noosphere-to-vault"], "manual-review");
+  assert.equal(merged.directionPreferences["vault-to-noosphere"], "preserve");
+});
+
+test("validateSyncConflictPreferencesUpdate rejects invalid behaviors and directions", () => {
+  const result = validateSyncConflictPreferencesUpdate({
+    defaultBehavior: "merge",
+    directionPreferences: {
+      "vault-to-noosphere": "preserve",
+      "sideways": "overwrite",
+      "noosphere-to-vault": "replace",
+    },
+    extra: true,
+  });
+
+  assert.equal(result.ok, false);
+  if (result.ok) return;
+  assert.ok(result.errors.some((error) => error.includes("defaultBehavior")));
+  assert.ok(result.errors.some((error) => error.includes("sideways")));
+  assert.ok(result.errors.some((error) => error.includes("noosphere-to-vault")));
+  assert.ok(result.errors.some((error) => error.includes("extra")));
+});
+
+test("validateSyncConflictPreferencesUpdate returns normalized partial updates", () => {
+  const result = validateSyncConflictPreferencesUpdate({
+    defaultBehavior: "overwrite",
+    directionPreferences: {
+      "vault-to-noosphere": "manual-review",
+    },
+  });
+
+  assert.equal(result.ok, true);
+  if (!result.ok) return;
+  assert.equal(result.updates.defaultBehavior, "overwrite");
+  assert.deepEqual(result.updates.directionPreferences, {
+    "vault-to-noosphere": "manual-review",
+  });
+});
+
+test("validateSyncConflictPreferencesContentLength rejects malformed and oversized headers", () => {
+  assert.deepEqual(validateSyncConflictPreferencesContentLength(null, 10), { ok: true });
+  assert.deepEqual(validateSyncConflictPreferencesContentLength("10", 10), { ok: true });
+  assert.deepEqual(validateSyncConflictPreferencesContentLength("abc", 10), {
+    ok: false,
+    status: 400,
+    error: "Invalid content-length header",
+  });
+  assert.deepEqual(validateSyncConflictPreferencesContentLength("", 10), {
+    ok: false,
+    status: 400,
+    error: "Invalid content-length header",
+  });
+  assert.deepEqual(validateSyncConflictPreferencesContentLength("-1", 10), {
+    ok: false,
+    status: 400,
+    error: "Invalid content-length header",
+  });
+  assert.deepEqual(validateSyncConflictPreferencesContentLength("11", 10), {
+    ok: false,
+    status: 413,
+    error: "Request body too large. Maximum size is 10 bytes.",
+  });
+});
+
+test("toPublicSyncConflictPreferences exposes safe metadata only", () => {
+  const updatedAt = new Date("2026-05-26T17:20:00Z");
+  const publicPreferences = toPublicSyncConflictPreferences(DEFAULT_SYNC_CONFLICT_PREFERENCES, updatedAt);
+
+  assert.equal(publicPreferences.updatedAt, "2026-05-26T17:20:00.000Z");
+  assert.deepEqual(publicPreferences.allowedBehaviors, ["preserve", "overwrite", "manual-review"]);
+  assert.deepEqual(publicPreferences.allowedDirections, ["noosphere-to-vault", "vault-to-noosphere"]);
+  assert.equal("id" in publicPreferences, false);
+});

--- a/src/app/api/sync/conflict-preferences/route.ts
+++ b/src/app/api/sync/conflict-preferences/route.ts
@@ -71,7 +71,7 @@ export async function POST(request: NextRequest) {
 
   const validation = validateSyncConflictPreferencesUpdate(body);
   if (!validation.ok) {
-    return NextResponse.json({ error: `Invalid fields: ${validation.errors.join("; ")}` }, { status: 400 });
+    return NextResponse.json({ error: validation.errors.join("; ") }, { status: 400 });
   }
 
   try {

--- a/src/app/api/sync/conflict-preferences/route.ts
+++ b/src/app/api/sync/conflict-preferences/route.ts
@@ -1,0 +1,84 @@
+/**
+ * GET/POST /api/sync/conflict-preferences
+ *
+ * Stores markdown sync conflict behavior preferences. Reads require READ so
+ * agents can inspect safe config; writes require ADMIN because these defaults
+ * can decide whether future sync flows preserve, overwrite, or queue conflicts.
+ */
+
+export const dynamic = "force-dynamic";
+
+import { NextRequest, NextResponse } from "next/server";
+import { requirePermission } from "@/lib/api/auth";
+import {
+  getSyncConflictPreferencesFromDB,
+  upsertSyncConflictPreferences,
+} from "@/lib/markdown-sync/api/conflict-preferences";
+import {
+  SYNC_CONFLICT_PREFERENCES_MAX_BODY_BYTES,
+  SYNC_CONFLICT_PREFERENCES_READ_PERMISSIONS,
+  SYNC_CONFLICT_PREFERENCES_WRITE_PERMISSIONS,
+  validateSyncConflictPreferencesContentLength,
+  validateSyncConflictPreferencesUpdate,
+} from "@/lib/markdown-sync/conflict-preferences";
+import { rateLimit } from "@/lib/rate-limit";
+
+export async function GET(request: NextRequest) {
+  const rl = rateLimit(request, { windowMs: 60_000, maxRequests: 60, keyPrefix: "sync-conflict-preferences-get" });
+  if (!rl.allowed) return rl.response;
+
+  const auth = await requirePermission(request, [...SYNC_CONFLICT_PREFERENCES_READ_PERMISSIONS]);
+  if (!auth.success) {
+    return auth.response;
+  }
+
+  try {
+    const preferences = await getSyncConflictPreferencesFromDB();
+    return NextResponse.json(preferences, { status: 200 });
+  } catch (error) {
+    console.error("[GET /api/sync/conflict-preferences]", error);
+    return NextResponse.json({ error: "Failed to retrieve conflict preferences" }, { status: 503 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const rl = rateLimit(request, { windowMs: 60_000, maxRequests: 30, keyPrefix: "sync-conflict-preferences-post" });
+  if (!rl.allowed) return rl.response;
+
+  const auth = await requirePermission(request, [...SYNC_CONFLICT_PREFERENCES_WRITE_PERMISSIONS]);
+  if (!auth.success) {
+    return auth.response;
+  }
+
+  const contentLengthValidation = validateSyncConflictPreferencesContentLength(request.headers.get("content-length"));
+  if (!contentLengthValidation.ok) {
+    return NextResponse.json({ error: contentLengthValidation.error }, { status: contentLengthValidation.status });
+  }
+
+  let body: unknown;
+  try {
+    const bodyText = await request.text();
+    if (new TextEncoder().encode(bodyText).byteLength > SYNC_CONFLICT_PREFERENCES_MAX_BODY_BYTES) {
+      return NextResponse.json(
+        { error: `Request body too large. Maximum size is ${SYNC_CONFLICT_PREFERENCES_MAX_BODY_BYTES} bytes.` },
+        { status: 413 },
+      );
+    }
+    body = JSON.parse(bodyText);
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const validation = validateSyncConflictPreferencesUpdate(body);
+  if (!validation.ok) {
+    return NextResponse.json({ error: `Invalid fields: ${validation.errors.join("; ")}` }, { status: 400 });
+  }
+
+  try {
+    const updated = await upsertSyncConflictPreferences(validation.updates);
+    return NextResponse.json(updated, { status: 200 });
+  } catch (error) {
+    console.error("[POST /api/sync/conflict-preferences]", error);
+    return NextResponse.json({ error: "Failed to update conflict preferences" }, { status: 503 });
+  }
+}

--- a/src/lib/markdown-sync/api/conflict-preferences.ts
+++ b/src/lib/markdown-sync/api/conflict-preferences.ts
@@ -1,0 +1,95 @@
+/**
+ * SyncConflictPreferences persistence helpers.
+ *
+ * Stores one normalized row with id="singleton". The API exposes only the
+ * public settings shape and does not leak internal database identifiers.
+ */
+
+import {
+  DEFAULT_SYNC_CONFLICT_PREFERENCES,
+  normalizeSyncConflictPreferences,
+  toPublicSyncConflictPreferences,
+  type PublicSyncConflictPreferences,
+  type SyncConflictBehavior,
+  type SyncConflictPreferences,
+  type SyncConflictPreferencesUpdate,
+} from "@/lib/markdown-sync/conflict-preferences";
+
+interface SyncConflictPreferencesRow {
+  id: string;
+  defaultBehavior: string;
+  noosphereToVault: string;
+  vaultToNoosphere: string;
+  updatedAt: Date;
+}
+
+function rowToSyncConflictPreferences(row: SyncConflictPreferencesRow | null): SyncConflictPreferences | null {
+  if (!row) return null;
+
+  return normalizeSyncConflictPreferences({
+    defaultBehavior: row.defaultBehavior as SyncConflictBehavior,
+    directionPreferences: {
+      "noosphere-to-vault": row.noosphereToVault as SyncConflictBehavior,
+      "vault-to-noosphere": row.vaultToNoosphere as SyncConflictBehavior,
+    },
+  });
+}
+
+export async function getSyncConflictPreferencesFromDB(): Promise<PublicSyncConflictPreferences> {
+  const { prisma } = await import("@/lib/prisma");
+
+  const row = await prisma.syncConflictPreferences.findUnique({
+    where: { id: "singleton" },
+  });
+
+  const preferences = rowToSyncConflictPreferences(row) ?? { ...DEFAULT_SYNC_CONFLICT_PREFERENCES };
+  return toPublicSyncConflictPreferences(preferences, row?.updatedAt ?? null);
+}
+
+export async function upsertSyncConflictPreferences(
+  updates: SyncConflictPreferencesUpdate,
+): Promise<PublicSyncConflictPreferences> {
+  const { prisma } = await import("@/lib/prisma");
+
+  const updateData: {
+    defaultBehavior?: SyncConflictBehavior;
+    noosphereToVault?: SyncConflictBehavior;
+    vaultToNoosphere?: SyncConflictBehavior;
+    updatedAt?: Date;
+  } = {};
+
+  if (updates.defaultBehavior !== undefined) {
+    updateData.defaultBehavior = updates.defaultBehavior;
+  }
+  if (updates.directionPreferences?.["noosphere-to-vault"] !== undefined) {
+    updateData.noosphereToVault = updates.directionPreferences["noosphere-to-vault"];
+  }
+  if (updates.directionPreferences?.["vault-to-noosphere"] !== undefined) {
+    updateData.vaultToNoosphere = updates.directionPreferences["vault-to-noosphere"];
+  }
+
+  if (Object.keys(updateData).length === 0) {
+    return getSyncConflictPreferencesFromDB();
+  }
+
+  updateData.updatedAt = new Date();
+
+  const row = await prisma.syncConflictPreferences.upsert({
+    where: { id: "singleton" },
+    update: updateData,
+    create: {
+      id: "singleton",
+      defaultBehavior: updates.defaultBehavior ?? DEFAULT_SYNC_CONFLICT_PREFERENCES.defaultBehavior,
+      noosphereToVault:
+        updates.directionPreferences?.["noosphere-to-vault"] ??
+        DEFAULT_SYNC_CONFLICT_PREFERENCES.directionPreferences["noosphere-to-vault"],
+      vaultToNoosphere:
+        updates.directionPreferences?.["vault-to-noosphere"] ??
+        DEFAULT_SYNC_CONFLICT_PREFERENCES.directionPreferences["vault-to-noosphere"],
+      updatedAt: updateData.updatedAt,
+    },
+  });
+
+  const preferences = rowToSyncConflictPreferences(row) ?? { ...DEFAULT_SYNC_CONFLICT_PREFERENCES };
+  return toPublicSyncConflictPreferences(preferences, row.updatedAt);
+}

--- a/src/lib/markdown-sync/conflict-preferences.ts
+++ b/src/lib/markdown-sync/conflict-preferences.ts
@@ -1,0 +1,207 @@
+/**
+ * User-configurable markdown sync conflict preferences.
+ *
+ * These settings are intentionally narrower than the Obsidian environment
+ * config. They describe what policy should be used when markdown and database
+ * state diverge; later phases can consume the same normalized shape from the
+ * forward sync, reverse scanner, and conflict review UI.
+ */
+
+import { Permissions } from "@prisma/client";
+
+export const SYNC_CONFLICT_BEHAVIORS = ["preserve", "overwrite", "manual-review"] as const;
+export type SyncConflictBehavior = (typeof SYNC_CONFLICT_BEHAVIORS)[number];
+
+export const SYNC_CONFLICT_DIRECTIONS = ["noosphere-to-vault", "vault-to-noosphere"] as const;
+export type SyncConflictDirection = (typeof SYNC_CONFLICT_DIRECTIONS)[number];
+
+export const SYNC_CONFLICT_PREFERENCES_READ_PERMISSIONS = [Permissions.READ] as const;
+export const SYNC_CONFLICT_PREFERENCES_WRITE_PERMISSIONS = [Permissions.ADMIN] as const;
+export const SYNC_CONFLICT_PREFERENCES_MAX_BODY_BYTES = 64 * 1024;
+
+export interface SyncConflictDirectionPreferences {
+  "noosphere-to-vault": SyncConflictBehavior;
+  "vault-to-noosphere": SyncConflictBehavior;
+}
+
+export interface SyncConflictPreferences {
+  defaultBehavior: SyncConflictBehavior;
+  directionPreferences: SyncConflictDirectionPreferences;
+}
+
+export interface PublicSyncConflictPreferences extends SyncConflictPreferences {
+  updatedAt: string | null;
+  allowedBehaviors: readonly SyncConflictBehavior[];
+  allowedDirections: readonly SyncConflictDirection[];
+}
+
+export interface SyncConflictPreferencesUpdate {
+  defaultBehavior?: SyncConflictBehavior;
+  directionPreferences?: Partial<SyncConflictDirectionPreferences>;
+}
+
+export type SyncConflictPreferencesValidationResult =
+  | { ok: true; updates: SyncConflictPreferencesUpdate }
+  | { ok: false; errors: string[] };
+
+export type ContentLengthValidationResult =
+  | { ok: true }
+  | { ok: false; status: 400 | 413; error: string };
+
+export const DEFAULT_SYNC_CONFLICT_PREFERENCES: SyncConflictPreferences = {
+  defaultBehavior: "manual-review",
+  directionPreferences: {
+    "noosphere-to-vault": "manual-review",
+    "vault-to-noosphere": "manual-review",
+  },
+};
+
+const VALID_BEHAVIORS = new Set<string>(SYNC_CONFLICT_BEHAVIORS);
+const VALID_DIRECTIONS = new Set<string>(SYNC_CONFLICT_DIRECTIONS);
+const ALLOWED_TOP_LEVEL_FIELDS = new Set(["defaultBehavior", "directionPreferences"]);
+
+export function isSyncConflictBehavior(value: unknown): value is SyncConflictBehavior {
+  return typeof value === "string" && VALID_BEHAVIORS.has(value);
+}
+
+export function normalizeSyncConflictPreferences(
+  input: Partial<SyncConflictPreferences> = {},
+): SyncConflictPreferences {
+  const defaultBehavior = isSyncConflictBehavior(input.defaultBehavior)
+    ? input.defaultBehavior
+    : DEFAULT_SYNC_CONFLICT_PREFERENCES.defaultBehavior;
+
+  const directionInput = input.directionPreferences;
+
+  return {
+    defaultBehavior,
+    directionPreferences: {
+      "noosphere-to-vault": isSyncConflictBehavior(directionInput?.["noosphere-to-vault"])
+        ? directionInput["noosphere-to-vault"]
+        : DEFAULT_SYNC_CONFLICT_PREFERENCES.directionPreferences["noosphere-to-vault"],
+      "vault-to-noosphere": isSyncConflictBehavior(directionInput?.["vault-to-noosphere"])
+        ? directionInput["vault-to-noosphere"]
+        : DEFAULT_SYNC_CONFLICT_PREFERENCES.directionPreferences["vault-to-noosphere"],
+    },
+  };
+}
+
+export function mergeSyncConflictPreferences(
+  base: SyncConflictPreferences,
+  updates: SyncConflictPreferencesUpdate,
+): SyncConflictPreferences {
+  return normalizeSyncConflictPreferences({
+    defaultBehavior: updates.defaultBehavior ?? base.defaultBehavior,
+    directionPreferences: {
+      ...base.directionPreferences,
+      ...updates.directionPreferences,
+    },
+  });
+}
+
+export function validateSyncConflictPreferencesUpdate(
+  body: unknown,
+): SyncConflictPreferencesValidationResult {
+  if (typeof body !== "object" || body === null || Array.isArray(body)) {
+    return { ok: false, errors: ["Body must be a JSON object"] };
+  }
+
+  const input = body as Record<string, unknown>;
+  const errors: string[] = [];
+  const updates: SyncConflictPreferencesUpdate = {};
+
+  for (const key of Object.keys(input)) {
+    if (!ALLOWED_TOP_LEVEL_FIELDS.has(key)) {
+      errors.push(`${key} is not a supported setting`);
+    }
+  }
+
+  if ("defaultBehavior" in input) {
+    if (isSyncConflictBehavior(input["defaultBehavior"])) {
+      updates.defaultBehavior = input["defaultBehavior"];
+    } else {
+      errors.push(`defaultBehavior must be one of: ${SYNC_CONFLICT_BEHAVIORS.join(", ")}`);
+    }
+  }
+
+  if ("directionPreferences" in input) {
+    const directionPreferences = input["directionPreferences"];
+    if (
+      typeof directionPreferences !== "object" ||
+      directionPreferences === null ||
+      Array.isArray(directionPreferences)
+    ) {
+      errors.push("directionPreferences must be an object");
+    } else {
+      const nextDirections: Partial<SyncConflictDirectionPreferences> = {};
+      for (const [direction, behavior] of Object.entries(directionPreferences)) {
+        if (!VALID_DIRECTIONS.has(direction)) {
+          errors.push(`${direction} is not a supported sync direction`);
+          continue;
+        }
+        if (!isSyncConflictBehavior(behavior)) {
+          errors.push(`${direction} must be one of: ${SYNC_CONFLICT_BEHAVIORS.join(", ")}`);
+          continue;
+        }
+        nextDirections[direction as SyncConflictDirection] = behavior;
+      }
+      updates.directionPreferences = nextDirections;
+    }
+  }
+
+  if (errors.length > 0) {
+    return { ok: false, errors };
+  }
+
+  return { ok: true, updates };
+}
+
+export function validateSyncConflictPreferencesContentLength(
+  contentLength: string | null,
+  maxBytes = SYNC_CONFLICT_PREFERENCES_MAX_BODY_BYTES,
+): ContentLengthValidationResult {
+  if (contentLength === null) {
+    return { ok: true };
+  }
+
+  const normalizedLength = contentLength.trim();
+  if (!/^\d+$/.test(normalizedLength)) {
+    return {
+      ok: false,
+      status: 400,
+      error: "Invalid content-length header",
+    };
+  }
+
+  const parsedLength = Number(normalizedLength);
+  if (!Number.isSafeInteger(parsedLength) || parsedLength < 0) {
+    return {
+      ok: false,
+      status: 400,
+      error: "Invalid content-length header",
+    };
+  }
+
+  if (parsedLength > maxBytes) {
+    return {
+      ok: false,
+      status: 413,
+      error: `Request body too large. Maximum size is ${maxBytes} bytes.`,
+    };
+  }
+
+  return { ok: true };
+}
+
+export function toPublicSyncConflictPreferences(
+  preferences: SyncConflictPreferences,
+  updatedAt: Date | string | null,
+): PublicSyncConflictPreferences {
+  return {
+    ...preferences,
+    directionPreferences: { ...preferences.directionPreferences },
+    updatedAt: updatedAt instanceof Date ? updatedAt.toISOString() : updatedAt,
+    allowedBehaviors: SYNC_CONFLICT_BEHAVIORS,
+    allowedDirections: SYNC_CONFLICT_DIRECTIONS,
+  };
+}


### PR DESCRIPTION
## Summary
- add DB-backed singleton SyncConflictPreferences model and migrations
- expose GET/POST /api/sync/conflict-preferences with READ-safe reads and ADMIN-only writes
- validate preserve/overwrite/manual-review defaults and per-direction preferences for noosphere-to-vault and vault-to-noosphere
- use atomic partial upserts to avoid lost updates and enforce bounded POST body reads
- add API-level tests for defaults, validation, public response shape, auth policy constants, and structural body errors

## Verification
- node --import tsx --test src/__tests__/api/sync-conflict-preferences.test.ts (9/9)
- DATABASE_URL=<docker-network noosphere> npm run test:api (66/66)
- DATABASE_URL=<local noosphere> npm run test:memory (177/177)
- DATABASE_URL=<local noosphere> npm run test:cache (6/6)
- DATABASE_URL=<local noosphere> npm run test:security (9/9)
- npm run lint (0 errors, 3 pre-existing warnings)
- DATABASE_URL=<docker-network noosphere> npm run build
- prisma migrate deploy applied via Docker network db:5432
- GitHub checks passed: Analyze actions/javascript-typescript/python, CodeQL, Kilo Code Review, Sourcery review, docker

## Notes
- This stores Phase 2 preferences only. Conflict review UI, reverse scanner, and apply workflow remain later phases.