### PR TITLE
fix(build): mark sync vault fs access runtime-only

### DIFF
--- a/src/app/api/sync/conflicts/[id]/archive/route.ts
+++ b/src/app/api/sync/conflicts/[id]/archive/route.ts
@@ -6,7 +6,6 @@
 
 export const dynamic = "force-dynamic";
 
-import { readFile } from "fs/promises";
 import { NextRequest, NextResponse } from "next/server";
 import { Permissions } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
@@ -14,6 +13,7 @@ import { requirePermission } from "@/lib/api/auth";
 import { getObsidianSyncConfig } from "@/lib/obsidian-sync/config";
 import { resolveVaultArchivePath } from "@/lib/markdown-sync/conflict-review";
 import { rateLimit } from "@/lib/rate-limit";
+import { runtimeReadTextFileAsync } from "@/lib/runtime-fs";
 
 export async function GET(
   request: NextRequest,
@@ -48,7 +48,7 @@ export async function GET(
   }
 
   try {
-    const content = await readFile(absolutePath, "utf-8");
+    const content = await runtimeReadTextFileAsync(absolutePath);
     const filename = (review.relativePath.split("/").pop() ?? "conflict.md").replace(/[^\w.-]/g, "_");
     return new NextResponse(content, {
       status: 200,

--- a/src/lib/markdown-sync/conflict-review.ts
+++ b/src/lib/markdown-sync/conflict-review.ts
@@ -1,6 +1,6 @@
 import { createHash } from "crypto";
-import { resolve } from "path";
 import { parseNoosphereMarkdown, readMarkdownString, readMarkdownStringArray } from "@/lib/markdown/noosphere-markdown";
+import { runtimeResolve } from "@/lib/runtime-fs";
 
 export const SYNC_CONFLICT_REVIEW_STATUSES = ["open", "resolved", "ignored-once", "ignored-always"] as const;
 export type SyncConflictReviewStatus = (typeof SYNC_CONFLICT_REVIEW_STATUSES)[number];
@@ -150,8 +150,8 @@ export function buildSyncConflictReviewCreateInput(args: {
 
 export function resolveVaultArchivePath(vaultPath: string, archivePath: string): string | null {
   const normalizedVault = vaultPath.replace(/[/\\]+$/, "");
-  const conflictRoot = resolve(normalizedVault, ".noosphere-sync", "conflicts").replace(/\\/g, "/");
-  const absolutePath = resolve(normalizedVault, archivePath).replace(/\\/g, "/");
+  const conflictRoot = runtimeResolve(normalizedVault, ".noosphere-sync", "conflicts").replace(/\\/g, "/");
+  const absolutePath = runtimeResolve(normalizedVault, archivePath).replace(/\\/g, "/");
 
   if (!absolutePath.startsWith(`${conflictRoot}/`)) return null;
   return absolutePath;

--- a/src/lib/markdown-sync/import-applier.ts
+++ b/src/lib/markdown-sync/import-applier.ts
@@ -13,8 +13,6 @@
  * 5. Return a detailed result object with stats and warnings
  */
 
-import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "fs";
-import { join } from "path";
 import type { PrismaClient } from "@prisma/client";
 import type {
   MarkdownImportCandidate,
@@ -25,6 +23,14 @@ import { invalidateSearchCache } from "@/lib/cache/search-cache";
 import { isValidConfidence, isValidStatus } from "@/lib/validation";
 import type { Manifest, ManifestEntry } from "@/lib/obsidian-sync";
 import type { ObsidianSyncConfig } from "@/lib/obsidian-sync/config";
+import {
+  runtimeExists,
+  runtimeJoin,
+  runtimeMkdir,
+  runtimeReadFile,
+  runtimeRename,
+  runtimeWriteTextFile,
+} from "@/lib/runtime-fs";
 
 export const MARKDOWN_IMPORT_APPLY_MAX_BODY_BYTES = 256 * 1024; // 256KB
 export const MARKDOWN_IMPORT_APPLY_PERMISSIONS = ["ADMIN"] as const;
@@ -354,7 +360,7 @@ async function applyCreateOrUpdate(
   // ── Read and parse the markdown file ─────────────────────────────────────
   let markdownContent: string;
   try {
-    markdownContent = readFileSync(absolutePath, "utf-8");
+    markdownContent = runtimeReadFile(absolutePath, "utf-8");
   } catch {
     await recordAudit(prisma, {
       articleId: candidate.articleId ?? null,
@@ -762,10 +768,10 @@ function writeManifest(
   config: ObsidianSyncConfig,
   manifest: Manifest
 ): void {
-  const dir = join(vaultPath, ".noosphere-sync");
-  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
-  const manifestFile = join(vaultPath, config.manifestPath);
+  const dir = runtimeJoin(vaultPath, ".noosphere-sync");
+  if (!runtimeExists(dir)) runtimeMkdir(dir);
+  const manifestFile = runtimeJoin(vaultPath, config.manifestPath);
   const tmp = `${manifestFile}.tmp.${Date.now()}`;
-  writeFileSync(tmp, JSON.stringify(manifest, null, 2), "utf-8");
-  renameSync(tmp, manifestFile);
+  runtimeWriteTextFile(tmp, JSON.stringify(manifest, null, 2));
+  runtimeRename(tmp, manifestFile);
 }

--- a/src/lib/markdown-sync/import-scanner.ts
+++ b/src/lib/markdown-sync/import-scanner.ts
@@ -6,8 +6,7 @@
  */
 
 import { createHash } from "crypto";
-import { existsSync, lstatSync, readdirSync, readFileSync, realpathSync } from "fs";
-import { join, relative, resolve } from "path";
+import { relative } from "path";
 import { Permissions } from "@prisma/client";
 import {
   parseNoosphereMarkdown,
@@ -15,6 +14,15 @@ import {
   readMarkdownStringArray,
 } from "@/lib/markdown/noosphere-markdown";
 import type { Manifest, ManifestEntry } from "@/lib/obsidian-sync";
+import {
+  runtimeExists,
+  runtimeJoin,
+  runtimeLstat,
+  runtimeReadDir,
+  runtimeReadFile,
+  runtimeRealpath,
+  runtimeResolve,
+} from "@/lib/runtime-fs";
 
 export const MARKDOWN_IMPORT_SCAN_MAX_BODY_BYTES = 32 * 1024;
 export const MARKDOWN_IMPORT_SCAN_DEFAULT_MAX_FILES = 5_000;
@@ -293,7 +301,7 @@ function scanTrackedEntry(
   }
 
   const baselineHash = entry.writtenHash ?? null;
-  if (!existsSync(absolutePath)) {
+  if (!runtimeExists(absolutePath)) {
     return {
       kind: "missing",
       relativePath,
@@ -360,10 +368,10 @@ function readManifest(vaultPath: string, manifestPath: string, warnings: string[
     return null;
   }
 
-  if (!existsSync(absolutePath)) return null;
+  if (!runtimeExists(absolutePath)) return null;
 
   try {
-    const parsed = JSON.parse(readFileSync(absolutePath, "utf-8")) as Manifest;
+    const parsed = JSON.parse(runtimeReadFile(absolutePath, "utf-8")) as Manifest;
     if (parsed.version !== 1 || !isManifestArticles(parsed.articles)) {
       warnings.push(`Unsupported manifest format: ${manifestPath}`);
       return null;
@@ -380,7 +388,7 @@ function loadMarkdownFile(vaultPath: string, relativePath: string): LoadedMarkdo
   if (!absolutePath) {
     throw new Error("File path escapes vault root, is a symlink, or is not a regular file");
   }
-  const content = readFileSync(absolutePath, "utf-8");
+  const content = runtimeReadFile(absolutePath, "utf-8");
   const parsed = parseNoosphereMarkdown(content);
   const markdownHash = hashMarkdownContent(content);
   const sizeBytes = Buffer.byteLength(content, "utf-8");
@@ -428,9 +436,9 @@ function listMarkdownFiles(
   warnings: string[],
   ignoredPaths: Set<string>,
 ): string[] {
-  if (!existsSync(vaultPath)) return [];
+  if (!runtimeExists(vaultPath)) return [];
 
-  const root = resolve(vaultPath);
+  const root = runtimeResolve(vaultPath);
   const files: string[] = [];
   walk(root);
   return files.sort();
@@ -438,7 +446,7 @@ function listMarkdownFiles(
   function walk(directory: string) {
     let entries;
     try {
-      entries = readdirSync(directory, { withFileTypes: true });
+      entries = runtimeReadDir(directory);
     } catch (error) {
       warnings.push(`Failed to read directory ${directory}: ${errorMessage(error)}`);
       return;
@@ -447,7 +455,7 @@ function listMarkdownFiles(
     entries.sort((a, b) => a.name.localeCompare(b.name));
 
     for (const entry of entries) {
-      const absolutePath = join(directory, entry.name);
+      const absolutePath = runtimeJoin(directory, entry.name);
       const relativePath = normalizeRelativePath(relative(root, absolutePath));
 
       if (entry.isDirectory()) {
@@ -479,8 +487,8 @@ function incrementCandidateStats(stats: MarkdownImportScanStats, candidate: Mark
 }
 
 function resolveVaultPath(vaultPath: string, relativePath: string): string | null {
-  const root = resolve(vaultPath).replace(/[/\\]+$/, "").replace(/\\/g, "/");
-  const absolutePath = resolve(vaultPath, relativePath).replace(/\\/g, "/");
+  const root = runtimeResolve(vaultPath).replace(/[/\\]+$/, "").replace(/\\/g, "/");
+  const absolutePath = runtimeResolve(vaultPath, relativePath).replace(/\\/g, "/");
   if (!absolutePath.startsWith(`${root}/`)) return null;
   return absolutePath;
 }
@@ -489,11 +497,11 @@ export function resolveExistingVaultFilePath(vaultPath: string, relativePath: st
   const absolutePath = resolveVaultPath(vaultPath, relativePath);
   if (!absolutePath) return null;
 
-  const stat = lstatSync(absolutePath);
+  const stat = runtimeLstat(absolutePath);
   if (stat.isSymbolicLink() || !stat.isFile()) return null;
 
-  const root = realpathSync(vaultPath).replace(/[/\\]+$/, "").replace(/\\/g, "/");
-  const realPath = realpathSync(absolutePath).replace(/\\/g, "/");
+  const root = runtimeRealpath(vaultPath).replace(/[/\\]+$/, "").replace(/\\/g, "/");
+  const realPath = runtimeRealpath(absolutePath).replace(/\\/g, "/");
   if (!realPath.startsWith(`${root}/`)) return null;
 
   return absolutePath;

--- a/src/lib/markdown-sync/manifest.ts
+++ b/src/lib/markdown-sync/manifest.ts
@@ -1,16 +1,15 @@
-import { existsSync, readFileSync } from "fs";
-import { resolve } from "path";
 import type { Manifest } from "@/lib/obsidian-sync";
+import { runtimeExists, runtimeReadFile, runtimeResolve } from "@/lib/runtime-fs";
 
 /**
  * Load and validate a Markdown sync manifest from the configured vault.
  */
 export function loadManifest(vaultPath: string, manifestRelPath: string): Manifest | null {
-  const manifestAbsPath = resolve(vaultPath, manifestRelPath);
-  if (!existsSync(manifestAbsPath)) return null;
+  const manifestAbsPath = runtimeResolve(vaultPath, manifestRelPath);
+  if (!runtimeExists(manifestAbsPath)) return null;
 
   try {
-    const parsed = JSON.parse(readFileSync(manifestAbsPath, "utf-8")) as Manifest;
+    const parsed = JSON.parse(runtimeReadFile(manifestAbsPath, "utf-8")) as Manifest;
     if (parsed.version !== 1) return null;
     return parsed;
   } catch {

--- a/src/lib/obsidian-sync/index.ts
+++ b/src/lib/obsidian-sync/index.ts
@@ -6,8 +6,7 @@
  */
 
 import { createHash } from "crypto";
-import { existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "fs";
-import { join, resolve, relative as pathRelative } from "path";
+import { relative as pathRelative } from "path";
 import { spawn } from "child_process";
 import type { ObsidianSyncConfig } from "./config";
 import { getObsidianSyncConfig } from "./config";
@@ -26,6 +25,17 @@ import {
   findIgnoredAlwaysSyncConflictReview,
   recordSyncConflictReview,
 } from "@/lib/markdown-sync/api/conflict-review";
+import {
+  runtimeExists,
+  runtimeJoin,
+  runtimeMkdir,
+  runtimeReadFile,
+  runtimeRename,
+  runtimeResolve,
+  runtimeUnlink,
+  runtimeWriteFile,
+  runtimeWriteTextFile,
+} from "@/lib/runtime-fs";
 
 // ─────────────────────────────────────────────
 // Types
@@ -314,10 +324,10 @@ function computeContentHash(article: ArticleForSync, topicPath: string[]): strin
 // ─────────────────────────────────────────────
 
 function readManifest(vaultPath: string, config: ObsidianSyncConfig): Manifest | null {
-  const manifestFile = join(vaultPath, config.manifestPath);
-  if (!existsSync(manifestFile)) return null;
+  const manifestFile = runtimeJoin(vaultPath, config.manifestPath);
+  if (!runtimeExists(manifestFile)) return null;
   try {
-    const raw = readFileSync(manifestFile, "utf-8");
+    const raw = runtimeReadFile(manifestFile, "utf-8");
     const m = JSON.parse(raw) as Manifest;
     if (m.version !== 1) return null;
     return m;
@@ -327,18 +337,18 @@ function readManifest(vaultPath: string, config: ObsidianSyncConfig): Manifest |
 }
 
 function writeManifest(vaultPath: string, config: ObsidianSyncConfig, manifest: Manifest): void {
-  const dir = join(vaultPath, ".noosphere-sync");
-  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
-  const manifestFile = join(vaultPath, config.manifestPath);
+  const dir = runtimeJoin(vaultPath, ".noosphere-sync");
+  if (!runtimeExists(dir)) runtimeMkdir(dir);
+  const manifestFile = runtimeJoin(vaultPath, config.manifestPath);
   const tmp = `${manifestFile}.tmp.${Date.now()}`;
-  writeFileSync(tmp, JSON.stringify(manifest, null, 2), "utf-8");
-  renameSync(tmp, manifestFile);
+  runtimeWriteTextFile(tmp, JSON.stringify(manifest, null, 2));
+  runtimeRename(tmp, manifestFile);
 }
 
 function writeLastRun(vaultPath: string, config: ObsidianSyncConfig, result: SyncResult): void {
-  const dir = join(vaultPath, ".noosphere-sync");
-  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
-  const lastRunFile = join(vaultPath, config.lastRunPath);
+  const dir = runtimeJoin(vaultPath, ".noosphere-sync");
+  if (!runtimeExists(dir)) runtimeMkdir(dir);
+  const lastRunFile = runtimeJoin(vaultPath, config.lastRunPath);
   const summary = {
     lastRunAt: new Date().toISOString(),
     mode: result.mode,
@@ -349,8 +359,8 @@ function writeLastRun(vaultPath: string, config: ObsidianSyncConfig, result: Syn
     success: result.success,
   };
   const tmp = `${lastRunFile}.tmp.${Date.now()}`;
-  writeFileSync(tmp, JSON.stringify(summary, null, 2), "utf-8");
-  renameSync(tmp, lastRunFile);
+  runtimeWriteTextFile(tmp, JSON.stringify(summary, null, 2));
+  runtimeRename(tmp, lastRunFile);
 }
 
 // ─────────────────────────────────────────────
@@ -361,7 +371,7 @@ function safePath(vaultPath: string, relativePath: string): string | null {
   // Normalize vaultPath: strip trailing separators so the startsWith boundary check
   // is not bypassed by resolve("/data/vault/", "../etc/passwd") → /data/etc/passwd
   const normalizedVault = vaultPath.replace(/[/\\]+$/, "").replace(/\\/g, "/");
-  const resolved = resolve(vaultPath.replace(/[/\\]+$/, ""), relativePath).replace(/\\/g, "/");
+  const resolved = runtimeResolve(vaultPath.replace(/[/\\]+$/, ""), relativePath).replace(/\\/g, "/");
   if (!resolved.startsWith(normalizedVault + "/")) return null; // path traversal
   return resolved;
 }
@@ -376,11 +386,11 @@ function archiveConflict(
   diskContent: string
 ): string {
   const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
-  const conflictDir = join(vaultPath, ".noosphere-sync", "conflicts");
-  if (!existsSync(conflictDir)) mkdirSync(conflictDir, { recursive: true });
+  const conflictDir = runtimeJoin(vaultPath, ".noosphere-sync", "conflicts");
+  if (!runtimeExists(conflictDir)) runtimeMkdir(conflictDir);
   const safeName = relativePath.replace(/\//g, "---");
-  const conflictFile = join(conflictDir, `${timestamp}-${safeName}`);
-  writeFileSync(conflictFile, diskContent, "utf-8");
+  const conflictFile = runtimeJoin(conflictDir, `${timestamp}-${safeName}`);
+  runtimeWriteTextFile(conflictFile, diskContent);
   return `.noosphere-sync/conflicts/${timestamp}-${safeName}`;
 }
 
@@ -390,17 +400,17 @@ function archiveConflict(
 
 function trashFile(vaultPath: string, absolutePath: string): void {
   const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
-  const trashDir = join(vaultPath, ".noosphere-sync", "trash");
-  if (!existsSync(trashDir)) mkdirSync(trashDir, { recursive: true });
+  const trashDir = runtimeJoin(vaultPath, ".noosphere-sync", "trash");
+  if (!runtimeExists(trashDir)) runtimeMkdir(trashDir);
   const rel = pathRelative(vaultPath, absolutePath);
-  const trashPath = join(trashDir, `${timestamp}-${rel.replace(/\//g, "---")}`);
+  const trashPath = runtimeJoin(trashDir, `${timestamp}-${rel.replace(/\//g, "---")}`);
   try {
-    renameSync(absolutePath, trashPath);
+    runtimeRename(absolutePath, trashPath);
   } catch {
     // Cross-device: copy then delete
     try {
-      writeFileSync(trashPath, readFileSync(absolutePath));
-      unlinkSync(absolutePath);
+      runtimeWriteFile(trashPath, runtimeReadFile(absolutePath));
+      runtimeUnlink(absolutePath);
     } catch (e) {
       console.error("[obsidian-sync] Failed to trash file:", absolutePath, e);
     }
@@ -413,10 +423,10 @@ function trashFile(vaultPath: string, absolutePath: string): void {
 
 function writeFileAtomic(absolutePath: string, content: string): void {
   const dir = absolutePath.slice(0, absolutePath.lastIndexOf("/"));
-  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  if (!runtimeExists(dir)) runtimeMkdir(dir);
   const tmp = `${absolutePath}.tmp.${Date.now()}.${Math.random().toString(36).slice(2)}`;
-  writeFileSync(tmp, content, "utf-8");
-  renameSync(tmp, absolutePath);
+  runtimeWriteTextFile(tmp, content);
+  runtimeRename(tmp, absolutePath);
 }
 
 // ─────────────────────────────────────────────
@@ -469,8 +479,8 @@ export async function runObsidianSync(options: SyncOptions): Promise<SyncResult>
 
   try {
     // ── Ensure vault root exists ─────────────────────────────────────────
-    if (!options.dryRun && !existsSync(vaultPath)) {
-      mkdirSync(vaultPath, { recursive: true });
+    if (!options.dryRun && !runtimeExists(vaultPath)) {
+      runtimeMkdir(vaultPath);
     }
 
     // ── Read manifest ──────────────────────────────────────────────────────
@@ -572,10 +582,10 @@ export async function runObsidianSync(options: SyncOptions): Promise<SyncResult>
         // A persisted empty string is different: it came from the short-lived
         // sentinel fallback and must be treated as invalid so we archive before
         // rewriting rather than silently blessing the current disk state.
-        if (existsSync(safe) && existingEntry) {
+        if (runtimeExists(safe) && existingEntry) {
           let diskBuffer: Buffer | null = null;
           try {
-            diskBuffer = readFileSync(safe);
+            diskBuffer = runtimeReadFile(safe);
           } catch {
             // File deleted or unreadable between existsSync and readFileSync —
             // skip conflict detection and proceed to write (re-creating the file).
@@ -681,11 +691,11 @@ export async function runObsidianSync(options: SyncOptions): Promise<SyncResult>
           delete manifest.articles[articleId];
           continue;
         }
-        if (existsSync(safeAbsPath)) {
+        if (runtimeExists(safeAbsPath)) {
           if (config.trashDeletions) {
             trashFile(vaultPath, safeAbsPath);
           } else {
-            unlinkSync(safeAbsPath);
+            runtimeUnlink(safeAbsPath);
           }
           stats.deleted++;
           warnings.push(`Removed soft-deleted mirror: ${entry.path}`);
@@ -711,7 +721,7 @@ export async function runObsidianSync(options: SyncOptions): Promise<SyncResult>
       stats,
       manifest: {
         updated: true,
-        path: join(vaultPath, config.manifestPath),
+        path: runtimeJoin(vaultPath, config.manifestPath),
       },
       warnings,
     };

--- a/src/lib/runtime-fs.ts
+++ b/src/lib/runtime-fs.ts
@@ -1,0 +1,84 @@
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  realpathSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from "fs";
+import { readFile } from "fs/promises";
+import type { Dirent, Stats } from "fs";
+import { join, resolve } from "path";
+
+/**
+ * Helpers for operator-configured runtime paths.
+ *
+ * Next/Turbopack output tracing is build-time analysis. Keeping vault file and
+ * path operations behind these wrappers prevents callers from exposing a local
+ * Obsidian vault path directly in route modules that Turbopack traces.
+ *
+ * The `turbopackIgnore` comments are visual markers for runtime-only path
+ * arguments. The wrapper boundary is the important part: it keeps operator
+ * configured vault paths out of direct build-time tracing paths.
+ */
+
+export function runtimeJoin(root: string, ...segments: string[]): string {
+  return join(/*turbopackIgnore: true*/ root, ...segments);
+}
+
+export function runtimeResolve(root: string, ...segments: string[]): string {
+  return resolve(/*turbopackIgnore: true*/ root, ...segments);
+}
+
+export function runtimeExists(path: string): boolean {
+  return existsSync(/*turbopackIgnore: true*/ path);
+}
+
+export function runtimeMkdir(path: string): void {
+  mkdirSync(/*turbopackIgnore: true*/ path, { recursive: true });
+}
+
+export function runtimeReadFile(path: string): Buffer;
+export function runtimeReadFile(path: string, encoding: BufferEncoding): string;
+export function runtimeReadFile(path: string, encoding?: BufferEncoding): Buffer | string {
+  return encoding
+    ? readFileSync(/*turbopackIgnore: true*/ path, encoding)
+    : readFileSync(/*turbopackIgnore: true*/ path);
+}
+
+export function runtimeReadTextFileAsync(path: string): Promise<string> {
+  return readFile(/*turbopackIgnore: true*/ path, "utf-8");
+}
+
+// Writes bytes or caller-supplied strings without forcing an encoding. Use
+// runtimeWriteTextFile for UTF-8 text output.
+export function runtimeWriteFile(path: string, content: string | Buffer): void {
+  writeFileSync(/*turbopackIgnore: true*/ path, content);
+}
+
+export function runtimeWriteTextFile(path: string, content: string): void {
+  writeFileSync(/*turbopackIgnore: true*/ path, content, "utf-8");
+}
+
+export function runtimeRename(from: string, to: string): void {
+  renameSync(/*turbopackIgnore: true*/ from, /*turbopackIgnore: true*/ to);
+}
+
+export function runtimeUnlink(path: string): void {
+  unlinkSync(/*turbopackIgnore: true*/ path);
+}
+
+export function runtimeReadDir(path: string): Dirent[] {
+  return readdirSync(/*turbopackIgnore: true*/ path, { withFileTypes: true });
+}
+
+export function runtimeLstat(path: string): Stats {
+  return lstatSync(/*turbopackIgnore: true*/ path);
+}
+
+export function runtimeRealpath(path: string): string {
+  return realpathSync(/*turbopackIgnore: true*/ path);
+}


### PR DESCRIPTION
## Summary

- Add `src/lib/runtime-fs.ts` for operator-configured runtime filesystem paths.
- Route Obsidian sync, markdown import scan/apply, manifest loading, and archived conflict reads through the runtime fs/path helpers.
- Preserve existing vault containment checks while adding Turbopack ignore markers to runtime-only filesystem access.

## Why

`next build` emitted a Turbopack NFT warning because output tracing saw broad filesystem access through the Obsidian sync/import routes and conservatively traced the project root:

- baseline trace: `next.config.ts -> src/lib/obsidian-sync/index.ts -> src/app/api/sync/obsidian/route.ts`
- after the first sync-engine fix, the warning moved to: `next.config.ts -> src/lib/markdown-sync/import-scanner.ts -> src/app/api/sync/import-scan/route.ts`

The vault path is configured at runtime by the operator, so it should not be traced into the standalone build bundle.

## Verification

- `DATABASE_URL=placeholder npm run build` passes with no `Turbopack build encountered` / `Encountered unexpected file in NFT list` warning in `/tmp/noosphere-build-after-5.log`.
- `npm run lint` passes with the two known pre-existing warnings:
  - `src/app/wiki/admin/topics/actions.ts:99` unused `descendants`
  - `src/lib/markdown-sync/import-applier.ts:358` unused `vaultPath`
- `npm run typecheck` passes.
- `git diff --check` passes.
- `npm audit --audit-level=high` exits clean; only known moderate advisories remain.
- `npx tsx src/__tests__/api/markdown-import-scanner.test.ts` passes: 12/12.
- `npx tsx src/__tests__/api/markdown-import-apply.test.ts` passes: 11/11.
- `npx tsx src/__tests__/obsidian-sync/index.test.ts` passes: 25/25.

## Note

`DATABASE_URL=placeholder npx tsx src/__tests__/api/sync-conflict-review.test.ts` passes the direct conflict-review path tests, including `resolveVaultArchivePath`, but one existing Prisma-mocking integration subtest fails under the placeholder Prisma client because `prisma.$queryRaw` is undefined for `mock.method(...)`. This appears unrelated to the runtime fs change.

## Summary by Sourcery

Route filesystem access for operator-configured vault paths through runtime-only helpers to avoid Turbopack tracing while preserving vault safety checks.

Enhancements:
- Introduce a runtime filesystem helper module that wraps path and file operations for vault-related access with Turbopack ignore markers.
- Update Obsidian sync, markdown import scanning/applying, and manifest/conflict handling code to use the runtime filesystem helpers instead of direct fs/path calls.