### PR TITLE
docs(memory): clarify providerPriority vs providerPriorityWeights distinction (#142)

### DIFF
--- a/src/lib/memory/api/recall.ts
+++ b/src/lib/memory/api/recall.ts
@@ -192,6 +192,11 @@ export async function executeMemoryRecallRequest(
   const controller = new AbortController();
 
   try {
+    // NOTE: Two separate priority mechanisms exist here with distinct purposes:
+    // deduplication.providerPriority (string[]) — ordered provider IDs for the
+    // "provider-priority" deduplication strategy.
+    // providerPriorityWeights (Record<string, number>) — per-provider scoring
+    // weights. See RecallSettings for details on the distinction.
     const orchestrator = createRecallOrchestrator({
       providers: providers.entries,
       globalResultCap: effectiveResultCap,

--- a/src/lib/memory/api/recall.ts
+++ b/src/lib/memory/api/recall.ts
@@ -192,11 +192,9 @@ export async function executeMemoryRecallRequest(
   const controller = new AbortController();
 
   try {
-    // NOTE: Two separate priority mechanisms exist here with distinct purposes:
-    // deduplication.providerPriority (string[]) — ordered provider IDs for the
-    // "provider-priority" deduplication strategy.
-    // providerPriorityWeights (Record<string, number>) — per-provider scoring
-    // weights. See RecallSettings for details on the distinction.
+    // NOTE: deduplication.providerPriority (string[]) uses enabledProviders,
+    // while providerPriorityWeights (Record<string, number>) is separate — see
+    // RecallSettings.enabledProviders and providerPriorityWeights for details.
     const orchestrator = createRecallOrchestrator({
       providers: providers.entries,
       globalResultCap: effectiveResultCap,

--- a/src/lib/memory/settings.ts
+++ b/src/lib/memory/settings.ts
@@ -40,10 +40,28 @@ export interface RecallSettings {
   /** Strategy for cross-provider deduplication. */
   deduplicationStrategy: DeduplicationStrategy;
 
-  /** Ordered list of enabled provider IDs. Disabled providers are excluded. */
+  /**
+   * Ordered list of enabled provider IDs. Disabled providers are excluded.
+   *
+   * NOTE: This is used for two distinct purposes in the orchestrator:
+   *   1. As deduplication.providerPriority (string[]) — ordered provider list for the
+   *      "provider-priority" deduplication strategy, controlling which provider wins
+   *      when duplicates are found.
+   *   2. As the default provider filter when no explicit providers are requested.
+   *
+   * This is NOT the same as providerPriorityWeights (Record<string, number>),
+   * which is a weighted scoring map used for result ranking.
+   */
   enabledProviders: string[];
 
-  /** Per-provider priority weights (provider ID → weight). */
+  /**
+   * Per-provider priority weights (provider ID → weight) for scoring/ranking.
+   *
+   * NOTE: This is distinct from enabledProviders (string[]). providerPriorityWeights
+   * is used for weighted scoring in the orchestrator, while enabledProviders is
+   * the ordered list for deduplication strategy ordering. They serve different
+   * purposes despite similar naming.
+   */
   providerPriorityWeights: Record<string, number>;
 
   /**

--- a/src/lib/memory/settings.ts
+++ b/src/lib/memory/settings.ts
@@ -55,12 +55,14 @@ export interface RecallSettings {
   enabledProviders: string[];
 
   /**
-   * Per-provider priority weights (provider ID → weight) for scoring/ranking.
+   * Per-provider priority weights (provider ID → weight) for scoring/ranking
+   * and conflict resolution.
    *
    * NOTE: This is distinct from enabledProviders (string[]). providerPriorityWeights
-   * is used for weighted scoring in the orchestrator, while enabledProviders is
-   * the ordered list for deduplication strategy ordering. They serve different
-   * purposes despite similar naming.
+   * is used for weighted scoring in the orchestrator and provider ranking in
+   * conflict resolution, while enabledProviders is the ordered list for
+   * deduplication strategy ordering. They serve different purposes despite
+   * similar naming.
    */
   providerPriorityWeights: Record<string, number>;
 


### PR DESCRIPTION
## Summary

Issue #142 reported a type mismatch in the orchestrator deduplication config. After thorough investigation, the issue description was found to be **inaccurate** — no actual type mismatch exists.

### Investigation Findings

| Claim in Issue | Actual Reality | Status |
|---|---|---|
| `DeduplicationConfig.providerPriority` expects `Record<string, number>` | It expects `string[]` | ❌ Inaccurate |
| `enabledProviders` → `providerPriority` is a type mismatch | `string[]` → `string[]` = compatible | ❌ Inaccurate |
| Add `tsc --noEmit` to CI | Already present as `npm run typecheck` | ❌ Inaccurate |

### What the Issue Got Right

The naming similarity between `providerPriority`, `enabledProviders`, and `providerPriorityWeights` creates **legitimate confusion**:

- `DeduplicationConfig.providerPriority` = `string[]` — ordered provider list for "provider-priority" deduplication strategy
- `RecallOrchestratorOptions.providerPriorityWeights` = `Record<string, number>` — per-provider scoring weights

These are **separate fields with different semantics**: ordering (string[]) vs. weighting (Record).

### Changes

- **`src/lib/memory/settings.ts`**: Added documentation to `enabledProviders` and `providerPriorityWeights` explaining the distinction
- **`src/lib/memory/api/recall.ts`**: Added NOTE explaining the two separate priority mechanisms

### Reviewers

2 sub-agents spawned for independent review. All findings confirmed:
- ❌ No type mismatch exists (false positive)
- ❌ CI already has `tsc --noEmit`
- ✅ Clarifying comments are accurate and helpful

Closes #142

## Summary by Sourcery

Clarify the distinct roles of enabledProviders, providerPriority, and providerPriorityWeights in memory recall configuration to avoid confusion about deduplication ordering vs scoring weights.

Enhancements:
- Add clarifying comments in the recall orchestrator to document the two separate priority mechanisms and reference RecallSettings for details.

Documentation:
- Expand inline documentation in RecallSettings to explain how enabledProviders feeds deduplication provider priority and default provider filtering, and how providerPriorityWeights is used for scoring/ranking.