### PR TITLE
fix(import-workflow): backward-compatible preview candidateIds and stricter maxFiles validation

### DIFF
--- a/src/__tests__/api/markdown-import-workflow.test.ts
+++ b/src/__tests__/api/markdown-import-workflow.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import {
   parseMarkdownImportCandidateIds,
   selectMarkdownImportCandidatesById,
+  selectMarkdownImportCandidatesByQueryIds,
   validateMarkdownImportCandidates,
 } from "@/lib/markdown-sync/import-workflow";
 import type { MarkdownImportCandidate } from "@/lib/markdown-sync/import-scanner";
@@ -105,6 +106,32 @@ test("selectMarkdownImportCandidatesById preserves requested order and reports m
 
   assert.deepEqual(result.candidates.map((item) => item.relativePath), ["projects/c.md", "projects/a.md"]);
   assert.deepEqual(result.notFound, ["projects/missing.md"]);
+});
+
+test("selectMarkdownImportCandidatesByQueryIds preserves single comma-bearing paths", () => {
+  const candidates = [
+    candidate("notes/a, b.md"),
+    candidate("notes/c.md"),
+  ];
+
+  const result = selectMarkdownImportCandidatesByQueryIds(candidates, ["notes/a, b.md"]);
+
+  assert.deepEqual(result.candidateIds, ["notes/a, b.md"]);
+  assert.deepEqual(result.candidates.map((item) => item.relativePath), ["notes/a, b.md"]);
+  assert.deepEqual(result.notFound, []);
+});
+
+test("selectMarkdownImportCandidatesByQueryIds falls back to legacy comma lists", () => {
+  const candidates = [
+    candidate("projects/a.md"),
+    candidate("projects/b.md"),
+  ];
+
+  const result = selectMarkdownImportCandidatesByQueryIds(candidates, ["projects/a.md, projects/b.md"]);
+
+  assert.deepEqual(result.candidateIds, ["projects/a.md", "projects/b.md"]);
+  assert.deepEqual(result.candidates.map((item) => item.relativePath), ["projects/a.md", "projects/b.md"]);
+  assert.deepEqual(result.notFound, []);
 });
 
 function candidate(relativePath: string): MarkdownImportCandidate {

--- a/src/__tests__/api/markdown-import-workflow.test.ts
+++ b/src/__tests__/api/markdown-import-workflow.test.ts
@@ -134,6 +134,16 @@ test("selectMarkdownImportCandidatesByQueryIds falls back to legacy comma lists"
   assert.deepEqual(result.notFound, []);
 });
 
