### PR TITLE
fix(security): require ADMIN for GET /api/log endpoint

### DIFF
--- a/src/app/api/log/route.ts
+++ b/src/app/api/log/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { Prisma } from "@prisma/client";
+import { Prisma, Permissions } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
 import { requirePermission } from "@/lib/api/auth";
 import { rateLimit } from "@/lib/rate-limit";
@@ -21,8 +21,8 @@ export async function GET(request: NextRequest) {
   const rl = await rateLimit(request, { windowMs: 60_000, maxRequests: 30, keyPrefix: "log-get" });
   if (!rl.allowed) return rl.response;
 
-  // Auth: API key (any permission) or session
-  const auth = await requirePermission(request, []);
+  // Auth: API key (ADMIN) or admin session
+  const auth = await requirePermission(request, [Permissions.ADMIN]);
   if (!auth.success) {
     return auth.response;
   }


### PR DESCRIPTION
## Summary

Fixes #132. The activity log endpoint `GET /api/log` was accessible to any authenticated caller, including READ-only API keys. This exposed sensitive operational data such as source URLs, author names, agent identities, and operation details.

## Changes

- Changed `requirePermission(request, [])` → `requirePermission(request, [Permissions.ADMIN])` in `GET /api/log`
- Added `Permissions` import from `@prisma/client`

## Security Impact

| Caller | Before | After |
|--------|--------|-------|
| READ API key | ✅ Allowed | ❌ 403 Forbidden |
| WRITE API key | ✅ Allowed | ❌ 403 Forbidden |
| ADMIN API key | ✅ Allowed | ✅ Allowed |
| VIEWER session | ✅ Allowed | ❌ 403 Forbidden |
| EDITOR session | ✅ Allowed | ❌ 403 Forbidden |
| ADMIN session | ✅ Allowed | ✅ Allowed |

## Verification

- `npm run lint` — 0 errors, 4 pre-existing warnings
- Auth hierarchy verified: `ADMIN(3) <= required(3)` passes; `READ(1)`, `WRITE(2)` fail

## Summary by Sourcery

Bug Fixes:
- Tighten authorization on GET /api/log so that only callers with ADMIN permission can access activity logs.