### PR TITLE
fix(import-workflow): address PR #154 review feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,8 @@ POST /api/sync/import-scan
 
 # Preview applying scan candidates by vault-relative path.
 # Read-only dry run; requires ADMIN.
-GET /api/sync/import-apply/preview?candidateIds=path/a.md,path/b.md&mode=upsert
+GET /api/sync/import-apply/preview?candidateIds=path/a.md&candidateIds=path/b.md&mode=upsert
+# Query params: candidateIds (repeatable), mode?, forceOverwrite?, includeUntracked?, maxFiles?
 
 # Apply scan candidates by vault-relative path. The server re-scans before
 # applying so agents do not need to submit full candidate objects.

--- a/docs/OBSIDIAN-SYNC-SPEC.md
+++ b/docs/OBSIDIAN-SYNC-SPEC.md
@@ -692,8 +692,10 @@ Recommended sequence:
 1. Run `POST /api/sync/import-scan` with `includeUntracked` and `maxFiles`
    appropriate for the vault.
 2. Select candidate `relativePath` values from the scan response.
-3. Run `GET /api/sync/import-apply/preview?candidateIds=<comma-list>` to get a
-   dry-run result from a fresh server-side scan.
+3. Run `GET /api/sync/import-apply/preview?candidateIds=<path>&candidateIds=<path>`
+   to get a dry-run result from a fresh server-side scan. The preview endpoint
+   also accepts `includeUntracked` and `maxFiles` query parameters so agents can
+   use the same scan controls for preview and apply.
 4. Run `POST /api/sync/import-apply` with `candidateIds`, `mode`,
    `forceOverwrite`, and optional scan controls.
 5. Inspect `notFound`, conflicts, warnings, and per-candidate results. A

--- a/src/__tests__/api/markdown-import-workflow.test.ts
+++ b/src/__tests__/api/markdown-import-workflow.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import {
   parseMarkdownImportCandidateIds,
   selectMarkdownImportCandidatesById,
+  validateMarkdownImportCandidates,
 } from "@/lib/markdown-sync/import-workflow";
 import type { MarkdownImportCandidate } from "@/lib/markdown-sync/import-scanner";
 
@@ -10,6 +11,13 @@ test("parseMarkdownImportCandidateIds accepts arrays and removes blank duplicate
   assert.deepEqual(
     parseMarkdownImportCandidateIds(["projects/a.md", " ", "projects/a.md", "projects/b.md"]),
     { ok: true, candidateIds: ["projects/a.md", "projects/b.md"] },
+  );
+});
+
+test("parseMarkdownImportCandidateIds preserves commas in array values", () => {
+  assert.deepEqual(
+    parseMarkdownImportCandidateIds(["notes/a, b.md", "projects/c.md"]),
+    { ok: true, candidateIds: ["notes/a, b.md", "projects/c.md"] },
   );
 });
 
