### PR TITLE
chore: pin compose volumes and verify deploy DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -796,21 +796,30 @@ Live verification from the Noosphere deployment on 2026-05-21:
 # 1. Sync latest code
 git pull origin master
 
-# 2. Build (pass ~/.noosphere/.env to ensure correct secrets are baked in)
-docker compose -f docker-compose.yml --env-file ~/.noosphere/.env build app
+# 2. Build with the canonical Compose file and project identity.
+# The Compose file pins the live data volumes to noosphere_postgres_data
+# and noosphere_redis_data so deploys do not drift onto a fresh DB volume.
+docker compose --env-file ~/.noosphere/.env build app
 
 # 3. Recreate app container with fresh image and ensure Redis exists
-docker compose -f docker-compose.yml --env-file ~/.noosphere/.env up -d redis app
+docker compose --env-file ~/.noosphere/.env up -d redis app
 
-# 4. Verify
+# 4. Verify health, DB volume identity, and non-empty wiki data
 curl http://127.0.0.1:6578/api/health
+npm run deploy:verify
 
 # Run production migrations after first deploy or schema changes
-docker compose -f docker-compose.yml --env-file ~/.noosphere/.env exec app node node_modules/prisma/build/index.js migrate deploy --schema prisma/schema.prisma
+docker compose --env-file ~/.noosphere/.env exec app node node_modules/prisma/build/index.js migrate deploy --schema prisma/schema.prisma
 
 # View logs
 docker compose logs -f app
 ```
+
+The post-deploy guard intentionally fails if `noosphere-db` is mounted to any
+Postgres data volume other than `noosphere_postgres_data`, or if the live DB has
+no topics, articles, or API keys. This catches the empty-volume failure mode
+where `/api/health` can pass while authenticated Noosphere tools return
+Unauthorized because the API key table is empty.
 
 ## Documentation
 

--- a/docker-compose.noosphere.yml
+++ b/docker-compose.noosphere.yml
@@ -1,6 +1,8 @@
 # Noosphere production Compose template for OpenClaw users.
 # Defaults are intentionally localhost-only. Override BIND_ADDRESS,
 # NOOSPHERE_PORT, or APP_URL in .env if needed.
+name: noosphere
+
 services:
   init:
     image: ghcr.io/sweetsophia/noosphere:${NOOSPHERE_VERSION:-latest}
@@ -94,8 +96,11 @@ services:
 
 volumes:
   noosphere_postgres_data:
+    name: noosphere_postgres_data
     driver: local
   noosphere_uploads:
+    name: noosphere_uploads
     driver: local
   noosphere_redis_data:
+    name: noosphere_redis_data
     driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,5 @@
+name: noosphere
+
 services:
   app:
     build:
@@ -83,8 +85,10 @@ services:
 
 volumes:
   postgres_data:
+    name: noosphere_postgres_data
     driver: local
   redis_data:
+    name: noosphere_redis_data
     driver: local
 
 networks:

--- a/docs/OPENCLAW-OFFICIAL-PLUGIN-SETUP.md
+++ b/docs/OPENCLAW-OFFICIAL-PLUGIN-SETUP.md
@@ -170,6 +170,7 @@ done
 
 The production Compose template includes a one-shot `init` service. It waits for PostgreSQL, applies migrations, runs bootstrap, then allows the app service to start.
 It also starts a Redis service for recall/search caching; if Redis is unavailable, Noosphere fails open and continues serving search from PostgreSQL.
+The template pins the Compose project and persistent volume names (`noosphere_postgres_data`, `noosphere_uploads`, and `noosphere_redis_data`) so moving the Compose file between directories does not silently create a second empty database.
 
 ## Manual OpenClaw plugin install
 
@@ -391,6 +392,14 @@ openclaw noosphere doctor
 ```
 
 The Compose `init` service runs migration/bootstrap logic before app startup, and `docker compose up -d` is preferred over app-only recreation when upgrading to versions that add services such as Redis. Bootstrap is repeatable and preserves article/topic content, but it reconciles the bootstrap admin account: it may reset that account's name/password to the values in `.env`, and `NOOSPHERE_FORCE_ADMIN=true` can force its role back to ADMIN.
+After an upgrade, verify the database volume identity before treating API-key errors as key rotation:
+
+```bash
+docker inspect noosphere-openclaw-db \
+  --format '{{range .Mounts}}{{if eq .Destination "/var/lib/postgresql/data"}}{{.Name}}{{end}}{{end}}'
+```
+
+The expected value is `noosphere_postgres_data`.
 
 ## Uninstall
 

--- a/install-openclaw.sh
+++ b/install-openclaw.sh
@@ -407,6 +407,8 @@ export NOOSPHERE_BOOTSTRAP_API_KEY="$API_KEY"
 write_runtime_env
 
 cat > "$NOOSPHERE_HOME/docker-compose.yml" <<YAML
+name: noosphere
+
 services:
   init:
     image: ${NOOSPHERE_IMAGE}
@@ -494,10 +496,13 @@ services:
 
 volumes:
   noosphere_postgres_data:
