### PR TITLE
refactor: share markdown sync manifest loader

### DIFF
--- a/src/app/api/sync/import-apply/preview/route.ts
+++ b/src/app/api/sync/import-apply/preview/route.ts
@@ -10,36 +10,19 @@
 export const dynamic = "force-dynamic";
 
 import { NextRequest, NextResponse } from "next/server";
-import { existsSync, readFileSync } from "fs";
-import { resolve } from "path";
 import { requirePermission } from "@/lib/api/auth";
 import { getObsidianSyncConfig } from "@/lib/obsidian-sync/config";
 import { rateLimit } from "@/lib/rate-limit";
 import { prisma } from "@/lib/prisma";
+import { loadManifest } from "@/lib/markdown-sync/manifest";
 import {
   applyMarkdownImports,
   MARKDOWN_IMPORT_APPLY_PERMISSIONS,
 } from "@/lib/markdown-sync/import-applier";
 import { scanMarkdownImportCandidates, MarkdownImportScanLimitError } from "@/lib/markdown-sync/import-scanner";
-import type { Manifest } from "@/lib/obsidian-sync";
 import type { MarkdownImportCandidate } from "@/lib/markdown-sync/import-scanner";
 
 const PREVIEW_RATE_LIMIT = { windowMs: 60_000, maxRequests: 10, keyPrefix: "sync-import-apply-preview" };
-
-/**
- * Load and validate a manifest from the vault.
- */
-function loadManifest(vaultPath: string, manifestRelPath: string): Manifest | null {
-  const manifestAbsPath = resolve(vaultPath, manifestRelPath);
-  if (!existsSync(manifestAbsPath)) return null;
-  try {
-    const parsed = JSON.parse(readFileSync(manifestAbsPath, "utf-8")) as Manifest;
-    if (parsed.version !== 1) return null;
-    return parsed;
-  } catch {
-    return null;
-  }
-}
 
 export async function GET(request: NextRequest) {
   // ── Rate Limiting (ADMIN only, 10/min) ──────────────────────────────────

--- a/src/app/api/sync/import-apply/route.ts
+++ b/src/app/api/sync/import-apply/route.ts
@@ -10,36 +10,19 @@
 export const dynamic = "force-dynamic";
 
 import { NextRequest, NextResponse } from "next/server";
-import { existsSync, readFileSync } from "fs";
-import { join, resolve } from "path";
 import { requirePermission } from "@/lib/api/auth";
 import { getObsidianSyncConfig } from "@/lib/obsidian-sync/config";
 import { rateLimit } from "@/lib/rate-limit";
 import { prisma } from "@/lib/prisma";
+import { loadManifest } from "@/lib/markdown-sync/manifest";
 import {
   applyMarkdownImports,
   MARKDOWN_IMPORT_APPLY_MAX_BODY_BYTES,
   MARKDOWN_IMPORT_APPLY_PERMISSIONS,
 } from "@/lib/markdown-sync/import-applier";
-import type { Manifest } from "@/lib/obsidian-sync";
 import type { MarkdownImportCandidate } from "@/lib/markdown-sync/import-scanner";
 
 const IMPORT_APPLY_RATE_LIMIT = { windowMs: 60_000, maxRequests: 5, keyPrefix: "sync-import-apply-post" };
-
-/**
- * Load and validate a manifest from the vault.
- */
-function loadManifest(vaultPath: string, manifestRelPath: string): Manifest | null {
-  const manifestAbsPath = resolve(vaultPath, manifestRelPath);
-  if (!existsSync(manifestAbsPath)) return null;
-  try {
-    const parsed = JSON.parse(readFileSync(manifestAbsPath, "utf-8")) as Manifest;
-    if (parsed.version !== 1) return null;
-    return parsed;
-  } catch {
-    return null;
-  }
-}
 
 export async function POST(request: NextRequest) {
   // ── Rate Limiting (ADMIN only, 5/min) ───────────────────────────────────

--- a/src/lib/markdown-sync/manifest.ts
+++ b/src/lib/markdown-sync/manifest.ts
@@ -1,0 +1,19 @@
+import { existsSync, readFileSync } from "fs";
+import { resolve } from "path";
+import type { Manifest } from "@/lib/obsidian-sync";
+
+/**
+ * Load and validate a Markdown sync manifest from the configured vault.
+ */
+export function loadManifest(vaultPath: string, manifestRelPath: string): Manifest | null {
+  const manifestAbsPath = resolve(vaultPath, manifestRelPath);
+  if (!existsSync(manifestAbsPath)) return null;
+
+  try {
+    const parsed = JSON.parse(readFileSync(manifestAbsPath, "utf-8")) as Manifest;
+    if (parsed.version !== 1) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- Extract duplicated import-apply manifest loading into src/lib/markdown-sync/manifest.ts
- Update apply and preview routes to share the helper
- Preserve existing manifest validation behavior

## Verification
- npm run lint (passes; existing warnings remain)
- DATABASE_URL=<container-db-url> npm run build (passes; known Turbopack tracing warning remains)

## Summary by Sourcery

Enhancements:
- Introduce a shared markdown sync manifest loader utility and update import-apply apply/preview routes to use it.