### PR TITLE
ci: add TypeScript type checking to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches: [master, main]
+  pull_request:
+    branches: [master, main]
+
+jobs:
+  lint-and-typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate Prisma client
+        run: npx prisma generate
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Type check
+        run: npm run typecheck

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test:api": "node --import tsx --test 'src/__tests__/api/**/*.test.ts'",
     "test:security": "node --import tsx --test src/__tests__/security/uploads.test.ts src/__tests__/security/proxy.test.ts",
     "lint": "eslint",
+    "typecheck": "tsc --noEmit",
     "db:migrate": "prisma migrate dev",
     "db:push": "prisma db push",
     "db:seed": "tsx scripts/seed-topics.ts",

--- a/src/__tests__/api/sync-conflict-review.test.ts
+++ b/src/__tests__/api/sync-conflict-review.test.ts
@@ -222,24 +222,17 @@ test("runObsidianSync keeps local markdown visible when conflict review persiste
       tags: [],
     };
 
-    const client = prisma as unknown as { $queryRaw: () => Promise<unknown> };
-    const originalQueryRaw = client.$queryRaw;
-    const originalTopicFindMany = prisma.topic.findMany;
-    const originalArticleFindMany = prisma.article.findMany;
-    const originalConflictFindFirst = prisma.syncConflictReview.findFirst;
-    const originalConflictCreate = prisma.syncConflictReview.create;
-    const originalActivityLogCreate = prisma.activityLog.create;
-    const originalConsoleError = console.error;
+    const { mock } = await import("node:test");
 
-    client.$queryRaw = async () => [{ acquire: true }];
-    prisma.topic.findMany = async () => [topic];
-    prisma.article.findMany = async () => [syncArticle];
-    prisma.syncConflictReview.findFirst = async () => null;
-    prisma.syncConflictReview.create = async () => {
+    mock.method(prisma, "$queryRaw", async () => [{ acquire: true }]);
+    mock.method(prisma.topic, "findMany", async () => [topic]);
+    mock.method(prisma.article, "findMany", async () => [syncArticle]);
+    mock.method(prisma.syncConflictReview, "findFirst", async () => null);
+    mock.method(prisma.syncConflictReview, "create", async () => {
       throw new Error("database unavailable");
-    };
-    prisma.activityLog.create = async () => ({});
-    console.error = () => {};
+    });
+    mock.method(prisma.activityLog, "create", async () => ({}));
+    mock.method(console, "error", () => {});
 
     try {
       const result = await runObsidianSync({ mode: "full", clean: false, git: false, dryRun: false });
@@ -253,13 +246,7 @@ test("runObsidianSync keeps local markdown visible when conflict review persiste
       );
       assert.equal(existsSync(join(vaultPath, ".noosphere-sync", "conflicts")), true);
     } finally {
-      client.$queryRaw = originalQueryRaw;
-      prisma.topic.findMany = originalTopicFindMany;
-      prisma.article.findMany = originalArticleFindMany;
-      prisma.syncConflictReview.findFirst = originalConflictFindFirst;
-      prisma.syncConflictReview.create = originalConflictCreate;
-      prisma.activityLog.create = originalActivityLogCreate;
-      console.error = originalConsoleError;
+      mock.restoreAll();
     }
   } finally {
     if (oldEnabled === undefined) delete process.env.OBSIDIAN_SYNC_ENABLED;

--- a/src/__tests__/memory/noosphere-plugin-env.test.ts
+++ b/src/__tests__/memory/noosphere-plugin-env.test.ts
@@ -14,7 +14,7 @@ describe("Noosphere plugin environment isolation", () => {
       NOOSPHERE_API_KEY: "noo_generic",
       OPENCODE_NOOSPHERE_AUTO_SAVE_TOPIC_ID: "  topic-opencode  ",
       NOOSPHERE_AUTO_SAVE_TOPIC_ID: "topic-generic",
-    } as NodeJS.ProcessEnv);
+    } as unknown as NodeJS.ProcessEnv);
 
     assert.equal(config.baseUrl, "https://opencode.example.test");
     assert.equal(config.apiKey, "noo_opencode");
