### PR TITLE
feat: add sync conflict review UI

### DIFF
--- a/prisma/migrations/20260526195500_add_sync_conflict_reviews/migration.sql
+++ b/prisma/migrations/20260526195500_add_sync_conflict_reviews/migration.sql
@@ -1,0 +1,44 @@
+-- CreateTable
+CREATE TABLE "SyncConflictReview" (
+    "id" TEXT NOT NULL,
+    "articleId" TEXT,
+    "direction" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'open',
+    "resolution" TEXT,
+    "relativePath" TEXT NOT NULL,
+    "archivePath" TEXT NOT NULL,
+    "noosphereHash" TEXT,
+    "markdownHash" TEXT,
+    "noosphereUpdatedAt" TIMESTAMP(3),
+    "markdownUpdatedAt" TIMESTAMP(3),
+    "summary" JSONB NOT NULL DEFAULT '{}',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "resolvedAt" TIMESTAMP(3),
+    "resolvedBy" TEXT,
+
+    CONSTRAINT "SyncConflictReview_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "SyncConflictReview_archivePath_key" ON "SyncConflictReview"("archivePath");
+
+-- CreateIndex
+CREATE INDEX "SyncConflictReview_articleId_idx" ON "SyncConflictReview"("articleId");
+
+-- CreateIndex
+CREATE INDEX "SyncConflictReview_status_idx" ON "SyncConflictReview"("status");
+
+-- CreateIndex
+CREATE INDEX "SyncConflictReview_direction_idx" ON "SyncConflictReview"("direction");
+
+-- CreateIndex
+CREATE INDEX "SyncConflictReview_createdAt_idx" ON "SyncConflictReview"("createdAt");
+
+-- AddForeignKey
+ALTER TABLE "SyncConflictReview" ADD CONSTRAINT "SyncConflictReview_articleId_fkey" FOREIGN KEY ("articleId") REFERENCES "Article"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- Add constraints
+ALTER TABLE "SyncConflictReview" ADD CONSTRAINT "SyncConflictReview_direction_check" CHECK ("direction" IN ('noosphere-to-vault', 'vault-to-noosphere'));
+ALTER TABLE "SyncConflictReview" ADD CONSTRAINT "SyncConflictReview_status_check" CHECK ("status" IN ('open', 'resolved', 'ignored-once', 'ignored-always'));
+ALTER TABLE "SyncConflictReview" ADD CONSTRAINT "SyncConflictReview_resolution_check" CHECK ("resolution" IS NULL OR "resolution" IN ('keep-noosphere', 'keep-markdown', 'mark-resolved', 'ignore-once', 'ignore-always'));

--- a/prisma/migrations/20260527130600_add_sync_conflict_review_identity_index/migration.sql
+++ b/prisma/migrations/20260527130600_add_sync_conflict_review_identity_index/migration.sql
@@ -1,0 +1,3 @@
+-- Speed up suppression checks for recurring ignored sync conflicts.
+CREATE INDEX "SyncConflictReview_articleId_relativePath_direction_status_idx"
+  ON "SyncConflictReview"("articleId", "relativePath", "direction", "status");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -53,6 +53,7 @@ model Article {
 
   tags      ArticleTag[]
   revisions ArticleRevision[]
+  syncConflictReviews SyncConflictReview[]
 
   // Source tracking — where this article's content originated
   sourceUrl  String?
@@ -294,4 +295,46 @@ model SyncConflictPreferences {
   vaultToNoosphere String @default("manual-review")
 
   updatedAt DateTime @updatedAt
+}
+
+// ─────────────────────────────────────────────
+// Sync Conflict Reviews — admin queue for markdown sync conflicts
+// ─────────────────────────────────────────────
+model SyncConflictReview {
+  id        String   @id @default(cuid())
+
+  articleId String?
+  article   Article? @relation(fields: [articleId], references: [id], onDelete: SetNull)
+
+  // Direction values match public sync preference directions:
+  // "noosphere-to-vault" and "vault-to-noosphere".
+  direction String
+
+  // Status values: "open" | "resolved" | "ignored-once" | "ignored-always"
+  status String @default("open")
+
+  // Resolution/action values: "keep-noosphere" | "keep-markdown" |
+  // "mark-resolved" | "ignore-once" | "ignore-always".
+  resolution String?
+
+  relativePath String
+  archivePath  String @unique
+
+  noosphereHash String?
+  markdownHash  String?
+
+  noosphereUpdatedAt DateTime?
+  markdownUpdatedAt  DateTime?
+
+  summary Json @default("{}")
+
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @default(now()) @updatedAt
+  resolvedAt DateTime?
+  resolvedBy String?
+
+  @@index([articleId])
+  @@index([status])
+  @@index([direction])
+  @@index([createdAt])
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -336,5 +336,6 @@ model SyncConflictReview {
   @@index([articleId])
   @@index([status])
   @@index([direction])
+  @@index([articleId, relativePath, direction, status])
   @@index([createdAt])
 }

--- a/src/__tests__/api/sync-conflict-review.test.ts
+++ b/src/__tests__/api/sync-conflict-review.test.ts
@@ -1,5 +1,15 @@
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 import test from "node:test";
+import { prisma } from "@/lib/prisma";
+import {
+  recordSyncConflictReview,
+  resolveSyncConflictReview,
+  SyncConflictReviewClosedError,
+} from "@/lib/markdown-sync/api/conflict-review";
+import { runObsidianSync } from "@/lib/obsidian-sync";
 import {
   buildSyncConflictReviewCreateInput,
   buildSyncConflictReviewSummary,
@@ -77,6 +87,189 @@ test("buildSyncConflictReviewCreateInput prepares vault-to-noosphere review rows
   assert.equal(input.relativePath, "projects/noosphere-source.md");
   assert.equal(input.summary.markdown.title, "Markdown Source");
   assert.equal(input.markdownUpdatedAt?.toISOString(), "2026-05-26T11:00:00.000Z");
+});
+
+test("recordSyncConflictReview suppresses exact ignored-always conflicts", async () => {
+  const input = buildSyncConflictReviewCreateInput({
+    article,
+    direction: "vault-to-noosphere",
+    relativePath: "projects/noosphere-source.md",
+    archivePath: ".noosphere-sync/conflicts/2026-projects---noosphere-source.md",
+    noosphereHash: "database-hash",
+    markdownContent: markdown,
+  });
+  const delegate = prisma.syncConflictReview as unknown as {
+    findFirst: (args: unknown) => Promise<unknown>;
+    create: (args: unknown) => Promise<unknown>;
+  };
+  const originalFindFirst = delegate.findFirst;
+  const originalCreate = delegate.create;
+  let findFirstCalls = 0;
+  let createCalls = 0;
+
+  try {
+    delegate.findFirst = async (args: unknown) => {
+      findFirstCalls++;
+      assert.deepEqual(args, {
+        where: {
+          articleId: "article-1",
+          direction: "vault-to-noosphere",
+          relativePath: "projects/noosphere-source.md",
+          markdownHash: input.markdownHash,
+          status: "ignored-always",
+        },
+        orderBy: [{ resolvedAt: "desc" }, { createdAt: "desc" }],
+      });
+      return { id: "ignored-review", status: "ignored-always" };
+    };
+    delegate.create = async () => {
+      createCalls++;
+      throw new Error("create should not run for ignored-always conflicts");
+    };
+
+    const review = await recordSyncConflictReview(input);
+
+    assert.equal((review as { id: string }).id, "ignored-review");
+    assert.equal(findFirstCalls, 1);
+    assert.equal(createCalls, 0);
+  } finally {
+    delegate.findFirst = originalFindFirst;
+    delegate.create = originalCreate;
+  }
+});
+
+test("resolveSyncConflictReview rejects already terminal reviews", async () => {
+  const tx = {
+    syncConflictReview: {
+      updateMany: async () => ({ count: 0 }),
+      findUnique: async () => ({ status: "ignored-always" }),
+    },
+    activityLog: {
+      create: async () => {
+        throw new Error("activity log should not be written for terminal reviews");
+      },
+    },
+  };
+  type TransactionStub = typeof tx;
+  const client = prisma as unknown as {
+    $transaction: <T>(fn: (tx: TransactionStub) => Promise<T>) => Promise<T>;
+  };
+  const originalTransaction = client.$transaction;
+
+  try {
+    client.$transaction = async (fn) => fn(tx);
+
+    await assert.rejects(
+      () =>
+        resolveSyncConflictReview({
+          id: "review-1",
+          action: "keep-noosphere",
+          resolvedBy: "Admin",
+        }),
+      SyncConflictReviewClosedError,
+    );
+  } finally {
+    client.$transaction = originalTransaction;
+  }
+});
+
+test("runObsidianSync keeps local markdown visible when conflict review persistence fails", async () => {
+  const vaultPath = `/tmp/noosphere-conflict-review-${Date.now()}-${process.pid}`;
+  const oldEnabled = process.env.OBSIDIAN_SYNC_ENABLED;
+  const oldVaultPath = process.env.OBSIDIAN_SYNC_VAULT_PATH;
+  const oldPreserve = process.env.OBSIDIAN_SYNC_PRESERVE_LOCAL_CHANGES;
+  const relativePath = "projects/noosphere-source.md";
+  const localMarkdown = "# Local-only markdown";
+
+  try {
+    process.env.OBSIDIAN_SYNC_ENABLED = "true";
+    process.env.OBSIDIAN_SYNC_VAULT_PATH = vaultPath;
+    process.env.OBSIDIAN_SYNC_PRESERVE_LOCAL_CHANGES = "true";
+
+    mkdirSync(join(vaultPath, "projects"), { recursive: true });
+    mkdirSync(join(vaultPath, ".noosphere-sync"), { recursive: true });
+    writeFileSync(join(vaultPath, relativePath), localMarkdown, "utf-8");
+    writeFileSync(
+      join(vaultPath, ".noosphere-sync", "manifest.json"),
+      JSON.stringify({
+        version: 1,
+        vaultPath,
+        lastRunAt: "2026-05-26T00:00:00.000Z",
+        articles: {
+          "article-1": {
+            path: relativePath,
+            updatedAt: "2026-05-26T09:00:00.000Z",
+            contentHash: "previous-noosphere-hash",
+            writtenHash: createHash("sha256").update("# Previous noosphere markdown").digest("hex"),
+            deletedAt: null,
+          },
+        },
+      }),
+      "utf-8",
+    );
+
+    const topic = { id: "topic-1", slug: "projects", parentId: null, name: "Projects" };
+    const syncArticle = {
+      ...article,
+      content: "# Noosphere markdown",
+      excerpt: null,
+      sourceUrl: null,
+      sourceType: null,
+      lastReviewed: null,
+      createdAt: new Date("2026-05-26T08:00:00.000Z"),
+      topicId: "topic-1",
+      topic,
+      tags: [],
+    };
+
+    const client = prisma as unknown as { $queryRaw: () => Promise<unknown> };
+    const originalQueryRaw = client.$queryRaw;
+    const originalTopicFindMany = prisma.topic.findMany;
+    const originalArticleFindMany = prisma.article.findMany;
+    const originalConflictFindFirst = prisma.syncConflictReview.findFirst;
+    const originalConflictCreate = prisma.syncConflictReview.create;
+    const originalActivityLogCreate = prisma.activityLog.create;
+    const originalConsoleError = console.error;
+
+    client.$queryRaw = async () => [{ acquire: true }];
+    prisma.topic.findMany = async () => [topic];
+    prisma.article.findMany = async () => [syncArticle];
+    prisma.syncConflictReview.findFirst = async () => null;
+    prisma.syncConflictReview.create = async () => {
+      throw new Error("database unavailable");
+    };
+    prisma.activityLog.create = async () => ({});
+    console.error = () => {};
+
+    try {
+      const result = await runObsidianSync({ mode: "full", clean: false, git: false, dryRun: false });
+
+      assert.equal(readFileSync(join(vaultPath, relativePath), "utf-8"), localMarkdown);
+      assert.equal(result.stats.skipped, 1);
+      assert.equal(result.stats.written, 0);
+      assert.equal(
+        result.warnings.some((warning) => warning.includes("Conflict review record failed; sync skipped")),
+        true,
+      );
+      assert.equal(existsSync(join(vaultPath, ".noosphere-sync", "conflicts")), true);
+    } finally {
+      client.$queryRaw = originalQueryRaw;
+      prisma.topic.findMany = originalTopicFindMany;
+      prisma.article.findMany = originalArticleFindMany;
+      prisma.syncConflictReview.findFirst = originalConflictFindFirst;
+      prisma.syncConflictReview.create = originalConflictCreate;
+      prisma.activityLog.create = originalActivityLogCreate;
+      console.error = originalConsoleError;
+    }
+  } finally {
+    if (oldEnabled === undefined) delete process.env.OBSIDIAN_SYNC_ENABLED;
+    else process.env.OBSIDIAN_SYNC_ENABLED = oldEnabled;
+    if (oldVaultPath === undefined) delete process.env.OBSIDIAN_SYNC_VAULT_PATH;
+    else process.env.OBSIDIAN_SYNC_VAULT_PATH = oldVaultPath;
+    if (oldPreserve === undefined) delete process.env.OBSIDIAN_SYNC_PRESERVE_LOCAL_CHANGES;
+    else process.env.OBSIDIAN_SYNC_PRESERVE_LOCAL_CHANGES = oldPreserve;
+    rmSync(vaultPath, { recursive: true, force: true });
+  }
 });
 
 test("resolveVaultArchivePath only allows archived conflict files", () => {

--- a/src/__tests__/api/sync-conflict-review.test.ts
+++ b/src/__tests__/api/sync-conflict-review.test.ts
@@ -65,7 +65,7 @@ test("buildSyncConflictReviewSummary extracts comparable metadata", () => {
 test("buildSyncConflictReviewCreateInput prepares vault-to-noosphere review rows", () => {
   const input = buildSyncConflictReviewCreateInput({
     article,
-    direction: "noosphere-to-vault",
+    direction: "vault-to-noosphere",
     relativePath: "projects/noosphere-source.md",
     archivePath: ".noosphere-sync/conflicts/2026-projects---noosphere-source.md",
     noosphereHash: "database-hash",
@@ -73,7 +73,7 @@ test("buildSyncConflictReviewCreateInput prepares vault-to-noosphere review rows
   });
 
   assert.equal(input.articleId, "article-1");
-  assert.equal(input.direction, "noosphere-to-vault");
+  assert.equal(input.direction, "vault-to-noosphere");
   assert.equal(input.relativePath, "projects/noosphere-source.md");
   assert.equal(input.summary.markdown.title, "Markdown Source");
   assert.equal(input.markdownUpdatedAt?.toISOString(), "2026-05-26T11:00:00.000Z");

--- a/src/__tests__/api/sync-conflict-review.test.ts
+++ b/src/__tests__/api/sync-conflict-review.test.ts
@@ -65,6 +65,7 @@ test("buildSyncConflictReviewSummary extracts comparable metadata", () => {
 test("buildSyncConflictReviewCreateInput prepares vault-to-noosphere review rows", () => {
   const input = buildSyncConflictReviewCreateInput({
     article,
+    direction: "noosphere-to-vault",
     relativePath: "projects/noosphere-source.md",
     archivePath: ".noosphere-sync/conflicts/2026-projects---noosphere-source.md",
     noosphereHash: "database-hash",
@@ -72,8 +73,7 @@ test("buildSyncConflictReviewCreateInput prepares vault-to-noosphere review rows
   });
 
   assert.equal(input.articleId, "article-1");
-  assert.equal(input.direction, "vault-to-noosphere");
-  assert.equal(input.status, undefined);
+  assert.equal(input.direction, "noosphere-to-vault");
   assert.equal(input.relativePath, "projects/noosphere-source.md");
   assert.equal(input.summary.markdown.title, "Markdown Source");
   assert.equal(input.markdownUpdatedAt?.toISOString(), "2026-05-26T11:00:00.000Z");

--- a/src/__tests__/api/sync-conflict-review.test.ts
+++ b/src/__tests__/api/sync-conflict-review.test.ts
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  buildSyncConflictReviewCreateInput,
+  buildSyncConflictReviewSummary,
+  isSyncConflictReviewAction,
+  resolveVaultArchivePath,
+  statusForSyncConflictReviewAction,
+} from "@/lib/markdown-sync/conflict-review";
+
+const article = {
+  id: "article-1",
+  title: "Noosphere Source",
+  slug: "noosphere-source",
+  updatedAt: new Date("2026-05-26T10:00:00.000Z"),
+  status: "published",
+  confidence: "high",
+  topic: { slug: "projects", name: "Projects" },
+  tags: [{ tag: { slug: "sync", name: "Sync" } }],
+};
+
+const markdown = `---
+title: Markdown Source
+slug: markdown-source
+topic: projects
+status: reviewed
+confidence: medium
+tags:
+  - sync
+  - local
+updatedAt: "2026-05-26T11:00:00.000Z"
+noosphere:
+  entity: article
+  schemaVersion: 1
+  syncedAt: "2026-05-26T11:30:00.000Z"
+---
+
+Local markdown copy.
+`;
+
+test("sync conflict review actions map to terminal statuses", () => {
+  assert.equal(isSyncConflictReviewAction("keep-noosphere"), true);
+  assert.equal(isSyncConflictReviewAction("keep-markdown"), true);
+  assert.equal(isSyncConflictReviewAction("delete-everything"), false);
+
+  assert.equal(statusForSyncConflictReviewAction("keep-noosphere"), "resolved");
+  assert.equal(statusForSyncConflictReviewAction("keep-markdown"), "resolved");
+  assert.equal(statusForSyncConflictReviewAction("mark-resolved"), "resolved");
+  assert.equal(statusForSyncConflictReviewAction("ignore-once"), "ignored-once");
+  assert.equal(statusForSyncConflictReviewAction("ignore-always"), "ignored-always");
+});
+
+test("buildSyncConflictReviewSummary extracts comparable metadata", () => {
+  const summary = buildSyncConflictReviewSummary(article, markdown, "database-hash");
+
+  assert.equal(summary.noosphere.title, "Noosphere Source");
+  assert.equal(summary.noosphere.contentHash, "database-hash");
+  assert.equal(summary.markdown.title, "Markdown Source");
+  assert.equal(summary.markdown.slug, "markdown-source");
+  assert.deepEqual(summary.markdown.tags, ["sync", "local"]);
+  assert.equal(summary.markdown.parseError, null);
+  assert.equal(typeof summary.markdown.contentHash, "string");
+});
+
+test("buildSyncConflictReviewCreateInput prepares vault-to-noosphere review rows", () => {
+  const input = buildSyncConflictReviewCreateInput({
+    article,
+    relativePath: "projects/noosphere-source.md",
+    archivePath: ".noosphere-sync/conflicts/2026-projects---noosphere-source.md",
+    noosphereHash: "database-hash",
+    markdownContent: markdown,
+  });
+
+  assert.equal(input.articleId, "article-1");
+  assert.equal(input.direction, "vault-to-noosphere");
+  assert.equal(input.status, undefined);
+  assert.equal(input.relativePath, "projects/noosphere-source.md");
+  assert.equal(input.summary.markdown.title, "Markdown Source");
+  assert.equal(input.markdownUpdatedAt?.toISOString(), "2026-05-26T11:00:00.000Z");
+});
+
+test("resolveVaultArchivePath only allows archived conflict files", () => {
+  const vaultPath = "/vault";
+
+  assert.equal(
+    resolveVaultArchivePath(vaultPath, ".noosphere-sync/conflicts/2026-file.md"),
+    "/vault/.noosphere-sync/conflicts/2026-file.md",
+  );
+  assert.equal(resolveVaultArchivePath(vaultPath, "../etc/passwd"), null);
+  assert.equal(resolveVaultArchivePath(vaultPath, ".noosphere-sync/manifest.json"), null);
+});

--- a/src/__tests__/obsidian-sync/index.test.ts
+++ b/src/__tests__/obsidian-sync/index.test.ts
@@ -21,6 +21,7 @@ import { spawn } from "child_process";
 // ─── Test helpers ────────────────────────────────────────────────────────────
 
 let testCounter = 0;
+let tempDirCounter = 0;
 function test(name: string, fn: () => void | Promise<void>): void {
   testCounter++;
   const label = `[${testCounter}] ${name}`;
@@ -55,7 +56,7 @@ function _rejects(promise: Promise<unknown>, msg = ""): Promise<void> {
 }
 
 async function withTempDir(fn: (dir: string) => void | Promise<void>): Promise<void> {
-  const dir = `/tmp/noosphere-sync-test-${Date.now()}`;
+  const dir = `/tmp/noosphere-sync-test-${Date.now()}-${process.pid}-${++tempDirCounter}`;
   mkdirSync(dir, { recursive: true });
   try {
     await fn(dir);

--- a/src/app/api/sync/conflicts/[id]/archive/route.ts
+++ b/src/app/api/sync/conflicts/[id]/archive/route.ts
@@ -1,0 +1,63 @@
+/**
+ * GET /api/sync/conflicts/:id/archive
+ *
+ * Serves archived local markdown copies for admin conflict review.
+ */
+
+export const dynamic = "force-dynamic";
+
+import { readFile } from "fs/promises";
+import { NextRequest, NextResponse } from "next/server";
+import { Permissions } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+import { requirePermission } from "@/lib/api/auth";
+import { getObsidianSyncConfig } from "@/lib/obsidian-sync/config";
+import { resolveVaultArchivePath } from "@/lib/markdown-sync/conflict-review";
+import { rateLimit } from "@/lib/rate-limit";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const rl = rateLimit(request, { windowMs: 60_000, maxRequests: 30, keyPrefix: "sync-conflict-archive-get" });
+  if (!rl.allowed) return rl.response;
+
+  const auth = await requirePermission(request, [Permissions.ADMIN]);
+  if (!auth.success) {
+    return auth.response;
+  }
+
+  const config = getObsidianSyncConfig();
+  if (!config) {
+    return NextResponse.json({ error: "Obsidian sync is not enabled" }, { status: 400 });
+  }
+
+  const { id } = await params;
+  const review = await prisma.syncConflictReview.findUnique({
+    where: { id },
+    select: { archivePath: true, relativePath: true },
+  });
+
+  if (!review) {
+    return NextResponse.json({ error: "Conflict not found" }, { status: 404 });
+  }
+
+  const absolutePath = resolveVaultArchivePath(config.vaultPath, review.archivePath);
+  if (!absolutePath) {
+    return NextResponse.json({ error: "Archived conflict path is invalid" }, { status: 404 });
+  }
+
+  try {
+    const content = await readFile(absolutePath, "utf-8");
+    const filename = (review.relativePath.split("/").pop() ?? "conflict.md").replace(/[^\w.-]/g, "_");
+    return new NextResponse(content, {
+      status: 200,
+      headers: {
+        "content-type": "text/markdown; charset=utf-8",
+        "content-disposition": `inline; filename="${filename.replace(/"/g, "")}"`,
+      },
+    });
+  } catch {
+    return NextResponse.json({ error: "Archived conflict file not found" }, { status: 404 });
+  }
+}

--- a/src/app/wiki/admin/log/page.tsx
+++ b/src/app/wiki/admin/log/page.tsx
@@ -17,6 +17,7 @@ const TYPE_COLORS: Record<string, string> = {
   update: "#f59e0b",
   delete: "#ef4444",
   lint: "#8b5cf6",
+  "sync-conflict": "#f97316",
 };
 
 function buildLogHref(type?: string, author?: string) {

--- a/src/app/wiki/admin/sync-conflicts/actions.ts
+++ b/src/app/wiki/admin/sync-conflicts/actions.ts
@@ -1,0 +1,44 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import {
+  isSyncConflictReviewAction,
+  type SyncConflictReviewAction,
+} from "@/lib/markdown-sync/conflict-review";
+import { resolveSyncConflictReview } from "@/lib/markdown-sync/api/conflict-review";
+
+async function requireAdminName() {
+  const session = await getServerSession(authOptions);
+
+  if (!session?.user || session.user.role !== "ADMIN") {
+    throw new Error("Admin access required.");
+  }
+
+  return session.user.name ?? session.user.email ?? "Admin";
+}
+
+export async function resolveSyncConflictAction(formData: FormData) {
+  const resolvedBy = await requireAdminName();
+  const id = formData.get("conflictId");
+  const action = formData.get("action");
+
+  if (typeof id !== "string" || !id) {
+    throw new Error("Missing conflict id.");
+  }
+
+  if (!isSyncConflictReviewAction(action)) {
+    throw new Error("Unsupported conflict action.");
+  }
+
+  await resolveSyncConflictReview({
+    id,
+    action: action as SyncConflictReviewAction,
+    resolvedBy,
+  });
+
+  revalidatePath("/wiki/admin/sync-conflicts");
+  redirect("/wiki/admin/sync-conflicts");
+}

--- a/src/app/wiki/admin/sync-conflicts/actions.ts
+++ b/src/app/wiki/admin/sync-conflicts/actions.ts
@@ -6,7 +6,9 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import {
   isSyncConflictReviewAction,
+  SYNC_CONFLICT_REVIEW_STATUSES,
   type SyncConflictReviewAction,
+  type SyncConflictReviewStatus,
 } from "@/lib/markdown-sync/conflict-review";
 import { resolveSyncConflictReview } from "@/lib/markdown-sync/api/conflict-review";
 
@@ -24,6 +26,7 @@ export async function resolveSyncConflictAction(formData: FormData) {
   const resolvedBy = await requireAdminName();
   const id = formData.get("conflictId");
   const action = formData.get("action");
+  const returnStatus = normalizeReturnStatus(formData.get("returnStatus"));
 
   if (typeof id !== "string" || !id) {
     throw new Error("Missing conflict id.");
@@ -40,5 +43,11 @@ export async function resolveSyncConflictAction(formData: FormData) {
   });
 
   revalidatePath("/wiki/admin/sync-conflicts");
-  redirect("/wiki/admin/sync-conflicts");
+  redirect(`/wiki/admin/sync-conflicts?status=${returnStatus}`);
+}
+
+function normalizeReturnStatus(value: FormDataEntryValue | null): SyncConflictReviewStatus {
+  return SYNC_CONFLICT_REVIEW_STATUSES.includes(value as SyncConflictReviewStatus)
+    ? (value as SyncConflictReviewStatus)
+    : "open";
 }

--- a/src/app/wiki/admin/sync-conflicts/page.tsx
+++ b/src/app/wiki/admin/sync-conflicts/page.tsx
@@ -184,11 +184,36 @@ export default async function SyncConflictsPage({
 
                 {review.status === "open" && (
                   <div className="sync-conflict-actions" aria-label="Resolve sync conflict">
-                    <ConflictActionButton label="Keep Noosphere" action="keep-noosphere" conflictId={review.id} />
-                    <ConflictActionButton label="Keep Markdown" action="keep-markdown" conflictId={review.id} />
-                    <ConflictActionButton label="Mark Resolved" action="mark-resolved" conflictId={review.id} />
-                    <ConflictActionButton label="Ignore Once" action="ignore-once" conflictId={review.id} />
-                    <ConflictActionButton label="Ignore Always" action="ignore-always" conflictId={review.id} />
+                    <ConflictActionButton
+                      label="Keep Noosphere"
+                      action="keep-noosphere"
+                      conflictId={review.id}
+                      returnStatus={status}
+                    />
+                    <ConflictActionButton
+                      label="Keep Markdown"
+                      action="keep-markdown"
+                      conflictId={review.id}
+                      returnStatus={status}
+                    />
+                    <ConflictActionButton
+                      label="Mark Resolved"
+                      action="mark-resolved"
+                      conflictId={review.id}
+                      returnStatus={status}
+                    />
+                    <ConflictActionButton
+                      label="Ignore Once"
+                      action="ignore-once"
+                      conflictId={review.id}
+                      returnStatus={status}
+                    />
+                    <ConflictActionButton
+                      label="Ignore Always"
+                      action="ignore-always"
+                      conflictId={review.id}
+                      returnStatus={status}
+                    />
                   </div>
                 )}
               </article>
@@ -220,15 +245,18 @@ function ConflictActionButton({
   label,
   action,
   conflictId,
+  returnStatus,
 }: {
   label: string;
   action: string;
   conflictId: string;
+  returnStatus: SyncConflictReviewStatus;
 }) {
   return (
     <form action={resolveSyncConflictAction}>
       <input type="hidden" name="conflictId" value={conflictId} />
       <input type="hidden" name="action" value={action} />
+      <input type="hidden" name="returnStatus" value={returnStatus} />
       <button className="btn btn-secondary btn-sm" type="submit">
         {label}
       </button>

--- a/src/app/wiki/admin/sync-conflicts/page.tsx
+++ b/src/app/wiki/admin/sync-conflicts/page.tsx
@@ -1,0 +1,237 @@
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { Breadcrumbs } from "@/components/wiki/Breadcrumbs";
+import { PageHeader } from "@/components/wiki/PageHeader";
+import { AdminNav } from "@/components/wiki/AdminNav";
+import { resolveSyncConflictAction } from "./actions";
+import { SYNC_CONFLICT_REVIEW_STATUSES, type SyncConflictReviewStatus } from "@/lib/markdown-sync/conflict-review";
+
+export const dynamic = "force-dynamic";
+
+export const metadata = {
+  title: "Sync Conflicts",
+  description: "Review archived markdown sync conflicts and record resolution decisions.",
+};
+
+const STATUS_LABELS: Record<SyncConflictReviewStatus, string> = {
+  open: "Open",
+  resolved: "Resolved",
+  "ignored-once": "Ignored Once",
+  "ignored-always": "Ignored Always",
+};
+
+function normalizeStatus(status: unknown): SyncConflictReviewStatus {
+  return SYNC_CONFLICT_REVIEW_STATUSES.includes(status as SyncConflictReviewStatus)
+    ? (status as SyncConflictReviewStatus)
+    : "open";
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
+}
+
+function stringValue(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value : null;
+}
+
+function tagList(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string" && item.trim() !== "") : [];
+}
+
+function formatDate(value: Date | string | null | undefined): string {
+  if (!value) return "—";
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.valueOf()) ? "—" : date.toLocaleString();
+}
+
+export default async function SyncConflictsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ status?: string }>;
+}) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user) {
+    redirect("/wiki/login");
+  }
+  if (session.user.role !== "ADMIN") {
+    redirect("/wiki");
+  }
+
+  const params = await searchParams;
+  const status = normalizeStatus(params.status);
+
+  const [reviews, counts] = await Promise.all([
+    prisma.syncConflictReview.findMany({
+      where: { status },
+      include: {
+        article: {
+          select: {
+            title: true,
+            slug: true,
+            topic: { select: { slug: true } },
+          },
+        },
+      },
+      orderBy: { createdAt: "desc" },
+      take: 100,
+    }),
+    prisma.syncConflictReview.groupBy({
+      by: ["status"],
+      _count: { status: true },
+    }),
+  ]);
+
+  const countByStatus = new Map(counts.map((item) => [item.status, item._count.status]));
+
+  return (
+    <div className="wiki-content" style={{ maxWidth: 1120 }}>
+      <Breadcrumbs
+        items={[
+          { label: "Noosphere", href: "/wiki" },
+          { label: "Admin" },
+          { label: "Sync Conflicts" },
+        ]}
+      />
+
+      <PageHeader
+        eyebrow="Admin Console"
+        title="Sync Conflicts"
+        description="Review archived markdown changes detected during sync and record the intended resolution."
+      />
+
+      <AdminNav current="sync-conflicts" />
+
+      <div className="activity-filter-bar" aria-label="Filter sync conflicts by status">
+        {SYNC_CONFLICT_REVIEW_STATUSES.map((item) => (
+          <Link
+            key={item}
+            href={`/wiki/admin/sync-conflicts?status=${item}`}
+            className={`filter-chip ${status === item ? "is-active" : ""}`}
+          >
+            {STATUS_LABELS[item]} <span className="filter-chip-count">({countByStatus.get(item) ?? 0})</span>
+          </Link>
+        ))}
+      </div>
+
+      {reviews.length === 0 ? (
+        <div className="empty-state activity-empty-state">
+          <h3>No {STATUS_LABELS[status].toLowerCase()} sync conflicts</h3>
+          <p>Conflicts will appear here when sync archives a locally modified markdown file.</p>
+        </div>
+      ) : (
+        <div className="sync-conflict-list">
+          {reviews.map((review) => {
+            const summary = asRecord(review.summary);
+            const noosphere = asRecord(summary.noosphere);
+            const markdown = asRecord(summary.markdown);
+            const articleHref = review.article
+              ? `/wiki/${[review.article.topic.slug, review.article.slug].join("/")}`
+              : null;
+
+            return (
+              <article key={review.id} className="admin-card sync-conflict-card">
+                <div className="sync-conflict-header">
+                  <div>
+                    <p className="page-eyebrow">{review.direction}</p>
+                    <h2 className="section-title">{review.relativePath}</h2>
+                    <div className="activity-meta">
+                      <span className="activity-type-badge">{review.status}</span>
+                      <time dateTime={review.createdAt.toISOString()}>{formatDate(review.createdAt)}</time>
+                      {articleHref && (
+                        <Link href={articleHref} className="activity-author-link">
+                          Open article
+                        </Link>
+                      )}
+                      <Link href={`/api/sync/conflicts/${review.id}/archive`} className="activity-author-link">
+                        Archived markdown
+                      </Link>
+                    </div>
+                  </div>
+                </div>
+
+                <div className="sync-conflict-diff-grid" aria-label="Conflict metadata comparison">
+                  <ConflictSide
+                    title="Noosphere"
+                    fields={[
+                      ["Title", stringValue(noosphere.title)],
+                      ["Slug", stringValue(noosphere.slug)],
+                      ["Topic", stringValue(noosphere.topic)],
+                      ["Updated", formatDate(stringValue(noosphere.updatedAt))],
+                      ["Status", stringValue(noosphere.status)],
+                      ["Confidence", stringValue(noosphere.confidence)],
+                      ["Tags", tagList(noosphere.tags).join(", ") || null],
+                      ["Hash", stringValue(noosphere.contentHash)],
+                    ]}
+                  />
+                  <ConflictSide
+                    title="Markdown"
+                    fields={[
+                      ["Title", stringValue(markdown.title)],
+                      ["Slug", stringValue(markdown.slug)],
+                      ["Topic", stringValue(markdown.topic)],
+                      ["Updated", formatDate(stringValue(markdown.updatedAt))],
+                      ["Status", stringValue(markdown.status)],
+                      ["Confidence", stringValue(markdown.confidence)],
+                      ["Tags", tagList(markdown.tags).join(", ") || null],
+                      ["Hash", stringValue(markdown.contentHash)],
+                      ["Parse", stringValue(markdown.parseError) ?? "OK"],
+                    ]}
+                  />
+                </div>
+
+                {review.status === "open" && (
+                  <div className="sync-conflict-actions" aria-label="Resolve sync conflict">
+                    <ConflictActionButton label="Keep Noosphere" action="keep-noosphere" conflictId={review.id} />
+                    <ConflictActionButton label="Keep Markdown" action="keep-markdown" conflictId={review.id} />
+                    <ConflictActionButton label="Mark Resolved" action="mark-resolved" conflictId={review.id} />
+                    <ConflictActionButton label="Ignore Once" action="ignore-once" conflictId={review.id} />
+                    <ConflictActionButton label="Ignore Always" action="ignore-always" conflictId={review.id} />
+                  </div>
+                )}
+              </article>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ConflictSide({ title, fields }: { title: string; fields: Array<[string, string | null]> }) {
+  return (
+    <section className="sync-conflict-side">
+      <h3>{title}</h3>
+      <dl>
+        {fields.map(([label, value]) => (
+          <div key={label} className="sync-conflict-field">
+            <dt>{label}</dt>
+            <dd>{value ?? "—"}</dd>
+          </div>
+        ))}
+      </dl>
+    </section>
+  );
+}
+
+function ConflictActionButton({
+  label,
+  action,
+  conflictId,
+}: {
+  label: string;
+  action: string;
+  conflictId: string;
+}) {
+  return (
+    <form action={resolveSyncConflictAction}>
+      <input type="hidden" name="conflictId" value={conflictId} />
+      <input type="hidden" name="action" value={action} />
+      <button className="btn btn-secondary btn-sm" type="submit">
+        {label}
+      </button>
+    </form>
+  );
+}

--- a/src/app/wiki/admin/sync-conflicts/page.tsx
+++ b/src/app/wiki/admin/sync-conflicts/page.tsx
@@ -183,38 +183,44 @@ export default async function SyncConflictsPage({
                 </div>
 
                 {review.status === "open" && (
-                  <div className="sync-conflict-actions" aria-label="Resolve sync conflict">
-                    <ConflictActionButton
-                      label="Keep Noosphere"
-                      action="keep-noosphere"
-                      conflictId={review.id}
-                      returnStatus={status}
-                    />
-                    <ConflictActionButton
-                      label="Keep Markdown"
-                      action="keep-markdown"
-                      conflictId={review.id}
-                      returnStatus={status}
-                    />
-                    <ConflictActionButton
-                      label="Mark Resolved"
-                      action="mark-resolved"
-                      conflictId={review.id}
-                      returnStatus={status}
-                    />
-                    <ConflictActionButton
-                      label="Ignore Once"
-                      action="ignore-once"
-                      conflictId={review.id}
-                      returnStatus={status}
-                    />
-                    <ConflictActionButton
-                      label="Ignore Always"
-                      action="ignore-always"
-                      conflictId={review.id}
-                      returnStatus={status}
-                    />
-                  </div>
+                  <>
+                    <p className="sync-conflict-decision-note">
+                      These actions record an audit decision only. They do not import markdown or rewrite vault
+                      files yet.
+                    </p>
+                    <div className="sync-conflict-actions" aria-label="Record sync conflict decision">
+                      <ConflictActionButton
+                        label="Record: Keep Noosphere"
+                        action="keep-noosphere"
+                        conflictId={review.id}
+                        returnStatus={status}
+                      />
+                      <ConflictActionButton
+                        label="Record: Keep Markdown"
+                        action="keep-markdown"
+                        conflictId={review.id}
+                        returnStatus={status}
+                      />
+                      <ConflictActionButton
+                        label="Record: Resolved"
+                        action="mark-resolved"
+                        conflictId={review.id}
+                        returnStatus={status}
+                      />
+                      <ConflictActionButton
+                        label="Ignore Once"
+                        action="ignore-once"
+                        conflictId={review.id}
+                        returnStatus={status}
+                      />
+                      <ConflictActionButton
+                        label="Ignore Always"
+                        action="ignore-always"
+                        conflictId={review.id}
+                        returnStatus={status}
+                      />
+                    </div>
+                  </>
                 )}
               </article>
             );

--- a/src/app/wiki/wiki.css
+++ b/src/app/wiki/wiki.css
@@ -1836,6 +1836,16 @@ h2.activity-title {
   padding-top: 0.25rem;
 }
 
+.sync-conflict-decision-note {
+  margin: 0;
+  padding: 0.7rem 0.85rem;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  background: var(--surface-muted);
+  color: var(--text-muted);
+  font-size: 0.88rem;
+}
+
 @media (max-width: 960px) {
   .wiki-header-top,
   .wiki-header-bottom,

--- a/src/app/wiki/wiki.css
+++ b/src/app/wiki/wiki.css
@@ -1763,6 +1763,79 @@ h2.activity-title {
   background: var(--surface-color);
 }
 
+.sync-conflict-list {
+  display: grid;
+  gap: 1rem;
+}
+
+.sync-conflict-card {
+  display: grid;
+  --activity-color: var(--accent-color);
+  gap: 1.15rem;
+}
+
+.sync-conflict-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+.sync-conflict-diff-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.sync-conflict-side {
+  min-width: 0;
+  padding: 1rem;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  background: var(--surface-inset);
+}
+
+.sync-conflict-side h3 {
+  margin: 0 0 0.85rem;
+  font-size: 0.95rem;
+}
+
+.sync-conflict-side dl {
+  display: grid;
+  gap: 0.65rem;
+  margin: 0;
+}
+
+.sync-conflict-field {
+  display: grid;
+  grid-template-columns: 7rem minmax(0, 1fr);
+  gap: 0.75rem;
+  align-items: baseline;
+}
+
+.sync-conflict-field dt {
+  color: var(--text-faint);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.sync-conflict-field dd {
+  min-width: 0;
+  margin: 0;
+  color: var(--text-muted);
+  overflow-wrap: anywhere;
+}
+
+.sync-conflict-actions {
+  display: flex;
+  gap: 0.55rem;
+  flex-wrap: wrap;
+  align-items: center;
+  padding-top: 0.25rem;
+}
+
 @media (max-width: 960px) {
   .wiki-header-top,
   .wiki-header-bottom,
@@ -1791,8 +1864,14 @@ h2.activity-title {
   .recent-updates-shell,
   .article-detail-grid,
   .topic-tree-card,
-  .topic-subtopic-card {
+  .topic-subtopic-card,
+  .sync-conflict-diff-grid {
     grid-template-columns: 1fr;
+  }
+
+  .sync-conflict-field {
+    grid-template-columns: 1fr;
+    gap: 0.2rem;
   }
 
   .secret-box-row,

--- a/src/components/wiki/AdminNav.tsx
+++ b/src/components/wiki/AdminNav.tsx
@@ -6,6 +6,7 @@ const NAV_ITEMS = [
   { href: "/wiki/admin/topics", label: "Topics", key: "topics" },
   { href: "/wiki/admin/tags", label: "Tags", key: "tags" },
   { href: "/wiki/admin/settings", label: "Recall Settings", key: "settings" },
+  { href: "/wiki/admin/sync-conflicts", label: "Sync Conflicts", key: "sync-conflicts" },
   { href: "/wiki/admin/trash", label: "Trash", key: "trash" },
 ];
 

--- a/src/lib/markdown-sync/api/conflict-review.ts
+++ b/src/lib/markdown-sync/api/conflict-review.ts
@@ -15,6 +15,8 @@ import {
 
 export async function recordSyncConflictReview(input: SyncConflictReviewCreateInput) {
   const now = new Date();
+  const ignored = await findIgnoredAlwaysSyncConflictReview(input);
+  if (ignored) return ignored;
 
   try {
     return await prisma.syncConflictReview.create({
@@ -47,6 +49,22 @@ export async function recordSyncConflictReview(input: SyncConflictReviewCreateIn
   }
 }
 
+export async function findIgnoredAlwaysSyncConflictReview(input: Pick<
+  SyncConflictReviewCreateInput,
+  "articleId" | "direction" | "relativePath" | "markdownHash"
+>) {
+  return prisma.syncConflictReview.findFirst({
+    where: {
+      articleId: input.articleId,
+      direction: input.direction,
+      relativePath: input.relativePath,
+      markdownHash: input.markdownHash,
+      status: "ignored-always",
+    },
+    orderBy: [{ resolvedAt: "desc" }, { createdAt: "desc" }],
+  });
+}
+
 export async function resolveSyncConflictReview(args: {
   id: string;
   action: SyncConflictReviewAction;
@@ -56,14 +74,29 @@ export async function resolveSyncConflictReview(args: {
   const resolvedAt = new Date();
 
   return prisma.$transaction(async (tx) => {
-    const review = await tx.syncConflictReview.update({
-      where: { id: args.id },
+    const update = await tx.syncConflictReview.updateMany({
+      where: { id: args.id, status: "open" },
       data: {
         status,
         resolution: args.action,
         resolvedAt,
         resolvedBy: args.resolvedBy,
       },
+    });
+
+    if (update.count === 0) {
+      const existing = await tx.syncConflictReview.findUnique({
+        where: { id: args.id },
+        select: { status: true },
+      });
+      if (existing) {
+        throw new SyncConflictReviewClosedError(existing.status);
+      }
+      throw new SyncConflictReviewNotFoundError(args.id);
+    }
+
+    const review = await tx.syncConflictReview.findUniqueOrThrow({
+      where: { id: args.id },
     });
 
     await tx.activityLog.create({
@@ -83,6 +116,20 @@ export async function resolveSyncConflictReview(args: {
 
     return review;
   });
+}
+
+export class SyncConflictReviewClosedError extends Error {
+  constructor(status: string) {
+    super(`Sync conflict review is already ${status}.`);
+    this.name = "SyncConflictReviewClosedError";
+  }
+}
+
+export class SyncConflictReviewNotFoundError extends Error {
+  constructor(id: string) {
+    super(`Sync conflict review not found: ${id}`);
+    this.name = "SyncConflictReviewNotFoundError";
+  }
 }
 
 function isPrismaUniqueConstraintError(error: unknown): boolean {

--- a/src/lib/markdown-sync/api/conflict-review.ts
+++ b/src/lib/markdown-sync/api/conflict-review.ts
@@ -16,36 +16,35 @@ import {
 export async function recordSyncConflictReview(input: SyncConflictReviewCreateInput) {
   const now = new Date();
 
-  return prisma.syncConflictReview.upsert({
-    where: { archivePath: input.archivePath },
-    update: {
-      articleId: input.articleId,
-      direction: input.direction,
-      status: "open",
-      resolution: null,
-      relativePath: input.relativePath,
-      noosphereHash: input.noosphereHash,
-      markdownHash: input.markdownHash,
-      noosphereUpdatedAt: input.noosphereUpdatedAt,
-      markdownUpdatedAt: input.markdownUpdatedAt,
-      summary: input.summary as unknown as Prisma.InputJsonValue,
-      resolvedAt: null,
-      resolvedBy: null,
-      updatedAt: now,
-    },
-    create: {
-      articleId: input.articleId,
-      direction: input.direction,
-      relativePath: input.relativePath,
-      archivePath: input.archivePath,
-      noosphereHash: input.noosphereHash,
-      markdownHash: input.markdownHash,
-      noosphereUpdatedAt: input.noosphereUpdatedAt,
-      markdownUpdatedAt: input.markdownUpdatedAt,
-      summary: input.summary as unknown as Prisma.InputJsonValue,
-      updatedAt: now,
-    },
-  });
+  try {
+    return await prisma.syncConflictReview.create({
+      data: {
+        articleId: input.articleId,
+        direction: input.direction,
+        relativePath: input.relativePath,
+        archivePath: input.archivePath,
+        noosphereHash: input.noosphereHash,
+        markdownHash: input.markdownHash,
+        noosphereUpdatedAt: input.noosphereUpdatedAt,
+        markdownUpdatedAt: input.markdownUpdatedAt,
+        summary: input.summary as unknown as Prisma.InputJsonValue,
+        updatedAt: now,
+      },
+    });
+  } catch (error) {
+    if (!isPrismaUniqueConstraintError(error)) {
+      throw error;
+    }
+
+    // Archive paths include a timestamp, so a duplicate should be rare. If it
+    // does happen, preserve the existing review state rather than reopening a
+    // conflict that an admin may already have resolved.
+    const existing = await prisma.syncConflictReview.findUnique({
+      where: { archivePath: input.archivePath },
+    });
+    if (existing) return existing;
+    throw error;
+  }
 }
 
 export async function resolveSyncConflictReview(args: {
@@ -56,30 +55,41 @@ export async function resolveSyncConflictReview(args: {
   const status = statusForSyncConflictReviewAction(args.action);
   const resolvedAt = new Date();
 
-  const review = await prisma.syncConflictReview.update({
-    where: { id: args.id },
-    data: {
-      status,
-      resolution: args.action,
-      resolvedAt,
-      resolvedBy: args.resolvedBy,
-    },
-  });
-
-  await prisma.activityLog.create({
-    data: {
-      type: "sync-conflict",
-      title: `Sync conflict ${status} — ${review.relativePath}`,
-      authorName: args.resolvedBy,
-      details: {
-        conflictId: review.id,
-        action: args.action,
+  return prisma.$transaction(async (tx) => {
+    const review = await tx.syncConflictReview.update({
+      where: { id: args.id },
+      data: {
         status,
-        archivePath: review.archivePath,
-        articleId: review.articleId,
+        resolution: args.action,
+        resolvedAt,
+        resolvedBy: args.resolvedBy,
       },
-    },
-  });
+    });
 
-  return review;
+    await tx.activityLog.create({
+      data: {
+        type: "sync-conflict",
+        title: `Sync conflict ${status} — ${review.relativePath}`,
+        authorName: args.resolvedBy,
+        details: {
+          conflictId: review.id,
+          action: args.action,
+          status,
+          archivePath: review.archivePath,
+          articleId: review.articleId,
+        },
+      },
+    });
+
+    return review;
+  });
+}
+
+function isPrismaUniqueConstraintError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error as { code?: unknown }).code === "P2002"
+  );
 }

--- a/src/lib/markdown-sync/api/conflict-review.ts
+++ b/src/lib/markdown-sync/api/conflict-review.ts
@@ -1,0 +1,85 @@
+/**
+ * Sync conflict review persistence helpers.
+ *
+ * These helpers intentionally record review decisions without applying markdown
+ * back into Noosphere yet. Reverse scan/import/apply is handled by later phases.
+ */
+
+import { Prisma } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+import {
+  statusForSyncConflictReviewAction,
+  type SyncConflictReviewAction,
+  type SyncConflictReviewCreateInput,
+} from "@/lib/markdown-sync/conflict-review";
+
+export async function recordSyncConflictReview(input: SyncConflictReviewCreateInput) {
+  const now = new Date();
+
+  return prisma.syncConflictReview.upsert({
+    where: { archivePath: input.archivePath },
+    update: {
+      articleId: input.articleId,
+      direction: input.direction,
+      status: "open",
+      resolution: null,
+      relativePath: input.relativePath,
+      noosphereHash: input.noosphereHash,
+      markdownHash: input.markdownHash,
+      noosphereUpdatedAt: input.noosphereUpdatedAt,
+      markdownUpdatedAt: input.markdownUpdatedAt,
+      summary: input.summary as unknown as Prisma.InputJsonValue,
+      resolvedAt: null,
+      resolvedBy: null,
+      updatedAt: now,
+    },
+    create: {
+      articleId: input.articleId,
+      direction: input.direction,
+      relativePath: input.relativePath,
+      archivePath: input.archivePath,
+      noosphereHash: input.noosphereHash,
+      markdownHash: input.markdownHash,
+      noosphereUpdatedAt: input.noosphereUpdatedAt,
+      markdownUpdatedAt: input.markdownUpdatedAt,
+      summary: input.summary as unknown as Prisma.InputJsonValue,
+      updatedAt: now,
+    },
+  });
+}
+
+export async function resolveSyncConflictReview(args: {
+  id: string;
+  action: SyncConflictReviewAction;
+  resolvedBy: string;
+}) {
+  const status = statusForSyncConflictReviewAction(args.action);
+  const resolvedAt = new Date();
+
+  const review = await prisma.syncConflictReview.update({
+    where: { id: args.id },
+    data: {
+      status,
+      resolution: args.action,
+      resolvedAt,
+      resolvedBy: args.resolvedBy,
+    },
+  });
+
+  await prisma.activityLog.create({
+    data: {
+      type: "sync-conflict",
+      title: `Sync conflict ${status} — ${review.relativePath}`,
+      authorName: args.resolvedBy,
+      details: {
+        conflictId: review.id,
+        action: args.action,
+        status,
+        archivePath: review.archivePath,
+        articleId: review.articleId,
+      },
+    },
+  });
+
+  return review;
+}

--- a/src/lib/markdown-sync/conflict-review.ts
+++ b/src/lib/markdown-sync/conflict-review.ts
@@ -126,6 +126,7 @@ export function buildSyncConflictReviewSummary(
 
 export function buildSyncConflictReviewCreateInput(args: {
   article: SyncConflictReviewArticleInput;
+  direction: "noosphere-to-vault" | "vault-to-noosphere";
   relativePath: string;
   archivePath: string;
   noosphereHash: string | null;
@@ -136,7 +137,7 @@ export function buildSyncConflictReviewCreateInput(args: {
 
   return {
     articleId: args.article.id,
-    direction: "vault-to-noosphere",
+    direction: args.direction,
     relativePath: args.relativePath,
     archivePath: args.archivePath,
     noosphereHash: args.noosphereHash,

--- a/src/lib/markdown-sync/conflict-review.ts
+++ b/src/lib/markdown-sync/conflict-review.ts
@@ -1,0 +1,177 @@
+import { createHash } from "crypto";
+import { resolve } from "path";
+import { parseNoosphereMarkdown, readMarkdownString, readMarkdownStringArray } from "@/lib/markdown/noosphere-markdown";
+
+export const SYNC_CONFLICT_REVIEW_STATUSES = ["open", "resolved", "ignored-once", "ignored-always"] as const;
+export type SyncConflictReviewStatus = (typeof SYNC_CONFLICT_REVIEW_STATUSES)[number];
+
+export const SYNC_CONFLICT_REVIEW_ACTIONS = [
+  "keep-noosphere",
+  "keep-markdown",
+  "mark-resolved",
+  "ignore-once",
+  "ignore-always",
+] as const;
+export type SyncConflictReviewAction = (typeof SYNC_CONFLICT_REVIEW_ACTIONS)[number];
+
+export interface SyncConflictReviewArticleInput {
+  id: string;
+  title: string;
+  slug: string;
+  updatedAt: Date;
+  status: string;
+  confidence: string | null;
+  topic: { slug: string; name: string };
+  tags?: Array<{ tag: { slug: string; name: string } }>;
+}
+
+export interface SyncConflictReviewSummary {
+  noosphere: {
+    title: string;
+    slug: string;
+    topic: string;
+    updatedAt: string;
+    status: string;
+    confidence: string | null;
+    tags: string[];
+    contentHash: string | null;
+  };
+  markdown: {
+    title: string | null;
+    slug: string | null;
+    topic: string | null;
+    updatedAt: string | null;
+    status: string | null;
+    confidence: string | null;
+    tags: string[];
+    contentHash: string;
+    parseError: string | null;
+  };
+}
+
+export interface SyncConflictReviewCreateInput {
+  articleId: string;
+  direction: "noosphere-to-vault" | "vault-to-noosphere";
+  relativePath: string;
+  archivePath: string;
+  noosphereHash: string | null;
+  markdownHash: string;
+  noosphereUpdatedAt: Date | null;
+  markdownUpdatedAt: Date | null;
+  summary: SyncConflictReviewSummary;
+}
+
+export function isSyncConflictReviewAction(value: unknown): value is SyncConflictReviewAction {
+  return typeof value === "string" && SYNC_CONFLICT_REVIEW_ACTIONS.includes(value as SyncConflictReviewAction);
+}
+
+export function statusForSyncConflictReviewAction(action: SyncConflictReviewAction): SyncConflictReviewStatus {
+  switch (action) {
+    case "ignore-once":
+      return "ignored-once";
+    case "ignore-always":
+      return "ignored-always";
+    default:
+      return "resolved";
+  }
+}
+
+export function hashMarkdownContent(content: string | Buffer): string {
+  return createHash("sha256").update(content).digest("hex");
+}
+
+export function buildSyncConflictReviewSummary(
+  article: SyncConflictReviewArticleInput,
+  markdownContent: string,
+  noosphereHash: string | null,
+): SyncConflictReviewSummary {
+  const parsed = parseNoosphereMarkdown(markdownContent);
+  const markdownHash = hashMarkdownContent(markdownContent);
+
+  if (!parsed.ok) {
+    return {
+      noosphere: noosphereSummary(article, noosphereHash),
+      markdown: {
+        title: null,
+        slug: null,
+        topic: null,
+        updatedAt: null,
+        status: null,
+        confidence: null,
+        tags: [],
+        contentHash: markdownHash,
+        parseError: parsed.error,
+      },
+    };
+  }
+
+  const frontmatter = parsed.markdown.frontmatter;
+  const updatedAt = readMarkdownString(frontmatter, "updatedAt") ?? readNoosphereSyncedAt(frontmatter);
+
+  return {
+    noosphere: noosphereSummary(article, noosphereHash),
+    markdown: {
+      title: readMarkdownString(frontmatter, "title") ?? null,
+      slug: readMarkdownString(frontmatter, "slug") ?? null,
+      topic: readMarkdownString(frontmatter, "topic") ?? null,
+      updatedAt: updatedAt ?? null,
+      status: readMarkdownString(frontmatter, "status") ?? null,
+      confidence: readMarkdownString(frontmatter, "confidence") ?? null,
+      tags: readMarkdownStringArray(frontmatter, "tags"),
+      contentHash: markdownHash,
+      parseError: null,
+    },
+  };
+}
+
+export function buildSyncConflictReviewCreateInput(args: {
+  article: SyncConflictReviewArticleInput;
+  relativePath: string;
+  archivePath: string;
+  noosphereHash: string | null;
+  markdownContent: string;
+}): SyncConflictReviewCreateInput {
+  const summary = buildSyncConflictReviewSummary(args.article, args.markdownContent, args.noosphereHash);
+  const markdownUpdatedAt = summary.markdown.updatedAt ? new Date(summary.markdown.updatedAt) : null;
+
+  return {
+    articleId: args.article.id,
+    direction: "vault-to-noosphere",
+    relativePath: args.relativePath,
+    archivePath: args.archivePath,
+    noosphereHash: args.noosphereHash,
+    markdownHash: summary.markdown.contentHash,
+    noosphereUpdatedAt: args.article.updatedAt,
+    markdownUpdatedAt: markdownUpdatedAt && !Number.isNaN(markdownUpdatedAt.valueOf()) ? markdownUpdatedAt : null,
+    summary,
+  };
+}
+
+export function resolveVaultArchivePath(vaultPath: string, archivePath: string): string | null {
+  const normalizedVault = vaultPath.replace(/[/\\]+$/, "");
+  const conflictRoot = resolve(normalizedVault, ".noosphere-sync", "conflicts").replace(/\\/g, "/");
+  const absolutePath = resolve(normalizedVault, archivePath).replace(/\\/g, "/");
+
+  if (!absolutePath.startsWith(`${conflictRoot}/`)) return null;
+  return absolutePath;
+}
+
+function noosphereSummary(article: SyncConflictReviewArticleInput, contentHash: string | null) {
+  return {
+    title: article.title,
+    slug: article.slug,
+    topic: article.topic.slug,
+    updatedAt: article.updatedAt.toISOString(),
+    status: article.status,
+    confidence: article.confidence,
+    tags: article.tags?.map((item) => item.tag.slug) ?? [],
+    contentHash,
+  };
+}
+
+function readNoosphereSyncedAt(frontmatter: Record<string, unknown>): string | undefined {
+  const noosphere = frontmatter["noosphere"];
+  if (!noosphere || typeof noosphere !== "object" || Array.isArray(noosphere)) return undefined;
+  const syncedAt = (noosphere as Record<string, unknown>)["syncedAt"];
+  return typeof syncedAt === "string" && syncedAt.trim() ? syncedAt.trim() : undefined;
+}

--- a/src/lib/obsidian-sync/index.ts
+++ b/src/lib/obsidian-sync/index.ts
@@ -581,6 +581,7 @@ export async function runObsidianSync(options: SyncOptions): Promise<SyncResult>
                   await recordSyncConflictReview(
                     buildSyncConflictReviewCreateInput({
                       article,
+                      direction: "noosphere-to-vault",
                       relativePath,
                       archivePath: backupRel,
                       noosphereHash: canonicalHash,

--- a/src/lib/obsidian-sync/index.ts
+++ b/src/lib/obsidian-sync/index.ts
@@ -18,6 +18,8 @@ import {
   renderNoosphereMarkdown,
   type NoosphereMarkdownArticle,
 } from "@/lib/markdown/noosphere-markdown";
+import { buildSyncConflictReviewCreateInput } from "@/lib/markdown-sync/conflict-review";
+import { recordSyncConflictReview } from "@/lib/markdown-sync/api/conflict-review";
 
 // ─────────────────────────────────────────────
 // Types
@@ -573,7 +575,22 @@ export async function runObsidianSync(options: SyncOptions): Promise<SyncResult>
               // File on disk differs from what we last wrote — genuine local modification.
               stats.conflictsDetected++;
               if (config.preserveLocalChanges) {
-                const backupRel = archiveConflict(vaultPath, relativePath, diskBuffer.toString("utf-8"));
+                const diskContent = diskBuffer.toString("utf-8");
+                const backupRel = archiveConflict(vaultPath, relativePath, diskContent);
+                try {
+                  await recordSyncConflictReview(
+                    buildSyncConflictReviewCreateInput({
+                      article,
+                      relativePath,
+                      archivePath: backupRel,
+                      noosphereHash: canonicalHash,
+                      markdownContent: diskContent,
+                    })
+                  );
+                } catch (error) {
+                  warnings.push(`Conflict review record failed: ${relativePath}`);
+                  console.error("[obsidian-sync] Failed to record conflict review", error);
+                }
                 warnings.push(`Local modification preserved: ${relativePath} → ${backupRel}`);
               } else {
                 warnings.push(`Local modification overwritten by database: ${relativePath}`);

--- a/src/lib/obsidian-sync/index.ts
+++ b/src/lib/obsidian-sync/index.ts
@@ -18,8 +18,14 @@ import {
   renderNoosphereMarkdown,
   type NoosphereMarkdownArticle,
 } from "@/lib/markdown/noosphere-markdown";
-import { buildSyncConflictReviewCreateInput } from "@/lib/markdown-sync/conflict-review";
-import { recordSyncConflictReview } from "@/lib/markdown-sync/api/conflict-review";
+import {
+  buildSyncConflictReviewCreateInput,
+  hashMarkdownContent,
+} from "@/lib/markdown-sync/conflict-review";
+import {
+  findIgnoredAlwaysSyncConflictReview,
+  recordSyncConflictReview,
+} from "@/lib/markdown-sync/api/conflict-review";
 
 // ─────────────────────────────────────────────
 // Types
@@ -567,8 +573,14 @@ export async function runObsidianSync(options: SyncOptions): Promise<SyncResult>
         // sentinel fallback and must be treated as invalid so we archive before
         // rewriting rather than silently blessing the current disk state.
         if (existsSync(safe) && existingEntry) {
+          let diskBuffer: Buffer | null = null;
           try {
-            const diskBuffer = readFileSync(safe);
+            diskBuffer = readFileSync(safe);
+          } catch {
+            // File deleted or unreadable between existsSync and readFileSync —
+            // skip conflict detection and proceed to write (re-creating the file).
+          }
+          if (diskBuffer) {
             const diskHash = createHash("sha256").update(diskBuffer).digest("hex");
             const baseline = existingEntry.writtenHash ?? diskHash;
             if (diskHash !== baseline) {
@@ -576,30 +588,43 @@ export async function runObsidianSync(options: SyncOptions): Promise<SyncResult>
               stats.conflictsDetected++;
               if (config.preserveLocalChanges) {
                 const diskContent = diskBuffer.toString("utf-8");
-                const backupRel = archiveConflict(vaultPath, relativePath, diskContent);
-                try {
-                  await recordSyncConflictReview(
-                    buildSyncConflictReviewCreateInput({
-                      article,
-                      direction: "vault-to-noosphere",
-                      relativePath,
-                      archivePath: backupRel,
-                      noosphereHash: canonicalHash,
-                      markdownContent: diskContent,
-                    })
-                  );
-                } catch (error) {
-                  warnings.push(`Conflict review record failed: ${relativePath}`);
-                  console.error("[obsidian-sync] Failed to record conflict review", error);
+                const ignoredReview = await findIgnoredAlwaysSyncConflictReview({
+                  articleId: article.id,
+                  direction: "vault-to-noosphere",
+                  relativePath,
+                  markdownHash: hashMarkdownContent(diskContent),
+                });
+                if (ignoredReview) {
+                  warnings.push(`Local modification ignored by prior decision: ${relativePath}`);
+                } else {
+                  const backupRel = archiveConflict(vaultPath, relativePath, diskContent);
+                  try {
+                    const review = await recordSyncConflictReview(
+                      buildSyncConflictReviewCreateInput({
+                        article,
+                        direction: "vault-to-noosphere",
+                        relativePath,
+                        archivePath: backupRel,
+                        noosphereHash: canonicalHash,
+                        markdownContent: diskContent,
+                      })
+                    );
+                    if (review.status === "ignored-always") {
+                      warnings.push(`Local modification ignored by prior decision: ${relativePath}`);
+                    } else {
+                      warnings.push(`Local modification preserved: ${relativePath} → ${backupRel}`);
+                    }
+                  } catch (error) {
+                    warnings.push(`Conflict review record failed; sync skipped for ${relativePath}`);
+                    console.error("[obsidian-sync] Failed to record conflict review", error);
+                    stats.skipped++;
+                    continue;
+                  }
                 }
-                warnings.push(`Local modification preserved: ${relativePath} → ${backupRel}`);
               } else {
                 warnings.push(`Local modification overwritten by database: ${relativePath}`);
               }
             }
-          } catch {
-            // File deleted or unreadable between existsSync and readFileSync —
-            // skip conflict detection and proceed to write (re-creating the file).
           }
         }
 

--- a/src/lib/obsidian-sync/index.ts
+++ b/src/lib/obsidian-sync/index.ts
@@ -581,7 +581,7 @@ export async function runObsidianSync(options: SyncOptions): Promise<SyncResult>
                   await recordSyncConflictReview(
                     buildSyncConflictReviewCreateInput({
                       article,
-                      direction: "noosphere-to-vault",
+                      direction: "vault-to-noosphere",
                       relativePath,
                       archivePath: backupRel,
                       noosphereHash: canonicalHash,


### PR DESCRIPTION
## Summary
- add a persisted SyncConflictReview queue for archived markdown sync conflicts
- record review entries when Obsidian sync preserves a locally modified markdown file
- add /wiki/admin/sync-conflicts with status filters, metadata comparison, archive links, and resolution actions
- add admin-only archive download route and activity-log entries for conflict decisions
- make the existing Obsidian sync test temp dirs unique so git helper tests are reliable

## Review follow-up
- preserve the current status filter after conflict resolution actions
- avoid reopening an existing archive-path review if a duplicate archive path is encountered
- wrap conflict status updates and audit-log creation in one Prisma transaction
- pass sync conflict direction explicitly instead of hardcoding it
- remove the undeclared-field assertion from the helper test

## Verification
- node --import tsx --test src/__tests__/api/sync-conflict-review.test.ts src/__tests__/api/sync-conflict-preferences.test.ts (13/13)
- DATABASE_URL=<docker-network noosphere> npm run test:api (70/70)
- node --import tsx --test src/__tests__/obsidian-sync/index.test.ts (25 sync checks)
- npm run lint (0 errors, 3 pre-existing warnings)
- DATABASE_URL=<local noosphere> npm run build (passes with existing Obsidian/Turbopack warning)

## Notes
- This PR intentionally records keep-markdown/keep-noosphere/ignore decisions only. Reverse markdown import and apply behavior remain later roadmap phases.
- Do not merge until Sophie explicitly approves after review/comments.