### PR TITLE
fix(api): hide soft-deleted related article targets

### DIFF
--- a/src/__tests__/api/article-relations-scope.test.ts
+++ b/src/__tests__/api/article-relations-scope.test.ts
@@ -198,3 +198,20 @@ test("filterVisibleRelatedArticleRows keeps existing scope filtering for live ta
 
   assert.deepEqual(result, [unrestricted, allowed]);
 });
+
+test("filterVisibleRelatedArticleRows short-circuits: soft-deleted targets are hidden from admin callers", () => {
+  // Even an admin ('*') cannot surface a soft-deleted target through the
+  // related-articles panel — soft-delete is an unconditional hide, matching
+  // the DELETE handler's 404-on-deleted contract.
+  const trashed = {
+    target: {
+      id: "a-trashed",
+      restrictedTags: ["financial"],
+      deletedAt: new Date("2024-01-01"),
+    },
+  };
+
+  const result = filterVisibleRelatedArticleRows([trashed], ["*"]);
+
+  assert.deepEqual(result, []);
+});

--- a/src/__tests__/api/article-relations-scope.test.ts
+++ b/src/__tests__/api/article-relations-scope.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   filterAccessibleRelatedTargets,
+  filterVisibleRelatedArticleRows,
   type ArticleRelationReader,
 } from "@/lib/articles/relations";
 
@@ -164,4 +165,36 @@ test("filterAccessibleRelatedTargets drops soft-deleted candidates", async () =>
   );
 
   assert.deepEqual(result, ["a-1"]);
+});
+
+test("filterVisibleRelatedArticleRows drops soft-deleted targets before rendering", () => {
+  const visible = {
+    target: { id: "a-visible", restrictedTags: [], deletedAt: null },
+  };
+  const deleted = {
+    target: { id: "a-deleted", restrictedTags: [], deletedAt: new Date("2024-01-01") },
+  };
+
+  const result = filterVisibleRelatedArticleRows([visible, deleted], ["*"]);
+
+  assert.deepEqual(result, [visible]);
+});
+
+test("filterVisibleRelatedArticleRows keeps existing scope filtering for live targets", () => {
+  const unrestricted = {
+    target: { id: "a-open", restrictedTags: [], deletedAt: null },
+  };
+  const allowed = {
+    target: { id: "a-health", restrictedTags: ["health"], deletedAt: null },
+  };
+  const forbidden = {
+    target: { id: "a-finance", restrictedTags: ["finance"], deletedAt: null },
+  };
+
+  const result = filterVisibleRelatedArticleRows(
+    [unrestricted, allowed, forbidden],
+    ["health"],
+  );
+
+  assert.deepEqual(result, [unrestricted, allowed]);
 });

--- a/src/app/api/articles/[id]/route.ts
+++ b/src/app/api/articles/[id]/route.ts
@@ -3,7 +3,11 @@ import { Permissions } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
 import { requirePermission, canAccessScopes } from "@/lib/api/auth";
 import { buildTagConnections } from "@/lib/wiki";
-import { syncArticleRelations, filterAccessibleRelatedTargets } from "@/lib/articles/relations";
+import {
+  syncArticleRelations,
+  filterAccessibleRelatedTargets,
+  filterVisibleRelatedArticleRows,
+} from "@/lib/articles/relations";
 import {
   ARTICLE_LIMITS,
   deriveExcerpt,
@@ -270,7 +274,7 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
           tags: { include: { tag: true } },
           relatedTo: {
             include: {
-              target: { select: { id: true, title: true, slug: true, topic: true, restrictedTags: true } },
+              target: { select: { id: true, title: true, slug: true, topic: true, restrictedTags: true, deletedAt: true } },
             },
           },
         },
@@ -290,8 +294,7 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
       status: updatedArticle!.status,
       restrictedTags: updatedArticle!.restrictedTags ?? [],
       lastReviewed: updatedArticle!.lastReviewed,