+    name: noosphere_postgres_data
     driver: local
   noosphere_uploads:
+    name: noosphere_uploads
     driver: local
   noosphere_redis_data:
+    name: noosphere_redis_data
     driver: local
 YAML
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "db:migrate": "prisma migrate dev",
     "db:push": "prisma db push",
     "db:seed": "tsx scripts/seed-topics.ts",
+    "deploy:verify": "bash scripts/verify-deploy.sh",
     "memory:scheduler": "tsx scripts/memory-scheduler.ts",
     "db:studio": "prisma studio",
     "version:sync": "node scripts/sync-version.mjs",

--- a/scripts/verify-deploy.sh
+++ b/scripts/verify-deploy.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_URL="${NOOSPHERE_APP_URL:-http://127.0.0.1:6578}"
+DB_CONTAINER="${NOOSPHERE_DB_CONTAINER:-noosphere-db}"
+DB_USER="${NOOSPHERE_DB_USER:-noosphere}"
+DB_NAME="${NOOSPHERE_DB_NAME:-noosphere}"
+EXPECTED_DB_VOLUME="${NOOSPHERE_EXPECTED_DB_VOLUME:-noosphere_postgres_data}"
+MIN_TOPICS="${NOOSPHERE_MIN_TOPICS:-1}"
+MIN_ARTICLES="${NOOSPHERE_MIN_ARTICLES:-1}"
+MIN_API_KEYS="${NOOSPHERE_MIN_API_KEYS:-1}"
+
+fail() {
+  printf 'Noosphere deploy verification failed: %s\n' "$1" >&2
+  exit 1
+}
+
+require_positive_int() {
+  local name="$1"
+  local value="$2"
+  [[ "$value" =~ ^[0-9]+$ ]] || fail "$name must be a non-negative integer, got '$value'"
+}
+
+require_positive_int "NOOSPHERE_MIN_TOPICS" "$MIN_TOPICS"
+require_positive_int "NOOSPHERE_MIN_ARTICLES" "$MIN_ARTICLES"
+require_positive_int "NOOSPHERE_MIN_API_KEYS" "$MIN_API_KEYS"
+
+docker inspect "$DB_CONTAINER" >/dev/null 2>&1 || fail "database container '$DB_CONTAINER' does not exist"
+
+mounted_volume="$(
+  docker inspect "$DB_CONTAINER" \
+    --format '{{range .Mounts}}{{if eq .Destination "/var/lib/postgresql/data"}}{{.Name}}{{end}}{{end}}'
+)"
+
+if [[ -z "$mounted_volume" ]]; then
+  fail "could not determine Postgres data volume mounted by '$DB_CONTAINER'"
+fi
+
+if [[ "$mounted_volume" != "$EXPECTED_DB_VOLUME" ]]; then
+  fail "database container uses volume '$mounted_volume', expected '$EXPECTED_DB_VOLUME'"
+fi
+
+curl -fsS "$APP_URL/api/health" >/dev/null || fail "health check failed at $APP_URL/api/health"
+
+counts="$(
+  docker exec "$DB_CONTAINER" psql -U "$DB_USER" -d "$DB_NAME" -v ON_ERROR_STOP=1 -Atc \
+    'select (select count(*) from "Topic"), (select count(*) from "Article" where "deletedAt" is null), (select count(*) from "ApiKey");'
+)"
+
+IFS='|' read -r topics articles api_keys <<< "$counts"
+
+require_positive_int "topic count" "$topics"
+require_positive_int "article count" "$articles"
+require_positive_int "API key count" "$api_keys"
+
+(( topics >= MIN_TOPICS )) || fail "topic count is $topics, expected at least $MIN_TOPICS"
+(( articles >= MIN_ARTICLES )) || fail "article count is $articles, expected at least $MIN_ARTICLES"
+(( api_keys >= MIN_API_KEYS )) || fail "API key count is $api_keys, expected at least $MIN_API_KEYS"
+
+printf 'Noosphere deploy verification passed: volume=%s health=ok topics=%s articles=%s apiKeys=%s\n' \
+  "$mounted_volume" "$topics" "$articles" "$api_keys"


### PR DESCRIPTION
## Summary
- Pin the Compose project and persistent volume names so deploys do not drift onto fresh directory-derived DB volumes.
- Add `npm run deploy:verify` to check app health, the mounted Postgres volume, and non-empty topic/article/API-key tables.
- Update deployment and OpenClaw setup docs with the volume guard procedure.

## Verification
- `bash -n scripts/verify-deploy.sh install-openclaw.sh`
- `docker compose --env-file /home/niya/.noosphere/.env config | rg 'name: noosphere(_postgres_data|_redis_data)?$|name: noosphere$'`
- `docker compose -f docker-compose.noosphere.yml config | rg 'name: noosphere(_postgres_data|_uploads|_redis_data)?$|name: noosphere$'`
- `npm run deploy:verify`
- `NOOSPHERE_EXPECTED_DB_VOLUME=definitely_wrong bash scripts/verify-deploy.sh` fails as expected
- `npm run version:check`
- `npm run lint` (0 errors, 4 existing warnings)