### PR TITLE
docs: add Hermes clone install method

### DIFF
--- a/hermes-noosphere-memory/README.md
+++ b/hermes-noosphere-memory/README.md
@@ -48,8 +48,24 @@ Not implemented yet:
 
 Those are intentionally left for later PRs so each step stays reviewable.
 
+## Install From a Cloned Repository
+
+Use this path when you have a local checkout of Noosphere and want the helper
+script to copy the Hermes plugin and setup skill into the active Hermes profile:
+
+```bash
+git clone https://github.com/SweetSophia/noosphere.git
+cd noosphere/hermes-noosphere-memory
+./install-hermes.sh
+```
+
+The installer uses `$HERMES_HOME` when it is set, otherwise it installs into
+`~/.hermes`. If the `hermes` CLI is available, it offers to run
+`hermes memory setup`; otherwise it prints the manual setup commands.
+
 ## Manual Install During Development
-Manual setup looks like this:
+
+Use this fallback when you need to copy the plugin files yourself:
 
     mkdir -p "$HERMES_HOME/plugins"
     cp -R plugins/memory/noosphere "$HERMES_HOME/plugins/noosphere"

--- a/hermes-noosphere-memory/README.md
+++ b/hermes-noosphere-memory/README.md
@@ -50,8 +50,8 @@ Those are intentionally left for later PRs so each step stays reviewable.
 
 ## Install From a Cloned Repository
 
-Use this path when you have a local checkout of Noosphere and want the helper
-script to copy the Hermes plugin and setup skill into the active Hermes profile:
+Use this path to clone the Noosphere repository and run the helper script that
+copies the Hermes plugin and setup skill into the active Hermes profile:
 
 ```bash
 git clone https://github.com/SweetSophia/noosphere.git
@@ -67,6 +67,7 @@ The installer uses `$HERMES_HOME` when it is set, otherwise it installs into
 
 Use this fallback when you need to copy the plugin files yourself:
 
+    export HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
     mkdir -p "$HERMES_HOME/plugins"
     cp -R plugins/memory/noosphere "$HERMES_HOME/plugins/noosphere"
     hermes config set memory.provider noosphere


### PR DESCRIPTION
## Summary
- add the cloned-repository install path to hermes-noosphere-memory/README.md
- keep the manual copy instructions as a fallback

## Verification
- git diff --check

## Summary by Sourcery

Document a new installation path for the Hermes Noosphere memory plugin using a cloned repository checkout while clarifying when to use manual installation steps.

Documentation:
- Add instructions for installing the Hermes Noosphere memory plugin from a locally cloned Noosphere repository, including environment detection behavior.
- Clarify the manual installation section as a fallback path when copying plugin files by hand.