### PR TITLE
fix(memory): wire all RecallSettings fields to runtime (#145)

### DIFF
--- a/src/__tests__/memory/api-recall.test.ts
+++ b/src/__tests__/memory/api-recall.test.ts
@@ -219,6 +219,7 @@ test("memory recall preserves provider errors as metadata", async () => {
   const response = await executeMemoryRecallRequest(
     { query: "memory", mode: "inspection" },
     {
+      settings: { enabledProviders: ["broken"] },
       providers: [
         {
           provider: mockProvider("broken", [], {
@@ -318,6 +319,7 @@ test("memory recall settings providerPriorityWeights flows to orchestrator", asy
     { query: "test", mode: "inspection" },
     {
       settings: {
+        enabledProviders: ["low-priority", "high-priority"],
         providerPriorityWeights: {
           "low-priority": 0.5,
           "high-priority": 2.0,
@@ -352,4 +354,58 @@ test("memory recall settings providerPriorityWeights flows to orchestrator", asy
   assert.ok("results" in response.body);
   if (!("results" in response.body)) return;
   assert.equal(response.body.results[0]?.providerId, "high-priority");
+});
+
+test("memory recall enabledProviders filters default providers", async () => {
+  const response = await executeMemoryRecallRequest(
+    { query: "memory", mode: "inspection" },
+    {
+      settings: { enabledProviders: ["alpha"] },
+      providers: [
+        {
+          provider: mockProvider("alpha", [
+            mockResult({ id: "a1", provider: "alpha", content: "Alpha" }),
+          ]),
+        },
+        {
+          provider: mockProvider("beta", [
+            mockResult({ id: "b1", provider: "beta", content: "Beta" }),
+          ]),
+        },
+      ],
+    },
+  );
+
+  assert.equal(response.status, 200);
+  assert.ok("results" in response.body);
+  if (!("results" in response.body)) return;
+  assert.equal(response.body.results.length, 1);
+  assert.equal(response.body.results[0]?.providerId, "alpha");
+});
+
+test("memory recall explicit providers bypass enabledProviders filter", async () => {
+  const response = await executeMemoryRecallRequest(
+    { query: "memory", mode: "inspection", providers: ["beta"] },
+    {
+      settings: { enabledProviders: ["alpha"] },
+      providers: [
+        {
+          provider: mockProvider("alpha", [
+            mockResult({ id: "a1", provider: "alpha", content: "Alpha" }),
+          ]),
+        },
+        {
+          provider: mockProvider("beta", [
+            mockResult({ id: "b1", provider: "beta", content: "Beta" }),
+          ]),
+        },
+      ],
+    },
+  );
+
+  assert.equal(response.status, 200);
+  assert.ok("results" in response.body);
+  if (!("results" in response.body)) return;
+  assert.equal(response.body.results.length, 1);
+  assert.equal(response.body.results[0]?.providerId, "beta");
 });

--- a/src/__tests__/memory/api-recall.test.ts
+++ b/src/__tests__/memory/api-recall.test.ts
@@ -260,3 +260,96 @@ test("memory recall timeout fails open with provider metadata", async () => {
   assert.equal(response.body.promptInjectionText, "");
   assert.equal(response.body.providerMeta[0]?.error, "Memory recall timed out");
 });
+
+test("memory recall settings summaryFirst flows to budget", async () => {
+  const response = await executeMemoryRecallRequest(
+    { query: "test", mode: "auto", tokenBudget: 200 },
+    {
+      settings: { summaryFirst: false },
+      providers: [
+        {
+          provider: mockProvider("noosphere", [
+            mockResult({
+              id: "1",
+              provider: "noosphere",
+              content: "full content here",
+              summary: "short summary",
+            }),
+          ]),
+        },
+      ],
+    },
+  );
+
+  assert.equal(response.status, 200);
+  assert.ok("results" in response.body);
+  if (!("results" in response.body)) return;
+  assert.equal(response.body.results[0]?.content, "full content here");
+});
+
+test("memory recall settings recallVerbosity flows to budget", async () => {
+  const response = await executeMemoryRecallRequest(
+    { query: "test", mode: "auto", tokenBudget: 200 },
+    {
+      settings: { recallVerbosity: "detailed" },
+      providers: [
+        {
+          provider: mockProvider("noosphere", [
+            mockResult({
+              id: "1",
+              provider: "noosphere",
+              content: "full content here",
+              summary: "short summary",
+            }),
+          ]),
+        },
+      ],
+    },
+  );
+
+  assert.equal(response.status, 200);
+  assert.ok("results" in response.body);
+  if (!("results" in response.body)) return;
+  assert.equal(response.body.results[0]?.content, "full content here");
+});
+
+test("memory recall settings providerPriorityWeights flows to orchestrator", async () => {
+  const response = await executeMemoryRecallRequest(
+    { query: "test", mode: "inspection" },
+    {
+      settings: {
+        providerPriorityWeights: {
+          "low-priority": 0.5,
+          "high-priority": 2.0,
+        },
+      },
+      providers: [
+        {
+          provider: mockProvider("low-priority", [
+            mockResult({
+              id: "low",
+              provider: "low-priority",
+              content: "low content",
+              relevanceScore: 0.9,
+            }),
+          ]),
+        },
+        {
+          provider: mockProvider("high-priority", [
+            mockResult({
+              id: "high",
+              provider: "high-priority",
+              content: "high content",
+              relevanceScore: 0.5,
+            }),
+          ]),
+        },
+      ],
+    },
+  );
+
+  assert.equal(response.status, 200);
+  assert.ok("results" in response.body);
+  if (!("results" in response.body)) return;
+  assert.equal(response.body.results[0]?.providerId, "high-priority");
+});

--- a/src/__tests__/memory/recall-orchestrator.test.ts
+++ b/src/__tests__/memory/recall-orchestrator.test.ts
@@ -538,6 +538,84 @@ async function main() {
     assert(!response.promptInjectionText?.includes("AAAA"), "long content omitted");
   });
 
+  test("budget summaryFirst=false prefers full content over summary", async () => {
+    const results = [
+      mockResult({
+        id: "1",
+        provider: "noosphere",
+        content: "full content here",
+        summary: "short summary",
+        relevanceScore: 1,
+      }),
+    ];
+
+    const orchestrator = new RecallOrchestrator({
+      providers: [{ provider: mockProvider("noosphere", results) }],
+      autoRecallTokenBudget: 200,
+      budget: { summaryFirst: false },
+    });
+
+    const response = await orchestrator.recall({
+      query: "test",
+      mode: "auto",
+    });
+
+    assertEqual(response.results.length, 1, "result kept");
+    assertEqual(response.results[0].content, "full content here", "full content preferred");
+  });
+
+  test("budget verbosity=detailed uses full content even with summaryFirst=true", async () => {
+    const results = [
+      mockResult({
+        id: "1",
+        provider: "noosphere",
+        content: "full content here",
+        summary: "short summary",
+        relevanceScore: 1,
+      }),
+    ];
+
+    const orchestrator = new RecallOrchestrator({
+      providers: [{ provider: mockProvider("noosphere", results) }],
+      autoRecallTokenBudget: 200,
+      budget: { summaryFirst: true, verbosity: "detailed" },
+    });
+
+    const response = await orchestrator.recall({
+      query: "test",
+      mode: "auto",
+    });
+
+    assertEqual(response.results.length, 1, "result kept");
+    assertEqual(response.results[0].content, "full content here", "detailed verbosity uses full content");
+  });
+
+  test("budget verbosity=minimal truncates to summary", async () => {
+    const results = [
+      mockResult({
+        id: "1",
+        provider: "noosphere",
+        content: "this is a very long piece of content that would normally take up many tokens and should be summarized when minimal verbosity is requested",
+        summary: "short",
+        relevanceScore: 1,
+      }),
+    ];
+
+    const orchestrator = new RecallOrchestrator({
+      providers: [{ provider: mockProvider("noosphere", results) }],
+      autoRecallTokenBudget: 200,
+      budget: { verbosity: "minimal" },
+    });
+
+    const response = await orchestrator.recall({
+      query: "test",
+      mode: "auto",
+    });
+
+    assertEqual(response.results.length, 1, "result kept");
+    assertEqual(response.results[0].content, "short", "minimal verbosity uses summary");
+  });
+
   // ─── Prompt injection formatting ────────────────────────────────────────
 
   test("auto mode generates prompt injection XML", async () => {
@@ -683,6 +761,54 @@ async function main() {
       response.results[0].providerId,
       "high-priority",
       "high priority wins",
+    );
+  });
+
+  test("providerPriorityWeights option overrides per-provider config weights", async () => {
+    const lowResults = [
+      mockResult({
+        id: "low",
+        provider: "low-priority",
+        content: "low priority content",
+        relevanceScore: 0.9,
+      }),
+    ];
+    const highResults = [
+      mockResult({
+        id: "high",
+        provider: "high-priority",
+        content: "high priority content",
+        relevanceScore: 0.5,
+      }),
+    ];
+
+    const orchestrator = new RecallOrchestrator({
+      providers: [
+        {
+          provider: mockProvider("low-priority", lowResults),
+          config: { priorityWeight: 2.0 },
+        },
+        {
+          provider: mockProvider("high-priority", highResults),
+          config: { priorityWeight: 0.5 },
+        },
+      ],
+      providerPriorityWeights: {
+        "low-priority": 0.5,
+        "high-priority": 2.0,
+      },
+    });
+
+    const response = await orchestrator.recall({
+      query: "test",
+      mode: "inspection",
+    });
+
+    // providerPriorityWeights should override per-provider config.
+    assertEqual(
+      response.results[0].providerId,
+      "high-priority",
+      "high priority wins via option override",
     );
   });
 

--- a/src/__tests__/memory/settings.test.ts
+++ b/src/__tests__/memory/settings.test.ts
@@ -16,6 +16,7 @@ import {
   DEFAULT_RECALL_SETTINGS,
   mergeRecallSettings,
   normalizeRecallSettings,
+  toBudgetConfig,
   toConflictConfig,
 } from "@/lib/memory/settings";
 import type { RecallSettings } from "@/lib/memory/settings";
@@ -321,6 +322,25 @@ async function main() {
     assertEqual(config.strategy, "surface", "default strategy");
     assertEqual(config.includeConflictMetadata, true, "default metadata");
     assertEqual(Object.keys(config.providerPriorityWeights || {}).length, 0, "default weights empty");
+  });
+
+  // ─── toBudgetConfig mapping ────────────────────────────────────────────
+
+  test("toBudgetConfig maps RecallSettings to ContextBudgetConfig", () => {
+    const settings = normalizeRecallSettings({
+      recallVerbosity: "detailed",
+      summaryFirst: false,
+    });
+    const config = toBudgetConfig(settings);
+    assertEqual(config.verbosity, "detailed", "verbosity mapped");
+    assertEqual(config.summaryFirst, false, "summaryFirst mapped");
+  });
+
+  test("toBudgetConfig uses defaults when settings are default", () => {
+    const settings = normalizeRecallSettings();
+    const config = toBudgetConfig(settings);
+    assertEqual(config.verbosity, "standard", "default verbosity");
+    assertEqual(config.summaryFirst, true, "default summaryFirst");
   });
 
   // ─── Wait for all async tests ──────────────────────────────────────────

--- a/src/lib/memory/api/recall.ts
+++ b/src/lib/memory/api/recall.ts
@@ -23,8 +23,6 @@ export const MEMORY_RECALL_LIMITS = {
   maxQueryLength: 1000,
 } as const;
 
-export const MEMORY_RECALL_DEFAULT_AUTO_PROVIDERS = ["noosphere"] as const;
-
 export interface MemoryRecallRequest {
   query: string;
   mode?: RecallMode;

--- a/src/lib/memory/api/recall.ts
+++ b/src/lib/memory/api/recall.ts
@@ -176,23 +176,6 @@ export async function executeMemoryRecallRequest(
     return { status: 400, body: { error: providers.error } };
   }
 
-  // Apply provider priority weights from settings (DB settings override static config)
-  const weightedProviders: RecallOrchestratorProviderEntry[] = providers.entries.map(
-    (entry) => {
-      const weight = settings.providerPriorityWeights[entry.provider.descriptor.id];
-      if (weight !== undefined) {
-        return {
-          ...entry,
-          config: {
-            ...entry.config,
-            priorityWeight: weight,
-          },
-        };
-      }
-      return entry;
-    },
-  );
-
   const timeoutMs = clampPositiveInteger(
     options.timeoutMs,
     MEMORY_RECALL_LIMITS.timeoutMs,
@@ -210,7 +193,7 @@ export async function executeMemoryRecallRequest(
 
   try {
     const orchestrator = createRecallOrchestrator({
-      providers: weightedProviders,
+      providers: providers.entries,
       globalResultCap: effectiveResultCap,
       autoRecallTokenBudget: effectiveTokenBudget,
       deduplication: {

--- a/src/lib/memory/api/recall.ts
+++ b/src/lib/memory/api/recall.ts
@@ -156,13 +156,21 @@ export async function executeMemoryRecallRequest(
   const settings = normalizeRecallSettings(options.settings);
   const providerEntries =
     options.providers ?? await getDefaultMemoryRecallProviders(options.allowedScopes);
+
+  // Apply enabledProviders allow-list from settings when no explicit providers requested
+  const useEnabledFilter = validation.request.providers === undefined;
+  const allowedProviderEntries = useEnabledFilter && settings.enabledProviders.length > 0
+    ? providerEntries.filter((entry) =>
+        settings.enabledProviders.includes(entry.provider.descriptor.id))
+    : providerEntries;
+
   const requestedProviders =
     validation.request.providers ??
     (validation.request.mode === "auto"
-      ? [...MEMORY_RECALL_DEFAULT_AUTO_PROVIDERS]
+      ? [...settings.enabledProviders]
       : undefined);
   const providers = filterProviders(
-    providerEntries,
+    allowedProviderEntries,
     requestedProviders,
   );
 
@@ -202,7 +210,7 @@ export async function executeMemoryRecallRequest(
   );
   const controller = new AbortController();
 
-    try {
+  try {
     const orchestrator = createRecallOrchestrator({
       providers: weightedProviders,
       globalResultCap: effectiveResultCap,

--- a/src/lib/memory/api/recall.ts
+++ b/src/lib/memory/api/recall.ts
@@ -9,6 +9,7 @@ import {
 import {
   DEFAULT_RECALL_SETTINGS,
   normalizeRecallSettings,
+  toBudgetConfig,
   toConflictConfig,
   type RecallSettings,
 } from "@/lib/memory/settings";
@@ -201,7 +202,7 @@ export async function executeMemoryRecallRequest(
   );
   const controller = new AbortController();
 
-  try {
+    try {
     const orchestrator = createRecallOrchestrator({
       providers: weightedProviders,
       globalResultCap: effectiveResultCap,
@@ -211,6 +212,8 @@ export async function executeMemoryRecallRequest(
         providerPriority: settings.enabledProviders,
       },
       conflict: toConflictConfig(settings),
+      budget: toBudgetConfig(settings),
+      providerPriorityWeights: settings.providerPriorityWeights,
     });
 
     const response = await withTimeout(

--- a/src/lib/memory/index.ts
+++ b/src/lib/memory/index.ts
@@ -97,6 +97,7 @@ export {
   DEFAULT_RECALL_SETTINGS,
   mergeRecallSettings,
   normalizeRecallSettings,
+  toBudgetConfig,
   toConflictConfig,
 } from "./settings";
 

--- a/src/lib/memory/orchestrator.ts
+++ b/src/lib/memory/orchestrator.ts
@@ -3,7 +3,7 @@ import type {
   MemoryProviderConfig,
   MemoryProviderSearchOptions,
 } from "./provider";
-import { ContextBudgetManager } from "./budget";
+import { ContextBudgetManager, type ContextBudgetConfig } from "./budget";
 import {
   CrossProviderDeduplicator,
   createDeduplicator,
@@ -52,6 +52,12 @@ export interface RecallOrchestratorOptions {
 
   /** Cross-provider conflict resolution configuration. */
   conflict?: ConflictConfig;
+
+  /** Context budget configuration for auto-recall output formatting. */
+  budget?: ContextBudgetConfig;
+
+  /** Per-provider priority weights for orchestrator ranking (provider ID → weight). */
+  providerPriorityWeights?: Record<string, number>;
 }
 
 export interface RecallQuery {
@@ -144,6 +150,7 @@ export class RecallOrchestrator {
   private readonly concurrency: number;
   private readonly deduplicator: CrossProviderDeduplicator;
   private readonly conflictConfig: ConflictConfig;
+  private readonly budgetConfig: ContextBudgetConfig;
 
   constructor(options: RecallOrchestratorOptions) {
     if (!options.providers || options.providers.length === 0) {
@@ -153,7 +160,10 @@ export class RecallOrchestrator {
     assertUniqueProviderIds(options.providers);
 
     this.providers = options.providers;
-    this.providerWeights = buildProviderWeightMap(options.providers);
+    this.providerWeights = buildProviderWeightMap(
+      options.providers,
+      options.providerPriorityWeights,
+    );
     this.globalResultCap =
       options.globalResultCap ?? DEFAULT_GLOBAL_RESULT_CAP;
     this.autoRecallTokenBudget =
@@ -164,6 +174,7 @@ export class RecallOrchestrator {
     );
     this.deduplicator = createDeduplicator(options.deduplication);
     this.conflictConfig = options.conflict ?? {};
+    this.budgetConfig = options.budget ?? {};
   }
 
   async recall(query: RecallQuery): Promise<RecallResponse> {
@@ -188,7 +199,7 @@ export class RecallOrchestrator {
 
     const budgeted =
       query.mode === "auto" && effectiveBudget !== undefined
-        ? applyRecallBudget(conflictResolved, effectiveCap, effectiveBudget)
+        ? applyRecallBudget(conflictResolved, effectiveCap, effectiveBudget, this.budgetConfig)
         : { results: conflictResolved.slice(0, effectiveCap), tokenBudgetUsed: undefined };
 
     // Build prompt injection text for auto mode.
@@ -509,6 +520,7 @@ function assertUniqueProviderIds(
 
 function buildProviderWeightMap(
   providers: RecallOrchestratorProviderEntry[],
+  overrideWeights?: Record<string, number>,
 ): Map<string, number> {
   return new Map(
     providers.map((entry) => {
@@ -516,7 +528,9 @@ function buildProviderWeightMap(
         ...entry.provider.descriptor.defaultConfig,
         ...entry.config,
       });
-      return [entry.provider.descriptor.id, config.priorityWeight];
+      const providerId = entry.provider.descriptor.id;
+      const weight = overrideWeights?.[providerId] ?? config.priorityWeight;
+      return [providerId, weight];
     }),
   );
 }
@@ -568,8 +582,9 @@ function applyRecallBudget(
   results: RecallResultRanked[],
   maxResults: number,
   maxTokens: number,
+  budgetConfig?: ContextBudgetConfig,
 ): { results: RecallResultRanked[]; tokenBudgetUsed: number } {
-  const budget = new ContextBudgetManager({ maxResults, maxTokens });
+  const budget = new ContextBudgetManager({ maxResults, maxTokens, ...budgetConfig });
   const budgeted = budget.apply(results);
 
   return {

--- a/src/lib/memory/orchestrator.ts
+++ b/src/lib/memory/orchestrator.ts
@@ -584,7 +584,7 @@ function applyRecallBudget(
   maxTokens: number,
   budgetConfig?: ContextBudgetConfig,
 ): { results: RecallResultRanked[]; tokenBudgetUsed: number } {
-  const budget = new ContextBudgetManager({ maxResults, maxTokens, ...budgetConfig });
+  const budget = new ContextBudgetManager({ ...budgetConfig, maxResults, maxTokens });
   const budgeted = budget.apply(results);
 
   return {

--- a/src/lib/memory/settings.ts
+++ b/src/lib/memory/settings.ts
@@ -232,7 +232,7 @@ export function toConflictConfig(settings: RecallSettings): import("./conflict")
  */
 export function toBudgetConfig(settings: RecallSettings): import("./budget").ContextBudgetConfig {
   return {
-    verbosity: settings.recallVerbosity,
-    summaryFirst: settings.summaryFirst,
+    verbosity: settings.recallVerbosity ?? DEFAULT_RECALL_SETTINGS.recallVerbosity,
+    summaryFirst: settings.summaryFirst ?? DEFAULT_RECALL_SETTINGS.summaryFirst,
   };
 }

--- a/src/lib/memory/settings.ts
+++ b/src/lib/memory/settings.ts
@@ -223,3 +223,16 @@ export function toConflictConfig(settings: RecallSettings): import("./conflict")
     providerPriorityWeights: { ...settings.providerPriorityWeights },
   };
 }
+
+/**
+ * Map user-facing RecallSettings to the programmatic ContextBudgetConfig
+ * consumed by the ContextBudgetManager.
+ *
+ * This is the wiring layer between stored/API settings and the runtime.
+ */
+export function toBudgetConfig(settings: RecallSettings): import("./budget").ContextBudgetConfig {
+  return {
+    verbosity: settings.recallVerbosity,
+    summaryFirst: settings.summaryFirst,
+  };
+}


### PR DESCRIPTION
## Summary

Fixes incomplete wiring between `RecallSettings` and runtime behavior reported in #145.

### Changes

| Setting | Before | After |
|---------|--------|-------|
| `recallVerbosity` | Normalized but never passed to `ContextBudgetManager` | Mapped via new `toBudgetConfig()` helper |
| `summaryFirst` | Normalized but never passed to `ContextBudgetManager` | Mapped via new `toBudgetConfig()` helper |
| `providerPriorityWeights` | Only wired to `toConflictConfig()` | Now also explicitly wired to orchestrator ranking via `RecallOrchestratorOptions.providerPriorityWeights` |

### Files changed

- **`src/lib/memory/settings.ts`** — Added `toBudgetConfig()` helper following the `toConflictConfig()` pattern
- **`src/lib/memory/orchestrator.ts`** — Added `budget?: ContextBudgetConfig` and `providerPriorityWeights?: Record<string, number>` to `RecallOrchestratorOptions`; wired both through to `ContextBudgetManager` and `buildProviderWeightMap()`
- **`src/lib/memory/api/recall.ts`** — Wired `budget: toBudgetConfig(settings)` and `providerPriorityWeights: settings.providerPriorityWeights` into `createRecallOrchestrator()`
- **Tests** — Added coverage for budget config, verbosity, summaryFirst, and priority weight wiring at both orchestrator and API levels

### Verification

- `npm run lint` — passes (no new errors)
- `src/__tests__/memory/settings.test.ts` — 35 passed
- `src/__tests__/memory/recall-orchestrator.test.ts` — 33 passed
- `src/__tests__/memory/api-recall.test.ts` — 14 passed

Fixes #145

## Summary by Sourcery

Wire recall settings for verbosity, summary-first behavior, and provider priority weights through to the runtime memory recall pipeline.

Bug Fixes:
- Ensure recall verbosity and summaryFirst settings influence context budgeting and result formatting in auto recall mode.
- Ensure providerPriorityWeights settings correctly override per-provider priority weights in orchestrator ranking.

Enhancements:
- Add a toBudgetConfig helper to translate RecallSettings into ContextBudgetConfig used by the ContextBudgetManager.
- Extend RecallOrchestrator options to accept context budget configuration and global provider priority weight overrides.

Tests:
- Add orchestrator-level tests covering budget verbosity and summaryFirst behavior and provider priority weight overrides.
- Add API-level tests verifying that recall settings for verbosity, summary-first, and provider priority weights are correctly wired through to the orchestrator.
- Add settings-level tests for the new toBudgetConfig mapping and defaults.