@@ -23,15 +31,62 @@ test("parseMarkdownImportCandidateIds accepts comma-separated strings", () => {
 test("parseMarkdownImportCandidateIds rejects malformed candidate IDs", () => {
   assert.deepEqual(parseMarkdownImportCandidateIds(undefined), {
     ok: false,
-    error: "candidateIds must be a non-empty string array or comma-separated string.",
+    error: "candidateIds must be a non-empty string array or comma-separated string; received undefined.",
+  });
+  assert.deepEqual(parseMarkdownImportCandidateIds(42), {
+    ok: false,
+    error: "candidateIds must be a non-empty string array or comma-separated string; received number.",
+  });
+  assert.deepEqual(parseMarkdownImportCandidateIds({}), {
+    ok: false,
+    error: "candidateIds must be a non-empty string array or comma-separated string; received object.",
   });
   assert.deepEqual(parseMarkdownImportCandidateIds(["projects/a.md", 42]), {
     ok: false,
-    error: "candidateIds must contain only strings.",
+    error: "candidateIds[1] must be a string; received number.",
   });
   assert.deepEqual(parseMarkdownImportCandidateIds(["", "  "]), {
     ok: false,
     error: "candidateIds must include at least one non-empty candidate ID.",
+  });
+});
+
+test("validateMarkdownImportCandidates rejects malformed legacy candidates", () => {
+  assert.deepEqual(validateMarkdownImportCandidates([]), {
+    ok: false,
+    error: "candidates must be a non-empty array.",
+  });
+  assert.deepEqual(validateMarkdownImportCandidates([42]), {
+    ok: false,
+    error: "candidates[0] must be an object.",
+  });
+  assert.deepEqual(validateMarkdownImportCandidates([{ kind: "modified" }]), {
+    ok: false,
+    error: "candidates[0].relativePath must be a non-empty string.",
+  });
+  assert.deepEqual(validateMarkdownImportCandidates([{ relativePath: "projects/a.md", kind: "invalid" }]), {
+    ok: false,
+    error: 'candidates[0].kind must be one of modified, missing, baseline-missing, untracked; received "invalid".',
+  });
+  assert.deepEqual(validateMarkdownImportCandidates([{ ...candidate("projects/a.md"), articleId: 42 }]), {
+    ok: false,
+    error: "candidates[0].articleId must be a string or null.",
+  });
+  assert.deepEqual(validateMarkdownImportCandidates([{ ...candidate("projects/a.md"), sizeBytes: -1 }]), {
+    ok: false,
+    error: "candidates[0].sizeBytes must be a non-negative integer or null.",
+  });
+  assert.deepEqual(validateMarkdownImportCandidates([{ ...candidate("projects/a.md"), metadata: [] }]), {
+    ok: false,
+    error: "candidates[0].metadata must be an object or null.",
+  });
+});
+
+test("validateMarkdownImportCandidates accepts minimal legacy candidates", () => {
+  const candidates = [candidate("projects/a.md")];
+  assert.deepEqual(validateMarkdownImportCandidates(candidates), {
+    ok: true,
+    candidates,
   });
 });
 

--- a/src/app/api/sync/import-apply/preview/route.ts
+++ b/src/app/api/sync/import-apply/preview/route.ts
@@ -19,7 +19,11 @@ import {
   applyMarkdownImports,
   MARKDOWN_IMPORT_APPLY_PERMISSIONS,
 } from "@/lib/markdown-sync/import-applier";
-import { scanMarkdownImportCandidates, MarkdownImportScanLimitError } from "@/lib/markdown-sync/import-scanner";
+import {
+  scanMarkdownImportCandidates,
+  MarkdownImportScanLimitError,
+  validateMarkdownImportScanRequestBody,
+} from "@/lib/markdown-sync/import-scanner";
 import {
   parseMarkdownImportCandidateIds,
   selectMarkdownImportCandidatesById,
@@ -40,16 +44,16 @@ export async function GET(request: NextRequest) {
 
   // ── Parse query parameters ─────────────────────────────────────────────────
   const searchParams = request.nextUrl.searchParams;
-  const candidateIdsParam = searchParams.get("candidateIds");
+  const candidateIdsParams = searchParams.getAll("candidateIds");
   const mode = (searchParams.get("mode") ?? "upsert") as "create" | "update" | "upsert";
   const forceOverwrite = searchParams.get("forceOverwrite") === "true";
 
-  if (!candidateIdsParam) {
+  if (candidateIdsParams.length === 0) {
     return NextResponse.json(
       {
         success: false,
         error:
-          "Missing 'candidateIds' query parameter (comma-separated list of relative paths). " +
+          "Missing 'candidateIds' query parameter. Repeat candidateIds for multiple relative paths. " +
           "Run POST /api/sync/import-scan first to get candidates.",
       },
       { status: 400 }
@@ -63,26 +67,37 @@ export async function GET(request: NextRequest) {
     );
   }
 
-  const candidateIdsResult = parseMarkdownImportCandidateIds(candidateIdsParam);
+  const candidateIdsResult = parseMarkdownImportCandidateIds(candidateIdsParams);
   if (!candidateIdsResult.ok) {
     return NextResponse.json({ success: false, error: candidateIdsResult.error }, { status: 400 });
   }
   const candidateIds = candidateIdsResult.candidateIds;
+
+  const scanOptions = parseScanOptions(searchParams);
+  if (!scanOptions.ok) {
+    return NextResponse.json({ success: false, error: scanOptions.error }, { status: 400 });
+  }
+
+  const scanValidation = validateMarkdownImportScanRequestBody(scanOptions.options);
+  if ("errors" in scanValidation) {
+    return NextResponse.json({ success: false, error: scanValidation.errors.join("; ") }, { status: 400 });
+  }
 
   // ── Load vault config ─────────────────────────────────────────────────────
   let config;
   try {
     config = getObsidianSyncConfig();
   } catch (err) {
+    console.error("[import-apply-preview] Obsidian sync configuration error:", err);
     return NextResponse.json(
-      { success: false, error: `Configuration error: ${(err as Error).message}` },
-      { status: 400 }
+      { success: false, error: "Obsidian sync configuration error." },
+      { status: 500 }
     );
   }
   if (!config) {
     return NextResponse.json(
       { success: false, error: "Obsidian sync is not enabled. Set OBSIDIAN_SYNC_ENABLED and OBSIDIAN_SYNC_VAULT_PATH." },
-      { status: 400 }
+      { status: 503 }
     );
   }
 
@@ -90,7 +105,7 @@ export async function GET(request: NextRequest) {
   const manifest = loadManifest(config.vaultPath, config.manifestPath);
   if (!manifest) {
     return NextResponse.json(
-      { success: false, error: "Manifest not found. Run POST /api/sync/obsidian first." },
+      { success: false, error: "Manifest missing or invalid. Ensure the vault has been synced with POST /api/sync/obsidian." },
       { status: 400 }
     );
   }
@@ -103,8 +118,8 @@ export async function GET(request: NextRequest) {
     const scanResult = scanMarkdownImportCandidates({
       vaultPath: config.vaultPath,
       manifestPath: config.manifestPath,
-      includeUntracked: true,
-      maxFiles: 5_000,
+      includeUntracked: scanValidation.includeUntracked,
+      maxFiles: scanValidation.maxFiles,
     });
 
     // Filter to only the requested candidate IDs.
@@ -145,8 +160,34 @@ export async function GET(request: NextRequest) {
     }
     console.error("[import-apply-preview] Error running preview:", err);
     return NextResponse.json(
-      { success: false, error: "Internal error during preview.", detail: String(err) },
+      { success: false, error: "Internal error during preview." },
       { status: 500 }
     );
   }
+}
+
+type PreviewScanOptionsParseResult =
+  | { ok: true; options: Record<string, unknown> }
+  | { ok: false; error: string };
+
+function parseScanOptions(searchParams: URLSearchParams): PreviewScanOptionsParseResult {
+  const options: Record<string, unknown> = {};
+
+  const includeUntracked = searchParams.get("includeUntracked");
+  if (includeUntracked !== null) {
+    if (includeUntracked !== "true" && includeUntracked !== "false") {
+      return { ok: false, error: 'includeUntracked must be "true" or "false" when provided.' };
+    }
+    options.includeUntracked = includeUntracked === "true";
+  }
+
+  const maxFiles = searchParams.get("maxFiles");
+  if (maxFiles !== null) {
+    if (!/^\d+$/.test(maxFiles)) {
+      return { ok: false, error: "maxFiles must be an integer between 1 and 50000." };
+    }
+    options.maxFiles = Number(maxFiles);
+  }
+
+  return { ok: true, options };
 }

--- a/src/app/api/sync/import-apply/route.ts
+++ b/src/app/api/sync/import-apply/route.ts
@@ -28,6 +28,7 @@ import {
 import {
   parseMarkdownImportCandidateIds,
   selectMarkdownImportCandidatesById,
+  validateMarkdownImportCandidates,
 } from "@/lib/markdown-sync/import-workflow";
 import type { MarkdownImportCandidate } from "@/lib/markdown-sync/import-scanner";
 
@@ -91,15 +92,16 @@ export async function POST(request: NextRequest) {
   try {
     config = getObsidianSyncConfig();
   } catch (err) {
+    console.error("[import-apply] Obsidian sync configuration error:", err);
     return NextResponse.json(
-      { success: false, error: `Configuration error: ${(err as Error).message}` },
-      { status: 400 }
+      { success: false, error: "Obsidian sync configuration error." },
+      { status: 500 }
     );
   }
   if (!config) {
     return NextResponse.json(
       { success: false, error: "Obsidian sync is not enabled. Set OBSIDIAN_SYNC_ENABLED and OBSIDIAN_SYNC_VAULT_PATH." },
-      { status: 400 }
+      { status: 503 }
     );
   }
 
@@ -107,7 +109,7 @@ export async function POST(request: NextRequest) {
   const manifest = loadManifest(config.vaultPath, config.manifestPath);
   if (!manifest) {
     return NextResponse.json(
-      { success: false, error: "Manifest not found. Run POST /api/sync/obsidian first." },
+      { success: false, error: "Manifest missing or invalid. Ensure the vault has been synced with POST /api/sync/obsidian." },
       { status: 400 }
     );
   }
@@ -145,7 +147,7 @@ export async function POST(request: NextRequest) {
       }
       console.error("[import-apply] Error scanning candidates:", err);
       return NextResponse.json(
-        { success: false, error: "Failed to scan markdown import candidates.", detail: String(err) },
+        { success: false, error: "Failed to scan markdown import candidates." },
         { status: 503 }
       );
     }
@@ -161,7 +163,11 @@ export async function POST(request: NextRequest) {
       );
     }
   } else {
-    candidates = body.candidates as MarkdownImportCandidate[];
+    const candidatesValidation = validateMarkdownImportCandidates(body.candidates);
+    if (!candidatesValidation.ok) {
+      return NextResponse.json({ success: false, error: candidatesValidation.error }, { status: 400 });
+    }
+    candidates = candidatesValidation.candidates;
   }
 
   // ── Apply imports ────────────────────────────────────────────────────────
@@ -189,7 +195,7 @@ export async function POST(request: NextRequest) {
   } catch (err) {
     console.error("[import-apply] Error applying imports:", err);
     return NextResponse.json(
-      { success: false, error: "Internal error during import.", detail: String(err) },
+      { success: false, error: "Internal error during import." },
       { status: 500 }
     );
   }

--- a/src/lib/markdown-sync/import-scanner.ts
+++ b/src/lib/markdown-sync/import-scanner.ts
@@ -20,11 +20,14 @@ export const MARKDOWN_IMPORT_SCAN_MAX_BODY_BYTES = 32 * 1024;
 export const MARKDOWN_IMPORT_SCAN_DEFAULT_MAX_FILES = 5_000;
 export const MARKDOWN_IMPORT_SCAN_PERMISSIONS = [Permissions.ADMIN] as const;
 
-export type MarkdownImportCandidateKind =
-  | "modified"
-  | "missing"
-  | "baseline-missing"
-  | "untracked";
+export const MARKDOWN_IMPORT_CANDIDATE_KINDS = [
+  "modified",
+  "missing",
+  "baseline-missing",
+  "untracked",
+] as const;
+
+export type MarkdownImportCandidateKind = (typeof MARKDOWN_IMPORT_CANDIDATE_KINDS)[number];
 
 export interface MarkdownImportScanOptions {
   vaultPath: string;

--- a/src/lib/markdown-sync/import-workflow.ts
+++ b/src/lib/markdown-sync/import-workflow.ts
@@ -1,4 +1,9 @@
-import type { MarkdownImportCandidate } from "@/lib/markdown-sync/import-scanner";
+import {
+  MARKDOWN_IMPORT_CANDIDATE_KINDS,
+  type MarkdownImportCandidate,
+} from "@/lib/markdown-sync/import-scanner";
+
+const MARKDOWN_IMPORT_CANDIDATE_KIND_SET = new Set<string>(MARKDOWN_IMPORT_CANDIDATE_KINDS);
 
 export type CandidateIdParseResult =
   | { ok: true; candidateIds: string[] }
@@ -8,6 +13,10 @@ export interface CandidateSelectionResult {
   candidates: MarkdownImportCandidate[];
   notFound: string[];
 }
+
+export type CandidateValidationResult =
+  | { ok: true; candidates: MarkdownImportCandidate[] }
+  | { ok: false; error: string };
 
 /**
  * Normalize candidate IDs passed by agents.
@@ -24,14 +33,20 @@ export function parseMarkdownImportCandidateIds(input: unknown): CandidateIdPars
       : null;
 
   if (!rawIds) {
-    return { ok: false, error: "candidateIds must be a non-empty string array or comma-separated string." };
+    return {
+      ok: false,
+      error: `candidateIds must be a non-empty string array or comma-separated string; received ${describeInputType(input)}.`,
+    };
   }
 
   const candidateIds: string[] = [];
   const seen = new Set<string>();
-  for (const rawId of rawIds) {
+  for (const [index, rawId] of rawIds.entries()) {
     if (typeof rawId !== "string") {
-      return { ok: false, error: "candidateIds must contain only strings." };
+      return {
+        ok: false,
+        error: `candidateIds[${index}] must be a string; received ${describeInputType(rawId)}.`,
+      };
     }
 
     const candidateId = rawId.trim();
@@ -46,6 +61,47 @@ export function parseMarkdownImportCandidateIds(input: unknown): CandidateIdPars
   }
 
   return { ok: true, candidateIds };
+}
+
+export function validateMarkdownImportCandidates(input: unknown): CandidateValidationResult {
+  if (!Array.isArray(input) || input.length === 0) {
+    return { ok: false, error: "candidates must be a non-empty array." };
+  }
+
+  for (const [index, candidate] of input.entries()) {
+    if (!isPlainObject(candidate)) {
+      return { ok: false, error: `candidates[${index}] must be an object.` };
+    }
+    if (typeof candidate["relativePath"] !== "string" || candidate["relativePath"].trim() === "") {
+      return { ok: false, error: `candidates[${index}].relativePath must be a non-empty string.` };
+    }
+    if (typeof candidate["kind"] !== "string" || !MARKDOWN_IMPORT_CANDIDATE_KIND_SET.has(candidate["kind"])) {
+      return {
+        ok: false,
+        error:
+          `candidates[${index}].kind must be one of ${MARKDOWN_IMPORT_CANDIDATE_KINDS.join(", ")}; ` +
+          `received ${describeInvalidValue(candidate["kind"])}.`,
+      };
+    }
+    const nullableStringFields = ["articleId", "manifestPath", "baselineHash", "markdownHash", "parseError"];
+    for (const field of nullableStringFields) {
+      const value = candidate[field];
+      if (value !== undefined && value !== null && typeof value !== "string") {
+        return { ok: false, error: `candidates[${index}].${field} must be a string or null.` };
+      }
+    }
+    const sizeBytes = candidate["sizeBytes"];
+    if (sizeBytes !== undefined && sizeBytes !== null) {
+      if (typeof sizeBytes !== "number" || !Number.isSafeInteger(sizeBytes) || sizeBytes < 0) {
+        return { ok: false, error: `candidates[${index}].sizeBytes must be a non-negative integer or null.` };
+      }
+    }
+    if (candidate["metadata"] !== undefined && candidate["metadata"] !== null && !isPlainObject(candidate["metadata"])) {
+      return { ok: false, error: `candidates[${index}].metadata must be an object or null.` };
+    }
+  }
+
+  return { ok: true, candidates: input as MarkdownImportCandidate[] };
 }
 
 export function selectMarkdownImportCandidatesById(
@@ -66,4 +122,18 @@ export function selectMarkdownImportCandidatesById(
   }
 
   return { candidates: selected, notFound };
+}
+
+function describeInputType(value: unknown): string {
+  if (value === null) return "null";
+  if (Array.isArray(value)) return "array";
+  return typeof value;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function describeInvalidValue(value: unknown): string {
+  return typeof value === "string" ? JSON.stringify(value) : describeInputType(value);
 }


### PR DESCRIPTION
## Summary
- remove raw exception details from import apply/preview API responses and return server-side config failures as 5xx
- let preview accept repeatable candidateIds plus includeUntracked/maxFiles scan controls
- tighten candidate ID errors and add lightweight validation for legacy candidates payloads
- update docs for repeatable preview candidateIds

## Verification
- node --import tsx --test src/__tests__/api/markdown-import-workflow.test.ts src/__tests__/api/markdown-import-scanner.test.ts
- npm run test:api (with DATABASE_URL derived from the running Docker DB container)
- npm run lint (0 errors, existing warnings only)
- npm run build (with DATABASE_URL derived from the running Docker DB container)
- npm run test:security (still fails on inherited proxy rate-limit test: expected 429, got 200)

## Summary by Sourcery

Tighten validation and error handling for the markdown import preview/apply workflow and align the API/docs with the updated query semantics.

Bug Fixes:
- Return generic configuration and internal error messages for import preview/apply instead of exposing raw exception details, and use appropriate 5xx status codes for server-side failures.
- Improve validation and error messaging for candidateIds and legacy candidates payloads in the markdown import workflow.

Enhancements:
- Allow the import preview endpoint to accept repeatable candidateIds query parameters and support includeUntracked and maxFiles scan controls that mirror the scan/apply behaviour.

Documentation:
- Update Obsidian sync documentation and README examples to describe repeatable candidateIds and the additional preview query parameters.

Tests:
- Extend markdown import workflow tests to cover stricter candidateIds validation, candidate validation, and preservation of comma-containing paths.