### PR TITLE
feat: add agent markdown import workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,16 @@ POST /api/import
 # Read-only; requires ADMIN.
 POST /api/sync/import-scan
 # JSON body: includeUntracked?, maxFiles?
+
+# Preview applying scan candidates by vault-relative path.
+# Read-only dry run; requires ADMIN.
+GET /api/sync/import-apply/preview?candidateIds=path/a.md,path/b.md&mode=upsert
+
+# Apply scan candidates by vault-relative path. The server re-scans before
+# applying so agents do not need to submit full candidate objects.
+# Requires ADMIN.
+POST /api/sync/import-apply
+# JSON body: candidateIds, mode, forceOverwrite?, dryRun?, includeUntracked?, maxFiles?
 ```
 
 Export, import, and Obsidian sync share the same versioned frontmatter codec in
@@ -293,7 +303,9 @@ Export, import, and Obsidian sync share the same versioned frontmatter codec in
 The reverse import scanner compares tracked vault files against
 `.noosphere-sync/manifest.json` and reports `modified`, `missing`,
 `baseline-missing`, and `untracked` candidates without writing to the database
-or filesystem.
+or filesystem. Agents should use the returned `relativePath` values as
+`candidateIds` for preview/apply calls, then inspect `notFound`, `conflicts`,
+and per-candidate results before considering the workflow complete.
 
 ## Memory Module API
 

--- a/docs/OBSIDIAN-SYNC-SPEC.md
+++ b/docs/OBSIDIAN-SYNC-SPEC.md
@@ -680,3 +680,26 @@ Scanner behavior:
 
 This gives agents and admins a deterministic inventory of possible vault-side
 changes before later phases implement apply/reconciliation behavior.
+
+## 11. Agent Markdown Import Workflow
+
+Agents can now run the reverse-import flow without resubmitting bulky scan
+candidate objects. The stable identifier for a candidate is its vault-relative
+`relativePath` from `POST /api/sync/import-scan`.
+
+Recommended sequence:
+
+1. Run `POST /api/sync/import-scan` with `includeUntracked` and `maxFiles`
+   appropriate for the vault.
+2. Select candidate `relativePath` values from the scan response.
+3. Run `GET /api/sync/import-apply/preview?candidateIds=<comma-list>` to get a
+   dry-run result from a fresh server-side scan.
+4. Run `POST /api/sync/import-apply` with `candidateIds`, `mode`,
+   `forceOverwrite`, and optional scan controls.
+5. Inspect `notFound`, conflicts, warnings, and per-candidate results. A
+   `notFound` entry means the file changed state between scan and apply and
+   should be re-scanned before retrying.
+
+The apply endpoint still accepts the Phase 5 `candidates` array for backwards
+compatibility, but new agent integrations should prefer `candidateIds` so the
+server always applies candidates from the current vault state.

--- a/src/__tests__/api/markdown-import-workflow.test.ts
+++ b/src/__tests__/api/markdown-import-workflow.test.ts
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  parseMarkdownImportCandidateIds,
+  selectMarkdownImportCandidatesById,
+} from "@/lib/markdown-sync/import-workflow";
+import type { MarkdownImportCandidate } from "@/lib/markdown-sync/import-scanner";
+
+test("parseMarkdownImportCandidateIds accepts arrays and removes blank duplicates", () => {
+  assert.deepEqual(
+    parseMarkdownImportCandidateIds(["projects/a.md", " ", "projects/a.md", "projects/b.md"]),
+    { ok: true, candidateIds: ["projects/a.md", "projects/b.md"] },
+  );
+});
+
+test("parseMarkdownImportCandidateIds accepts comma-separated strings", () => {
+  assert.deepEqual(
+    parseMarkdownImportCandidateIds("projects/a.md, projects/b.md,,projects/a.md"),
+    { ok: true, candidateIds: ["projects/a.md", "projects/b.md"] },
+  );
+});
+
+test("parseMarkdownImportCandidateIds rejects malformed candidate IDs", () => {
+  assert.deepEqual(parseMarkdownImportCandidateIds(undefined), {
+    ok: false,
+    error: "candidateIds must be a non-empty string array or comma-separated string.",
+  });
+  assert.deepEqual(parseMarkdownImportCandidateIds(["projects/a.md", 42]), {
+    ok: false,
+    error: "candidateIds must contain only strings.",
+  });
+  assert.deepEqual(parseMarkdownImportCandidateIds(["", "  "]), {
+    ok: false,
+    error: "candidateIds must include at least one non-empty candidate ID.",
+  });
+});
+
+test("selectMarkdownImportCandidatesById preserves requested order and reports misses", () => {
+  const candidates = [
+    candidate("projects/a.md"),
+    candidate("projects/b.md"),
+    candidate("projects/c.md"),
+  ];
+
+  const result = selectMarkdownImportCandidatesById(candidates, [
+    "projects/c.md",
+    "projects/missing.md",
+    "projects/a.md",
+  ]);
+
+  assert.deepEqual(result.candidates.map((item) => item.relativePath), ["projects/c.md", "projects/a.md"]);
+  assert.deepEqual(result.notFound, ["projects/missing.md"]);
+});
+
+function candidate(relativePath: string): MarkdownImportCandidate {
+  return {
+    kind: "modified",
+    relativePath,
+    articleId: null,
+    manifestPath: relativePath,
+    baselineHash: "old",
+    markdownHash: "new",
+    sizeBytes: 12,
+    metadata: null,
+    parseError: null,
+  };
+}

--- a/src/app/api/sync/import-apply/preview/route.ts
+++ b/src/app/api/sync/import-apply/preview/route.ts
@@ -20,7 +20,10 @@ import {
   MARKDOWN_IMPORT_APPLY_PERMISSIONS,
 } from "@/lib/markdown-sync/import-applier";
 import { scanMarkdownImportCandidates, MarkdownImportScanLimitError } from "@/lib/markdown-sync/import-scanner";
-import type { MarkdownImportCandidate } from "@/lib/markdown-sync/import-scanner";
+import {
+  parseMarkdownImportCandidateIds,
+  selectMarkdownImportCandidatesById,
+} from "@/lib/markdown-sync/import-workflow";
 
 const PREVIEW_RATE_LIMIT = { windowMs: 60_000, maxRequests: 10, keyPrefix: "sync-import-apply-preview" };
 
@@ -60,10 +63,11 @@ export async function GET(request: NextRequest) {
     );
   }
 
-  const candidateIds = candidateIdsParam.split(",").map((id) => id.trim()).filter(Boolean);
-  if (candidateIds.length === 0) {
-    return NextResponse.json({ success: false, error: "Empty 'candidateIds'." }, { status: 400 });
+  const candidateIdsResult = parseMarkdownImportCandidateIds(candidateIdsParam);
+  if (!candidateIdsResult.ok) {
+    return NextResponse.json({ success: false, error: candidateIdsResult.error }, { status: 400 });
   }
+  const candidateIds = candidateIdsResult.candidateIds;
 
   // ── Load vault config ─────────────────────────────────────────────────────
   let config;
@@ -78,7 +82,7 @@ export async function GET(request: NextRequest) {
   if (!config) {
     return NextResponse.json(
       { success: false, error: "Obsidian sync is not enabled. Set OBSIDIAN_SYNC_ENABLED and OBSIDIAN_SYNC_VAULT_PATH." },
-      { status: 500 }
+      { status: 400 }
     );
   }
 
@@ -103,25 +107,15 @@ export async function GET(request: NextRequest) {
       maxFiles: 5_000,
     });
 
-    // Filter to only the requested candidate IDs
-    const requestedCandidates: MarkdownImportCandidate[] = [];
-    const notFound: string[] = [];
+    // Filter to only the requested candidate IDs.
+    const selection = selectMarkdownImportCandidatesById(scanResult.candidates, candidateIds);
 
-    for (const candidateId of candidateIds) {
-      const candidate = scanResult.candidates.find((c) => c.relativePath === candidateId);
-      if (candidate) {
-        requestedCandidates.push(candidate);
-      } else {
-        notFound.push(candidateId);
-      }
-    }
-
-    if (requestedCandidates.length === 0) {
+    if (selection.candidates.length === 0) {
       return NextResponse.json(
         {
           success: false,
           error: "None of the specified candidate IDs were found in the current scan.",
-          notFound,
+          notFound: selection.notFound,
         },
         { status: 404 }
       );
@@ -131,7 +125,7 @@ export async function GET(request: NextRequest) {
       vaultPath: config.vaultPath,
       manifest,
       config,
-      candidates: requestedCandidates,
+      candidates: selection.candidates,
       mode,
       forceOverwrite,
       dryRun: true,
@@ -140,7 +134,7 @@ export async function GET(request: NextRequest) {
 
     return NextResponse.json({
       ...result,
-      notFound: notFound.length > 0 ? notFound : undefined,
+      notFound: selection.notFound.length > 0 ? selection.notFound : undefined,
     });
   } catch (err) {
     if (err instanceof MarkdownImportScanLimitError) {

--- a/src/app/api/sync/import-apply/route.ts
+++ b/src/app/api/sync/import-apply/route.ts
@@ -20,6 +20,15 @@ import {
   MARKDOWN_IMPORT_APPLY_MAX_BODY_BYTES,
   MARKDOWN_IMPORT_APPLY_PERMISSIONS,
 } from "@/lib/markdown-sync/import-applier";
+import {
+  MarkdownImportScanLimitError,
+  scanMarkdownImportCandidates,
+  validateMarkdownImportScanRequestBody,
+} from "@/lib/markdown-sync/import-scanner";
+import {
+  parseMarkdownImportCandidateIds,
+  selectMarkdownImportCandidatesById,
+} from "@/lib/markdown-sync/import-workflow";
 import type { MarkdownImportCandidate } from "@/lib/markdown-sync/import-scanner";
 
 const IMPORT_APPLY_RATE_LIMIT = { windowMs: 60_000, maxRequests: 5, keyPrefix: "sync-import-apply-post" };
@@ -54,9 +63,18 @@ export async function POST(request: NextRequest) {
   }
 
   // ── Validate request body ─────────────────────────────────────────────────
-  if (!body.candidates || !Array.isArray(body.candidates) || body.candidates.length === 0) {
+  const hasCandidates = Array.isArray(body.candidates) && body.candidates.length > 0;
+  const hasCandidateIds = body.candidateIds !== undefined;
+  if (!hasCandidates && !hasCandidateIds) {
     return NextResponse.json(
-      { success: false, error: "Missing or empty 'candidates' array." },
+      { success: false, error: "Provide either a non-empty 'candidates' array or 'candidateIds'." },
+      { status: 400 }
+    );
+  }
+
+  if (hasCandidates && hasCandidateIds) {
+    return NextResponse.json(
+      { success: false, error: "Provide either 'candidates' or 'candidateIds', not both." },
       { status: 400 }
     );
   }
@@ -81,7 +99,7 @@ export async function POST(request: NextRequest) {
   if (!config) {
     return NextResponse.json(
       { success: false, error: "Obsidian sync is not enabled. Set OBSIDIAN_SYNC_ENABLED and OBSIDIAN_SYNC_VAULT_PATH." },
-      { status: 500 }
+      { status: 400 }
     );
   }
 
@@ -94,6 +112,58 @@ export async function POST(request: NextRequest) {
     );
   }
 
+  // ── Resolve candidates ───────────────────────────────────────────────────
+  let candidates: MarkdownImportCandidate[];
+  let notFound: string[] = [];
+  if (hasCandidateIds) {
+    const candidateIdsResult = parseMarkdownImportCandidateIds(body.candidateIds);
+    if (!candidateIdsResult.ok) {
+      return NextResponse.json({ success: false, error: candidateIdsResult.error }, { status: 400 });
+    }
+
+    const scanValidation = validateMarkdownImportScanRequestBody({
+      includeUntracked: body.includeUntracked,
+      maxFiles: body.maxFiles,
+    });
+    if ("errors" in scanValidation) {
+      return NextResponse.json({ success: false, error: scanValidation.errors.join("; ") }, { status: 400 });
+    }
+
+    try {
+      const scanResult = scanMarkdownImportCandidates({
+        vaultPath: config.vaultPath,
+        manifestPath: config.manifestPath,
+        includeUntracked: scanValidation.includeUntracked,
+        maxFiles: scanValidation.maxFiles,
+      });
+      const selection = selectMarkdownImportCandidatesById(scanResult.candidates, candidateIdsResult.candidateIds);
+      candidates = selection.candidates;
+      notFound = selection.notFound;
+    } catch (err) {
+      if (err instanceof MarkdownImportScanLimitError) {
+        return NextResponse.json({ success: false, error: err.message }, { status: 413 });
+      }
+      console.error("[import-apply] Error scanning candidates:", err);
+      return NextResponse.json(
+        { success: false, error: "Failed to scan markdown import candidates.", detail: String(err) },
+        { status: 503 }
+      );
+    }
+
+    if (candidates.length === 0) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: "None of the specified candidate IDs were found in the current scan.",
+          notFound,
+        },
+        { status: 404 }
+      );
+    }
+  } else {
+    candidates = body.candidates as MarkdownImportCandidate[];
+  }
+
   // ── Apply imports ────────────────────────────────────────────────────────
   const performedBy = auth.auth.name ?? auth.auth.keyId ?? auth.auth.userId ?? "system";
 
@@ -102,14 +172,20 @@ export async function POST(request: NextRequest) {
       vaultPath: config.vaultPath,
       manifest,
       config,
-      candidates: body.candidates as MarkdownImportCandidate[],
+      candidates,
       mode: body.mode,
       forceOverwrite: body.forceOverwrite ?? false,
       dryRun: body.dryRun ?? false,
       performedBy,
     });
 
-    return NextResponse.json(result, { status: result.success ? 200 : 500 });
+    return NextResponse.json(
+      {
+        ...result,
+        notFound: notFound.length > 0 ? notFound : undefined,
+      },
+      { status: result.success ? 200 : 500 }
+    );
   } catch (err) {
     console.error("[import-apply] Error applying imports:", err);
     return NextResponse.json(
@@ -120,8 +196,11 @@ export async function POST(request: NextRequest) {
 }
 
 interface ImportApplyRequestBody {
-  candidates: unknown;
+  candidates?: unknown;
+  candidateIds?: unknown;
   mode: "create" | "update" | "upsert";
   forceOverwrite?: boolean;
   dryRun?: boolean;
+  includeUntracked?: unknown;
+  maxFiles?: unknown;
 }

--- a/src/lib/markdown-sync/import-workflow.ts
+++ b/src/lib/markdown-sync/import-workflow.ts
@@ -1,0 +1,69 @@
+import type { MarkdownImportCandidate } from "@/lib/markdown-sync/import-scanner";
+
+export type CandidateIdParseResult =
+  | { ok: true; candidateIds: string[] }
+  | { ok: false; error: string };
+
+export interface CandidateSelectionResult {
+  candidates: MarkdownImportCandidate[];
+  notFound: string[];
+}
+
+/**
+ * Normalize candidate IDs passed by agents.
+ *
+ * Candidate IDs are vault-relative Markdown paths from the import scan result.
+ * Accepting either a JSON array or a comma-separated string keeps the API easy
+ * to call from shell-based agents while preserving strict non-empty strings.
+ */
+export function parseMarkdownImportCandidateIds(input: unknown): CandidateIdParseResult {
+  const rawIds = typeof input === "string"
+    ? input.split(",")
+    : Array.isArray(input)
+      ? input
+      : null;
+
+  if (!rawIds) {
+    return { ok: false, error: "candidateIds must be a non-empty string array or comma-separated string." };
+  }
+
+  const candidateIds: string[] = [];
+  const seen = new Set<string>();
+  for (const rawId of rawIds) {
+    if (typeof rawId !== "string") {
+      return { ok: false, error: "candidateIds must contain only strings." };
+    }
+
+    const candidateId = rawId.trim();
+    if (!candidateId || seen.has(candidateId)) continue;
+
+    seen.add(candidateId);
+    candidateIds.push(candidateId);
+  }
+
+  if (candidateIds.length === 0) {
+    return { ok: false, error: "candidateIds must include at least one non-empty candidate ID." };
+  }
+
+  return { ok: true, candidateIds };
+}
+
+export function selectMarkdownImportCandidatesById(
+  candidates: MarkdownImportCandidate[],
+  candidateIds: string[],
+): CandidateSelectionResult {
+  const byRelativePath = new Map(candidates.map((candidate) => [candidate.relativePath, candidate]));
+  const selected: MarkdownImportCandidate[] = [];
+  const notFound: string[] = [];
+
+  for (const candidateId of candidateIds) {
+    const candidate = byRelativePath.get(candidateId);
+    if (candidate) {
+      selected.push(candidate);
+    } else {
+      notFound.push(candidateId);
+    }
+  }
+
+  return { candidates: selected, notFound };
+}


### PR DESCRIPTION
## Summary
- add `candidateIds` support to `POST /api/sync/import-apply` so agents can apply by vault-relative paths from a fresh server-side scan
- share candidate-id parsing/selection with the preview endpoint
- document the scan -> preview -> apply agent workflow in README and the Obsidian sync spec

## Verification
- `node --import tsx --test src/__tests__/api/markdown-import-workflow.test.ts src/__tests__/api/markdown-import-scanner.test.ts`
- `npm run test:api`
- `npm run lint` (passes with existing warnings only)
- `npm run build`

## Note
- `npm run test:security` currently fails on the existing proxy rate-limit test because rate limiting fails open when Redis is not ready/configured; this is inherited from `master` and outside this PR's import workflow changes.

## Summary by Sourcery

Add support for applying markdown import candidates by stable vault-relative IDs and document the end-to-end agent markdown import workflow.

New Features:
- Support specifying markdown import candidates via candidateIds on the POST /api/sync/import-apply endpoint so agents can apply from server-side scan results.
- Share candidate ID parsing and candidate selection logic between import preview and apply endpoints through a new import workflow helper module.
- Expose scan controls (includeUntracked and maxFiles) on the apply endpoint to control the server-side rescan before applying candidates.

Enhancements:
- Adjust error handling and HTTP status codes for missing Obsidian sync configuration and import scan limit errors, and surface notFound candidate IDs in apply responses.
- Refine candidate ID validation and normalization for the preview endpoint by centralizing parsing and duplicate/empty handling logic.

Documentation:
- Document the agent markdown import workflow, including scan, preview, apply, and result inspection steps, in the Obsidian sync spec and README.

Tests:
- Add unit tests for candidate ID parsing and selection helpers used by the markdown import workflow.