### PR TITLE
Fix: scope wiki topic counts

### DIFF
--- a/src/__tests__/api/wiki-home-scope.test.ts
+++ b/src/__tests__/api/wiki-home-scope.test.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { loadWikiHomeData, type WikiHomeDb } from "@/lib/wiki-home";
+
+describe("wiki home scope filtering", () => {
+  it("uses the scoped article filter for topic count aggregation", async () => {
+    const calls: { method: string; where?: Record<string, unknown> }[] = [];
+    const db: WikiHomeDb<unknown> = {
+      topic: {
+        async findMany() {
+          return [];
+        },
+      },
+      article: {
+        async groupBy(args) {
+          calls.push({ method: "groupBy", where: args.where });
+          return [];
+        },
+        async findMany(args) {
+          calls.push({ method: "findMany", where: args.where });
+          return [];
+        },
+      },
+    };
+
+    await loadWikiHomeData(db, undefined);
+
+    assert.deepEqual(
+      calls.find((call) => call.method === "groupBy")?.where,
+      { deletedAt: null, restrictedTags: { isEmpty: true } },
+      "topic counts must use the same scoped filter as visible articles",
+    );
+    assert.deepEqual(
+      calls.find((call) => call.method === "findMany")?.where,
+      { deletedAt: null, restrictedTags: { isEmpty: true } },
+      "recent articles and topic counts must stay aligned",
+    );
+  });
+});

--- a/src/app/wiki/page.tsx
+++ b/src/app/wiki/page.tsx
@@ -1,18 +1,15 @@
 import Link from "next/link";
 import { getServerSession } from "next-auth";
+import type { Prisma } from "@prisma/client";
 import { EmptyState } from "@/components/wiki/EmptyState";
 import { PageHeader } from "@/components/wiki/PageHeader";
 import { prisma } from "@/lib/prisma";
 import { authOptions } from "@/lib/auth";
-import { buildScopeFilter } from "@/lib/api/auth";
+import { loadWikiHomeData, type WikiHomeDb, type WikiHomeTopic } from "@/lib/wiki-home";
 
 export const dynamic = "force-dynamic";
 
-interface TopicNode {
-  id: string;
-  name: string;
-  slug: string;
-  description: string | null;
+interface TopicNode extends Omit<WikiHomeTopic, "parentId"> {
   children: TopicNode[];
 }
 
@@ -26,6 +23,13 @@ interface TopicRenderNode {
   descendantCount: number;
   children: TopicRenderNode[];
 }
+
+type WikiHomeArticle = Prisma.ArticleGetPayload<{
+  include: {
+    topic: true;
+    tags: { include: { tag: true } };
+  };
+}>;
 
 function buildTopicRenderNode(node: TopicNode, countMap: ArticleCountMap): TopicRenderNode {
   const children = node.children.map((child) => buildTopicRenderNode(child, countMap));
@@ -86,25 +90,10 @@ export default async function WikiHomePage() {
   // Unauthenticated users only see unrestricted articles.
   // Human sessions always have full access — they bypass restrictions.
   const allowedScopes = session ? ["*"] : undefined;
-  const scopeWhere = buildScopeFilter(allowedScopes, { deletedAt: null });
-
-  const [allTopics, topicCounts, recentArticles] = await Promise.all([
-    prisma.topic.findMany({ orderBy: { name: "asc" } }),
-    prisma.article.groupBy({
-      by: ["topicId"],
-      where: { deletedAt: null },
-      _count: { topicId: true },
-    }),
-    prisma.article.findMany({
-      where: scopeWhere,
-      include: {
-        topic: true,
-        tags: { include: { tag: true } },
-      },
-      orderBy: { updatedAt: "desc" },
-      take: 8,
-    }),
-  ]);
+  const { allTopics, topicCounts, recentArticles } = await loadWikiHomeData<WikiHomeArticle>(
+    prisma as unknown as WikiHomeDb<WikiHomeArticle>,
+    allowedScopes,
+  );
 
   const countMap: ArticleCountMap = Object.fromEntries(topicCounts.map((t) => [t.topicId, t._count.topicId]));
 

--- a/src/lib/wiki-home.ts
+++ b/src/lib/wiki-home.ts
@@ -1,0 +1,63 @@
+import { buildScopeFilter } from "@/lib/api/auth";
+
+export interface WikiHomeTopic {
+  id: string;
+  name: string;
+  slug: string;
+  description: string | null;
+  parentId: string | null;
+}
+
+export interface WikiHomeTopicCount {
+  topicId: string;
+  _count: { topicId: number };
+}
+
+export interface WikiHomeDb<TArticle> {
+  topic: {
+    findMany(args: { orderBy: { name: "asc" } }): Promise<WikiHomeTopic[]>;
+  };
+  article: {
+    groupBy(args: {
+      by: ["topicId"];
+      where: Record<string, unknown>;
+      _count: { topicId: true };
+    }): Promise<WikiHomeTopicCount[]>;
+    findMany(args: {
+      where: Record<string, unknown>;
+      include: {
+        topic: true;
+        tags: { include: { tag: true } };
+      };
+      orderBy: { updatedAt: "desc" };
+      take: 8;
+    }): Promise<TArticle[]>;
+  };
+}
+
+export async function loadWikiHomeData<TArticle>(
+  db: WikiHomeDb<TArticle>,
+  allowedScopes: string[] | undefined,
+) {
+  const scopeWhere = buildScopeFilter(allowedScopes, { deletedAt: null });
+
+  const [allTopics, topicCounts, recentArticles] = await Promise.all([
+    db.topic.findMany({ orderBy: { name: "asc" } }),
+    db.article.groupBy({
+      by: ["topicId"],
+      where: scopeWhere,
+      _count: { topicId: true },
+    }),
+    db.article.findMany({
+      where: scopeWhere,
+      include: {
+        topic: true,
+        tags: { include: { tag: true } },
+      },
+      orderBy: { updatedAt: "desc" },
+      take: 8,
+    }),
+  ]);
+
+  return { allTopics, topicCounts, recentArticles };
+}


### PR DESCRIPTION
## Summary
- Apply the existing wiki scope filter to the homepage topic-count aggregation
- Add a focused regression test so the topic-count query cannot fall back to unscoped totals

## Verification
- `node --import tsx --test src/__tests__/api/wiki-home-scope.test.ts`
- `npx eslint src/app/wiki/page.tsx src/__tests__/api/wiki-home-scope.test.ts`
- `npm run test:api` with the local Noosphere Docker database env
- `npm run build` with the local Noosphere app env

## Notes
This intentionally replaces the security-fix portion of #149 without carrying the Redis rate-limiter, scheduler, or documentation changes from that broader branch.

## Summary by Sourcery

Scope wiki homepage topic-count aggregation to the existing wiki filter and add coverage to prevent regressions.

Bug Fixes:
- Ensure wiki homepage topic-count aggregation respects the existing wiki scope filter instead of using unscoped totals.

Tests:
- Add a regression test to verify the wiki homepage topic-count query always applies the configured scope filter.