### PR TITLE
fix(hermes): report Noosphere init failures

### DIFF
--- a/hermes-noosphere-memory/plugins/memory/noosphere/__init__.py
+++ b/hermes-noosphere-memory/plugins/memory/noosphere/__init__.py
@@ -243,6 +243,7 @@ class NoosphereMemoryProvider(MemoryProvider):
         self._agent_context = ""
         self._write_enabled = True
         self._active = False
+        self._inactive_reason = ""
         self._client: Optional[NoosphereClient] = None
         self._save_queue: queue.Queue[Dict[str, Any]] = queue.Queue(maxsize=_SAVE_QUEUE_MAXSIZE)
         self._save_worker: Optional[threading.Thread] = None
@@ -286,24 +287,30 @@ class NoosphereMemoryProvider(MemoryProvider):
         self._platform = _as_string(kwargs.get("platform"))
         self._agent_identity = _as_string(kwargs.get("agent_identity"), "default") or "default"
         self._agent_context = _as_string(kwargs.get("agent_context"))
+        self._inactive_reason = ""
 
         try:
             self._config = _load_noosphere_config(self._hermes_home)
-        except ValueError:
+        except ValueError as error:
             self._active = False
             self._client = None
+            self._inactive_reason = f"Noosphere is disabled because noosphere.json is invalid: {error}"
             return
         env_base_url = _env_first("HERMES_NOOSPHERE_BASE_URL", "NOOSPHERE_BASE_URL")
         if env_base_url:
             try:
                 self._config["base_url"] = normalize_base_url(env_base_url)
-            except ValueError:
+            except ValueError as error:
                 logger.warning(
                     "Unsafe Hermes Noosphere base URL ignored; Noosphere disabled",
                     exc_info=True,
                 )
                 self._active = False
                 self._client = None
+                self._inactive_reason = (
+                    "Noosphere is disabled because HERMES_NOOSPHERE_BASE_URL "
+                    f"or NOOSPHERE_BASE_URL is invalid: {error}"
+                )
                 return
 
         self._api_key = _env_first("HERMES_NOOSPHERE_API_KEY", "NOOSPHERE_API_KEY")
@@ -356,7 +363,7 @@ class NoosphereMemoryProvider(MemoryProvider):
 
     def handle_tool_call(self, tool_name: str, args: Dict[str, Any], **kwargs: Any) -> str:
         if not self._active or not self._client:
-            error = (
+            error = self._inactive_reason or (
                 "Noosphere is not configured. Set HERMES_NOOSPHERE_API_KEY, "
                 "or NOOSPHERE_API_KEY as a compatibility fallback."
             )

--- a/hermes-noosphere-memory/tests/test_noosphere_provider_phase1.py
+++ b/hermes-noosphere-memory/tests/test_noosphere_provider_phase1.py
@@ -247,6 +247,24 @@ class NoosphereProviderPhase1Test(unittest.TestCase):
         self.assertIsNone(provider._client)
         self.assertIn("Unsafe Noosphere config", "\n".join(logs.output))
 
+    def test_status_reports_config_error_after_failed_initialize(self):
+        module = load_plugin()
+        provider = module.NoosphereMemoryProvider()
+
+        with tempfile.TemporaryDirectory() as hermes_home:
+            path = Path(hermes_home) / "noosphere.json"
+            path.write_text(json.dumps({"base_url": "http://100.111.85.48:6578"}), encoding="utf-8")
+
+            with mock.patch.dict(os.environ, {"NOOSPHERE_API_KEY": "noo_test"}, clear=True):
+                with self.assertLogs(module.logger, level="WARNING"):
+                    provider.initialize("session-1", hermes_home=hermes_home)
+
+        result = json.loads(provider.handle_tool_call("noosphere_status", {}))
+
+        self.assertIn("noosphere.json", result["error"])
+        self.assertIn("loopback", result["error"])
+        self.assertNotIn("HERMES_NOOSPHERE_API_KEY", result["error"])
+
     def test_register_adds_memory_provider(self):
         module = load_plugin()
         registered = []


### PR DESCRIPTION
## Summary
- preserve Hermes Noosphere provider initialization failure reasons
- return invalid noosphere.json / base URL diagnostics from noosphere_status instead of a generic API-key hint
- add a regression for a valid API key with an unsafe stored HTTP Tailscale base_url

## Verification
- python3 -m unittest discover -s hermes-noosphere-memory/tests
- python3 -m compileall hermes-noosphere-memory/plugins/memory/noosphere
- git diff --check

## Notes
- Runtime fix for the already-running Hermes gateway still requires a service restart so the corrected noosphere.json is loaded.

## Summary by Sourcery

Preserve and surface specific Noosphere configuration and initialization failure reasons in Hermes, and update status reporting accordingly.

Bug Fixes:
- Ensure noosphere_status reports detailed configuration errors from previous initialization failures instead of a generic API key hint.

Enhancements:
- Track and expose a human-readable inactive_reason for the Noosphere provider when initialization is disabled by invalid configuration or unsafe base URLs.

Tests:
- Add a regression test verifying that noosphere_status includes invalid noosphere.json and unsafe base URL diagnostics after a failed initialize and omits misleading API key hints.