### PR TITLE
fix(api): reuse shared slug derivation in answer route

### DIFF
--- a/src/app/api/answer/route.ts
+++ b/src/app/api/answer/route.ts
@@ -12,6 +12,9 @@ import {
 } from "@/lib/validation";
 import { rateLimit } from "@/lib/rate-limit";
 import { invalidateSearchCache } from "@/lib/cache/search-cache";
+import { slugify } from "@/lib/wiki";
+
+const ANSWER_SLUG_MAX_LENGTH = 80;
 
 // POST /api/answer — Save a synthesized answer as a new wiki article
 // Auth: API key (WRITE/ADMIN) or session (EDITOR/ADMIN)
@@ -88,15 +91,7 @@ export async function POST(request: NextRequest) {
   }
 
   // Derive slug from title
-  const slug = validateSlug(
-    title
-      .toLowerCase()
-      .replace(/[^a-z0-9 -]/g, "")
-      .replace(/\s+/g, "-")
-      .replace(/-+/g, "-")
-      .trim()
-      .slice(0, 80)
-  );
+  const slug = validateSlug(slugify(title).slice(0, ANSWER_SLUG_MAX_LENGTH));
   if (!slug.ok) {
     return NextResponse.json({ error: slug.error }, { status: 400 });
   }


### PR DESCRIPTION
## Summary
- replace local answer-route slug regex pipeline with shared slugify(title) + validateSlug(...)
- keep existing answer creation, uniqueness, and tag behavior unchanged

Closes #141

## Verification
- npm run typecheck
- node --import tsx --test src/__tests__/api/wiki-utils.test.ts src/__tests__/api/validation.test.ts
- npm run lint (0 errors, 2 pre-existing warnings)

## Summary by Sourcery

Bug Fixes:
- Align answer route slug generation with the shared slugify + validateSlug logic to avoid inconsistencies with other parts of the API.