@@ -29,7 +29,7 @@ describe("Noosphere plugin environment isolation", () => {
       new URL("../../../opencode-noosphere-memory/dist/config.js", import.meta.url).href
     );
 
-    const client = new NoosphereClient(resolveConfig(undefined, {} as NodeJS.ProcessEnv));
+    const client = new NoosphereClient(resolveConfig(undefined, {} as unknown as NodeJS.ProcessEnv));
 
     await assert.rejects(() => client.status(), (error) => {
       const message = error instanceof Error ? error.message : String(error);
@@ -51,7 +51,7 @@ describe("Noosphere plugin environment isolation", () => {
       NOOSPHERE_API_KEY: "noo_generic",
       KILOCODE_NOOSPHERE_AUTO_SAVE_TOPIC_ID: "  topic-kilo  ",
       NOOSPHERE_AUTO_SAVE_TOPIC_ID: "topic-generic",
-    } as NodeJS.ProcessEnv);
+    } as unknown as NodeJS.ProcessEnv);
 
     assert.equal(config.baseUrl, "https://kilo.example.test");
     assert.equal(config.apiKey, "noo_kilo");
@@ -66,7 +66,7 @@ describe("Noosphere plugin environment isolation", () => {
       new URL("../../../kilocode-noosphere-memory/dist/config.js", import.meta.url).href
     );
 
-    const client = new NoosphereClient(resolveConfig(undefined, {} as NodeJS.ProcessEnv));
+    const client = new NoosphereClient(resolveConfig(undefined, {} as unknown as NodeJS.ProcessEnv));
 
     await assert.rejects(() => client.status(), (error) => {
       const message = error instanceof Error ? error.message : String(error);
@@ -85,7 +85,7 @@ describe("Noosphere plugin environment isolation", () => {
     );
 
     const client = new NoosphereMemoryClient(
-      resolveNoosphereMemoryConfig({}, {} as NodeJS.ProcessEnv),
+      resolveNoosphereMemoryConfig({}, {} as unknown as NodeJS.ProcessEnv),
     );
 
     await assert.rejects(() => client.status(), (error) => {

--- a/src/__tests__/memory/openclaw-plugin-auto-recall.test.ts
+++ b/src/__tests__/memory/openclaw-plugin-auto-recall.test.ts
@@ -155,7 +155,7 @@ describe("OpenClaw Noosphere plugin auto-recall", () => {
       NOOSPHERE_API_KEY: "noo_generic",
       OPENCLAW_NOOSPHERE_TIMEOUT_MS: "1234",
       NOOSPHERE_TIMEOUT_MS: "9999",
-    } as NodeJS.ProcessEnv;
+    } as unknown as NodeJS.ProcessEnv;
 
     const config = resolveNoosphereMemoryConfig({}, env);
 
@@ -169,7 +169,7 @@ describe("OpenClaw Noosphere plugin auto-recall", () => {
       NOOSPHERE_API_KEY_CYLENA: "noo_cylena",
       OPENCLAW_NOOSPHERE_API_KEY: "noo_openclaw",
       NOOSPHERE_API_KEY: "noo_generic",
-    } as NodeJS.ProcessEnv;
+    } as unknown as NodeJS.ProcessEnv;
 
     assert.equal(resolveApiKeyForAgent({}, env, undefined, "cylena"), "noo_cylena");
     assert.equal(resolveApiKeyForAgent({}, env, undefined, "other"), "noo_openclaw");

--- a/src/__tests__/rate-limit.test.ts
+++ b/src/__tests__/rate-limit.test.ts
@@ -101,7 +101,7 @@ class FakeRedisClient {
         const results: Array<[Error | null, unknown]> = [];
         for (const cmd of commands) {
           try {
-            const result = (this as Record<string, (...args: unknown[]) => unknown>)[cmd.method](...cmd.args);
+            const result = (this as unknown as Record<string, (...args: unknown[]) => unknown>)[cmd.method](...cmd.args);
             results.push([null, result]);
           } catch (err) {
             results.push([err as Error, null]);
@@ -147,8 +147,10 @@ describe("Redis Rate Limiter", () => {
     await rateLimit(request, options);
     const result = await rateLimit(request, options);
 
-    assert.deepStrictEqual(result, { allowed: false });
-    assert.equal(result.response.status, 429);
+    assert.equal(result.allowed, false);
+    if (!result.allowed) {
+      assert.equal(result.response.status, 429);
+    }
   });
 
   it("uses unique keys per client IP", async () => {
@@ -236,7 +238,9 @@ describe("Rate Limiter Edge Cases", () => {
     const result = await rateLimit(request, options);
 
     assert.equal(result.allowed, false);
-    assert.equal(result.response.status, 429);
+    if (!result.allowed) {
+      assert.equal(result.response.status, 429);
+    }
   });
 
   it("handles concurrent requests from same IP", async () => {


### PR DESCRIPTION
## Summary

Fixes #146. The repository had no CI step for TypeScript type checking, and `npx tsc --noEmit` was failing with 13 errors across 4 test files.

## Changes

### CI/CD
- **New workflow** `.github/workflows/ci.yml`: runs `npm run lint` and `npm run typecheck` on every push/PR to `master`/`main`
- **New script** `package.json`: `"typecheck": "tsc --noEmit"`

### Type fixes (test files only)
| File | Errors fixed |
|------|-------------|
| `sync-conflict-review.test.ts` | 5 — Prisma mock return type mismatches (`PrismaPromise` vs `Promise`) |
| `noosphere-plugin-env.test.ts` | 2 — `as NodeJS.ProcessEnv` missing `NODE_ENV` property |
| `openclaw-plugin-auto-recall.test.ts` | 2 — same `ProcessEnv` cast issue |
| `rate-limit.test.ts` | 4 — `this` cast to `Record` without `unknown` intermediate; direct `.response` access on union type |

## Verification

- `npm run typecheck` — 0 errors
- `npm run lint` — 0 errors, 4 pre-existing warnings

## Summary by Sourcery

Add CI workflow to run linting and TypeScript type checking and fix associated test-only type issues.

New Features:
- Introduce npm script for running TypeScript type checking without emitting artifacts.
- Add GitHub Actions workflow to run linting and TypeScript type checking on pushes and pull requests to main branches.

Bug Fixes:
- Resolve TypeScript typing issues in Prisma-based sync conflict review tests by aligning mocked delegate types with Promise-based APIs.
- Fix TypeScript typing issues in rate limit tests by correcting casts and guarding access to response fields based on the allowed flag.
- Address environment typing issues in Noosphere and OpenClaw plugin tests by using safer casts for ProcessEnv objects.

Tests:
- Adjust multiple test suites to satisfy TypeScript type checking while preserving existing test behavior.