### PR TITLE
feat: Phase 5 — reverse markdown import apply flow

### DIFF
--- a/prisma/migrations/20260528100000_add_sync_import_audit/migration.sql
+++ b/prisma/migrations/20260528100000_add_sync_import_audit/migration.sql
@@ -1,0 +1,39 @@
+-- CreateTable
+CREATE TABLE "SyncImportAudit" (
+    "id" TEXT NOT NULL,
+    "articleId" TEXT,
+    "relativePath" TEXT NOT NULL,
+    "action" TEXT NOT NULL,
+    "kind" TEXT NOT NULL,
+    "dryRun" BOOLEAN NOT NULL,
+    "forceOverwrite" BOOLEAN NOT NULL DEFAULT false,
+    "mode" TEXT NOT NULL,
+    "markdownHash" TEXT,
+    "noosphereHash" TEXT,
+    "conflictReason" TEXT,
+    "performedBy" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "SyncImportAudit_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "SyncImportAudit_articleId_idx" ON "SyncImportAudit"("articleId");
+
+-- CreateIndex
+CREATE INDEX "SyncImportAudit_action_idx" ON "SyncImportAudit"("action");
+
+-- CreateIndex
+CREATE INDEX "SyncImportAudit_kind_idx" ON "SyncImportAudit"("kind");
+
+-- CreateIndex
+CREATE INDEX "SyncImportAudit_createdAt_idx" ON "SyncImportAudit"("createdAt");
+
+-- CreateIndex
+CREATE INDEX "SyncImportAudit_relativePath_idx" ON "SyncImportAudit"("relativePath");
+
+-- CreateIndex
+CREATE INDEX "SyncImportAudit_performedBy_idx" ON "SyncImportAudit"("performedBy");
+
+-- AddForeignKey
+ALTER TABLE "SyncImportAudit" ADD CONSTRAINT "SyncImportAudit_articleId_fkey" FOREIGN KEY ("articleId") REFERENCES "Article"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -54,6 +54,7 @@ model Article {
   tags      ArticleTag[]
   revisions ArticleRevision[]
   syncConflictReviews SyncConflictReview[]
+  syncImportAudits SyncImportAudit[]
 
   // Source tracking — where this article's content originated
   sourceUrl  String?
@@ -338,4 +339,55 @@ model SyncConflictReview {
   @@index([direction])
   @@index([articleId, relativePath, direction, status])
   @@index([createdAt])
+}
+
+// ─────────────────────────────────────────────
+// Sync Import Audit — records every vault-to-noosphere import action
+// ─────────────────────────────────────────────
+model SyncImportAudit {
+  id        String   @id @default(cuid())
+
+  // The article that was created/updated. Null if the import created no article
+  // (e.g., skipped or conflict).
+  articleId String?
+  article   Article? @relation(fields: [articleId], references: [id], onDelete: SetNull)
+
+  // Which vault file was imported.
+  relativePath String
+
+  // What action was taken.
+  // "created"  — new article written to DB
+  // "updated"  — existing article overwritten
+  // "skipped"  — no DB write (validation failure, not a Noosphere article, etc.)
+  // "conflict" — skipped due to a conflict (DB newer than vault or parse error)
+  action String
+
+  // The candidate kind that triggered this audit entry.
+  // "modified" | "missing" | "baseline-missing" | "untracked"
+  kind String
+
+  // Import parameters used.
+  dryRun         Boolean
+  forceOverwrite Boolean @default(false)
+  // "create" | "update" | "upsert"
+  mode String
+
+  // Hashes for verification.
+  markdownHash String?
+  noosphereHash String?  // hash of DB state before import (for updates)
+
+  // For conflicts: why the import was skipped.
+  conflictReason String?
+
+  // Who performed the import. "system" for automated, API key name or session for admin.
+  performedBy String
+
+  createdAt DateTime @default(now())
+
+  @@index([articleId])
+  @@index([action])
+  @@index([kind])
+  @@index([createdAt])
+  @@index([relativePath])
+  @@index([performedBy])
 }

--- a/src/app/api/sync/import-apply/preview/route.ts
+++ b/src/app/api/sync/import-apply/preview/route.ts
@@ -1,0 +1,163 @@
+/**
+ * GET /api/sync/import-apply/preview
+ *
+ * Preview what would happen if we applied certain candidates from the import scan.
+ * This is a read-only simulation — it never writes to the DB.
+ *
+ * Requires ADMIN permission (same as the apply endpoint).
+ */
+
+export const dynamic = "force-dynamic";
+
+import { NextRequest, NextResponse } from "next/server";
+import { existsSync, readFileSync } from "fs";
+import { resolve } from "path";
+import { requirePermission } from "@/lib/api/auth";
+import { getObsidianSyncConfig } from "@/lib/obsidian-sync/config";
+import { rateLimit } from "@/lib/rate-limit";
+import { prisma } from "@/lib/prisma";
+import {
+  applyMarkdownImports,
+  MARKDOWN_IMPORT_APPLY_PERMISSIONS,
+} from "@/lib/markdown-sync/import-applier";
+import { scanMarkdownImportCandidates } from "@/lib/markdown-sync/import-scanner";
+import type { Manifest } from "@/lib/obsidian-sync";
+import type { MarkdownImportCandidate } from "@/lib/markdown-sync/import-scanner";
+
+const PREVIEW_RATE_LIMIT = { windowMs: 60_000, maxRequests: 10, keyPrefix: "sync-import-apply-preview" };
+
+/**
+ * Load and validate a manifest from the vault.
+ */
+function loadManifest(vaultPath: string, manifestRelPath: string): Manifest | null {
+  const manifestAbsPath = resolve(vaultPath, manifestRelPath);
+  if (!existsSync(manifestAbsPath)) return null;
+  try {
+    const parsed = JSON.parse(readFileSync(manifestAbsPath, "utf-8")) as Manifest;
+    if (parsed.version !== 1) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export async function GET(request: NextRequest) {
+  // ── Rate Limiting (ADMIN only, 10/min) ──────────────────────────────────
+  const rl = await rateLimit(request, PREVIEW_RATE_LIMIT);
+  if (!rl.allowed) return rl.response;
+
+  // ── Auth Check ────────────────────────────────────────────────────────────
+  const auth = await requirePermission(request, [...MARKDOWN_IMPORT_APPLY_PERMISSIONS]);
+  if (!auth.success) {
+    return auth.response;
+  }
+
+  // ── Parse query parameters ─────────────────────────────────────────────────
+  const searchParams = request.nextUrl.searchParams;
+  const candidateIdsParam = searchParams.get("candidateIds");
+  const mode = (searchParams.get("mode") ?? "upsert") as "create" | "update" | "upsert";
+  const forceOverwrite = searchParams.get("forceOverwrite") === "true";
+
+  if (!candidateIdsParam) {
+    return NextResponse.json(
+      {
+        success: false,
+        error:
+          "Missing 'candidateIds' query parameter (comma-separated list of relative paths). " +
+          "Run POST /api/sync/import-scan first to get candidates.",
+      },
+      { status: 400 }
+    );
+  }
+
+  if (!["create", "update", "upsert"].includes(mode)) {
+    return NextResponse.json(
+      { success: false, error: "Invalid 'mode'. Must be 'create', 'update', or 'upsert'." },
+      { status: 400 }
+    );
+  }
+
+  const candidateIds = candidateIdsParam.split(",").map((id) => id.trim()).filter(Boolean);
+  if (candidateIds.length === 0) {
+    return NextResponse.json({ success: false, error: "Empty 'candidateIds'." }, { status: 400 });
+  }
+
+  // ── Load vault config ─────────────────────────────────────────────────────
+  const config = getObsidianSyncConfig();
+  if (!config) {
+    return NextResponse.json(
+      { success: false, error: "Obsidian sync is not enabled. Set OBSIDIAN_SYNC_ENABLED and OBSIDIAN_SYNC_VAULT_PATH." },
+      { status: 500 }
+    );
+  }
+
+  // ── Load manifest ─────────────────────────────────────────────────────────
+  const manifest = loadManifest(config.vaultPath, config.manifestPath);
+  if (!manifest) {
+    return NextResponse.json(
+      { success: false, error: "Manifest not found. Run POST /api/sync/obsidian first." },
+      { status: 400 }
+    );
+  }
+
+  // ── Run full scan to get fresh candidate data ─────────────────────────────
+  // Note: scanMarkdownImportCandidates returns MarkdownImportScanResult with success: true.
+  // If it fails, it throws an exception (e.g., MarkdownImportScanLimitError).
+  // The try-catch below handles this.
+  const scanResult = scanMarkdownImportCandidates({
+    vaultPath: config.vaultPath,
+    manifestPath: config.manifestPath,
+    includeUntracked: true,
+    maxFiles: 5_000,
+  });
+
+  // Filter to only the requested candidate IDs
+  const requestedCandidates: MarkdownImportCandidate[] = [];
+  const notFound: string[] = [];
+
+  for (const candidateId of candidateIds) {
+    const candidate = scanResult.candidates.find((c) => c.relativePath === candidateId);
+    if (candidate) {
+      requestedCandidates.push(candidate);
+    } else {
+      notFound.push(candidateId);
+    }
+  }
+
+  if (requestedCandidates.length === 0) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: "None of the specified candidate IDs were found in the current scan.",
+        notFound,
+      },
+      { status: 404 }
+    );
+  }
+
+  // ── Preview apply (dry-run) ──────────────────────────────────────────────
+  const performedBy = auth.auth.name ?? auth.auth.keyId ?? auth.auth.userId ?? "system";
+
+  try {
+    const result = await applyMarkdownImports(prisma, {
+      vaultPath: config.vaultPath,
+      manifest,
+      candidates: requestedCandidates,
+      mode,
+      forceOverwrite,
+      dryRun: true,
+      performedBy,
+    });
+
+    return NextResponse.json({
+      ...result,
+      notFound: notFound.length > 0 ? notFound : undefined,
+    });
+  } catch (err) {
+    console.error("[import-apply-preview] Error running preview:", err);
+    return NextResponse.json(
+      { success: false, error: "Internal error during preview.", detail: String(err) },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/sync/import-apply/preview/route.ts
+++ b/src/app/api/sync/import-apply/preview/route.ts
@@ -142,6 +142,7 @@ export async function GET(request: NextRequest) {
     const result = await applyMarkdownImports(prisma, {
       vaultPath: config.vaultPath,
       manifest,
+      config,
       candidates: requestedCandidates,
       mode,
       forceOverwrite,

--- a/src/app/api/sync/import-apply/preview/route.ts
+++ b/src/app/api/sync/import-apply/preview/route.ts
@@ -20,7 +20,7 @@ import {
   applyMarkdownImports,
   MARKDOWN_IMPORT_APPLY_PERMISSIONS,
 } from "@/lib/markdown-sync/import-applier";
-import { scanMarkdownImportCandidates } from "@/lib/markdown-sync/import-scanner";
+import { scanMarkdownImportCandidates, MarkdownImportScanLimitError } from "@/lib/markdown-sync/import-scanner";
 import type { Manifest } from "@/lib/obsidian-sync";
 import type { MarkdownImportCandidate } from "@/lib/markdown-sync/import-scanner";
 
@@ -83,7 +83,15 @@ export async function GET(request: NextRequest) {
   }
 
   // ── Load vault config ─────────────────────────────────────────────────────
-  const config = getObsidianSyncConfig();
+  let config;
+  try {
+    config = getObsidianSyncConfig();
+  } catch (err) {
+    return NextResponse.json(
+      { success: false, error: `Configuration error: ${(err as Error).message}` },
+      { status: 400 }
+    );
+  }
   if (!config) {
     return NextResponse.json(
       { success: false, error: "Obsidian sync is not enabled. Set OBSIDIAN_SYNC_ENABLED and OBSIDIAN_SYNC_VAULT_PATH." },
@@ -100,45 +108,42 @@ export async function GET(request: NextRequest) {
     );
   }
 
-  // ── Run full scan to get fresh candidate data ─────────────────────────────
-  // Note: scanMarkdownImportCandidates returns MarkdownImportScanResult with success: true.
-  // If it fails, it throws an exception (e.g., MarkdownImportScanLimitError).
-  // The try-catch below handles this.
-  const scanResult = scanMarkdownImportCandidates({
-    vaultPath: config.vaultPath,
-    manifestPath: config.manifestPath,
-    includeUntracked: true,
-    maxFiles: 5_000,
-  });
-
-  // Filter to only the requested candidate IDs
-  const requestedCandidates: MarkdownImportCandidate[] = [];
-  const notFound: string[] = [];
-
-  for (const candidateId of candidateIds) {
-    const candidate = scanResult.candidates.find((c) => c.relativePath === candidateId);
-    if (candidate) {
-      requestedCandidates.push(candidate);
-    } else {
-      notFound.push(candidateId);
-    }
-  }
-
-  if (requestedCandidates.length === 0) {
-    return NextResponse.json(
-      {
-        success: false,
-        error: "None of the specified candidate IDs were found in the current scan.",
-        notFound,
-      },
-      { status: 404 }
-    );
-  }
-
   // ── Preview apply (dry-run) ──────────────────────────────────────────────
   const performedBy = auth.auth.name ?? auth.auth.keyId ?? auth.auth.userId ?? "system";
 
   try {
+    // ── Run full scan to get fresh candidate data ─────────────────────────────
+    const scanResult = scanMarkdownImportCandidates({
+      vaultPath: config.vaultPath,
+      manifestPath: config.manifestPath,
+      includeUntracked: true,
+      maxFiles: 5_000,
+    });
+
+    // Filter to only the requested candidate IDs
+    const requestedCandidates: MarkdownImportCandidate[] = [];
+    const notFound: string[] = [];
+
+    for (const candidateId of candidateIds) {
+      const candidate = scanResult.candidates.find((c) => c.relativePath === candidateId);
+      if (candidate) {
+        requestedCandidates.push(candidate);
+      } else {
+        notFound.push(candidateId);
+      }
+    }
+
+    if (requestedCandidates.length === 0) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: "None of the specified candidate IDs were found in the current scan.",
+          notFound,
+        },
+        { status: 404 }
+      );
+    }
+
     const result = await applyMarkdownImports(prisma, {
       vaultPath: config.vaultPath,
       manifest,
@@ -155,6 +160,12 @@ export async function GET(request: NextRequest) {
       notFound: notFound.length > 0 ? notFound : undefined,
     });
   } catch (err) {
+    if (err instanceof MarkdownImportScanLimitError) {
+      return NextResponse.json(
+        { success: false, error: err.message },
+        { status: 413 }
+      );
+    }
     console.error("[import-apply-preview] Error running preview:", err);
     return NextResponse.json(
       { success: false, error: "Internal error during preview.", detail: String(err) },

--- a/src/app/api/sync/import-apply/route.ts
+++ b/src/app/api/sync/import-apply/route.ts
@@ -1,0 +1,135 @@
+/**
+ * POST /api/sync/import-apply
+ *
+ * Applies vault-side markdown changes back into Noosphere DB.
+ * This is a write-capable admin endpoint with tight security.
+ *
+ * Phase 5 of the obsidian sync pipeline.
+ */
+
+export const dynamic = "force-dynamic";
+
+import { NextRequest, NextResponse } from "next/server";
+import { existsSync, readFileSync } from "fs";
+import { join, resolve } from "path";
+import { requirePermission } from "@/lib/api/auth";
+import { getObsidianSyncConfig } from "@/lib/obsidian-sync/config";
+import { rateLimit } from "@/lib/rate-limit";
+import { prisma } from "@/lib/prisma";
+import {
+  applyMarkdownImports,
+  MARKDOWN_IMPORT_APPLY_MAX_BODY_BYTES,
+  MARKDOWN_IMPORT_APPLY_PERMISSIONS,
+} from "@/lib/markdown-sync/import-applier";
+import type { Manifest } from "@/lib/obsidian-sync";
+import type { MarkdownImportCandidate } from "@/lib/markdown-sync/import-scanner";
+
+const IMPORT_APPLY_RATE_LIMIT = { windowMs: 60_000, maxRequests: 5, keyPrefix: "sync-import-apply-post" };
+
+/**
+ * Load and validate a manifest from the vault.
+ */
+function loadManifest(vaultPath: string, manifestRelPath: string): Manifest | null {
+  const manifestAbsPath = resolve(vaultPath, manifestRelPath);
+  if (!existsSync(manifestAbsPath)) return null;
+  try {
+    const parsed = JSON.parse(readFileSync(manifestAbsPath, "utf-8")) as Manifest;
+    if (parsed.version !== 1) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export async function POST(request: NextRequest) {
+  // ── Rate Limiting (ADMIN only, 5/min) ───────────────────────────────────
+  const rl = await rateLimit(request, IMPORT_APPLY_RATE_LIMIT);
+  if (!rl.allowed) return rl.response;
+
+  // ── Auth Check ────────────────────────────────────────────────────────────
+  const auth = await requirePermission(request, [...MARKDOWN_IMPORT_APPLY_PERMISSIONS]);
+  if (!auth.success) {
+    return auth.response;
+  }
+
+  // ── Parse request body ───────────────────────────────────────────────────
+  let body: ImportApplyRequestBody;
+  try {
+    const rawBody = await request.text();
+    if (rawBody.length > MARKDOWN_IMPORT_APPLY_MAX_BODY_BYTES) {
+      return NextResponse.json(
+        { success: false, error: "Request body too large." },
+        { status: 413 }
+      );
+    }
+    body = JSON.parse(rawBody);
+  } catch {
+    return NextResponse.json(
+      { success: false, error: "Invalid JSON body." },
+      { status: 400 }
+    );
+  }
+
+  // ── Validate request body ─────────────────────────────────────────────────
+  if (!body.candidates || !Array.isArray(body.candidates) || body.candidates.length === 0) {
+    return NextResponse.json(
+      { success: false, error: "Missing or empty 'candidates' array." },
+      { status: 400 }
+    );
+  }
+
+  if (!["create", "update", "upsert"].includes(body.mode)) {
+    return NextResponse.json(
+      { success: false, error: "Invalid 'mode'. Must be 'create', 'update', or 'upsert'." },
+      { status: 400 }
+    );
+  }
+
+  // ── Load vault config ─────────────────────────────────────────────────────
+  const config = getObsidianSyncConfig();
+  if (!config) {
+    return NextResponse.json(
+      { success: false, error: "Obsidian sync is not enabled. Set OBSIDIAN_SYNC_ENABLED and OBSIDIAN_SYNC_VAULT_PATH." },
+      { status: 500 }
+    );
+  }
+
+  // ── Load manifest ─────────────────────────────────────────────────────────
+  const manifest = loadManifest(config.vaultPath, config.manifestPath);
+  if (!manifest) {
+    return NextResponse.json(
+      { success: false, error: "Manifest not found. Run POST /api/sync/obsidian first." },
+      { status: 400 }
+    );
+  }
+
+  // ── Apply imports ────────────────────────────────────────────────────────
+  const performedBy = auth.auth.name ?? auth.auth.keyId ?? auth.auth.userId ?? "system";
+
+  try {
+    const result = await applyMarkdownImports(prisma, {
+      vaultPath: config.vaultPath,
+      manifest,
+      candidates: body.candidates as MarkdownImportCandidate[],
+      mode: body.mode,
+      forceOverwrite: body.forceOverwrite ?? false,
+      dryRun: body.dryRun ?? false,
+      performedBy,
+    });
+
+    return NextResponse.json(result, { status: result.success ? 200 : 500 });
+  } catch (err) {
+    console.error("[import-apply] Error applying imports:", err);
+    return NextResponse.json(
+      { success: false, error: "Internal error during import.", detail: String(err) },
+      { status: 500 }
+    );
+  }
+}
+
+interface ImportApplyRequestBody {
+  candidates: unknown;
+  mode: "create" | "update" | "upsert";
+  forceOverwrite?: boolean;
+  dryRun?: boolean;
+}

--- a/src/app/api/sync/import-apply/route.ts
+++ b/src/app/api/sync/import-apply/route.ts
@@ -110,6 +110,7 @@ export async function POST(request: NextRequest) {
     const result = await applyMarkdownImports(prisma, {
       vaultPath: config.vaultPath,
       manifest,
+      config,
       candidates: body.candidates as MarkdownImportCandidate[],
       mode: body.mode,
       forceOverwrite: body.forceOverwrite ?? false,

--- a/src/app/api/sync/import-apply/route.ts
+++ b/src/app/api/sync/import-apply/route.ts
@@ -56,7 +56,7 @@ export async function POST(request: NextRequest) {
   let body: ImportApplyRequestBody;
   try {
     const rawBody = await request.text();
-    if (rawBody.length > MARKDOWN_IMPORT_APPLY_MAX_BODY_BYTES) {
+    if (Buffer.byteLength(rawBody, "utf-8") > MARKDOWN_IMPORT_APPLY_MAX_BODY_BYTES) {
       return NextResponse.json(
         { success: false, error: "Request body too large." },
         { status: 413 }
@@ -86,7 +86,15 @@ export async function POST(request: NextRequest) {
   }
 
   // ── Load vault config ─────────────────────────────────────────────────────
-  const config = getObsidianSyncConfig();
+  let config;
+  try {
+    config = getObsidianSyncConfig();
+  } catch (err) {
+    return NextResponse.json(
+      { success: false, error: `Configuration error: ${(err as Error).message}` },
+      { status: 400 }
+    );
+  }
   if (!config) {
     return NextResponse.json(
       { success: false, error: "Obsidian sync is not enabled. Set OBSIDIAN_SYNC_ENABLED and OBSIDIAN_SYNC_VAULT_PATH." },

--- a/src/lib/markdown-sync/import-applier.ts
+++ b/src/lib/markdown-sync/import-applier.ts
@@ -19,7 +19,10 @@ import type { PrismaClient } from "@prisma/client";
 import type {
   MarkdownImportCandidate,
 } from "@/lib/markdown-sync/import-scanner";
+import { resolveExistingVaultFilePath } from "@/lib/markdown-sync/import-scanner";
 import { parseNoosphereMarkdown } from "@/lib/markdown/noosphere-markdown";
+import { invalidateSearchCache } from "@/lib/cache/search-cache";
+import { isValidConfidence, isValidStatus } from "@/lib/validation";
 import type { Manifest, ManifestEntry } from "@/lib/obsidian-sync";
 import type { ObsidianSyncConfig } from "@/lib/obsidian-sync/config";
 
@@ -114,6 +117,11 @@ export async function applyMarkdownImports(
     }
   }
 
+  // Invalidate search cache if any articles were created or updated
+  if (!dryRun && (created > 0 || updated > 0)) {
+    await invalidateSearchCache();
+  }
+
   // Persist manifest to disk after all candidates have been processed
   // (only in real mode, not dry-run)
   if (!dryRun) {
@@ -152,7 +160,9 @@ async function applySingleCandidate(
   options: ApplySingleOptions
 ): Promise<ImportApplyCandidateResult> {
   const { candidate, vaultPath, manifest, mode, forceOverwrite, dryRun, performedBy } = options;
-  const absolutePath = join(vaultPath, candidate.relativePath);
+
+  // ── Validate path to prevent directory traversal ────────────────────────
+  const absolutePath = resolveExistingVaultFilePath(vaultPath, candidate.relativePath);
 
   // ── Handle `missing` candidates ──────────────────────────────────────────
   // A "missing" candidate means the file existed before but is now gone.
@@ -177,6 +187,31 @@ async function applySingleCandidate(
       action: "skipped",
       articleId: candidate.articleId,
       conflictReason: "File is missing from vault — DB article untouched.",
+      warning: null,
+    };
+  }
+
+  // ── Reject candidates with invalid paths (traversal, symlinks, etc.) ────
+  if (!absolutePath) {
+    await recordAudit(prisma, {
+      articleId: candidate.articleId ?? null,
+      relativePath: candidate.relativePath,
+      action: "skipped",
+      kind: candidate.kind,
+      dryRun,
+      mode,
+      forceOverwrite,
+      markdownHash: candidate.markdownHash ?? null,
+      noosphereHash: null,
+      conflictReason: "Path traversal rejected: file is outside the vault, is a symlink, or does not exist.",
+      performedBy,
+    });
+
+    return {
+      candidate,
+      action: "skipped",
+      articleId: candidate.articleId ?? null,
+      conflictReason: "Path traversal rejected: file is outside the vault, is a symlink, or does not exist.",
       warning: null,
     };
   }
@@ -235,9 +270,9 @@ async function applySingleCandidate(
             if (candidate.markdownHash !== candidate.baselineHash) {
               // File has been modified since baseline. This is expected for "modified" candidates.
               // For baseline-missing, we don't have a baseline, so we can't do this check.
-              // We only conflict if forceOverwrite is false and mode is "update".
-              if (!forceOverwrite && mode === "update") {
-                // In update mode without force, we skip if there's an existing article
+              // We only conflict if forceOverwrite is false.
+              if (!forceOverwrite) {
+                // In update/upsert mode without force, we skip if there's an existing article
                 // to avoid accidentally overwriting newer DB content.
                 await recordAudit(prisma, {
                   articleId: candidate.articleId,
@@ -249,7 +284,7 @@ async function applySingleCandidate(
                   forceOverwrite,
                   markdownHash: candidate.markdownHash ?? null,
                   noosphereHash: candidate.baselineHash ?? null,
-                  conflictReason: "Article exists in DB and mode is 'update' without forceOverwrite. Skipped to preserve DB state.",
+                  conflictReason: "Article exists in DB and forceOverwrite is false. Skipped to preserve DB state.",
                   performedBy,
                 });
 
@@ -257,7 +292,7 @@ async function applySingleCandidate(
                   candidate,
                   action: "conflict",
                   articleId: candidate.articleId,
-                  conflictReason: "Article exists in DB and mode is 'update' without forceOverwrite. Skipped to preserve DB state.",
+                  conflictReason: "Article exists in DB and forceOverwrite is false. Skipped to preserve DB state.",
                   warning: null,
                 };
               }
@@ -455,6 +490,12 @@ async function applyCreateOrUpdate(
     };
   }
 
+  // ── Validate confidence and status ───────────────────────────────────────
+  const rawConfidence = typeof frontmatter.confidence === "string" ? frontmatter.confidence : null;
+  const rawStatus = typeof frontmatter.status === "string" ? frontmatter.status : null;
+  const confidence = rawConfidence && isValidConfidence(rawConfidence) ? rawConfidence : "medium";
+  const status = rawStatus && isValidStatus(rawStatus) ? rawStatus : "published";
+
   // ── Build article data ─────────────────────────────────────────────────────
   const articleData = {
     title: (frontmatter.title as string | null) ?? metadata?.title ?? slug,
@@ -465,8 +506,8 @@ async function applyCreateOrUpdate(
     topicId: topic.id,
     sourceType: "markdown-import" as const,
     sourceUrl: null,
-    confidence: ((frontmatter.confidence as string) ?? "medium") as "low" | "medium" | "high",
-    status: ((frontmatter.status as string) ?? "published") as "draft" | "reviewed" | "published",
+    confidence,
+    status,
     restrictedTags: (frontmatter.restrictedTags as string[] | undefined) ?? metadata?.restrictedTags ?? [],
   };
 
@@ -474,13 +515,13 @@ async function applyCreateOrUpdate(
   let action: ImportApplyAction;
 
   if (existingArticle) {
-    if (!forceOverwrite && mode === "update") {
-      // Already checked above, but double-check
+    if (!forceOverwrite && (mode === "update" || mode === "upsert")) {
+      // Guard against overwriting existing articles without explicit forceOverwrite
       return {
         candidate,
         action: "conflict",
         articleId: existingArticle.id,
-        conflictReason: "Existing article found and mode is 'update' without forceOverwrite.",
+        conflictReason: "Existing article found and forceOverwrite is false.",
         warning: null,
       };
     }
@@ -545,14 +586,24 @@ async function applyCreateOrUpdate(
   }
 
   // ── Handle tags ────────────────────────────────────────────────────────────
-  const tags = (frontmatter.tags as string[] | undefined) ?? metadata?.tags ?? [];
-  if (!dryRun && articleId && tags.length > 0) {
-    await syncArticleTags(prisma, articleId, tags);
+  const rawTags = (frontmatter.tags as unknown[] | undefined) ?? metadata?.tags ?? [];
+  // Validate: keep only non-empty strings, then deduplicate by slug
+  const validTags: string[] = [];
+  const seenSlugs = new Set<string>();
+  for (const tag of rawTags) {
+    if (typeof tag !== "string" || tag.trim().length === 0) continue;
+    const tagSlug = slugify(tag);
+    if (tagSlug.length === 0 || seenSlugs.has(tagSlug)) continue;
+    seenSlugs.add(tagSlug);
+    validTags.push(tag);
+  }
+  if (!dryRun && articleId && validTags.length > 0) {
+    await syncArticleTags(prisma, articleId, validTags);
   }
 
   // ── Update manifest with new written hash ──────────────────────────────────
   if (!dryRun && articleId && candidate.markdownHash) {
-    await updateManifestHash(manifest, vaultPath, candidate.relativePath, candidate.markdownHash);
+    updateManifestHash(manifest, vaultPath, candidate.relativePath, candidate.markdownHash);
   }
 
   return {

--- a/src/lib/markdown-sync/import-applier.ts
+++ b/src/lib/markdown-sync/import-applier.ts
@@ -66,6 +66,7 @@ export interface ImportApplyCandidateResult {
   articleId: string | null;
   conflictReason: string | null;
   warning: string | null;
+  updatedAtIso?: string;
 }
 
 /**
@@ -255,47 +256,40 @@ async function applySingleCandidate(
       });
 
       if (existingArticle) {
-        // Conflict check: if the article was updated in DB AFTER the markdown file
-        // was last modified (according to the manifest's baseline hash), skip.
+        // Conflict check: compare DB modification time with manifest's last update time.
+        // If DB was updated AFTER manifest's updatedAt, the article was modified in DB
+        // after Noosphere last synced, so we should not overwrite without forceOverwrite.
         if (!forceOverwrite && candidate.baselineHash) {
-          // We use the markdown file's mtime as a proxy for when it was last changed.
-          // If we have a manifest entry with writtenHash, we compare.
           const manifestEntry = findManifestEntry(manifest, candidate.relativePath);
           if (manifestEntry) {
-            // The file has been modified since Noosphere last wrote it.
-            // Check if DB is newer than the file change.
-            // Since we don't have the exact file mtime in the candidate, we use
-            // the markdownHash comparison as a proxy.
-            // If markdownHash !== baselineHash, the file was modified.
-            if (candidate.markdownHash !== candidate.baselineHash) {
-              // File has been modified since baseline. This is expected for "modified" candidates.
-              // For baseline-missing, we don't have a baseline, so we can't do this check.
-              // We only conflict if forceOverwrite is false.
-              if (!forceOverwrite) {
-                // In update/upsert mode without force, we skip if there's an existing article
-                // to avoid accidentally overwriting newer DB content.
-                await recordAudit(prisma, {
-                  articleId: candidate.articleId,
-                  relativePath: candidate.relativePath,
-                  action: "conflict",
-                  kind: candidate.kind,
-                  dryRun,
-                  mode,
-                  forceOverwrite,
-                  markdownHash: candidate.markdownHash ?? null,
-                  noosphereHash: candidate.baselineHash ?? null,
-                  conflictReason: "Article exists in DB and forceOverwrite is false. Skipped to preserve DB state.",
-                  performedBy,
-                });
+            // Compare DB updatedAt with manifest updatedAt to detect DB-side changes
+            const dbUpdatedAtMs = existingArticle.updatedAt.getTime();
+            const manifestUpdatedAtMs = new Date(manifestEntry.updatedAt).getTime();
+            const dbWasUpdated = dbUpdatedAtMs > manifestUpdatedAtMs;
 
-                return {
-                  candidate,
-                  action: "conflict",
-                  articleId: candidate.articleId,
-                  conflictReason: "Article exists in DB and forceOverwrite is false. Skipped to preserve DB state.",
-                  warning: null,
-                };
-              }
+            // Only conflict if DB was updated AND file was modified since baseline
+            if (dbWasUpdated && candidate.markdownHash !== candidate.baselineHash) {
+              await recordAudit(prisma, {
+                articleId: candidate.articleId,
+                relativePath: candidate.relativePath,
+                action: "conflict",
+                kind: candidate.kind,
+                dryRun,
+                mode,
+                forceOverwrite,
+                markdownHash: candidate.markdownHash ?? null,
+                noosphereHash: candidate.baselineHash ?? null,
+                conflictReason: "Article was modified in DB after last sync. Skipped to preserve DB state.",
+                performedBy,
+              });
+
+              return {
+                candidate,
+                action: "conflict",
+                articleId: candidate.articleId,
+                conflictReason: "Article was modified in DB after last sync. Skipped to preserve DB state.",
+                warning: null,
+              };
             }
           }
         }
@@ -513,15 +507,16 @@ async function applyCreateOrUpdate(
 
   let articleId: string;
   let action: ImportApplyAction;
+  let updatedAtIso: string | undefined;
 
   if (existingArticle) {
-    if (!forceOverwrite && (mode === "update" || mode === "upsert")) {
+    if (!forceOverwrite && (mode === "update" || mode === "upsert") && candidate.kind === "baseline-missing") {
       // Guard against overwriting existing articles without explicit forceOverwrite
       return {
         candidate,
         action: "conflict",
         articleId: existingArticle.id,
-        conflictReason: "Existing article found and forceOverwrite is false.",
+        conflictReason: "Article was modified in DB after last sync. Skipped to preserve DB state.",
         warning: null,
       };
     }
@@ -540,6 +535,7 @@ async function applyCreateOrUpdate(
 
       articleId = updated.id;
       action = "updated";
+      updatedAtIso = updated.updatedAt.toISOString();
 
       // Record audit
       await recordAudit(prisma, {
@@ -567,6 +563,7 @@ async function applyCreateOrUpdate(
 
       articleId = created.id;
       action = "created";
+      updatedAtIso = created.updatedAt.toISOString();
 
       // Record audit
       await recordAudit(prisma, {
@@ -597,13 +594,20 @@ async function applyCreateOrUpdate(
     seenSlugs.add(tagSlug);
     validTags.push(tag);
   }
-  if (!dryRun && articleId && validTags.length > 0) {
+  if (!dryRun && articleId) {
     await syncArticleTags(prisma, articleId, validTags);
   }
 
-  // ── Update manifest with new written hash ──────────────────────────────────
+  // ── Update manifest entry ─────────────────────────────────────────────────────
   if (!dryRun && articleId && candidate.markdownHash) {
-    updateManifestHash(manifest, vaultPath, candidate.relativePath, candidate.markdownHash);
+    updateManifestEntry(
+      manifest,
+      articleId,
+      candidate.relativePath,
+      updatedAtIso ?? new Date().toISOString(),
+      candidate.markdownHash,
+      candidate.markdownHash
+    );
   }
 
   return {
@@ -612,6 +616,7 @@ async function applyCreateOrUpdate(
     articleId,
     conflictReason: null,
     warning: null,
+    updatedAtIso,
   };
 }
 
@@ -688,22 +693,35 @@ function findManifestEntry(manifest: Manifest, relativePath: string): ManifestEn
 }
 
 /**
- * Update the writtenHash for a manifest entry identified by its relative path.
+ * Add or update a manifest entry for an article.
+ * - Removes any stale entries for the same relativePath with a different articleId.
+ * - Creates or updates the entry with all required fields.
  * Note: The manifest file itself should be written back by the caller
  * after all candidates are processed.
  */
-function updateManifestHash(
+function updateManifestEntry(
   manifest: Manifest,
-  _vaultPath: string,
+  articleId: string,
   relativePath: string,
-  newHash: string
+  updatedAt: string,
+  contentHash: string,
+  writtenHash: string
 ): void {
-  for (const entry of Object.values(manifest.articles)) {
-    if (entry.path === relativePath) {
-      entry.writtenHash = newHash;
-      break;
+  // Clean up stale entries for the same path (different articleId)
+  for (const [id, entry] of Object.entries(manifest.articles)) {
+    if (entry.path === relativePath && id !== articleId) {
+      delete manifest.articles[id];
     }
   }
+
+  // Create or update the manifest entry
+  manifest.articles[articleId] = {
+    path: relativePath,
+    updatedAt,
+    contentHash,
+    writtenHash,
+    deletedAt: null,
+  };
 }
 
 function deriveSlugFromTitle(title: string): string {

--- a/src/lib/markdown-sync/import-applier.ts
+++ b/src/lib/markdown-sync/import-applier.ts
@@ -13,15 +13,15 @@
  * 5. Return a detailed result object with stats and warnings
  */
 
-import { readFileSync } from "fs";
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "fs";
 import { join } from "path";
 import type { PrismaClient } from "@prisma/client";
 import type {
   MarkdownImportCandidate,
-  MarkdownImportMetadata,
 } from "@/lib/markdown-sync/import-scanner";
 import { parseNoosphereMarkdown } from "@/lib/markdown/noosphere-markdown";
 import type { Manifest, ManifestEntry } from "@/lib/obsidian-sync";
+import type { ObsidianSyncConfig } from "@/lib/obsidian-sync/config";
 
 export const MARKDOWN_IMPORT_APPLY_MAX_BODY_BYTES = 256 * 1024; // 256KB
 export const MARKDOWN_IMPORT_APPLY_PERMISSIONS = ["ADMIN"] as const;
@@ -32,6 +32,7 @@ export type ImportApplyAction = "created" | "updated" | "skipped" | "conflict";
 export interface ImportApplyOptions {
   vaultPath: string;
   manifest: Manifest;
+  config: ObsidianSyncConfig;
   candidates: MarkdownImportCandidate[];
   mode: ImportApplyMode;
   forceOverwrite: boolean;
@@ -72,7 +73,7 @@ export async function applyMarkdownImports(
   options: ImportApplyOptions
 ): Promise<ImportApplyResult> {
   const startMs = Date.now();
-  const { vaultPath, manifest, candidates, mode, forceOverwrite, dryRun, performedBy } = options;
+  const { vaultPath, manifest, config, candidates, mode, forceOverwrite, dryRun, performedBy } = options;
 
   const results: ImportApplyCandidateResult[] = [];
   let created = 0;
@@ -111,6 +112,12 @@ export async function applyMarkdownImports(
     if (result.warning) {
       warnings.push(result.warning);
     }
+  }
+
+  // Persist manifest to disk after all candidates have been processed
+  // (only in real mode, not dry-run)
+  if (!dryRun) {
+    writeManifest(vaultPath, config, manifest);
   }
 
   return {
@@ -216,7 +223,6 @@ async function applySingleCandidate(
         // Conflict check: if the article was updated in DB AFTER the markdown file
         // was last modified (according to the manifest's baseline hash), skip.
         if (!forceOverwrite && candidate.baselineHash) {
-          const dbUpdatedAt = existingArticle.updatedAt.getTime();
           // We use the markdown file's mtime as a proxy for when it was last changed.
           // If we have a manifest entry with writtenHash, we compare.
           const manifestEntry = findManifestEntry(manifest, candidate.relativePath);
@@ -676,4 +682,21 @@ function hashContent(content: string): string {
     hash = hash & hash;
   }
   return Math.abs(hash).toString(16);
+}
+
+/**
+ * Write the manifest to disk using an atomic write (write to temp, then rename).
+ * This mirrors the writeManifest function in src/lib/obsidian-sync/index.ts.
+ */
+function writeManifest(
+  vaultPath: string,
+  config: ObsidianSyncConfig,
+  manifest: Manifest
+): void {
+  const dir = join(vaultPath, ".noosphere-sync");
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  const manifestFile = join(vaultPath, config.manifestPath);
+  const tmp = `${manifestFile}.tmp.${Date.now()}`;
+  writeFileSync(tmp, JSON.stringify(manifest, null, 2), "utf-8");
+  renameSync(tmp, manifestFile);
 }

--- a/src/lib/markdown-sync/import-applier.ts
+++ b/src/lib/markdown-sync/import-applier.ts
@@ -1,0 +1,679 @@
+/**
+ * Reverse markdown import applier.
+ *
+ * Phase 5 of the obsidian sync pipeline: applies vault-side markdown changes
+ * back into Noosphere DB. This is intentionally write-capable and requires
+ * ADMIN permission.
+ *
+ * Core responsibilities:
+ * 1. Parse and validate markdown files from the vault
+ * 2. Determine whether to create, update, or skip each candidate
+ * 3. Write articles to the DB (or simulate in dry-run mode)
+ * 4. Record audit entries for every action taken
+ * 5. Return a detailed result object with stats and warnings
+ */
+
+import { readFileSync } from "fs";
+import { join } from "path";
+import type { PrismaClient } from "@prisma/client";
+import type {
+  MarkdownImportCandidate,
+  MarkdownImportMetadata,
+} from "@/lib/markdown-sync/import-scanner";
+import { parseNoosphereMarkdown } from "@/lib/markdown/noosphere-markdown";
+import type { Manifest, ManifestEntry } from "@/lib/obsidian-sync";
+
+export const MARKDOWN_IMPORT_APPLY_MAX_BODY_BYTES = 256 * 1024; // 256KB
+export const MARKDOWN_IMPORT_APPLY_PERMISSIONS = ["ADMIN"] as const;
+
+export type ImportApplyMode = "create" | "update" | "upsert";
+export type ImportApplyAction = "created" | "updated" | "skipped" | "conflict";
+
+export interface ImportApplyOptions {
+  vaultPath: string;
+  manifest: Manifest;
+  candidates: MarkdownImportCandidate[];
+  mode: ImportApplyMode;
+  forceOverwrite: boolean;
+  dryRun: boolean;
+  performedBy: string;
+}
+
+export interface ImportApplyResult {
+  success: boolean;
+  dryRun: boolean;
+  vaultPath: string;
+  stats: {
+    total: number;
+    created: number;
+    updated: number;
+    skipped: number;
+    conflicts: number;
+    durationMs: number;
+  };
+  // One entry per candidate, in the same order as input
+  results: ImportApplyCandidateResult[];
+  warnings: string[];
+}
+
+export interface ImportApplyCandidateResult {
+  candidate: MarkdownImportCandidate;
+  action: ImportApplyAction | null;
+  articleId: string | null;
+  conflictReason: string | null;
+  warning: string | null;
+}
+
+/**
+ * Main entry point: apply markdown imports from a list of scan candidates.
+ */
+export async function applyMarkdownImports(
+  prisma: PrismaClient,
+  options: ImportApplyOptions
+): Promise<ImportApplyResult> {
+  const startMs = Date.now();
+  const { vaultPath, manifest, candidates, mode, forceOverwrite, dryRun, performedBy } = options;
+
+  const results: ImportApplyCandidateResult[] = [];
+  let created = 0;
+  let updated = 0;
+  let skipped = 0;
+  let conflicts = 0;
+  const warnings: string[] = [];
+
+  for (const candidate of candidates) {
+    const result = await applySingleCandidate(prisma, {
+      candidate,
+      vaultPath,
+      manifest,
+      mode,
+      forceOverwrite,
+      dryRun,
+      performedBy,
+    });
+
+    results.push(result);
+
+    if (dryRun) {
+      // In dry-run mode, we report what WOULD have happened
+      if (result.action === "created") created++;
+      else if (result.action === "updated") updated++;
+      else if (result.action === "conflict") conflicts++;
+      else skipped++;
+    } else {
+      // In real mode, we count what actually happened
+      if (result.action === "created") created++;
+      else if (result.action === "updated") updated++;
+      else if (result.action === "conflict") conflicts++;
+      else skipped++;
+    }
+
+    if (result.warning) {
+      warnings.push(result.warning);
+    }
+  }
+
+  return {
+    success: true,
+    dryRun,
+    vaultPath,
+    stats: {
+      total: candidates.length,
+      created,
+      updated,
+      skipped,
+      conflicts,
+      durationMs: Date.now() - startMs,
+    },
+    results,
+    warnings,
+  };
+}
+
+interface ApplySingleOptions {
+  candidate: MarkdownImportCandidate;
+  vaultPath: string;
+  manifest: Manifest;
+  mode: ImportApplyMode;
+  forceOverwrite: boolean;
+  dryRun: boolean;
+  performedBy: string;
+}
+
+async function applySingleCandidate(
+  prisma: PrismaClient,
+  options: ApplySingleOptions
+): Promise<ImportApplyCandidateResult> {
+  const { candidate, vaultPath, manifest, mode, forceOverwrite, dryRun, performedBy } = options;
+  const absolutePath = join(vaultPath, candidate.relativePath);
+
+  // ── Handle `missing` candidates ──────────────────────────────────────────
+  // A "missing" candidate means the file existed before but is now gone.
+  // We don't delete DB articles automatically (DB wins). Skip silently.
+  if (candidate.kind === "missing") {
+    await recordAudit(prisma, {
+      articleId: candidate.articleId,
+      relativePath: candidate.relativePath,
+      action: "skipped",
+      kind: "missing",
+      dryRun,
+      mode,
+      forceOverwrite,
+      markdownHash: candidate.markdownHash ?? null,
+      noosphereHash: null,
+      conflictReason: "File is missing from vault — DB article untouched.",
+      performedBy,
+    });
+
+    return {
+      candidate,
+      action: "skipped",
+      articleId: candidate.articleId,
+      conflictReason: "File is missing from vault — DB article untouched.",
+      warning: null,
+    };
+  }
+
+  // ── Handle `untracked` candidates ────────────────────────────────────────
+  // Untracked files are not in the manifest and were never synced by Noosphere.
+  // Only import if mode is "create" or "upsert", never "update".
+  if (candidate.kind === "untracked") {
+    if (mode === "update") {
+      return {
+        candidate,
+        action: "skipped",
+        articleId: null,
+        conflictReason: null,
+        warning: `Untracked file ${candidate.relativePath} skipped in "update" mode. Use "create" or "upsert" to import.`,
+      };
+    }
+
+    // Try to create a new article
+    return applyCreateOrUpdate(prisma, {
+      candidate,
+      absolutePath,
+      vaultPath,
+      manifest,
+      mode,
+      forceOverwrite,
+      dryRun,
+      performedBy,
+    });
+  }
+
+  // ── Handle `modified` and `baseline-missing` candidates ──────────────────
+  // These are files that Noosphere previously wrote (or tried to write).
+  // We need to decide whether to update the DB or skip due to conflict.
+  if (candidate.kind === "modified" || candidate.kind === "baseline-missing") {
+    // If there's an articleId, check for conflicts
+    if (candidate.articleId) {
+      const existingArticle = await prisma.article.findUnique({
+        where: { id: candidate.articleId },
+        select: { id: true, updatedAt: true, content: true },
+      });
+
+      if (existingArticle) {
+        // Conflict check: if the article was updated in DB AFTER the markdown file
+        // was last modified (according to the manifest's baseline hash), skip.
+        if (!forceOverwrite && candidate.baselineHash) {
+          const dbUpdatedAt = existingArticle.updatedAt.getTime();
+          // We use the markdown file's mtime as a proxy for when it was last changed.
+          // If we have a manifest entry with writtenHash, we compare.
+          const manifestEntry = findManifestEntry(manifest, candidate.relativePath);
+          if (manifestEntry) {
+            // The file has been modified since Noosphere last wrote it.
+            // Check if DB is newer than the file change.
+            // Since we don't have the exact file mtime in the candidate, we use
+            // the markdownHash comparison as a proxy.
+            // If markdownHash !== baselineHash, the file was modified.
+            if (candidate.markdownHash !== candidate.baselineHash) {
+              // File has been modified since baseline. This is expected for "modified" candidates.
+              // For baseline-missing, we don't have a baseline, so we can't do this check.
+              // We only conflict if forceOverwrite is false and mode is "update".
+              if (!forceOverwrite && mode === "update") {
+                // In update mode without force, we skip if there's an existing article
+                // to avoid accidentally overwriting newer DB content.
+                await recordAudit(prisma, {
+                  articleId: candidate.articleId,
+                  relativePath: candidate.relativePath,
+                  action: "conflict",
+                  kind: candidate.kind,
+                  dryRun,
+                  mode,
+                  forceOverwrite,
+                  markdownHash: candidate.markdownHash ?? null,
+                  noosphereHash: candidate.baselineHash ?? null,
+                  conflictReason: "Article exists in DB and mode is 'update' without forceOverwrite. Skipped to preserve DB state.",
+                  performedBy,
+                });
+
+                return {
+                  candidate,
+                  action: "conflict",
+                  articleId: candidate.articleId,
+                  conflictReason: "Article exists in DB and mode is 'update' without forceOverwrite. Skipped to preserve DB state.",
+                  warning: null,
+                };
+              }
+            }
+          }
+        }
+      }
+    }
+
+    // Determine action based on mode and whether article exists
+    if (mode === "create") {
+      if (candidate.articleId) {
+        // Can't create if article already exists
+        return {
+          candidate,
+          action: "skipped",
+          articleId: candidate.articleId,
+          conflictReason: null,
+          warning: `Article ${candidate.articleId} already exists. Cannot create in "create" mode.`,
+        };
+      }
+      // Fall through to create
+    }
+
+    // Proceed with create or update
+    return applyCreateOrUpdate(prisma, {
+      candidate,
+      absolutePath,
+      vaultPath,
+      manifest,
+      mode,
+      forceOverwrite,
+      dryRun,
+      performedBy,
+    });
+  }
+
+  // Unknown candidate kind — skip
+  return {
+    candidate,
+    action: "skipped",
+    articleId: candidate.articleId,
+    conflictReason: null,
+    warning: `Unknown candidate kind: ${candidate.kind}`,
+  };
+}
+
+interface ApplyCreateOrUpdateOptions {
+  candidate: MarkdownImportCandidate;
+  absolutePath: string;
+  vaultPath: string;
+  manifest: Manifest;
+  mode: ImportApplyMode;
+  forceOverwrite: boolean;
+  dryRun: boolean;
+  performedBy: string;
+}
+
+async function applyCreateOrUpdate(
+  prisma: PrismaClient,
+  options: ApplyCreateOrUpdateOptions
+): Promise<ImportApplyCandidateResult> {
+  const { candidate, absolutePath, vaultPath, manifest, mode, forceOverwrite, dryRun, performedBy } = options;
+
+  // ── Read and parse the markdown file ─────────────────────────────────────
+  let markdownContent: string;
+  try {
+    markdownContent = readFileSync(absolutePath, "utf-8");
+  } catch {
+    await recordAudit(prisma, {
+      articleId: candidate.articleId ?? null,
+      relativePath: candidate.relativePath,
+      action: "skipped",
+      kind: candidate.kind,
+      dryRun,
+      mode,
+      forceOverwrite,
+      markdownHash: candidate.markdownHash ?? null,
+      noosphereHash: null,
+      conflictReason: "Could not read markdown file from disk.",
+      performedBy,
+    });
+
+    return {
+      candidate,
+      action: "skipped",
+      articleId: null,
+      conflictReason: "Could not read markdown file from disk.",
+      warning: null,
+    };
+  }
+
+  // ── Parse frontmatter ──────────────────────────────────────────────────────
+  const parseResult = parseNoosphereMarkdown(markdownContent);
+
+  if (!parseResult.ok) {
+    await recordAudit(prisma, {
+      articleId: candidate.articleId ?? null,
+      relativePath: candidate.relativePath,
+      action: "skipped",
+      kind: candidate.kind,
+      dryRun,
+      mode,
+      forceOverwrite,
+      markdownHash: candidate.markdownHash ?? null,
+      noosphereHash: null,
+      conflictReason: `Markdown parse error: ${parseResult.error}`,
+      performedBy,
+    });
+
+    return {
+      candidate,
+      action: "skipped",
+      articleId: null,
+      conflictReason: `Markdown parse error: ${parseResult.error}`,
+      warning: null,
+    };
+  }
+
+  const frontmatter = parseResult.markdown.frontmatter as Record<string, unknown>;
+  const body = parseResult.markdown.content;
+  const metadata = candidate.metadata;
+
+  // ── Determine topic ────────────────────────────────────────────────────────
+  if (!metadata?.topic) {
+    await recordAudit(prisma, {
+      articleId: candidate.articleId ?? null,
+      relativePath: candidate.relativePath,
+      action: "skipped",
+      kind: candidate.kind,
+      dryRun,
+      mode,
+      forceOverwrite,
+      markdownHash: candidate.markdownHash ?? null,
+      noosphereHash: null,
+      conflictReason: "Markdown has no topic in frontmatter. Cannot import without a topic.",
+      performedBy,
+    });
+
+    return {
+      candidate,
+      action: "skipped",
+      articleId: null,
+      conflictReason: "Markdown has no topic in frontmatter. Cannot import without a topic.",
+      warning: null,
+    };
+  }
+
+  // Look up topic by slug
+  const topic = await prisma.topic.findUnique({
+    where: { slug: metadata.topic },
+  });
+
+  if (!topic) {
+    await recordAudit(prisma, {
+      articleId: candidate.articleId ?? null,
+      relativePath: candidate.relativePath,
+      action: "skipped",
+      kind: candidate.kind,
+      dryRun,
+      mode,
+      forceOverwrite,
+      markdownHash: candidate.markdownHash ?? null,
+      noosphereHash: null,
+      conflictReason: `Topic '${metadata.topic}' not found in Noosphere. Create the topic first.`,
+      performedBy,
+    });
+
+    return {
+      candidate,
+      action: "skipped",
+      articleId: null,
+      conflictReason: `Topic '${metadata.topic}' not found in Noosphere. Create the topic first.`,
+      warning: null,
+    };
+  }
+
+  // ── Determine slug ──────────────────────────────────────────────────────────
+  const slug = metadata.slug ?? deriveSlugFromTitle(
+    (frontmatter.title as string | null) ?? metadata.title ?? candidate.relativePath
+  );
+
+  // ── Check for existing article ──────────────────────────────────────────────
+  const existingArticle = candidate.articleId
+    ? await prisma.article.findUnique({ where: { id: candidate.articleId } })
+    : await prisma.article.findUnique({ where: { topicId_slug: { topicId: topic.id, slug } } });
+
+  if (existingArticle && mode === "create") {
+    return {
+      candidate,
+      action: "skipped",
+      articleId: existingArticle.id,
+      conflictReason: null,
+      warning: `Article with slug '${slug}' already exists in topic '${topic.slug}'. Cannot create in "create" mode.`,
+    };
+  }
+
+  // ── Build article data ─────────────────────────────────────────────────────
+  const articleData = {
+    title: (frontmatter.title as string | null) ?? metadata?.title ?? slug,
+    slug,
+    content: body,
+    excerpt: (frontmatter.excerpt as string | null) ?? null,
+    authorName: (frontmatter.authorName as string | null) ?? null,
+    topicId: topic.id,
+    sourceType: "markdown-import" as const,
+    sourceUrl: null,
+    confidence: ((frontmatter.confidence as string) ?? "medium") as "low" | "medium" | "high",
+    status: ((frontmatter.status as string) ?? "published") as "draft" | "reviewed" | "published",
+    restrictedTags: (frontmatter.restrictedTags as string[] | undefined) ?? metadata?.restrictedTags ?? [],
+  };
+
+  let articleId: string;
+  let action: ImportApplyAction;
+
+  if (existingArticle) {
+    if (!forceOverwrite && mode === "update") {
+      // Already checked above, but double-check
+      return {
+        candidate,
+        action: "conflict",
+        articleId: existingArticle.id,
+        conflictReason: "Existing article found and mode is 'update' without forceOverwrite.",
+        warning: null,
+      };
+    }
+
+    if (dryRun) {
+      articleId = existingArticle.id;
+      action = "updated";
+    } else {
+      // Get current hash for audit
+      const currentHash = hashContent(existingArticle.content);
+
+      const updated = await prisma.article.update({
+        where: { id: existingArticle.id },
+        data: articleData,
+      });
+
+      articleId = updated.id;
+      action = "updated";
+
+      // Record audit
+      await recordAudit(prisma, {
+        articleId,
+        relativePath: candidate.relativePath,
+        action: "updated",
+        kind: candidate.kind,
+        dryRun,
+        mode,
+        forceOverwrite,
+        markdownHash: candidate.markdownHash ?? null,
+        noosphereHash: currentHash,
+        conflictReason: null,
+        performedBy,
+      });
+    }
+  } else {
+    if (dryRun) {
+      articleId = "(would be created)";
+      action = "created";
+    } else {
+      const created = await prisma.article.create({
+        data: articleData,
+      });
+
+      articleId = created.id;
+      action = "created";
+
+      // Record audit
+      await recordAudit(prisma, {
+        articleId,
+        relativePath: candidate.relativePath,
+        action: "created",
+        kind: candidate.kind,
+        dryRun,
+        mode,
+        forceOverwrite,
+        markdownHash: candidate.markdownHash ?? null,
+        noosphereHash: null,
+        conflictReason: null,
+        performedBy,
+      });
+    }
+  }
+
+  // ── Handle tags ────────────────────────────────────────────────────────────
+  const tags = (frontmatter.tags as string[] | undefined) ?? metadata?.tags ?? [];
+  if (!dryRun && articleId && tags.length > 0) {
+    await syncArticleTags(prisma, articleId, tags);
+  }
+
+  // ── Update manifest with new written hash ──────────────────────────────────
+  if (!dryRun && articleId && candidate.markdownHash) {
+    await updateManifestHash(manifest, vaultPath, candidate.relativePath, candidate.markdownHash);
+  }
+
+  return {
+    candidate,
+    action,
+    articleId,
+    conflictReason: null,
+    warning: null,
+  };
+}
+
+async function recordAudit(
+  prisma: PrismaClient,
+  params: {
+    articleId: string | null;
+    relativePath: string;
+    action: ImportApplyAction;
+    kind: string;
+    dryRun: boolean;
+    mode: ImportApplyMode;
+    forceOverwrite: boolean;
+    markdownHash: string | null;
+    noosphereHash: string | null;
+    conflictReason: string | null;
+    performedBy: string;
+  }
+) {
+  if (params.dryRun) return; // No audit in dry-run mode
+
+  await prisma.syncImportAudit.create({
+    data: {
+      articleId: params.articleId,
+      relativePath: params.relativePath,
+      action: params.action,
+      kind: params.kind,
+      dryRun: params.dryRun,
+      forceOverwrite: params.forceOverwrite,
+      mode: params.mode,
+      markdownHash: params.markdownHash,
+      noosphereHash: params.noosphereHash,
+      conflictReason: params.conflictReason,
+      performedBy: params.performedBy,
+    },
+  });
+}
+
+async function syncArticleTags(prisma: PrismaClient, articleId: string, tagNames: string[]) {
+  // Remove existing tags for this article
+  await prisma.articleTag.deleteMany({
+    where: { articleId },
+  });
+
+  // Create or find each tag and link it
+  for (const tagName of tagNames) {
+    const tagSlug = slugify(tagName);
+    const tag = await prisma.tag.upsert({
+      where: { slug: tagSlug },
+      create: { name: tagName, slug: tagSlug },
+      update: {},
+    });
+
+    await prisma.articleTag.create({
+      data: {
+        articleId,
+        tagId: tag.id,
+      },
+    });
+  }
+}
+
+/**
+ * Find a manifest entry by its relative path.
+ * Note: manifest.articles is keyed by articleId, not path, so we must iterate.
+ */
+function findManifestEntry(manifest: Manifest, relativePath: string): ManifestEntry | undefined {
+  for (const entry of Object.values(manifest.articles)) {
+    if (entry.path === relativePath) {
+      return entry;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Update the writtenHash for a manifest entry identified by its relative path.
+ * Note: The manifest file itself should be written back by the caller
+ * after all candidates are processed.
+ */
+function updateManifestHash(
+  manifest: Manifest,
+  _vaultPath: string,
+  relativePath: string,
+  newHash: string
+): void {
+  for (const entry of Object.values(manifest.articles)) {
+    if (entry.path === relativePath) {
+      entry.writtenHash = newHash;
+      break;
+    }
+  }
+}
+
+function deriveSlugFromTitle(title: string): string {
+  return title
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, "")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-")
+    .slice(0, 100);
+}
+
+function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, "")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-")
+    .slice(0, 80);
+}
+
+function hashContent(content: string): string {
+  // Simple hash for audit logging — not cryptographic
+  let hash = 0;
+  for (let i = 0; i < content.length; i++) {
+    const char = content.charCodeAt(i);
+    hash = (hash << 5) - hash + char;
+    hash = hash & hash;
+  }
+  return Math.abs(hash).toString(16);
+}

--- a/src/lib/markdown-sync/import-scanner.ts
+++ b/src/lib/markdown-sync/import-scanner.ts
@@ -482,7 +482,7 @@ function resolveVaultPath(vaultPath: string, relativePath: string): string | nul
   return absolutePath;
 }
 
-function resolveExistingVaultFilePath(vaultPath: string, relativePath: string): string | null {
+export function resolveExistingVaultFilePath(vaultPath: string, relativePath: string): string | null {
   const absolutePath = resolveVaultPath(vaultPath, relativePath);
   if (!absolutePath) return null;
 


### PR DESCRIPTION
## Summary  
Phase 5 implements the reverse import apply flow — turning read-only scan results into controlled admin actions that write Noosphere records from Markdown files.

### New Features

**New API Endpoints:**
 —
 Apply vault-side markdown changes to Noosphere DB (ADMIN only, 5/min rate limit)
-  — Preview what would happen if we apply certain candidates (ADMIN only, 10/min rate limit)\n\n**New Prisma Model:**
-  — records every vault-to-noosphere import action (created/updated/skipped/conflict)
- ### How It Works
- . Admin runs  to get candidates
- 2. Admin runs  to preview
- 3. Admin runs  with candidates array and mode
-  System creates/updates articles and records audit entries
- 
- ### Security\n\n- ADMIN permission required (not just WRITE
- 5/min rate limit on apply, 10/min on preview
- Body size validation (256KB max)\n- All actions logged to SyncImportAudit
- dryRun mode available for safe testing


- ### Files Changed
-  — added SyncImportAudit model
-   — core apply logic (new file)\n-  — POST endpoint (new file)
-   — preview endpoint (new file)\n\n### Testing\n\n- Manual testing recommended: run scan, then preview, then applyu
- Watch for: correct topic resolution, tag syncing, conflict handling

## Summary by Sourcery

Introduce an admin-only phase of the Obsidian sync pipeline that applies vault-side Markdown changes back into the Noosphere database, with dry-run preview and detailed auditing.

New Features:
- Add a markdown import applier that turns scanned vault candidates into article create/update operations with topic and tag resolution, optional dry-run, and manifest updates.
- Expose a POST /api/sync/import-apply endpoint to execute apply operations with mode and overwrite controls, guarded by admin auth, rate limiting, and body size validation.
- Expose a GET /api/sync/import-apply/preview endpoint to simulate import-apply effects for selected candidates without writing to the database.

Enhancements:
- Add a SyncImportAudit persistence model and recording logic to track every vault-to-database import decision and outcome for observability and debugging.