### PR TITLE
[codex] fix PATCH article relation preservation

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -67,6 +67,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Log in to GitHub Container Registry
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
@@ -88,7 +89,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           build-args: |
             # Note: prisma generate doesn't need a real database connection,
             # just a valid-format URL. Runtime DATABASE_URL comes from docker-compose env.

--- a/src/__tests__/api/article-relations.test.ts
+++ b/src/__tests__/api/article-relations.test.ts
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { syncArticleRelations } from "@/lib/articles/relations";
+
+function relationTx() {
+  const calls: Array<{ method: "deleteMany" | "createMany"; args: unknown }> = [];
+
+  return {
+    calls,
+    tx: {
+      articleRelation: {
+        deleteMany: async (args: unknown) => {
+          calls.push({ method: "deleteMany", args });
+        },
+        createMany: async (args: unknown) => {
+          calls.push({ method: "createMany", args });
+        },
+      },
+    },
+  };
+}
+
+test("syncArticleRelations leaves existing relations untouched when relatedArticleIds is omitted", async () => {
+  const { calls, tx } = relationTx();
+
+  await syncArticleRelations(tx, "article-1", undefined);
+
+  assert.deepEqual(calls, []);
+});
+
+test("syncArticleRelations clears existing relations when relatedArticleIds is an empty array", async () => {
+  const { calls, tx } = relationTx();
+
+  await syncArticleRelations(tx, "article-1", []);
+
+  assert.deepEqual(calls, [
+    {
+      method: "deleteMany",
+      args: { where: { sourceId: "article-1" } },
+    },
+  ]);
+});
+
+test("syncArticleRelations replaces explicit relations and ignores self references", async () => {
+  const { calls, tx } = relationTx();
+
+  await syncArticleRelations(tx, "article-1", ["article-2", "article-1", "article-3"]);
+
+  assert.deepEqual(calls, [
+    {
+      method: "deleteMany",
+      args: { where: { sourceId: "article-1" } },
+    },
+    {
+      method: "createMany",
+      args: {
+        data: [
+          { sourceId: "article-1", targetId: "article-2" },
+          { sourceId: "article-1", targetId: "article-3" },
+        ],
+        skipDuplicates: true,
+      },
+    },
+  ]);
+});

--- a/src/__tests__/api/article-relations.test.ts
+++ b/src/__tests__/api/article-relations.test.ts
@@ -63,3 +63,26 @@ test("syncArticleRelations replaces explicit relations and ignores self referenc
     },
   ]);
 });
+
+test("syncArticleRelations deduplicates explicit relations before insert", async () => {
+  const { calls, tx } = relationTx();
+
+  await syncArticleRelations(tx, "article-1", ["article-2", "article-2", "article-3"]);
+
+  assert.deepEqual(calls, [
+    {
+      method: "deleteMany",
+      args: { where: { sourceId: "article-1" } },
+    },
+    {
+      method: "createMany",
+      args: {
+        data: [
+          { sourceId: "article-1", targetId: "article-2" },
+          { sourceId: "article-1", targetId: "article-3" },
+        ],
+        skipDuplicates: true,
+      },
+    },
+  ]);
+});

--- a/src/app/api/articles/[id]/route.ts
+++ b/src/app/api/articles/[id]/route.ts
@@ -3,6 +3,7 @@ import { Permissions } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
 import { requirePermission, canAccessScopes } from "@/lib/api/auth";
 import { buildTagConnections } from "@/lib/wiki";
+import { syncArticleRelations } from "@/lib/articles/relations";
 import {
   ARTICLE_LIMITS,
   deriveExcerpt,
@@ -248,16 +249,7 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
         }
       }
 
-      // Sync related articles via ArticleRelation table
-      await tx.articleRelation.deleteMany({ where: { sourceId: id } });
-      if (relatedArticleIds !== undefined && relatedArticleIds.length > 0) {
-        await tx.articleRelation.createMany({
-          data: relatedArticleIds
-            .filter((targetId: string) => targetId !== id) // prevent self-reference
-            .map((targetId: string) => ({ sourceId: id, targetId })),
-          skipDuplicates: true,
-        });
-      }
+      await syncArticleRelations(tx, id, relatedArticleIds);
 
       // Return updated article with relations
       return tx.article.findUnique({

--- a/src/lib/articles/relations.ts
+++ b/src/lib/articles/relations.ts
@@ -1,0 +1,32 @@
+interface ArticleRelationWriter {
+  articleRelation: {
+    deleteMany: (args: { where: { sourceId: string } }) => Promise<unknown>;
+    createMany: (args: {
+      data: Array<{ sourceId: string; targetId: string }>;
+      skipDuplicates: true;
+    }) => Promise<unknown>;
+  };
+}
+
+export async function syncArticleRelations(
+  tx: ArticleRelationWriter,
+  sourceId: string,
+  relatedArticleIds: string[] | undefined,
+) {
+  if (relatedArticleIds === undefined) {
+    return;
+  }
+
+  await tx.articleRelation.deleteMany({ where: { sourceId } });
+
+  const relationRows = relatedArticleIds
+    .filter((targetId) => targetId !== sourceId)
+    .map((targetId) => ({ sourceId, targetId }));
+
+  if (relationRows.length > 0) {
+    await tx.articleRelation.createMany({
+      data: relationRows,
+      skipDuplicates: true,
+    });
+  }
+}

--- a/src/lib/articles/relations.ts
+++ b/src/lib/articles/relations.ts
@@ -19,7 +19,7 @@ export async function syncArticleRelations(
 
   await tx.articleRelation.deleteMany({ where: { sourceId } });
 
-  const relationRows = relatedArticleIds
+  const relationRows = Array.from(new Set(relatedArticleIds))
     .filter((targetId) => targetId !== sourceId)
     .map((targetId) => ({ sourceId, targetId }));
 


### PR DESCRIPTION
## Summary

Fixes #131.

- Adds `syncArticleRelations` so relation sync semantics are explicit and covered by tests.
- Updates `PATCH /api/articles/[id]` so omitted `relatedArticleIds` does not touch existing `ArticleRelation` rows.
- Keeps explicit `relatedArticleIds: []` behavior as a clear request to delete all outgoing relations.
- Deduplicates explicit relation IDs in memory before insert while keeping `skipDuplicates` as the database guard.
- Updates the Docker publish workflow so pull request builds do not try to publish GHCR images.

## Root Cause

The PATCH transaction always called `articleRelation.deleteMany({ sourceId })` before checking whether `relatedArticleIds` was present. Partial updates that changed unrelated fields therefore wiped article links.

The Docker check also attempted to push GHCR images during pull request runs; the PR build succeeded, then publish authorization failed.

## Validation

- `node --import tsx --test src/__tests__/api/article-relations.test.ts` -> 4/4 pass
- `git diff --check` -> pass
- `npm run lint` -> exits 0 with 4 existing warnings outside this change
- PR checks after the workflow fix -> CodeQL, Docker, Kilo, Sourcery, and CodeQL language analysis all pass

## Known Existing Check Gaps

- `npm run test:api` currently fails in this checkout because several existing API tests import Prisma without `DATABASE_URL` set.
- `npx tsc --noEmit` currently reports existing test typing errors unrelated to this diff.