-      relatedArticles: updatedArticle!.relatedTo
-        .filter((r) => canAccessScopes(r.target.restrictedTags ?? [], auth.auth.allowedScopes))
+      relatedArticles: filterVisibleRelatedArticleRows(updatedArticle!.relatedTo, auth.auth.allowedScopes)
         .map((r) => ({
           id: r.target.id,
           title: r.target.title,

--- a/src/app/api/articles/route.ts
+++ b/src/app/api/articles/route.ts
@@ -1,12 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
 import { Permissions } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
-import { requirePermission, buildScopeFilter, canAccessScopes } from "@/lib/api/auth";
+import { requirePermission, buildScopeFilter } from "@/lib/api/auth";
 import { resolveRestrictedTagsForCaller } from "@/lib/api/restricted-scopes";
 import { buildTagConnections, countSearchArticles, searchArticleIds } from "@/lib/wiki";
 import { detectSecretInInputs } from "@/lib/memory/api/save";
 import { invalidateSearchCache } from "@/lib/cache/search-cache";
-import { filterAccessibleRelatedTargets } from "@/lib/articles/relations";
+import { filterAccessibleRelatedTargets, filterVisibleRelatedArticleRows } from "@/lib/articles/relations";
 import {
   ARTICLE_LIMITS,
   QUERY_LIMITS,
@@ -108,7 +108,7 @@ export async function GET(request: NextRequest) {
               author: { select: { id: true, name: true } },
               relatedTo: {
                 include: {
-                  target: { select: { id: true, title: true, slug: true, topic: true, restrictedTags: true } },
+                  target: { select: { id: true, title: true, slug: true, topic: true, restrictedTags: true, deletedAt: true } },
                 },
               },
             },
@@ -127,7 +127,7 @@ export async function GET(request: NextRequest) {
             author: { select: { id: true, name: true } },
             relatedTo: {
               include: {
-                target: { select: { id: true, title: true, slug: true, topic: true, restrictedTags: true } },
+                target: { select: { id: true, title: true, slug: true, topic: true, restrictedTags: true, deletedAt: true } },
               },
             },
           },
@@ -158,8 +158,7 @@ export async function GET(request: NextRequest) {
       status: a.status,
       restrictedTags: a.restrictedTags ?? [],
       lastReviewed: a.lastReviewed,
-      relatedArticles: a.relatedTo
-        .filter((r) => canAccessScopes(r.target.restrictedTags ?? [], auth.auth.allowedScopes))
+      relatedArticles: filterVisibleRelatedArticleRows(a.relatedTo, auth.auth.allowedScopes)
         .map((r) => ({
           id: r.target.id,
           title: r.target.title,

--- a/src/app/wiki/[topicSlug]/[articleSlug]/page.tsx
+++ b/src/app/wiki/[topicSlug]/[articleSlug]/page.tsx
@@ -5,7 +5,7 @@ import { getServerSession } from "next-auth";
 import { Breadcrumbs } from "@/components/wiki/Breadcrumbs";
 import { prisma } from "@/lib/prisma";
 import { authOptions } from "@/lib/auth";
-import { canAccessScopes } from "@/lib/api/auth";
+import { filterVisibleRelatedArticleRows } from "@/lib/articles/relations";
 import { DeleteArticleForm } from "@/components/wiki/DeleteArticleForm";
 import { PageHeader } from "@/components/wiki/PageHeader";
 import ReactMarkdown from "react-markdown";
@@ -54,7 +54,7 @@ export default async function ArticlePage({ params }: Props) {
       relatedTo: {
         include: {
           target: {
-            select: { id: true, title: true, slug: true, topic: { select: { slug: true } }, restrictedTags: true },
+            select: { id: true, title: true, slug: true, topic: { select: { slug: true } }, restrictedTags: true, deletedAt: true },
           },
         },
       },
@@ -179,8 +179,9 @@ export default async function ArticlePage({ params }: Props) {
           <section className="article-detail-card">
             <p className="article-detail-label">Connected pages</p>
             {(() => {
-              const accessibleRelated = article.relatedTo.filter((rel) =>
-                canAccessScopes(rel.target.restrictedTags ?? [], session ? ["*"] : undefined)
+              const accessibleRelated = filterVisibleRelatedArticleRows(
+                article.relatedTo,
+                session ? ["*"] : undefined,
               );
               return accessibleRelated.length > 0 ? (
                 <div className="article-link-list">

--- a/src/lib/articles/relations.ts
+++ b/src/lib/articles/relations.ts
@@ -19,6 +19,13 @@ export interface ArticleRelationReader {
   };
 }
 
+export type RelatedArticleRow = {
+  target: {
+    deletedAt: Date | null;
+    restrictedTags: string[] | null;
+  };
+};
+
 export async function syncArticleRelations(
   tx: ArticleRelationWriter,
   sourceId: string,
@@ -68,4 +75,20 @@ export async function filterAccessibleRelatedTargets(
   return existing
     .filter((article) => canAccessScopes(article.restrictedTags, allowedScopes))
     .map((article) => article.id);
+}
+
+/**
+ * Keep related-article render paths aligned with write-time relation filtering.
+ * Old relation rows can outlive a later soft-delete, so read projections must
+ * still suppress deleted targets before serializing or rendering link metadata.
+ */
+export function filterVisibleRelatedArticleRows<T extends RelatedArticleRow>(
+  relations: T[],
+  allowedScopes: string[] | undefined,
+): T[] {
+  return relations.filter(
+    (relation) =>
+      relation.target.deletedAt === null &&
+      canAccessScopes(relation.target.restrictedTags ?? [], allowedScopes),
+  );
 }

--- a/src/lib/articles/relations.ts
+++ b/src/lib/articles/relations.ts
@@ -22,7 +22,7 @@ export interface ArticleRelationReader {
 export type RelatedArticleRow = {
   target: {
     deletedAt: Date | null;
-    restrictedTags: string[] | null;
+    restrictedTags: string[];
   };
 };
 
@@ -89,6 +89,6 @@ export function filterVisibleRelatedArticleRows<T extends RelatedArticleRow>(
   return relations.filter(
     (relation) =>
       relation.target.deletedAt === null &&
-      canAccessScopes(relation.target.restrictedTags ?? [], allowedScopes),
+      canAccessScopes(relation.target.restrictedTags, allowedScopes),
   );
 }


### PR DESCRIPTION
## Summary
- adds a shared related-article visibility helper that filters soft-deleted targets before serialization/rendering
- applies it to `GET /api/articles`, `PATCH /api/articles/:id` responses, and the wiki article connected-pages panel
- adds focused regression coverage for soft-deleted stale relations and scope filtering

## Semantic anchors
- STRIDE: Information Disclosure, because stale relation rows could expose deleted target metadata
- TDD: focused regression tests around the relation projection invariant
- GitHub Flow + Definition of Done: small branch, verified locally before PR

## Verification
- `node --import tsx --test src/__tests__/api/article-relations-scope.test.ts src/__tests__/api/article-relations.test.ts` — 15/15 pass
- `npm run typecheck` — pass
- `npm run lint` — pass with 2 pre-existing warnings
- `set -a; . ./.env.test; set +a; npm run build` — pass, with existing Turbopack tracing warning
- `node --env-file=.env.test --import tsx --test 'src/__tests__/api/**/*.test.ts'` — 236/237 pass; pre-existing `sync-conflict-review` Node mock failure remains\n- `npm audit --omit=dev --audit-level=high` — no high/critical vulnerabilities; existing moderate `next-auth -> uuid` advisory remains\n\n## Notes\n`npm test` without env still fails on API tests that import Prisma without `DATABASE_URL`; reran API suite with `.env.test` for the meaningful local gate.

## Summary by Sourcery

Ensure related articles never expose soft-deleted targets in API and wiki responses.

Bug Fixes:
- Prevent soft-deleted related article targets from being returned in article API responses and wiki connected-pages views.

Enhancements:
- Introduce a shared helper to filter visible related-article rows using both soft-delete and scope restrictions, and apply it to API and wiki render paths.

Tests:
- Add regression tests to verify that soft-deleted related article targets are filtered out and that existing scope-based filtering remains unchanged.