+test("selectMarkdownImportCandidatesByQueryIds does not split non-existent comma-bearing paths", () => {
+  const candidates = [candidate("notes/c.md")];
+
+  const result = selectMarkdownImportCandidatesByQueryIds(candidates, ["notes/a, b.md"]);
+
+  assert.deepEqual(result.candidateIds, ["notes/a, b.md"]);
+  assert.deepEqual(result.candidates, []);
+  assert.deepEqual(result.notFound, ["notes/a, b.md"]);
+});
+
 function candidate(relativePath: string): MarkdownImportCandidate {
   return {
     kind: "modified",

--- a/src/app/api/sync/import-apply/preview/route.ts
+++ b/src/app/api/sync/import-apply/preview/route.ts
@@ -53,7 +53,8 @@ export async function GET(request: NextRequest) {
       {
         success: false,
         error:
-          "Missing 'candidateIds' query parameter. Repeat candidateIds for multiple relative paths. " +
+          "Missing 'candidateIds' query parameter. Use repeated candidateIds for multiple paths " +
+          "(e.g. ?candidateIds=a.md&candidateIds=b.md) or a single comma-separated list for backwards compatibility. " +
           "Run POST /api/sync/import-scan first to get candidates.",
       },
       { status: 400 }
@@ -67,7 +68,11 @@ export async function GET(request: NextRequest) {
     );
   }
 
-  const candidateIdsResult = parseMarkdownImportCandidateIds(candidateIdsParams);
+  // Support both repeated query params and single comma-separated list for backward compatibility.
+  const candidateIdsInput = candidateIdsParams.length === 1 && candidateIdsParams[0].includes(",")
+    ? candidateIdsParams[0]
+    : candidateIdsParams;
+  const candidateIdsResult = parseMarkdownImportCandidateIds(candidateIdsInput);
   if (!candidateIdsResult.ok) {
     return NextResponse.json({ success: false, error: candidateIdsResult.error }, { status: 400 });
   }
@@ -183,7 +188,7 @@ function parseScanOptions(searchParams: URLSearchParams): PreviewScanOptionsPars
 
   const maxFiles = searchParams.get("maxFiles");
   if (maxFiles !== null) {
-    if (!/^\d+$/.test(maxFiles)) {
+    if (!/^[1-9]\d*$/.test(maxFiles)) {
       return { ok: false, error: "maxFiles must be an integer between 1 and 50000." };
     }
     options.maxFiles = Number(maxFiles);

--- a/src/app/api/sync/import-apply/preview/route.ts
+++ b/src/app/api/sync/import-apply/preview/route.ts
@@ -26,7 +26,7 @@ import {
 } from "@/lib/markdown-sync/import-scanner";
 import {
   parseMarkdownImportCandidateIds,
-  selectMarkdownImportCandidatesById,
+  selectMarkdownImportCandidatesByQueryIds,
 } from "@/lib/markdown-sync/import-workflow";
 
 const PREVIEW_RATE_LIMIT = { windowMs: 60_000, maxRequests: 10, keyPrefix: "sync-import-apply-preview" };
@@ -68,15 +68,10 @@ export async function GET(request: NextRequest) {
     );
   }
 
-  // Support both repeated query params and single comma-separated list for backward compatibility.
-  const candidateIdsInput = candidateIdsParams.length === 1 && candidateIdsParams[0].includes(",")
-    ? candidateIdsParams[0]
-    : candidateIdsParams;
-  const candidateIdsResult = parseMarkdownImportCandidateIds(candidateIdsInput);
+  const candidateIdsResult = parseMarkdownImportCandidateIds(candidateIdsParams);
   if (!candidateIdsResult.ok) {
     return NextResponse.json({ success: false, error: candidateIdsResult.error }, { status: 400 });
   }
-  const candidateIds = candidateIdsResult.candidateIds;
 
   const scanOptions = parseScanOptions(searchParams);
   if (!scanOptions.ok) {
@@ -127,8 +122,10 @@ export async function GET(request: NextRequest) {
       maxFiles: scanValidation.maxFiles,
     });
 
-    // Filter to only the requested candidate IDs.
-    const selection = selectMarkdownImportCandidatesById(scanResult.candidates, candidateIds);
+    // Filter to only the requested candidate IDs. Exact query values win first so
+    // vault paths containing commas are preserved; legacy comma-list parsing is
+    // only used if a single exact value matches nothing.
+    const selection = selectMarkdownImportCandidatesByQueryIds(scanResult.candidates, candidateIdsParams);
 
     if (selection.candidates.length === 0) {
       return NextResponse.json(

--- a/src/lib/markdown-sync/import-workflow.ts
+++ b/src/lib/markdown-sync/import-workflow.ts
@@ -152,7 +152,10 @@ export function selectMarkdownImportCandidatesByQueryIds(
   }
 
   const legacySelection = selectMarkdownImportCandidatesById(candidates, legacyCandidateIds.candidateIds);
-  return { ...legacySelection, candidateIds: legacyCandidateIds.candidateIds };
+  if (legacySelection.candidates.length > 0) {
+    return { ...legacySelection, candidateIds: legacyCandidateIds.candidateIds };
+  }
+  return { ...exactSelection, candidateIds: exactCandidateIds.candidateIds };
 }
 
 function describeInputType(value: unknown): string {

--- a/src/lib/markdown-sync/import-workflow.ts
+++ b/src/lib/markdown-sync/import-workflow.ts
@@ -14,6 +14,10 @@ export interface CandidateSelectionResult {
   notFound: string[];
 }
 
+export interface CandidateQuerySelectionResult extends CandidateSelectionResult {
+  candidateIds: string[];
+}
+
 export type CandidateValidationResult =
   | { ok: true; candidates: MarkdownImportCandidate[] }
   | { ok: false; error: string };
@@ -122,6 +126,33 @@ export function selectMarkdownImportCandidatesById(
   }
 
   return { candidates: selected, notFound };
+}
+
+export function selectMarkdownImportCandidatesByQueryIds(
+  candidates: MarkdownImportCandidate[],
+  candidateIdsParams: string[],
+): CandidateQuerySelectionResult {
+  const exactCandidateIds = parseMarkdownImportCandidateIds(candidateIdsParams);
+  if (!exactCandidateIds.ok) {
+    return { candidates: [], notFound: candidateIdsParams, candidateIds: [] };
+  }
+
+  const exactSelection = selectMarkdownImportCandidatesById(candidates, exactCandidateIds.candidateIds);
+  if (
+    exactSelection.candidates.length > 0 ||
+    candidateIdsParams.length !== 1 ||
+    !candidateIdsParams[0].includes(",")
+  ) {
+    return { ...exactSelection, candidateIds: exactCandidateIds.candidateIds };
+  }
+
+  const legacyCandidateIds = parseMarkdownImportCandidateIds(candidateIdsParams[0]);
+  if (!legacyCandidateIds.ok) {
+    return { ...exactSelection, candidateIds: exactCandidateIds.candidateIds };
+  }
+
+  const legacySelection = selectMarkdownImportCandidatesById(candidates, legacyCandidateIds.candidateIds);
+  return { ...legacySelection, candidateIds: legacyCandidateIds.candidateIds };
 }
 
 function describeInputType(value: unknown): string {


### PR DESCRIPTION
## Summary

Follow-up to PR #155 addressing review feedback that was merged before all comments could be addressed.

## Changes

- **Preview endpoint backward compatibility**: The preview endpoint now supports repeated `candidateIds` query params (`?candidateIds=a.md&candidateIds=b.md`) and legacy single comma-separated values (`?candidateIds=a.md,b.md`). Exact repeated-param values are matched before legacy splitting, so paths containing commas such as `notes/a, b.md` are preserved.

- **Stricter maxFiles validation**: `parseScanOptions` now rejects `maxFiles=0` at parse time instead of passing it through to downstream validation. The regex changed from `/^\d+$/` to `/^[1-9]\d*$/`.

- **Updated error message**: The missing `candidateIds` error now documents both supported formats.

## Reviewer Notes

- Codex flagged the comma-bearing candidate ID regression. This preserves exact query values first and only falls back to legacy comma-list parsing when a single exact value matches nothing.
- kilo-code-bot noted that `parseScanOptions` passed invalid values downstream. The maxFiles fix addresses one remaining edge case (zero value) that slipped through.

## Verification

- `node --import tsx --test src/__tests__/api/markdown-import-workflow.test.ts src/__tests__/api/markdown-import-scanner.test.ts` — all 21 tests pass
- `npm run lint` — 0 errors, 4 pre-existing warnings
- PR checks after the latest push — CodeQL, Docker, Kilo, Sourcery, and CodeQL language analysis all pass