### PR TITLE
test(api): add unit tests for log date filter validation (closes #165)

### DIFF
--- a/src/__tests__/api/log.test.ts
+++ b/src/__tests__/api/log.test.ts
@@ -13,9 +13,9 @@ test.describe("parseDateFilter", () => {
     assert.equal(result.to, undefined);
   });
 
-  test("returns ok with no dates when both params are undefined-equivalent (null)", () => {
-    // Explicit null: no date filter
-    const r = parseDateFilter(null, null);
+  test("returns ok with no dates when from is null and to is empty string", () => {
+    // Mixed: from=null, to="" (both treated as missing)
+    const r = parseDateFilter(null, "");
     assert.equal(r.ok, true);
     if (!r.ok) return;
     assert.equal(r.from, undefined);
@@ -146,7 +146,7 @@ test.describe("parseDateFilter", () => {
     assert.equal(r2.error, "to date string too long");
   });
 
-  test("accepts exactly 100-character string (boundary)", () => {
+  test("rejects 100-char invalid string at length boundary (not length error)", () => {
     const maxString = "a".repeat(100);
     const r = parseDateFilter(maxString, null);
     // 'aaaaa...' (100 chars) is not a valid date, but should NOT fail length check

--- a/src/__tests__/api/log.test.ts
+++ b/src/__tests__/api/log.test.ts
@@ -1,0 +1,170 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { parseDateFilter } from "@/lib/log-validation";
+
+test.describe("parseDateFilter", () => {
+  // ── Both params null / no filter applied ────────────────────────────────
+
+  test("returns ok with no dates when both params are null", () => {
+    const result = parseDateFilter(null, null);
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.equal(result.from, undefined);
+    assert.equal(result.to, undefined);
+  });
+
+  test("returns ok with no dates when both params are undefined-equivalent (null)", () => {
+    // Explicit null: no date filter
+    const r = parseDateFilter(null, null);
+    assert.equal(r.ok, true);
+    if (!r.ok) return;
+    assert.equal(r.from, undefined);
+    assert.equal(r.to, undefined);
+  });
+
+  // ── Empty string handling ────────────────────────────────────────────────
+
+  test("treats empty string '' as missing (not an error)", () => {
+    // Empty string is a common "present but blank" case from URL params
+    const result = parseDateFilter("", "");
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.equal(result.from, undefined);
+    assert.equal(result.to, undefined);
+  });
+
+  test("treats empty string for 'from' while 'to' is valid", () => {
+    const result = parseDateFilter("", "2024-06-01T00:00:00Z");
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.equal(result.from, undefined);
+    assert.ok(result.to instanceof Date);
+  });
+
+  test("treats empty string for 'to' while 'from' is valid", () => {
+    const result = parseDateFilter("2024-01-01T00:00:00Z", "");
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.ok(result.from instanceof Date);
+    assert.equal(result.to, undefined);
+  });
+
+  // ── Valid ISO date strings ──────────────────────────────────────────────
+
+  test("accepts valid ISO 8601 date for 'from'", () => {
+    const result = parseDateFilter("2024-06-01T00:00:00Z", null);
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.ok(result.from instanceof Date);
+    assert.equal(result.from?.toISOString(), "2024-06-01T00:00:00.000Z");
+    assert.equal(result.to, undefined);
+  });
+
+  test("accepts valid ISO 8601 date for 'to'", () => {
+    const result = parseDateFilter(null, "2024-12-31T23:59:59Z");
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.equal(result.from, undefined);
+    assert.ok(result.to instanceof Date);
+    assert.equal(result.to?.toISOString(), "2024-12-31T23:59:59.000Z");
+  });
+
+  test("accepts both 'from' and 'to' valid ISO dates", () => {
+    const result = parseDateFilter("2024-01-01T00:00:00Z", "2024-12-31T23:59:59Z");
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.ok(result.from instanceof Date);
+    assert.ok(result.to instanceof Date);
+    assert.equal(result.from?.toISOString(), "2024-01-01T00:00:00.000Z");
+    assert.equal(result.to?.toISOString(), "2024-12-31T23:59:59.000Z");
+  });
+
+  test("accepts date-only format (YYYY-MM-DD)", () => {
+    const result = parseDateFilter("2024-06-01", null);
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.ok(result.from instanceof Date);
+  });
+
+  // ── Invalid date strings ────────────────────────────────────────────────
+
+  test("rejects invalid 'from' date string with 400-style error", () => {
+    const result = parseDateFilter("not-a-date", null);
+    assert.equal(result.ok, false);
+    if (result.ok) return;
+    assert.equal(result.error, "Invalid 'from' date format");
+  });
+
+  test("rejects invalid 'to' date string with 400-style error", () => {
+    const result = parseDateFilter(null, "also-not-a-date");
+    assert.equal(result.ok, false);
+    if (result.ok) return;
+    assert.equal(result.error, "Invalid 'to' date format");
+  });
+
+  test("rejects gibberish date strings", () => {
+    const r1 = parseDateFilter("abcdef", null);
+    assert.equal(r1.ok, false);
+    if (r1.ok) return;
+    assert.equal(r1.error, "Invalid 'from' date format");
+
+    const r2 = parseDateFilter(null, "hello-world");
+    assert.equal(r2.ok, false);
+    if (r2.ok) return;
+    assert.equal(r2.error, "Invalid 'to' date format");
+  });
+
+  // ── Edge cases ─────────────────────────────────────────────────────────
+
+  test("accepts valid ISO epoch-0 date string for 'from'", () => {
+    // Use the ISO string for Unix epoch 0, not the raw number "0" (which JS parses as a year).
+    const result = parseDateFilter("1970-01-01T00:00:00.000Z", null);
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.ok(result.from instanceof Date);
+    assert.equal(result.from?.toISOString(), "1970-01-01T00:00:00.000Z");
+  });
+
+  test("accepts valid ISO epoch-0 date string for 'to'", () => {
+    const result = parseDateFilter(null, "1970-01-01T00:00:00.000Z");
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.ok(result.to instanceof Date);
+    assert.equal(result.to?.toISOString(), "1970-01-01T00:00:00.000Z");
+  });
+
+  test("rejects strings that are too long (> 100 chars)", () => {
+    const longString = "a".repeat(101);
+    const r1 = parseDateFilter(longString, null);
+    assert.equal(r1.ok, false);
+    if (r1.ok) return;
+    assert.equal(r1.error, "from date string too long");
+
+    const r2 = parseDateFilter(null, longString);
+    assert.equal(r2.ok, false);
+    if (r2.ok) return;
+    assert.equal(r2.error, "to date string too long");
+  });
+
+  test("accepts exactly 100-character string (boundary)", () => {
+    const maxString = "a".repeat(100);
+    const r = parseDateFilter(maxString, null);
+    // 'aaaaa...' (100 chars) is not a valid date, but should NOT fail length check
+    // It should fail date parsing instead
+    assert.equal(r.ok, false);
+    if (r.ok) return;
+    assert.equal(r.error, "Invalid 'from' date format");
+  });
+
+  test("accepts valid date string at exactly 100 characters", () => {
+    // Use extended year format (+002024) with fractional seconds to pad to 100 chars.
+    // Base: "+002024-06-01T00:00:00." (23 chars) + "Z" (1 char) = 24 chars fixed.
+    // Remaining 76 chars: fractional seconds "111..." (76 ones) are valid ISO 8601.
+    const paddedDate = "+002024-06-01T00:00:00." + "1".repeat(76) + "Z";
+    assert.equal(paddedDate.length, 100);
+    const result = parseDateFilter(paddedDate, null);
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.ok(result.from instanceof Date);
+  });
+});

--- a/src/app/api/log/route.ts
+++ b/src/app/api/log/route.ts
@@ -4,6 +4,7 @@ import { prisma } from "@/lib/prisma";
 import { requirePermission } from "@/lib/api/auth";
 import { rateLimit } from "@/lib/rate-limit";
 import { sanitizeAuthorName } from "@/lib/validation";
+import { parseDateFilter } from "@/lib/log-validation";
 
 // GET /api/log — Query the activity log
 //
@@ -31,7 +32,6 @@ export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
 
   const MAX_TYPE_LENGTH = 50;
-  const MAX_DATE_STRING_LENGTH = 100;
 
   const type = searchParams.get("type");
   if (type && type.length > MAX_TYPE_LENGTH) {
@@ -43,11 +43,10 @@ export async function GET(request: NextRequest) {
 
   const from = searchParams.get("from");
   const to = searchParams.get("to");
-  if (from && from.length > MAX_DATE_STRING_LENGTH) {
-    return NextResponse.json({ error: "from date string too long" }, { status: 400 });
-  }
-  if (to && to.length > MAX_DATE_STRING_LENGTH) {
-    return NextResponse.json({ error: "to date string too long" }, { status: 400 });
+
+  const dateFilter = parseDateFilter(from, to);
+  if (!dateFilter.ok) {
+    return NextResponse.json({ error: dateFilter.error }, { status: 400 });
   }
 
   const limit = Math.min(parseInt(searchParams.get("limit") ?? "50", 10), 200);
@@ -64,21 +63,13 @@ export async function GET(request: NextRequest) {
     where.authorName = { equals: author, mode: "insensitive" };
   }
 
-  if (from || to) {
+  if (dateFilter.from || dateFilter.to) {
     const createdAt: Prisma.DateTimeFilter = {};
-    if (from) {
-      const parsed = new Date(from);
-      if (isNaN(parsed.getTime())) {
-        return NextResponse.json({ error: "Invalid 'from' date format" }, { status: 400 });
-      }
-      createdAt.gte = parsed;
+    if (dateFilter.from) {
+      createdAt.gte = dateFilter.from;
     }
-    if (to) {
-      const parsed = new Date(to);
-      if (isNaN(parsed.getTime())) {
-        return NextResponse.json({ error: "Invalid 'to' date format" }, { status: 400 });
-      }
-      createdAt.lt = parsed;
+    if (dateFilter.to) {
+      createdAt.lt = dateFilter.to;
     }
     where.createdAt = createdAt;
   }

--- a/src/lib/log-validation.ts
+++ b/src/lib/log-validation.ts
@@ -1,0 +1,56 @@
+/**
+ * Shared date-filter parsing logic for the activity log API.
+ * Extracted as a pure function to enable unit testing without database dependencies.
+ */
+
+const MAX_DATE_STRING_LENGTH = 100;
+
+export type DateFilterResult =
+  | { ok: true; from: Date | undefined; to: Date | undefined }
+  | { ok: false; error: string };
+
+/**
+ * Parse and validate `from` and `to` date filter parameters.
+ * Returns a structured result so callers can build Prisma where clauses.
+ *
+ * Validation rules:
+ * - Both params are optional; omitting both is valid (no date filter applied)
+ * - Empty string "" is treated as missing (not an error)
+ * - ISO 8601 strings are parsed; invalid strings return an error
+ * - Unix epoch (0) is accepted as a valid date (1970-01-01T00:00:00Z)
+ * - Strings exceeding MAX_DATE_STRING_LENGTH return an error
+ */
+export function parseDateFilter(
+  from: string | null,
+  to: string | null
+): DateFilterResult {
+  // Treat empty strings as missing (consistent with other optional params)
+  const fromVal = from === "" ? null : from;
+  const toVal = to === "" ? null : to;
+
+  if (fromVal && fromVal.length > MAX_DATE_STRING_LENGTH) {
+    return { ok: false, error: "from date string too long" };
+  }
+  if (toVal && toVal.length > MAX_DATE_STRING_LENGTH) {
+    return { ok: false, error: "to date string too long" };
+  }
+
+  if (fromVal) {
+    const parsed = new Date(fromVal);
+    if (isNaN(parsed.getTime())) {
+      return { ok: false, error: "Invalid 'from' date format" };
+    }
+  }
+  if (toVal) {
+    const parsed = new Date(toVal);
+    if (isNaN(parsed.getTime())) {
+      return { ok: false, error: "Invalid 'to' date format" };
+    }
+  }
+
+  return {
+    ok: true,
+    from: fromVal ? new Date(fromVal) : undefined,
+    to: toVal ? new Date(toVal) : undefined,
+  };
+}

--- a/src/lib/log-validation.ts
+++ b/src/lib/log-validation.ts
@@ -17,7 +17,7 @@ export type DateFilterResult =
  * - Both params are optional; omitting both is valid (no date filter applied)
  * - Empty string "" is treated as missing (not an error)
  * - ISO 8601 strings are parsed; invalid strings return an error
- * - Unix epoch (0) is accepted as a valid date (1970-01-01T00:00:00Z)
+ * - Unix epoch 1970-01-01T00:00:00.000Z is accepted as a valid date
  * - Strings exceeding MAX_DATE_STRING_LENGTH return an error
  */
 export function parseDateFilter(

--- a/src/lib/log-validation.ts
+++ b/src/lib/log-validation.ts
@@ -35,22 +35,19 @@ export function parseDateFilter(
     return { ok: false, error: "to date string too long" };
   }
 
-  if (fromVal) {
-    const parsed = new Date(fromVal);
-    if (isNaN(parsed.getTime())) {
-      return { ok: false, error: "Invalid 'from' date format" };
-    }
+  // Parse once and reuse — avoids duplicate Date construction (sourcery-ai, gemini-code-assist)
+  const fromDate = fromVal ? new Date(fromVal) : null;
+  if (fromDate && isNaN(fromDate.getTime())) {
+    return { ok: false, error: "Invalid 'from' date format" };
   }
-  if (toVal) {
-    const parsed = new Date(toVal);
-    if (isNaN(parsed.getTime())) {
-      return { ok: false, error: "Invalid 'to' date format" };
-    }
+  const toDate = toVal ? new Date(toVal) : null;
+  if (toDate && isNaN(toDate.getTime())) {
+    return { ok: false, error: "Invalid 'to' date format" };
   }
 
   return {
     ok: true,
-    from: fromVal ? new Date(fromVal) : undefined,
-    to: toVal ? new Date(toVal) : undefined,
+    from: fromDate ?? undefined,
+    to: toDate ?? undefined,
   };
 }


### PR DESCRIPTION
## Summary

Adds comprehensive unit tests for the date filter validation in `GET /api/log`, addressing issue #165.

### Changes

**New file: `src/lib/log-validation.ts`**
- Extracted `parseDateFilter()` as a pure function outside the route handler
- Enables unit testing without database dependencies
- Exported `DateFilterResult` type for structured results

**New file: `src/__tests__/api/log.test.ts`**
- 17 tests covering all date filter validation scenarios:
  - `null`, empty string ``, and valid ISO dates for both `from` and `to`
  - Date-only format (`YYYY-MM-DD`)
  - Invalid and gibberish date strings → appropriate error messages
  - Unix epoch 0 as valid ISO date string (`1970-01-01T00:00:00.000Z`)
  - 100-character boundary: valid dates accepted at exactly 100 chars, invalid rejected at 101

**Modified: `src/app/api/log/route.ts`**
- Imports `parseDateFilter` from `@/lib/log-validation` instead of inline validation

### Testing
- All 17 new tests pass
- TypeScript: 0 errors, 0 warnings (new files)
- Existing validation.test.ts (13/13 ✅) and lint.test.ts (22/22 ✅) unaffected
- Memory tests: 184/184 ✅

### Existing coverage (confirmed pre-existing)
- `validateSearchQuery`: tested in validation.test.ts ✅
- `staleDays`/`tagMin` (lint): tested in lint.test.ts ✅
- Date validation in log route: NEW tests (this PR) ✅

Closes #165

## Summary by Sourcery

Extract shared date filter parsing for the log API into a reusable helper and add comprehensive tests around log date filter validation, while reusing the slugification helper in the answer creation endpoint.

New Features:
- Introduce a reusable parseDateFilter helper and DateFilterResult type to encapsulate log date query parameter validation.

Enhancements:
- Refactor the log API route to rely on the shared date filter parser instead of inline validation logic.
- Update the answer API route to derive slugs using the shared slugify helper with a defined maximum slug length constant.

Tests:
- Add a dedicated test suite for the log API covering date filter validation scenarios, including boundary cases and invalid inputs.