### PR TITLE
feat: add reverse markdown import scanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Frontpage | Logging
 - **Scoped API keys** — assign per-key allowed scopes (e.g. `financial`, `health`) that control access to restricted articles.
 - **Restricted articles** — tag articles with scopes to restrict access; unauthenticated web users and scoped API keys see only allowed content.
 - **Sync/export** content for Obsidian and Markdown workflows.
+- **Reverse Markdown scan** — inspect vault-side Markdown edits before later import/apply phases.
 - **Images Support** you can add images to articles
 
 ## Getting Started
@@ -279,11 +280,20 @@ GET /api/export
 # Import from a Markdown vault zip
 POST /api/import
 # multipart form fields: file, defaultTopicSlug?, overwrite?
+
+# Scan the configured Obsidian vault for reverse-import candidates.
+# Read-only; requires ADMIN.
+POST /api/sync/import-scan
+# JSON body: includeUntracked?, maxFiles?
 ```
 
 Export, import, and Obsidian sync share the same versioned frontmatter codec in
 `src/lib/markdown/noosphere-markdown.ts`, including `noosphere.schemaVersion`,
 `noosphere.contentHash`, topic metadata, tags, and restricted scopes.
+The reverse import scanner compares tracked vault files against
+`.noosphere-sync/manifest.json` and reports `modified`, `missing`,
+`baseline-missing`, and `untracked` candidates without writing to the database
+or filesystem.
 
 ## Memory Module API
 

--- a/docs/OBSIDIAN-SYNC-SPEC.md
+++ b/docs/OBSIDIAN-SYNC-SPEC.md
@@ -16,7 +16,8 @@ Add a one-way "shadow sync" that writes Noosphere articles to a local Obsidian-c
 
 ### Non-goals
 1. No bidirectional sync.
-2. No importing edits from Obsidian back into the database.
+2. No applying edits from Obsidian back into the database during shadow sync.
+   Reverse-import work starts with a separate read-only scanner.
 3. No real-time file watching in v1.
 4. No per-file conflict resolution UI in v1.
 5. No support for multiple output formats beyond markdown in v1.
@@ -651,6 +652,31 @@ To keep implementation practical, v1 should ship with these defaults:
 3. Soft-deleted articles removed from mirror
 4. Local edits overwritten, optionally backed up
 5. Git commit optional and best-effort
-6. No reverse import from Obsidian
+6. No automatic reverse import from Obsidian during shadow sync
 
 This gives a robust one-way shadow vault without turning Noosphere into a bidirectional sync engine.
+
+## 10. Reverse Markdown Import Scanner
+
+The first reverse-import phase is intentionally read-only. `POST
+/api/sync/import-scan` inspects the configured Obsidian vault and returns
+candidate Markdown files for later review/apply phases.
+
+Scanner behavior:
+
+1. Load `.noosphere-sync/manifest.json` when present.
+2. Compare tracked files against `writtenHash`, the exact bytes Noosphere last
+   wrote to disk.
+3. Report tracked files as:
+   - `modified` when the current vault hash differs from `writtenHash`
+   - `missing` when the manifest path no longer exists
+   - `baseline-missing` when an old manifest entry lacks `writtenHash`
+4. Optionally include `untracked` `.md` files outside `.noosphere-sync/` and
+   `.git/`.
+5. Parse Noosphere frontmatter with the shared codec and return safe metadata
+   plus parse errors.
+6. Never write vault files, DB records, manifests, review rows, or activity log
+   entries.
+
+This gives agents and admins a deterministic inventory of possible vault-side
+changes before later phases implement apply/reconciliation behavior.

--- a/src/__tests__/api/markdown-import-scanner.test.ts
+++ b/src/__tests__/api/markdown-import-scanner.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import test from "node:test";
 import {
@@ -193,8 +193,76 @@ test("scanMarkdownImportCandidates enforces maxFiles for tracked manifest entrie
   });
 });
 
+test("scanMarkdownImportCandidates does not count tracked paths against untracked walk", () => {
+  withVault((vaultPath) => {
+    const content = markdown({ id: "one", title: "One" }, "One");
+    writeFileSync(join(vaultPath, "projects/one.md"), content, "utf-8");
+    writeManifest(vaultPath, {
+      one: {
+        path: "projects/one.md",
+        updatedAt: "2026-05-27T10:00:00.000Z",
+        contentHash: "one-db-hash",
+        writtenHash: sha256(content),
+        deletedAt: null,
+      },
+    });
+
+    const result = scanMarkdownImportCandidates({
+      vaultPath,
+      manifestPath,
+      includeUntracked: true,
+      maxFiles: 1,
+    });
+
+    assert.equal(result.stats.unchanged, 1);
+    assert.equal(result.candidates.length, 0);
+  });
+});
+
+test("scanMarkdownImportCandidates rejects malformed manifest article maps", () => {
+  withVault((vaultPath) => {
+    writeFileSync(
+      join(vaultPath, manifestPath),
+      JSON.stringify({
+        version: 1,
+        vaultPath,
+        lastRunAt: "2026-05-27T10:00:00.000Z",
+        articles: [],
+      }),
+      "utf-8",
+    );
+
+    const result = scanMarkdownImportCandidates({ vaultPath, manifestPath, includeUntracked: false });
+
+    assert.equal(result.manifest.present, false);
+    assert.equal(result.warnings.some((warning) => warning.includes("Unsupported manifest format")), true);
+  });
+});
+
+test("scanMarkdownImportCandidates rejects tracked symlink targets", () => {
+  withVault((vaultPath) => {
+    symlinkSync("/etc/passwd", join(vaultPath, "projects/link.md"));
+    writeManifest(vaultPath, {
+      link: {
+        path: "projects/link.md",
+        updatedAt: "2026-05-27T10:00:00.000Z",
+        contentHash: "link-db-hash",
+        writtenHash: sha256("old"),
+        deletedAt: null,
+      },
+    });
+
+    const result = scanMarkdownImportCandidates({ vaultPath, manifestPath, includeUntracked: false });
+
+    assert.equal(result.stats.modified, 1);
+    assert.equal(result.candidates[0].markdownHash, null);
+    assert.match(result.candidates[0].parseError ?? "", /symlink|vault root/);
+  });
+});
+
 test("markdown import scan request validation rejects malformed input", () => {
   assert.deepEqual(validateMarkdownImportScanContentLength(null, 10), { ok: true });
+  assert.deepEqual(validateMarkdownImportScanContentLength(" 10 ", 10), { ok: true });
   assert.deepEqual(validateMarkdownImportScanContentLength("abc", 10), {
     ok: false,
     status: 400,

--- a/src/__tests__/api/markdown-import-scanner.test.ts
+++ b/src/__tests__/api/markdown-import-scanner.test.ts
@@ -1,0 +1,236 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import test from "node:test";
+import {
+  MARKDOWN_IMPORT_SCAN_PERMISSIONS,
+  MarkdownImportScanLimitError,
+  scanMarkdownImportCandidates,
+  validateMarkdownImportScanContentLength,
+  validateMarkdownImportScanRequestBody,
+} from "@/lib/markdown-sync/import-scanner";
+
+const manifestPath = ".noosphere-sync/manifest.json";
+
+test("markdown import scan API policy is admin-only", () => {
+  assert.deepEqual(MARKDOWN_IMPORT_SCAN_PERMISSIONS, ["ADMIN"]);
+});
+
+test("scanMarkdownImportCandidates reports modified managed markdown with parsed metadata", () => {
+  withVault((vaultPath) => {
+    const relativePath = "projects/noosphere-source.md";
+    const previous = markdown({ id: "article-1", title: "Previous", slug: "noosphere-source" }, "Old body");
+    const current = markdown({ id: "article-1", title: "Edited", slug: "noosphere-source" }, "Edited body");
+    writeFileSync(join(vaultPath, relativePath), current, "utf-8");
+    writeManifest(vaultPath, {
+      "article-1": {
+        path: relativePath,
+        updatedAt: "2026-05-27T10:00:00.000Z",
+        contentHash: "canonical-db-hash",
+        writtenHash: sha256(previous),
+        deletedAt: null,
+      },
+    });
+
+    const result = scanMarkdownImportCandidates({
+      vaultPath,
+      manifestPath,
+      includeUntracked: false,
+    });
+
+    assert.equal(result.manifest.present, true);
+    assert.equal(result.stats.tracked, 1);
+    assert.equal(result.stats.modified, 1);
+    assert.equal(result.stats.unchanged, 0);
+    assert.equal(result.candidates.length, 1);
+    assert.equal(result.candidates[0].kind, "modified");
+    assert.equal(result.candidates[0].articleId, "article-1");
+    assert.equal(result.candidates[0].metadata?.title, "Edited");
+    assert.equal(result.candidates[0].metadata?.noosphere.schemaVersion, 1);
+  });
+});
+
+test("scanMarkdownImportCandidates omits unchanged managed markdown", () => {
+  withVault((vaultPath) => {
+    const relativePath = "projects/noosphere-source.md";
+    const content = markdown({ id: "article-1", title: "Noosphere Source", slug: "noosphere-source" }, "Body");
+    writeFileSync(join(vaultPath, relativePath), content, "utf-8");
+    writeManifest(vaultPath, {
+      "article-1": {
+        path: relativePath,
+        updatedAt: "2026-05-27T10:00:00.000Z",
+        contentHash: "canonical-db-hash",
+        writtenHash: sha256(content),
+        deletedAt: null,
+      },
+    });
+
+    const result = scanMarkdownImportCandidates({
+      vaultPath,
+      manifestPath,
+      includeUntracked: false,
+    });
+
+    assert.equal(result.stats.unchanged, 1);
+    assert.equal(result.stats.modified, 0);
+    assert.equal(result.candidates.length, 0);
+  });
+});
+
+test("scanMarkdownImportCandidates reports missing and baseline-missing tracked entries", () => {
+  withVault((vaultPath) => {
+    const baselineMissingPath = "projects/baseline-missing.md";
+    const content = markdown({ id: "article-2", title: "Baseline Missing", slug: "baseline-missing" }, "Body");
+    writeFileSync(join(vaultPath, baselineMissingPath), content, "utf-8");
+    writeManifest(vaultPath, {
+      "article-1": {
+        path: "projects/missing.md",
+        updatedAt: "2026-05-27T10:00:00.000Z",
+        contentHash: "canonical-db-hash",
+        writtenHash: sha256("missing-old-content"),
+        deletedAt: null,
+      },
+      "article-2": {
+        path: baselineMissingPath,
+        updatedAt: "2026-05-27T10:00:00.000Z",
+        contentHash: "canonical-db-hash",
+        deletedAt: null,
+      },
+    });
+
+    const result = scanMarkdownImportCandidates({
+      vaultPath,
+      manifestPath,
+      includeUntracked: false,
+    });
+
+    assert.equal(result.stats.missing, 1);
+    assert.equal(result.stats.baselineMissing, 1);
+    assert.deepEqual(result.candidates.map((candidate) => candidate.kind).sort(), ["baseline-missing", "missing"]);
+  });
+});
+
+test("scanMarkdownImportCandidates reports untracked markdown and ignores internal files", () => {
+  withVault((vaultPath) => {
+    writeFileSync(
+      join(vaultPath, "inbox/untracked.md"),
+      markdown({ title: "Untracked", slug: "untracked" }, "Body"),
+      "utf-8",
+    );
+    mkdirSync(join(vaultPath, ".noosphere-sync/conflicts"), { recursive: true });
+    writeFileSync(join(vaultPath, ".noosphere-sync/conflicts/internal.md"), "# Internal", "utf-8");
+    writeManifest(vaultPath, {});
+
+    const result = scanMarkdownImportCandidates({
+      vaultPath,
+      manifestPath,
+      includeUntracked: true,
+    });
+
+    assert.equal(result.stats.untracked, 1);
+    assert.equal(result.candidates.length, 1);
+    assert.equal(result.candidates[0].relativePath, "inbox/untracked.md");
+    assert.equal(result.candidates[0].metadata?.title, "Untracked");
+  });
+});
+
+test("scanMarkdownImportCandidates captures parse errors without aborting scan", () => {
+  withVault((vaultPath) => {
+    writeFileSync(join(vaultPath, "bad.md"), "# Missing frontmatter", "utf-8");
+    writeManifest(vaultPath, {});
+
+    const result = scanMarkdownImportCandidates({
+      vaultPath,
+      manifestPath,
+      includeUntracked: true,
+    });
+
+    assert.equal(result.stats.parseErrors, 1);
+    assert.equal(result.candidates[0].parseError, "No YAML frontmatter found");
+  });
+});
+
+test("scanMarkdownImportCandidates enforces maxFiles", () => {
+  withVault((vaultPath) => {
+    writeFileSync(join(vaultPath, "one.md"), markdown({ title: "One" }, "One"), "utf-8");
+    writeFileSync(join(vaultPath, "two.md"), markdown({ title: "Two" }, "Two"), "utf-8");
+    writeManifest(vaultPath, {});
+
+    assert.throws(
+      () => scanMarkdownImportCandidates({ vaultPath, manifestPath, includeUntracked: true, maxFiles: 1 }),
+      MarkdownImportScanLimitError,
+    );
+  });
+});
+
+test("markdown import scan request validation rejects malformed input", () => {
+  assert.deepEqual(validateMarkdownImportScanContentLength(null, 10), { ok: true });
+  assert.deepEqual(validateMarkdownImportScanContentLength("abc", 10), {
+    ok: false,
+    status: 400,
+    error: "Invalid content-length header",
+  });
+  assert.deepEqual(validateMarkdownImportScanContentLength("11", 10), {
+    ok: false,
+    status: 413,
+    error: "Request body too large. Maximum size is 10 bytes.",
+  });
+  assert.deepEqual(validateMarkdownImportScanRequestBody([]), { errors: ["Body must be a JSON object"] });
+  assert.deepEqual(validateMarkdownImportScanRequestBody({ includeUntracked: "yes" }), {
+    errors: ["includeUntracked must be a boolean"],
+  });
+});
+
+function withVault(run: (vaultPath: string) => void) {
+  const vaultPath = `/tmp/noosphere-import-scan-${Date.now()}-${process.pid}-${Math.random().toString(36).slice(2)}`;
+  try {
+    mkdirSync(join(vaultPath, "projects"), { recursive: true });
+    mkdirSync(join(vaultPath, "inbox"), { recursive: true });
+    mkdirSync(join(vaultPath, ".noosphere-sync"), { recursive: true });
+    run(vaultPath);
+  } finally {
+    rmSync(vaultPath, { recursive: true, force: true });
+  }
+}
+
+function writeManifest(vaultPath: string, articles: Record<string, object>) {
+  writeFileSync(
+    join(vaultPath, manifestPath),
+    JSON.stringify({
+      version: 1,
+      vaultPath,
+      lastRunAt: "2026-05-27T10:00:00.000Z",
+      articles,
+    }),
+    "utf-8",
+  );
+}
+
+function markdown(frontmatter: Record<string, unknown>, body: string): string {
+  const lines = [
+    "---",
+    `id: ${frontmatter["id"] ?? ""}`,
+    `slug: ${frontmatter["slug"] ?? "sample"}`,
+    `title: ${frontmatter["title"]}`,
+    "topic: projects",
+    "topicPath:",
+    "  - projects",
+    "tags:",
+    "  - sync",
+    "updatedAt: \"2026-05-27T10:00:00.000Z\"",
+    "noosphere:",
+    "  entity: article",
+    "  schemaVersion: 1",
+    "  syncedAt: \"2026-05-27T10:01:00.000Z\"",
+    "  sourceOfTruth: database",
+    "---",
+    "",
+    body,
+  ];
+  return lines.join("\n");
+}
+
+function sha256(content: string): string {
+  return createHash("sha256").update(content).digest("hex");
+}

--- a/src/__tests__/api/markdown-import-scanner.test.ts
+++ b/src/__tests__/api/markdown-import-scanner.test.ts
@@ -7,6 +7,7 @@ import {
   MARKDOWN_IMPORT_SCAN_PERMISSIONS,
   MarkdownImportScanLimitError,
   scanMarkdownImportCandidates,
+  validateMarkdownImportScanBodyText,
   validateMarkdownImportScanContentLength,
   validateMarkdownImportScanRequestBody,
 } from "@/lib/markdown-sync/import-scanner";
@@ -164,6 +165,34 @@ test("scanMarkdownImportCandidates enforces maxFiles", () => {
   });
 });
 
+test("scanMarkdownImportCandidates enforces maxFiles for tracked manifest entries", () => {
+  withVault((vaultPath) => {
+    writeFileSync(join(vaultPath, "projects/one.md"), markdown({ id: "one", title: "One" }, "One"), "utf-8");
+    writeFileSync(join(vaultPath, "projects/two.md"), markdown({ id: "two", title: "Two" }, "Two"), "utf-8");
+    writeManifest(vaultPath, {
+      one: {
+        path: "projects/one.md",
+        updatedAt: "2026-05-27T10:00:00.000Z",
+        contentHash: "one-db-hash",
+        writtenHash: sha256("one-old"),
+        deletedAt: null,
+      },
+      two: {
+        path: "projects/two.md",
+        updatedAt: "2026-05-27T10:00:00.000Z",
+        contentHash: "two-db-hash",
+        writtenHash: sha256("two-old"),
+        deletedAt: null,
+      },
+    });
+
+    assert.throws(
+      () => scanMarkdownImportCandidates({ vaultPath, manifestPath, includeUntracked: false, maxFiles: 1 }),
+      MarkdownImportScanLimitError,
+    );
+  });
+});
+
 test("markdown import scan request validation rejects malformed input", () => {
   assert.deepEqual(validateMarkdownImportScanContentLength(null, 10), { ok: true });
   assert.deepEqual(validateMarkdownImportScanContentLength("abc", 10), {
@@ -172,6 +201,11 @@ test("markdown import scan request validation rejects malformed input", () => {
     error: "Invalid content-length header",
   });
   assert.deepEqual(validateMarkdownImportScanContentLength("11", 10), {
+    ok: false,
+    status: 413,
+    error: "Request body too large. Maximum size is 10 bytes.",
+  });
+  assert.deepEqual(validateMarkdownImportScanBodyText("12345678901", 10), {
     ok: false,
     status: 413,
     error: "Request body too large. Maximum size is 10 bytes.",

--- a/src/app/api/sync/import-scan/route.ts
+++ b/src/app/api/sync/import-scan/route.ts
@@ -12,9 +12,9 @@ import { Permissions } from "@prisma/client";
 import { requirePermission } from "@/lib/api/auth";
 import { getObsidianSyncConfig } from "@/lib/obsidian-sync/config";
 import {
-  MARKDOWN_IMPORT_SCAN_MAX_BODY_BYTES,
   MarkdownImportScanLimitError,
   scanMarkdownImportCandidates,
+  validateMarkdownImportScanBodyText,
   validateMarkdownImportScanContentLength,
   validateMarkdownImportScanRequestBody,
 } from "@/lib/markdown-sync/import-scanner";
@@ -29,7 +29,16 @@ export async function POST(request: NextRequest) {
     return auth.response;
   }
 
-  const config = getObsidianSyncConfig();
+  let config;
+  try {
+    config = getObsidianSyncConfig();
+  } catch (err) {
+    return NextResponse.json(
+      { error: `Configuration error: ${(err as Error).message}` },
+      { status: 400 },
+    );
+  }
+
   if (!config) {
     return NextResponse.json({ error: "Obsidian sync is not enabled" }, { status: 400 });
   }
@@ -43,11 +52,9 @@ export async function POST(request: NextRequest) {
   try {
     const bodyText = await request.text();
     if (bodyText.trim()) {
-      if (new TextEncoder().encode(bodyText).byteLength > MARKDOWN_IMPORT_SCAN_MAX_BODY_BYTES) {
-        return NextResponse.json(
-          { error: `Request body too large. Maximum size is ${MARKDOWN_IMPORT_SCAN_MAX_BODY_BYTES} bytes.` },
-          { status: 413 },
-        );
+      const bodyTextValidation = validateMarkdownImportScanBodyText(bodyText);
+      if (!bodyTextValidation.ok) {
+        return NextResponse.json({ error: bodyTextValidation.error }, { status: bodyTextValidation.status });
       }
       body = JSON.parse(bodyText);
     }

--- a/src/app/api/sync/import-scan/route.ts
+++ b/src/app/api/sync/import-scan/route.ts
@@ -8,11 +8,11 @@
 export const dynamic = "force-dynamic";
 
 import { NextRequest, NextResponse } from "next/server";
-import { Permissions } from "@prisma/client";
 import { requirePermission } from "@/lib/api/auth";
 import { getObsidianSyncConfig } from "@/lib/obsidian-sync/config";
 import {
   MarkdownImportScanLimitError,
+  MARKDOWN_IMPORT_SCAN_PERMISSIONS,
   scanMarkdownImportCandidates,
   validateMarkdownImportScanBodyText,
   validateMarkdownImportScanContentLength,
@@ -24,7 +24,7 @@ export async function POST(request: NextRequest) {
   const rl = rateLimit(request, { windowMs: 60_000, maxRequests: 20, keyPrefix: "sync-import-scan-post" });
   if (!rl.allowed) return rl.response;
 
-  const auth = await requirePermission(request, [Permissions.ADMIN]);
+  const auth = await requirePermission(request, [...MARKDOWN_IMPORT_SCAN_PERMISSIONS]);
   if (!auth.success) {
     return auth.response;
   }

--- a/src/app/api/sync/import-scan/route.ts
+++ b/src/app/api/sync/import-scan/route.ts
@@ -1,0 +1,78 @@
+/**
+ * POST /api/sync/import-scan
+ *
+ * Read-only reverse markdown import scanner. It reports vault-side markdown
+ * candidates for later import/apply phases without changing DB or files.
+ */
+
+export const dynamic = "force-dynamic";
+
+import { NextRequest, NextResponse } from "next/server";
+import { Permissions } from "@prisma/client";
+import { requirePermission } from "@/lib/api/auth";
+import { getObsidianSyncConfig } from "@/lib/obsidian-sync/config";
+import {
+  MARKDOWN_IMPORT_SCAN_MAX_BODY_BYTES,
+  MarkdownImportScanLimitError,
+  scanMarkdownImportCandidates,
+  validateMarkdownImportScanContentLength,
+  validateMarkdownImportScanRequestBody,
+} from "@/lib/markdown-sync/import-scanner";
+import { rateLimit } from "@/lib/rate-limit";
+
+export async function POST(request: NextRequest) {
+  const rl = rateLimit(request, { windowMs: 60_000, maxRequests: 20, keyPrefix: "sync-import-scan-post" });
+  if (!rl.allowed) return rl.response;
+
+  const auth = await requirePermission(request, [Permissions.ADMIN]);
+  if (!auth.success) {
+    return auth.response;
+  }
+
+  const config = getObsidianSyncConfig();
+  if (!config) {
+    return NextResponse.json({ error: "Obsidian sync is not enabled" }, { status: 400 });
+  }
+
+  const contentLengthValidation = validateMarkdownImportScanContentLength(request.headers.get("content-length"));
+  if (!contentLengthValidation.ok) {
+    return NextResponse.json({ error: contentLengthValidation.error }, { status: contentLengthValidation.status });
+  }
+
+  let body: unknown = {};
+  try {
+    const bodyText = await request.text();
+    if (bodyText.trim()) {
+      if (new TextEncoder().encode(bodyText).byteLength > MARKDOWN_IMPORT_SCAN_MAX_BODY_BYTES) {
+        return NextResponse.json(
+          { error: `Request body too large. Maximum size is ${MARKDOWN_IMPORT_SCAN_MAX_BODY_BYTES} bytes.` },
+          { status: 413 },
+        );
+      }
+      body = JSON.parse(bodyText);
+    }
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const validation = validateMarkdownImportScanRequestBody(body);
+  if ("errors" in validation) {
+    return NextResponse.json({ error: validation.errors.join("; ") }, { status: 400 });
+  }
+
+  try {
+    const result = scanMarkdownImportCandidates({
+      vaultPath: config.vaultPath,
+      manifestPath: config.manifestPath,
+      includeUntracked: validation.includeUntracked,
+      maxFiles: validation.maxFiles,
+    });
+    return NextResponse.json(result, { status: 200 });
+  } catch (error) {
+    if (error instanceof MarkdownImportScanLimitError) {
+      return NextResponse.json({ error: error.message }, { status: 413 });
+    }
+    console.error("[POST /api/sync/import-scan]", error);
+    return NextResponse.json({ error: "Failed to scan markdown import candidates" }, { status: 503 });
+  }
+}

--- a/src/lib/markdown-sync/import-scanner.ts
+++ b/src/lib/markdown-sync/import-scanner.ts
@@ -6,8 +6,9 @@
  */
 
 import { createHash } from "crypto";
-import { existsSync, readdirSync, readFileSync } from "fs";
+import { existsSync, lstatSync, readdirSync, readFileSync, realpathSync } from "fs";
 import { join, relative, resolve } from "path";
+import { Permissions } from "@prisma/client";
 import {
   parseNoosphereMarkdown,
   readMarkdownString,
@@ -17,7 +18,7 @@ import type { Manifest, ManifestEntry } from "@/lib/obsidian-sync";
 
 export const MARKDOWN_IMPORT_SCAN_MAX_BODY_BYTES = 32 * 1024;
 export const MARKDOWN_IMPORT_SCAN_DEFAULT_MAX_FILES = 5_000;
-export const MARKDOWN_IMPORT_SCAN_PERMISSIONS = ["ADMIN"] as const;
+export const MARKDOWN_IMPORT_SCAN_PERMISSIONS = [Permissions.ADMIN] as const;
 
 export type MarkdownImportCandidateKind =
   | "modified"
@@ -110,11 +111,12 @@ export function validateMarkdownImportScanContentLength(
   maxBytes = MARKDOWN_IMPORT_SCAN_MAX_BODY_BYTES,
 ): MarkdownImportScanBodyValidationResult {
   if (headerValue === null) return { ok: true };
-  if (!/^\d+$/.test(headerValue)) {
+  const normalized = headerValue.trim();
+  if (!/^\d+$/.test(normalized)) {
     return { ok: false, status: 400, error: "Invalid content-length header" };
   }
 
-  const length = Number(headerValue);
+  const length = Number(normalized);
   if (!Number.isSafeInteger(length)) {
     return { ok: false, status: 400, error: "Invalid content-length header" };
   }
@@ -210,9 +212,11 @@ export function scanMarkdownImportCandidates(options: MarkdownImportScanOptions)
   }
 
   if (includeUntracked) {
-    const markdownPaths = listMarkdownFiles(options.vaultPath, maxFiles, warnings);
+    const remainingFileBudget = maxFiles - trackedEntries.length;
+    const markdownPaths = remainingFileBudget > 0
+      ? listMarkdownFiles(options.vaultPath, remainingFileBudget, warnings, trackedPaths)
+      : [];
     for (const relativePath of markdownPaths) {
-      if (trackedPaths.has(relativePath)) continue;
       const absolutePath = resolveVaultPath(options.vaultPath, relativePath);
       if (!absolutePath) {
         warnings.push(`Path traversal rejected during scan: ${relativePath}`);
@@ -222,7 +226,7 @@ export function scanMarkdownImportCandidates(options: MarkdownImportScanOptions)
 
       let loaded: LoadedMarkdown;
       try {
-        loaded = loadMarkdownFile(absolutePath);
+        loaded = loadMarkdownFile(options.vaultPath, relativePath);
       } catch (error) {
         warnings.push(`Failed to read untracked file ${relativePath}: ${errorMessage(error)}`);
         stats.skipped++;
@@ -277,7 +281,7 @@ function scanTrackedEntry(
       relativePath,
       articleId,
       manifestPath: relativePath,
-      baselineHash: entry.writtenHash ?? entry.contentHash ?? null,
+      baselineHash: entry.writtenHash ?? null,
       markdownHash: null,
       sizeBytes: null,
       metadata: null,
@@ -302,7 +306,7 @@ function scanTrackedEntry(
 
   let loaded: LoadedMarkdown;
   try {
-    loaded = loadMarkdownFile(absolutePath);
+    loaded = loadMarkdownFile(vaultPath, relativePath);
   } catch (error) {
     return {
       kind: baselineHash ? "modified" : "baseline-missing",
@@ -357,7 +361,7 @@ function readManifest(vaultPath: string, manifestPath: string, warnings: string[
 
   try {
     const parsed = JSON.parse(readFileSync(absolutePath, "utf-8")) as Manifest;
-    if (parsed.version !== 1 || !parsed.articles || typeof parsed.articles !== "object") {
+    if (parsed.version !== 1 || !isManifestArticles(parsed.articles)) {
       warnings.push(`Unsupported manifest format: ${manifestPath}`);
       return null;
     }
@@ -368,7 +372,11 @@ function readManifest(vaultPath: string, manifestPath: string, warnings: string[
   }
 }
 
-function loadMarkdownFile(absolutePath: string): LoadedMarkdown {
+function loadMarkdownFile(vaultPath: string, relativePath: string): LoadedMarkdown {
+  const absolutePath = resolveExistingVaultFilePath(vaultPath, relativePath);
+  if (!absolutePath) {
+    throw new Error("File path escapes vault root, is a symlink, or is not a regular file");
+  }
   const content = readFileSync(absolutePath, "utf-8");
   const parsed = parseNoosphereMarkdown(content);
   const markdownHash = hashMarkdownContent(content);
@@ -411,7 +419,12 @@ function extractMetadata(frontmatter: Record<string, unknown>): MarkdownImportMe
   };
 }
 
-function listMarkdownFiles(vaultPath: string, maxFiles: number, warnings: string[]): string[] {
+function listMarkdownFiles(
+  vaultPath: string,
+  maxFiles: number,
+  warnings: string[],
+  ignoredPaths: Set<string>,
+): string[] {
   if (!existsSync(vaultPath)) return [];
 
   const root = resolve(vaultPath);
@@ -443,6 +456,7 @@ function listMarkdownFiles(vaultPath: string, maxFiles: number, warnings: string
       }
 
       if (!entry.isFile() || !entry.name.toLowerCase().endsWith(".md")) continue;
+      if (ignoredPaths.has(relativePath)) continue;
 
       files.push(relativePath);
       if (files.length > maxFiles) {
@@ -465,6 +479,20 @@ function resolveVaultPath(vaultPath: string, relativePath: string): string | nul
   const root = resolve(vaultPath).replace(/[/\\]+$/, "").replace(/\\/g, "/");
   const absolutePath = resolve(vaultPath, relativePath).replace(/\\/g, "/");
   if (!absolutePath.startsWith(`${root}/`)) return null;
+  return absolutePath;
+}
+
+function resolveExistingVaultFilePath(vaultPath: string, relativePath: string): string | null {
+  const absolutePath = resolveVaultPath(vaultPath, relativePath);
+  if (!absolutePath) return null;
+
+  const stat = lstatSync(absolutePath);
+  if (stat.isSymbolicLink() || !stat.isFile()) return null;
+
+  const root = realpathSync(vaultPath).replace(/[/\\]+$/, "").replace(/\\/g, "/");
+  const realPath = realpathSync(absolutePath).replace(/\\/g, "/");
+  if (!realPath.startsWith(`${root}/`)) return null;
+
   return absolutePath;
 }
 
@@ -491,6 +519,20 @@ function readNestedString(record: Record<string, unknown>, key: string): string 
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isManifestArticles(value: unknown): value is Record<string, ManifestEntry> {
+  if (!isPlainObject(value)) return false;
+  return Object.values(value).every((entry) => {
+    if (!isPlainObject(entry)) return false;
+    return (
+      typeof entry["path"] === "string" &&
+      typeof entry["updatedAt"] === "string" &&
+      typeof entry["contentHash"] === "string" &&
+      (entry["writtenHash"] === undefined || typeof entry["writtenHash"] === "string") &&
+      (entry["deletedAt"] === null || typeof entry["deletedAt"] === "string")
+    );
+  });
 }
 
 function errorMessage(error: unknown): string {

--- a/src/lib/markdown-sync/import-scanner.ts
+++ b/src/lib/markdown-sync/import-scanner.ts
@@ -6,7 +6,7 @@
  */
 
 import { createHash } from "crypto";
-import { existsSync, readdirSync, readFileSync, statSync } from "fs";
+import { existsSync, readdirSync, readFileSync } from "fs";
 import { join, relative, resolve } from "path";
 import {
   parseNoosphereMarkdown,
@@ -126,6 +126,17 @@ export function validateMarkdownImportScanContentLength(
   return { ok: true };
 }
 
+export function validateMarkdownImportScanBodyText(
+  bodyText: string,
+  maxBytes = MARKDOWN_IMPORT_SCAN_MAX_BODY_BYTES,
+): MarkdownImportScanBodyValidationResult {
+  if (Buffer.byteLength(bodyText, "utf-8") > maxBytes) {
+    return { ok: false, status: 413, error: `Request body too large. Maximum size is ${maxBytes} bytes.` };
+  }
+
+  return { ok: true };
+}
+
 export function validateMarkdownImportScanRequestBody(body: unknown): {
   includeUntracked: boolean;
   maxFiles: number;
@@ -182,6 +193,10 @@ export function scanMarkdownImportCandidates(options: MarkdownImportScanOptions)
     durationMs: 0,
   };
 
+  if (trackedEntries.length > maxFiles) {
+    throw new MarkdownImportScanLimitError(maxFiles);
+  }
+
   for (const [articleId, entry] of trackedEntries) {
     trackedPaths.add(normalizeRelativePath(entry.path));
     const candidate = scanTrackedEntry(options.vaultPath, articleId, entry, warnings);
@@ -195,7 +210,7 @@ export function scanMarkdownImportCandidates(options: MarkdownImportScanOptions)
   }
 
   if (includeUntracked) {
-    const markdownPaths = listMarkdownFiles(options.vaultPath, maxFiles);
+    const markdownPaths = listMarkdownFiles(options.vaultPath, maxFiles, warnings);
     for (const relativePath of markdownPaths) {
       if (trackedPaths.has(relativePath)) continue;
       const absolutePath = resolveVaultPath(options.vaultPath, relativePath);
@@ -205,7 +220,15 @@ export function scanMarkdownImportCandidates(options: MarkdownImportScanOptions)
         continue;
       }
 
-      const loaded = loadMarkdownFile(absolutePath);
+      let loaded: LoadedMarkdown;
+      try {
+        loaded = loadMarkdownFile(absolutePath);
+      } catch (error) {
+        warnings.push(`Failed to read untracked file ${relativePath}: ${errorMessage(error)}`);
+        stats.skipped++;
+        continue;
+      }
+
       const candidate: MarkdownImportCandidate = {
         kind: "untracked",
         relativePath,
@@ -277,7 +300,23 @@ function scanTrackedEntry(
     };
   }
 
-  const loaded = loadMarkdownFile(absolutePath);
+  let loaded: LoadedMarkdown;
+  try {
+    loaded = loadMarkdownFile(absolutePath);
+  } catch (error) {
+    return {
+      kind: baselineHash ? "modified" : "baseline-missing",
+      relativePath,
+      articleId,
+      manifestPath: relativePath,
+      baselineHash,
+      markdownHash: null,
+      sizeBytes: null,
+      metadata: null,
+      parseError: `Failed to read file: ${errorMessage(error)}`,
+    };
+  }
+
   if (!baselineHash) {
     return {
       kind: "baseline-missing",
@@ -372,7 +411,7 @@ function extractMetadata(frontmatter: Record<string, unknown>): MarkdownImportMe
   };
 }
 
-function listMarkdownFiles(vaultPath: string, maxFiles: number): string[] {
+function listMarkdownFiles(vaultPath: string, maxFiles: number, warnings: string[]): string[] {
   if (!existsSync(vaultPath)) return [];
 
   const root = resolve(vaultPath);
@@ -381,8 +420,15 @@ function listMarkdownFiles(vaultPath: string, maxFiles: number): string[] {
   return files.sort();
 
   function walk(directory: string) {
-    const entries = readdirSync(directory, { withFileTypes: true })
-      .sort((a, b) => a.name.localeCompare(b.name));
+    let entries;
+    try {
+      entries = readdirSync(directory, { withFileTypes: true });
+    } catch (error) {
+      warnings.push(`Failed to read directory ${directory}: ${errorMessage(error)}`);
+      return;
+    }
+
+    entries.sort((a, b) => a.name.localeCompare(b.name));
 
     for (const entry of entries) {
       const absolutePath = join(directory, entry.name);
@@ -397,7 +443,6 @@ function listMarkdownFiles(vaultPath: string, maxFiles: number): string[] {
       }
 
       if (!entry.isFile() || !entry.name.toLowerCase().endsWith(".md")) continue;
-      if (!safeListedPath(root, absolutePath)) continue;
 
       files.push(relativePath);
       if (files.length > maxFiles) {
@@ -423,12 +468,6 @@ function resolveVaultPath(vaultPath: string, relativePath: string): string | nul
   return absolutePath;
 }
 
-function safeListedPath(root: string, absolutePath: string): boolean {
-  const normalizedRoot = root.replace(/[/\\]+$/, "").replace(/\\/g, "/");
-  const normalizedPath = absolutePath.replace(/\\/g, "/");
-  return normalizedPath.startsWith(`${normalizedRoot}/`) && statSync(absolutePath).isFile();
-}
-
 function normalizeRelativePath(path: string): string {
   return path.replace(/\\/g, "/").replace(/^\/+/, "");
 }
@@ -452,4 +491,8 @@ function readNestedString(record: Record<string, unknown>, key: string): string 
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }

--- a/src/lib/markdown-sync/import-scanner.ts
+++ b/src/lib/markdown-sync/import-scanner.ts
@@ -1,0 +1,455 @@
+/**
+ * Reverse markdown import scanner.
+ *
+ * This phase is deliberately read-only: it identifies vault-side markdown that
+ * could be imported later, but it never mutates Noosphere records or vault files.
+ */
+
+import { createHash } from "crypto";
+import { existsSync, readdirSync, readFileSync, statSync } from "fs";
+import { join, relative, resolve } from "path";
+import {
+  parseNoosphereMarkdown,
+  readMarkdownString,
+  readMarkdownStringArray,
+} from "@/lib/markdown/noosphere-markdown";
+import type { Manifest, ManifestEntry } from "@/lib/obsidian-sync";
+
+export const MARKDOWN_IMPORT_SCAN_MAX_BODY_BYTES = 32 * 1024;
+export const MARKDOWN_IMPORT_SCAN_DEFAULT_MAX_FILES = 5_000;
+export const MARKDOWN_IMPORT_SCAN_PERMISSIONS = ["ADMIN"] as const;
+
+export type MarkdownImportCandidateKind =
+  | "modified"
+  | "missing"
+  | "baseline-missing"
+  | "untracked";
+
+export interface MarkdownImportScanOptions {
+  vaultPath: string;
+  manifestPath: string;
+  includeUntracked?: boolean;
+  maxFiles?: number;
+}
+
+export interface MarkdownImportMetadata {
+  id: string | null;
+  slug: string | null;
+  title: string | null;
+  topic: string | null;
+  topicPath: string[];
+  tags: string[];
+  restrictedTags: string[];
+  updatedAt: string | null;
+  noosphere: {
+    schemaVersion: number | null;
+    contentHash: string | null;
+    syncedAt: string | null;
+    sourceOfTruth: string | null;
+  };
+}
+
+export interface MarkdownImportCandidate {
+  kind: MarkdownImportCandidateKind;
+  relativePath: string;
+  articleId: string | null;
+  manifestPath: string | null;
+  baselineHash: string | null;
+  markdownHash: string | null;
+  sizeBytes: number | null;
+  metadata: MarkdownImportMetadata | null;
+  parseError: string | null;
+}
+
+export interface MarkdownImportScanStats {
+  tracked: number;
+  scanned: number;
+  unchanged: number;
+  modified: number;
+  missing: number;
+  baselineMissing: number;
+  untracked: number;
+  parseErrors: number;
+  skipped: number;
+  durationMs: number;
+}
+
+export interface MarkdownImportScanResult {
+  success: true;
+  vaultPath: string;
+  manifest: {
+    path: string;
+    present: boolean;
+    articleCount: number;
+  };
+  stats: MarkdownImportScanStats;
+  candidates: MarkdownImportCandidate[];
+  warnings: string[];
+}
+
+export type MarkdownImportScanBodyValidationResult =
+  | { ok: true }
+  | { ok: false; status: 400 | 413; error: string };
+
+interface LoadedMarkdown {
+  markdownHash: string;
+  sizeBytes: number;
+  metadata: MarkdownImportMetadata | null;
+  parseError: string | null;
+}
+
+export class MarkdownImportScanLimitError extends Error {
+  constructor(limit: number) {
+    super(`Markdown import scan exceeded ${limit} markdown files.`);
+    this.name = "MarkdownImportScanLimitError";
+  }
+}
+
+export function validateMarkdownImportScanContentLength(
+  headerValue: string | null,
+  maxBytes = MARKDOWN_IMPORT_SCAN_MAX_BODY_BYTES,
+): MarkdownImportScanBodyValidationResult {
+  if (headerValue === null) return { ok: true };
+  if (!/^\d+$/.test(headerValue)) {
+    return { ok: false, status: 400, error: "Invalid content-length header" };
+  }
+
+  const length = Number(headerValue);
+  if (!Number.isSafeInteger(length)) {
+    return { ok: false, status: 400, error: "Invalid content-length header" };
+  }
+
+  if (length > maxBytes) {
+    return { ok: false, status: 413, error: `Request body too large. Maximum size is ${maxBytes} bytes.` };
+  }
+
+  return { ok: true };
+}
+
+export function validateMarkdownImportScanRequestBody(body: unknown): {
+  includeUntracked: boolean;
+  maxFiles: number;
+} | { errors: string[] } {
+  if (!isPlainObject(body)) {
+    return { errors: ["Body must be a JSON object"] };
+  }
+
+  const errors: string[] = [];
+  const allowed = new Set(["includeUntracked", "maxFiles"]);
+  for (const key of Object.keys(body)) {
+    if (!allowed.has(key)) errors.push(`Unsupported field: ${key}`);
+  }
+
+  const includeUntrackedRaw = body["includeUntracked"];
+  const includeUntracked = includeUntrackedRaw === undefined ? true : includeUntrackedRaw;
+  if (typeof includeUntracked !== "boolean") {
+    errors.push("includeUntracked must be a boolean");
+  }
+
+  const maxFilesRaw = body["maxFiles"];
+  const maxFiles = maxFilesRaw === undefined ? MARKDOWN_IMPORT_SCAN_DEFAULT_MAX_FILES : maxFilesRaw;
+  if (!Number.isSafeInteger(maxFiles) || (maxFiles as number) < 1 || (maxFiles as number) > 50_000) {
+    errors.push("maxFiles must be an integer between 1 and 50000");
+  }
+
+  if (errors.length > 0) return { errors };
+
+  return {
+    includeUntracked: includeUntracked as boolean,
+    maxFiles: maxFiles as number,
+  };
+}
+
+export function scanMarkdownImportCandidates(options: MarkdownImportScanOptions): MarkdownImportScanResult {
+  const startedAt = Date.now();
+  const includeUntracked = options.includeUntracked ?? true;
+  const maxFiles = options.maxFiles ?? MARKDOWN_IMPORT_SCAN_DEFAULT_MAX_FILES;
+  const warnings: string[] = [];
+  const candidates: MarkdownImportCandidate[] = [];
+  const manifest = readManifest(options.vaultPath, options.manifestPath, warnings);
+  const trackedEntries = manifest ? Object.entries(manifest.articles) : [];
+  const trackedPaths = new Set<string>();
+  const stats: MarkdownImportScanStats = {
+    tracked: trackedEntries.length,
+    scanned: 0,
+    unchanged: 0,
+    modified: 0,
+    missing: 0,
+    baselineMissing: 0,
+    untracked: 0,
+    parseErrors: 0,
+    skipped: 0,
+    durationMs: 0,
+  };
+
+  for (const [articleId, entry] of trackedEntries) {
+    trackedPaths.add(normalizeRelativePath(entry.path));
+    const candidate = scanTrackedEntry(options.vaultPath, articleId, entry, warnings);
+    if (!candidate) {
+      stats.unchanged++;
+      continue;
+    }
+
+    candidates.push(candidate);
+    incrementCandidateStats(stats, candidate);
+  }
+
+  if (includeUntracked) {
+    const markdownPaths = listMarkdownFiles(options.vaultPath, maxFiles);
+    for (const relativePath of markdownPaths) {
+      if (trackedPaths.has(relativePath)) continue;
+      const absolutePath = resolveVaultPath(options.vaultPath, relativePath);
+      if (!absolutePath) {
+        warnings.push(`Path traversal rejected during scan: ${relativePath}`);
+        stats.skipped++;
+        continue;
+      }
+
+      const loaded = loadMarkdownFile(absolutePath);
+      const candidate: MarkdownImportCandidate = {
+        kind: "untracked",
+        relativePath,
+        articleId: loaded.metadata?.id ?? null,
+        manifestPath: null,
+        baselineHash: null,
+        markdownHash: loaded.markdownHash,
+        sizeBytes: loaded.sizeBytes,
+        metadata: loaded.metadata,
+        parseError: loaded.parseError,
+      };
+      candidates.push(candidate);
+      incrementCandidateStats(stats, candidate);
+    }
+  }
+
+  stats.scanned = candidates.length + stats.unchanged;
+  stats.durationMs = Date.now() - startedAt;
+
+  return {
+    success: true,
+    vaultPath: options.vaultPath,
+    manifest: {
+      path: options.manifestPath,
+      present: manifest !== null,
+      articleCount: trackedEntries.length,
+    },
+    stats,
+    candidates,
+    warnings,
+  };
+}
+
+function scanTrackedEntry(
+  vaultPath: string,
+  articleId: string,
+  entry: ManifestEntry,
+  warnings: string[],
+): MarkdownImportCandidate | null {
+  const relativePath = normalizeRelativePath(entry.path);
+  const absolutePath = resolveVaultPath(vaultPath, relativePath);
+  if (!absolutePath) {
+    warnings.push(`Path traversal rejected during scan: ${relativePath}`);
+    return {
+      kind: "missing",
+      relativePath,
+      articleId,
+      manifestPath: relativePath,
+      baselineHash: entry.writtenHash ?? entry.contentHash ?? null,
+      markdownHash: null,
+      sizeBytes: null,
+      metadata: null,
+      parseError: "Manifest path escapes vault root",
+    };
+  }
+
+  const baselineHash = entry.writtenHash ?? null;
+  if (!existsSync(absolutePath)) {
+    return {
+      kind: "missing",
+      relativePath,
+      articleId,
+      manifestPath: relativePath,
+      baselineHash,
+      markdownHash: null,
+      sizeBytes: null,
+      metadata: null,
+      parseError: null,
+    };
+  }
+
+  const loaded = loadMarkdownFile(absolutePath);
+  if (!baselineHash) {
+    return {
+      kind: "baseline-missing",
+      relativePath,
+      articleId,
+      manifestPath: relativePath,
+      baselineHash: null,
+      markdownHash: loaded.markdownHash,
+      sizeBytes: loaded.sizeBytes,
+      metadata: loaded.metadata,
+      parseError: loaded.parseError,
+    };
+  }
+
+  if (loaded.markdownHash === baselineHash) return null;
+
+  return {
+    kind: "modified",
+    relativePath,
+    articleId,
+    manifestPath: relativePath,
+    baselineHash,
+    markdownHash: loaded.markdownHash,
+    sizeBytes: loaded.sizeBytes,
+    metadata: loaded.metadata,
+    parseError: loaded.parseError,
+  };
+}
+
+function readManifest(vaultPath: string, manifestPath: string, warnings: string[]): Manifest | null {
+  const absolutePath = resolveVaultPath(vaultPath, manifestPath);
+  if (!absolutePath) {
+    warnings.push(`Manifest path escapes vault root: ${manifestPath}`);
+    return null;
+  }
+
+  if (!existsSync(absolutePath)) return null;
+
+  try {
+    const parsed = JSON.parse(readFileSync(absolutePath, "utf-8")) as Manifest;
+    if (parsed.version !== 1 || !parsed.articles || typeof parsed.articles !== "object") {
+      warnings.push(`Unsupported manifest format: ${manifestPath}`);
+      return null;
+    }
+    return parsed;
+  } catch {
+    warnings.push(`Failed to read manifest: ${manifestPath}`);
+    return null;
+  }
+}
+
+function loadMarkdownFile(absolutePath: string): LoadedMarkdown {
+  const content = readFileSync(absolutePath, "utf-8");
+  const parsed = parseNoosphereMarkdown(content);
+  const markdownHash = hashMarkdownContent(content);
+  const sizeBytes = Buffer.byteLength(content, "utf-8");
+
+  if (!parsed.ok) {
+    return {
+      markdownHash,
+      sizeBytes,
+      metadata: null,
+      parseError: parsed.error,
+    };
+  }
+
+  return {
+    markdownHash,
+    sizeBytes,
+    metadata: extractMetadata(parsed.markdown.frontmatter),
+    parseError: null,
+  };
+}
+
+function extractMetadata(frontmatter: Record<string, unknown>): MarkdownImportMetadata {
+  const noosphere = readNoosphereObject(frontmatter);
+  return {
+    id: readMarkdownString(frontmatter, "id") ?? null,
+    slug: readMarkdownString(frontmatter, "slug") ?? null,
+    title: readMarkdownString(frontmatter, "title") ?? null,
+    topic: readMarkdownString(frontmatter, "topic") ?? null,
+    topicPath: readMarkdownStringArray(frontmatter, "topicPath"),
+    tags: readMarkdownStringArray(frontmatter, "tags"),
+    restrictedTags: readMarkdownStringArray(frontmatter, "restrictedTags"),
+    updatedAt: readMarkdownString(frontmatter, "updatedAt") ?? null,
+    noosphere: {
+      schemaVersion: typeof noosphere["schemaVersion"] === "number" ? noosphere["schemaVersion"] : null,
+      contentHash: readNestedString(noosphere, "contentHash"),
+      syncedAt: readNestedString(noosphere, "syncedAt"),
+      sourceOfTruth: readNestedString(noosphere, "sourceOfTruth"),
+    },
+  };
+}
+
+function listMarkdownFiles(vaultPath: string, maxFiles: number): string[] {
+  if (!existsSync(vaultPath)) return [];
+
+  const root = resolve(vaultPath);
+  const files: string[] = [];
+  walk(root);
+  return files.sort();
+
+  function walk(directory: string) {
+    const entries = readdirSync(directory, { withFileTypes: true })
+      .sort((a, b) => a.name.localeCompare(b.name));
+
+    for (const entry of entries) {
+      const absolutePath = join(directory, entry.name);
+      const relativePath = normalizeRelativePath(relative(root, absolutePath));
+
+      if (entry.isDirectory()) {
+        if (entry.name === ".git" || entry.name === ".noosphere-sync" || entry.name === "node_modules") {
+          continue;
+        }
+        walk(absolutePath);
+        continue;
+      }
+
+      if (!entry.isFile() || !entry.name.toLowerCase().endsWith(".md")) continue;
+      if (!safeListedPath(root, absolutePath)) continue;
+
+      files.push(relativePath);
+      if (files.length > maxFiles) {
+        throw new MarkdownImportScanLimitError(maxFiles);
+      }
+    }
+  }
+}
+
+function incrementCandidateStats(stats: MarkdownImportScanStats, candidate: MarkdownImportCandidate) {
+  if (candidate.kind === "modified") stats.modified++;
+  else if (candidate.kind === "missing") stats.missing++;
+  else if (candidate.kind === "baseline-missing") stats.baselineMissing++;
+  else if (candidate.kind === "untracked") stats.untracked++;
+
+  if (candidate.parseError) stats.parseErrors++;
+}
+
+function resolveVaultPath(vaultPath: string, relativePath: string): string | null {
+  const root = resolve(vaultPath).replace(/[/\\]+$/, "").replace(/\\/g, "/");
+  const absolutePath = resolve(vaultPath, relativePath).replace(/\\/g, "/");
+  if (!absolutePath.startsWith(`${root}/`)) return null;
+  return absolutePath;
+}
+
+function safeListedPath(root: string, absolutePath: string): boolean {
+  const normalizedRoot = root.replace(/[/\\]+$/, "").replace(/\\/g, "/");
+  const normalizedPath = absolutePath.replace(/\\/g, "/");
+  return normalizedPath.startsWith(`${normalizedRoot}/`) && statSync(absolutePath).isFile();
+}
+
+function normalizeRelativePath(path: string): string {
+  return path.replace(/\\/g, "/").replace(/^\/+/, "");
+}
+
+function hashMarkdownContent(content: string): string {
+  return createHash("sha256").update(content).digest("hex");
+}
+
+function readNoosphereObject(frontmatter: Record<string, unknown>): Record<string, unknown> {
+  const value = frontmatter["noosphere"];
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  return value as Record<string, unknown>;
+}
+
+function readNestedString(record: Record<string, unknown>, key: string): string | null {
+  const value = record[key];
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed || null;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}


### PR DESCRIPTION
## Summary
- add a read-only reverse Markdown import scanner for the configured Obsidian vault
- expose admin-only POST /api/sync/import-scan with body size and request validation
- report modified, missing, baseline-missing, and untracked Markdown candidates without writing DB rows or vault files
- document the new scanner endpoint and Phase 4 behavior

## Verification
- DATABASE_URL='postgresql://noosphere:test@localhost:5433/noosphere' node --import tsx --test src/__tests__/api/markdown-import-scanner.test.ts
- docker run --rm --network noosphere-net -v "/home/niya/github/noosphere":/app -w /app -e DATABASE_URL='postgresql://noosphere:test@db:5432/noosphere' node:22-bookworm bash -lc 'npm run test:api'
- npm run test:cache
- npm run test:security
- npm run lint
- DATABASE_URL='postgresql://noosphere:buildtime@db:5432/noosphere' npm run build

Note: lint still reports the 3 pre-existing unrelated wiki action warnings; build still reports the known Turbopack/Obsidian sync filesystem tracing warning. The first build attempt without DATABASE_URL failed on the existing Prisma env guard, then passed with the build-time DATABASE_URL.

## Summary by Sourcery

Add a read-only reverse Markdown import scanner and expose it via an admin-only API endpoint for inspecting Obsidian vault changes before future import phases.

New Features:
- Introduce a reverse Markdown import scanner that inventories tracked and untracked vault-side Markdown files using the Obsidian sync manifest.
- Expose a POST /api/sync/import-scan endpoint that runs the scanner with request validation, rate limiting, and admin-only access.
- Parse Noosphere frontmatter from scanned Markdown files to return structured metadata and parse errors without persisting any changes.

Enhancements:
- Extend Obsidian sync documentation with a new reverse-import scanner phase clarifying behavior and non-goals.
- Update the README to describe the reverse Markdown scan endpoint and its role in the multi-phase import flow.

Tests:
- Add API- and scanner-level tests covering modified/missing/baseline-missing/untracked detection, parse error handling, max file limits, permissions, and request validation.