### PR TITLE
fix(import): validate caller can assign restrictedTags on import

### DIFF
--- a/docs/RESTRICTED-TAGS-SPEC.md
+++ b/docs/RESTRICTED-TAGS-SPEC.md
@@ -260,6 +260,19 @@ Add `restrictedTags` to request body and response:
 
 Import files declare `restrictedTags` in each article's frontmatter. The route applies the same caller-can-assign and tag-must-exist checks as `POST /api/articles`, but with one contract difference: an omitted or empty `restrictedTags` value means "no restricted tags" and is **not** auto-assigned to the caller's scopes (the import file is the source of truth, not the caller's existing scopes). Validation lives in `resolveImportRestrictedTags` in `src/lib/api/restricted-scopes.ts`. Articles whose `restrictedTags` fail validation are recorded with an error message in the import summary and skipped without aborting the batch. See issue #136 for the original report.
 
+**Overwrite semantics (`overwrite=true`):** the import route is a content channel, not an authorisation channel. The frontmatter `restrictedTags` is the **new desired state**, but the route enforces a stricter rule on top of the create-path checks:
+
+- **New article:** importer may create public content if `restrictedTags` is omitted or `[]`. Not declassification because there is no prior protected state.
+- **Overwrite an unrestricted article:** importer may keep it public, or classify it to scopes they are allowed to assign — *only if* the caller has ADMIN (or session `["*"]`) authority. The import file is content, so a non-ADMIN caller cannot use overwrite to *narrow* who can read existing content.
+- **Overwrite a restricted article:**
+  - omitted `restrictedTags` ⇒ preserve the existing classification (no-op, allowed for any caller who can already read it);
+  - same `restrictedTags` as the existing set ⇒ no-op, allowed;
+  - `[]` (explicit) ⇒ declassification, requires ADMIN;
+  - different set ⇒ reclassification, requires ADMIN.
+- Only ADMIN, an API key with `allowedScopes: ["*"]`, or a session caller (any role) may cross a classification boundary on overwrite. Scoped WRITE keys can still edit the *content* of articles they can read, but cannot make restricted content more public or change its access boundary.
+
+Validation rejects any boundary-crossing attempt with a 400 and an article-level error message; the row is skipped, the rest of the batch proceeds.
+
 #### `PATCH /api/articles/:id` — Article update
 
 Add `restrictedTags` to updatable fields:

--- a/docs/RESTRICTED-TAGS-SPEC.md
+++ b/docs/RESTRICTED-TAGS-SPEC.md
@@ -256,6 +256,10 @@ Add `restrictedTags` to request body and response:
 - If an agent passes a tag not in `RestrictedScope`, return 400 with helpful message listing valid tags
 - Sophie can set any tags she pre-approved; agents are encouraged to suggest tags and let Sophie add them to the scope registry first
 
+#### `POST /api/import` — Bulk article import
+
+Import files declare `restrictedTags` in each article's frontmatter. The route applies the same caller-can-assign and tag-must-exist checks as `POST /api/articles`, but with one contract difference: an omitted or empty `restrictedTags` value means "no restricted tags" and is **not** auto-assigned to the caller's scopes (the import file is the source of truth, not the caller's existing scopes). Validation lives in `resolveImportRestrictedTags` in `src/lib/api/restricted-scopes.ts`. Articles whose `restrictedTags` fail validation are recorded with an error message in the import summary and skipped without aborting the batch. See issue #136 for the original report.
+
 #### `PATCH /api/articles/:id` — Article update
 
 Add `restrictedTags` to updatable fields:

--- a/docs/RESTRICTED-TAGS-SPEC.md
+++ b/docs/RESTRICTED-TAGS-SPEC.md
@@ -271,7 +271,7 @@ Import files declare `restrictedTags` in each article's frontmatter. The route a
   - different set ⇒ reclassification, requires ADMIN.
 - Only ADMIN, an API key with `allowedScopes: ["*"]`, or a session caller (any role) may cross a classification boundary on overwrite. Scoped WRITE keys can still edit the *content* of articles they can read, but cannot make restricted content more public or change its access boundary.
 
-Validation rejects any boundary-crossing attempt with a 400 and an article-level error message; the row is skipped, the rest of the batch proceeds.
+Validation rejects any boundary-crossing attempt with an article-level error message in the import summary; the row is skipped, the rest of the batch proceeds.
 
 #### `PATCH /api/articles/:id` — Article update
 

--- a/src/__tests__/api/import-restricted-tags-comparison.test.ts
+++ b/src/__tests__/api/import-restricted-tags-comparison.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { sameRestrictedTags } from "@/app/api/import/route";
+
+// Pure-function tests pinning the C4 contract: `sameRestrictedTags` is
+// order-insensitive AND duplicate-tolerant. The pre-C4 implementation
+// returned `true` for `[a, a]` vs `[a, b]` because both entries of the
+// first set were `has(tag)` on the second; the fix compares set sizes.
+
+test("sameRestrictedTags returns true for identical sets", () => {
+  assert.equal(sameRestrictedTags(["a", "b"], ["a", "b"]), true);
+});
+
+test("sameRestrictedTags is order-insensitive", () => {
+  assert.equal(sameRestrictedTags(["a", "b"], ["b", "a"]), true);
+});
+
+test("sameRestrictedTags rejects different sets of the same length", () => {
+  assert.equal(sameRestrictedTags(["a", "b"], ["a", "c"]), false);
+  assert.equal(sameRestrictedTags(["a", "b"], ["c", "d"]), false);
+});
+
+test("sameRestrictedTags rejects sets of different sizes", () => {
+  assert.equal(sameRestrictedTags(["a"], ["a", "b"]), false);
+  assert.equal(sameRestrictedTags(["a", "b"], ["a"]), false);
+});
+
+test("sameRestrictedTags is duplicate-tolerant (regression: C4)", () => {
+  // `[a, a]` and `[a]` represent the same logical set, so this is equal.
+  // The pre-C4 implementation rejected this case because `a.length === 2`
+  // and `b.length === 1` failed the length check.
+  assert.equal(sameRestrictedTags(["a", "a"], ["a"]), true);
+  assert.equal(sameRestrictedTags(["a"], ["a", "a"]), true);
+});
+
+test("sameRestrictedTags still rejects duplicates that mask a real diff", () => {
+  // `[a, a]` and `[a, b]` are NOT the same set: deduping the first gives
+  // `{a}`; the second is `{a, b}`. The pre-C4 implementation would have
+  // returned `true` here because both `a` entries of the first set have a
+  // matching tag in the second. The C4 fix makes the comparison set-based.
+  assert.equal(sameRestrictedTags(["a", "a"], ["a", "b"]), false);
+});
+
+test("sameRestrictedTags handles empty arrays symmetrically", () => {
+  assert.equal(sameRestrictedTags([], []), true);
+  assert.equal(sameRestrictedTags(["a"], []), false);
+  assert.equal(sameRestrictedTags([], ["a"]), false);
+});

--- a/src/__tests__/api/import-restricted-tags-permissions.test.ts
+++ b/src/__tests__/api/import-restricted-tags-permissions.test.ts
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { Permissions } from "@prisma/client";
+
+import { canChangeExistingRestrictedTags } from "@/app/api/import/route";
+
+// Pure-function tests for the declassification gate.
+// These pin the contract Copilot Fagan Inspection flagged as C1: session
+// callers with `["*"]` allowedScopes (no `keyId`) must be treated the same
+// as ADMIN API keys, because `checkRouteAuth` grants every human session
+// `allowedScopes: ["*"]` and never sets `keyId`.
+
+test("ADMIN permission grants reclassification", () => {
+  assert.equal(
+    canChangeExistingRestrictedTags({ permissions: Permissions.ADMIN }),
+    true,
+  );
+});
+
+test("ADMIN role grants reclassification", () => {
+  assert.equal(canChangeExistingRestrictedTags({ role: "ADMIN" }), true);
+});
+
+test("API key with wildcard scope grants reclassification", () => {
+  assert.equal(
+    canChangeExistingRestrictedTags({
+      keyId: "key_abc",
+      permissions: Permissions.WRITE,
+      allowedScopes: ["*"],
+    }),
+    true,
+  );
+});
+
+test("session caller with wildcard scope grants reclassification (no keyId)", () => {
+  // Regression: this was the C1 bug. The old helper only honoured the
+  // wildcard when a keyId was present, so EDITOR sessions (no keyId,
+  // allowedScopes=["*"]) were incorrectly blocked from reclassifying on
+  // overwrite.
+  assert.equal(
+    canChangeExistingRestrictedTags({
+      role: "EDITOR",
+      allowedScopes: ["*"],
+    }),
+    true,
+  );
+});
+
+test("scoped WRITE key without wildcard is denied reclassification", () => {
+  assert.equal(
+    canChangeExistingRestrictedTags({
+      keyId: "key_abc",
+      permissions: Permissions.WRITE,
+      allowedScopes: ["health"],
+    }),
+    false,
+  );
+});
+
+test("session caller with only restricted scopes is denied reclassification", () => {
+  assert.equal(
+    canChangeExistingRestrictedTags({
+      role: "EDITOR",
+      allowedScopes: ["health"],
+    }),
+    false,
+  );
+});
+
+test("empty auth shape is denied reclassification", () => {
+  assert.equal(canChangeExistingRestrictedTags({}), false);
+});

--- a/src/__tests__/api/import-route-validation.test.ts
+++ b/src/__tests__/api/import-route-validation.test.ts
@@ -507,6 +507,22 @@ ADMIN explicitly makes this article public.`,
       orderBy: { createdAt: "desc" },
     });
     assert.ok(logEntry, "classification changes should be audit logged");
+    const details = (logEntry?.details ?? {}) as Record<string, unknown>;
+    assert.equal(
+      details.declassified,
+      true,
+      "declassification must set declassified: true (C3)",
+    );
+    assert.equal(
+      details.classified,
+      false,
+      "declassification must not also set classified: true (C3)",
+    );
+    assert.equal(
+      details.reclassified,
+      false,
+      "declassification must not also set reclassified: true (C3)",
+    );
   } finally {
     await prisma.article.deleteMany({
       where: { topic: { slug: TEST_TOPIC_SLUG } },
@@ -522,6 +538,386 @@ ADMIN explicitly makes this article public.`,
     });
     await prisma.activityLog.deleteMany({
       where: { title: "Updated restrictedTags via import: Admin Declassify" },
+    });
+  }
+});
+
+test("POST /api/import rejects scoped WRITE overwrite that classifies an existing unrestricted article (C2)", async () => {
+  const { prisma } = await import("@/lib/prisma");
+  const { POST } = await import("@/app/api/import/route");
+
+  await prisma.restrictedScope.upsert({
+    where: { tag: TEST_SCOPE_OWNED },
+    create: { tag: TEST_SCOPE_OWNED, description: "Test owned scope" },
+    update: {},
+  });
+  const topic = await prisma.topic.upsert({
+    where: { slug: TEST_TOPIC_SLUG },
+    create: { name: "Test Import Validation", slug: TEST_TOPIC_SLUG },
+    update: {},
+  });
+
+  const rawKey = `noo_${crypto.randomBytes(32).toString("base64url")}`;
+  await upsertImportApiKey(prisma, rawKey, [TEST_SCOPE_OWNED]);
+
+  try {
+    await prisma.article.deleteMany({
+      where: { slug: "classify-attempt", topicId: topic.id },
+    });
+    await prisma.article.create({
+      data: {
+        title: "Classify Attempt",
+        slug: "classify-attempt",
+        topicId: topic.id,
+        content: "Originally public content",
+        restrictedTags: [],
+      },
+    });
+
+    const zipBuffer = await buildZip([
+      {
+        filename: "classify-attempt.md",
+        content: `---
+title: Classify Attempt
+topic: ${TEST_TOPIC_SLUG}
+slug: classify-attempt
+restrictedTags: [${TEST_SCOPE_OWNED}]
+---
+
+# Classify Attempt
+
+This update tries to take a public article and classify it.`,
+      },
+    ]);
+
+    const request = buildImportRequest(zipBuffer, rawKey, "true");
+    const response = await POST(request);
+    const body = (await response.json()) as {
+      summary: { imported: number; errors: number };
+      articles: Array<{ filename: string; error?: string }>;
+    };
+
+    assert.equal(
+      body.summary.imported,
+      0,
+      "scoped classification must not import (C2)",
+    );
+    assert.equal(
+      body.summary.errors,
+      1,
+      "scoped classification should be an article error",
+    );
+    assert.match(
+      body.articles[0]?.error ?? "",
+      /requires ADMIN access/,
+      "error should name the required privilege",
+    );
+
+    const unchanged = await prisma.article.findFirstOrThrow({
+      where: { slug: "classify-attempt", topicId: topic.id },
+    });
+    assert.deepEqual(
+      unchanged.restrictedTags,
+      [],
+      "public classification must be rejected for scoped WRITE",
+    );
+  } finally {
+    await prisma.article.deleteMany({
+      where: { topic: { slug: TEST_TOPIC_SLUG } },
+    });
+    await prisma.topic.deleteMany({
+      where: { slug: TEST_TOPIC_SLUG },
+    });
+    await prisma.apiKey.deleteMany({
+      where: { name: TEST_KEY_NAME },
+    });
+    await prisma.restrictedScope.deleteMany({
+      where: { tag: { in: [TEST_SCOPE_OWNED, TEST_SCOPE_FORBIDDEN] } },
+    });
+  }
+});
+
+test("POST /api/import allows ADMIN overwrite to classify an existing unrestricted article (C2)", async () => {
+  const { prisma } = await import("@/lib/prisma");
+  const { POST } = await import("@/app/api/import/route");
+
+  await prisma.restrictedScope.upsert({
+    where: { tag: TEST_SCOPE_OWNED },
+    create: { tag: TEST_SCOPE_OWNED, description: "Test owned scope" },
+    update: {},
+  });
+  const topic = await prisma.topic.upsert({
+    where: { slug: TEST_TOPIC_SLUG },
+    create: { name: "Test Import Validation", slug: TEST_TOPIC_SLUG },
+    update: {},
+  });
+
+  const rawKey = `noo_${crypto.randomBytes(32).toString("base64url")}`;
+  await upsertImportApiKey(prisma, rawKey, ["*"], "ADMIN");
+
+  try {
+    await prisma.article.deleteMany({
+      where: { slug: "admin-classify", topicId: topic.id },
+    });
+    await prisma.article.create({
+      data: {
+        title: "Admin Classify",
+        slug: "admin-classify",
+        topicId: topic.id,
+        content: "Originally public content",
+        restrictedTags: [],
+      },
+    });
+
+    const zipBuffer = await buildZip([
+      {
+        filename: "admin-classify.md",
+        content: `---
+title: Admin Classify
+topic: ${TEST_TOPIC_SLUG}
+slug: admin-classify
+restrictedTags: [${TEST_SCOPE_OWNED}]
+---
+
+# Admin Classify
+
+ADMIN explicitly classifies an existing public article.`,
+      },
+    ]);
+
+    const request = buildImportRequest(zipBuffer, rawKey, "true");
+    const response = await POST(request);
+    const body = (await response.json()) as {
+      summary: { imported: number; errors: number };
+    };
+
+    assert.equal(body.summary.imported, 1, "ADMIN classification should import");
+    assert.equal(body.summary.errors, 0, "ADMIN classification should not error");
+
+    const updated = await prisma.article.findFirstOrThrow({
+      where: { slug: "admin-classify", topicId: topic.id },
+    });
+    assert.deepEqual(updated.restrictedTags, [TEST_SCOPE_OWNED]);
+
+    const logEntry = await prisma.activityLog.findFirst({
+      where: {
+        type: "update",
+        title: "Updated restrictedTags via import: Admin Classify",
+      },
+      orderBy: { createdAt: "desc" },
+    });
+    assert.ok(logEntry, "first-time classification should be audit logged");
+    const details = (logEntry?.details ?? {}) as Record<string, unknown>;
+    assert.equal(
+      details.classified,
+      true,
+      "first-time classification must set classified: true (C3)",
+    );
+    assert.equal(
+      details.declassified,
+      false,
+      "first-time classification must not also set declassified: true (C3)",
+    );
+    assert.equal(
+      details.reclassified,
+      false,
+      "first-time classification must not also set reclassified: true (C3)",
+    );
+  } finally {
+    await prisma.article.deleteMany({
+      where: { topic: { slug: TEST_TOPIC_SLUG } },
+    });
+    await prisma.topic.deleteMany({
+      where: { slug: TEST_TOPIC_SLUG },
+    });
+    await prisma.apiKey.deleteMany({
+      where: { name: TEST_KEY_NAME },
+    });
+    await prisma.restrictedScope.deleteMany({
+      where: { tag: { in: [TEST_SCOPE_OWNED, TEST_SCOPE_FORBIDDEN] } },
+    });
+    await prisma.activityLog.deleteMany({
+      where: { title: "Updated restrictedTags via import: Admin Classify" },
+    });
+  }
+});
+
+test("POST /api/import rejects scoped WRITE overwrite that reclassifies a restricted article (C2 + C4)", async () => {
+  const { prisma } = await import("@/lib/prisma");
+  const { POST } = await import("@/app/api/import/route");
+
+  await prisma.restrictedScope.upsert({
+    where: { tag: TEST_SCOPE_OWNED },
+    create: { tag: TEST_SCOPE_OWNED, description: "Test owned scope" },
+    update: {},
+  });
+  await prisma.restrictedScope.upsert({
+    where: { tag: `${TEST_PREFIX}other` },
+    create: {
+      tag: `${TEST_PREFIX}other`,
+      description: "Test other scope",
+    },
+    update: {},
+  });
+  const topic = await prisma.topic.upsert({
+    where: { slug: TEST_TOPIC_SLUG },
+    create: { name: "Test Import Validation", slug: TEST_TOPIC_SLUG },
+    update: {},
+  });
+
+  // Give the caller both scopes so the can-assign check passes; the
+  // reclassification must still be blocked by the C2 ADMIN gate because
+  // the existing restricted set is being changed.
+  const rawKey = `noo_${crypto.randomBytes(32).toString("base64url")}`;
+  await upsertImportApiKey(prisma, rawKey, [
+    TEST_SCOPE_OWNED,
+    `${TEST_PREFIX}other`,
+  ]);
+
+  try {
+    await prisma.article.deleteMany({
+      where: { slug: "reclassify-attempt", topicId: topic.id },
+    });
+    await prisma.article.create({
+      data: {
+        title: "Reclassify Attempt",
+        slug: "reclassify-attempt",
+        topicId: topic.id,
+        content: "Original restricted content",
+        restrictedTags: [TEST_SCOPE_OWNED],
+      },
+    });
+
+    const zipBuffer = await buildZip([
+      {
+        filename: "reclassify-attempt.md",
+        content: `---
+title: Reclassify Attempt
+topic: ${TEST_TOPIC_SLUG}
+slug: reclassify-attempt
+restrictedTags: [${TEST_SCOPE_OWNED}, ${TEST_PREFIX}other]
+---
+
+# Reclassify Attempt
+
+Tries to expand the access boundary on an already restricted article.`,
+      },
+    ]);
+
+    const request = buildImportRequest(zipBuffer, rawKey, "true");
+    const response = await POST(request);
+    const body = (await response.json()) as {
+      summary: { imported: number; errors: number };
+      articles: Array<{ filename: string; error?: string }>;
+    };
+
+    assert.equal(body.summary.imported, 0, "reclassification must not import");
+    assert.equal(body.summary.errors, 1, "reclassification should be an article error");
+    assert.match(
+      body.articles[0]?.error ?? "",
+      /requires ADMIN access/,
+      "reclassification by a scoped WRITE key must hit the ADMIN gate (C2)",
+    );
+
+    const unchanged = await prisma.article.findFirstOrThrow({
+      where: { slug: "reclassify-attempt", topicId: topic.id },
+    });
+    assert.deepEqual(unchanged.restrictedTags, [TEST_SCOPE_OWNED]);
+  } finally {
+    await prisma.article.deleteMany({
+      where: { topic: { slug: TEST_TOPIC_SLUG } },
+    });
+    await prisma.topic.deleteMany({
+      where: { slug: TEST_TOPIC_SLUG },
+    });
+    await prisma.apiKey.deleteMany({
+      where: { name: TEST_KEY_NAME },
+    });
+    await prisma.restrictedScope.deleteMany({
+      where: {
+        tag: { in: [TEST_SCOPE_OWNED, `${TEST_PREFIX}other`] },
+      },
+    });
+  }
+});
+
+test("POST /api/import allows scoped WRITE overwrite to leave restrictedTags unchanged (C4)", async () => {
+  // Pins the C4 fix: `[a, a]` from the import file dedupes to `{a}` and is
+  // therefore a no-op against an existing `[a]`. The pre-fix implementation
+  // would have flagged this as a change and blocked the call with
+  // "requires ADMIN access".
+  const { prisma } = await import("@/lib/prisma");
+  const { POST } = await import("@/app/api/import/route");
+
+  await prisma.restrictedScope.upsert({
+    where: { tag: TEST_SCOPE_OWNED },
+    create: { tag: TEST_SCOPE_OWNED, description: "Test owned scope" },
+    update: {},
+  });
+  const topic = await prisma.topic.upsert({
+    where: { slug: TEST_TOPIC_SLUG },
+    create: { name: "Test Import Validation", slug: TEST_TOPIC_SLUG },
+    update: {},
+  });
+
+  const rawKey = `noo_${crypto.randomBytes(32).toString("base64url")}`;
+  await upsertImportApiKey(prisma, rawKey, [TEST_SCOPE_OWNED]);
+
+  try {
+    await prisma.article.deleteMany({
+      where: { slug: "duplicate-tags", topicId: topic.id },
+    });
+    await prisma.article.create({
+      data: {
+        title: "Duplicate Tags",
+        slug: "duplicate-tags",
+        topicId: topic.id,
+        content: "Original content",
+        restrictedTags: [TEST_SCOPE_OWNED],
+      },
+    });
+
+    const zipBuffer = await buildZip([
+      {
+        filename: "duplicate-tags.md",
+        content: `---
+title: Duplicate Tags
+topic: ${TEST_TOPIC_SLUG}
+slug: duplicate-tags
+restrictedTags: [${TEST_SCOPE_OWNED}, ${TEST_SCOPE_OWNED}]
+---
+
+# Duplicate Tags
+
+restrictedTags carries an accidental duplicate; after dedup it equals
+the existing set, so the change check should treat it as a no-op.`,
+      },
+    ]);
+
+    const request = buildImportRequest(zipBuffer, rawKey, "true");
+    const response = await POST(request);
+    const body = (await response.json()) as {
+      summary: { imported: number; errors: number };
+    };
+
+    assert.equal(
+      body.summary.imported,
+      1,
+      "duplicate-but-equivalent restrictedTags must be a no-op (C4)",
+    );
+    assert.equal(body.summary.errors, 0, "no error should be raised for a no-op");
+  } finally {
+    await prisma.article.deleteMany({
+      where: { topic: { slug: TEST_TOPIC_SLUG } },
+    });
+    await prisma.topic.deleteMany({
+      where: { slug: TEST_TOPIC_SLUG },
+    });
+    await prisma.apiKey.deleteMany({
+      where: { name: TEST_KEY_NAME },
+    });
+    await prisma.restrictedScope.deleteMany({
+      where: { tag: { in: [TEST_SCOPE_OWNED, TEST_SCOPE_FORBIDDEN] } },
     });
   }
 });

--- a/src/__tests__/api/import-route-validation.test.ts
+++ b/src/__tests__/api/import-route-validation.test.ts
@@ -6,9 +6,10 @@ import type { NextRequest } from "next/server";
 import type { PrismaClient } from "@prisma/client";
 
 // Connect to dev DB before any module that reads it loads.
-// This test requires the local dev stack: `docker compose up -d db redis`.
-process.env.DATABASE_URL ??=
-  "postgresql://noosphere:noosphere_secret@127.0.0.1:5433/noosphere";
+// This test requires the local dev stack and an explicit DATABASE_URL.
+if (!process.env.DATABASE_URL) {
+  throw new Error("DATABASE_URL environment variable must be set for tests");
+}
 
 const TEST_PREFIX = "test-issue136-";
 const TEST_SCOPE_OWNED = `${TEST_PREFIX}owned`;
@@ -906,6 +907,93 @@ the existing set, so the change check should treat it as a no-op.`,
       "duplicate-but-equivalent restrictedTags must be a no-op (C4)",
     );
     assert.equal(body.summary.errors, 0, "no error should be raised for a no-op");
+  } finally {
+    await prisma.article.deleteMany({
+      where: { topic: { slug: TEST_TOPIC_SLUG } },
+    });
+    await prisma.topic.deleteMany({
+      where: { slug: TEST_TOPIC_SLUG },
+    });
+    await prisma.apiKey.deleteMany({
+      where: { name: TEST_KEY_NAME },
+    });
+    await prisma.restrictedScope.deleteMany({
+      where: { tag: { in: [TEST_SCOPE_OWNED, TEST_SCOPE_FORBIDDEN] } },
+    });
+  }
+});
+
+test("POST /api/import allows scoped WRITE explicit no-op on multi-scope restricted article", async () => {
+  const { prisma } = await import("@/lib/prisma");
+  const { POST } = await import("@/app/api/import/route");
+
+  await prisma.restrictedScope.upsert({
+    where: { tag: TEST_SCOPE_OWNED },
+    create: { tag: TEST_SCOPE_OWNED, description: "Test owned scope" },
+    update: {},
+  });
+  await prisma.restrictedScope.upsert({
+    where: { tag: TEST_SCOPE_FORBIDDEN },
+    create: { tag: TEST_SCOPE_FORBIDDEN, description: "Test forbidden scope" },
+    update: {},
+  });
+  const topic = await prisma.topic.upsert({
+    where: { slug: TEST_TOPIC_SLUG },
+    create: { name: "Test Import Validation", slug: TEST_TOPIC_SLUG },
+    update: {},
+  });
+
+  const rawKey = `noo_${crypto.randomBytes(32).toString("base64url")}`;
+  await upsertImportApiKey(prisma, rawKey, [TEST_SCOPE_OWNED]);
+
+  try {
+    await prisma.article.deleteMany({
+      where: { slug: "multi-scope-noop", topicId: topic.id },
+    });
+    await prisma.article.create({
+      data: {
+        title: "Multi Scope Noop",
+        slug: "multi-scope-noop",
+        topicId: topic.id,
+        content: "Original restricted content",
+        restrictedTags: [TEST_SCOPE_OWNED, TEST_SCOPE_FORBIDDEN],
+      },
+    });
+
+    const zipBuffer = await buildZip([
+      {
+        filename: "multi-scope-noop.md",
+        content: `---
+title: Multi Scope Noop
+topic: ${TEST_TOPIC_SLUG}
+slug: multi-scope-noop
+restrictedTags: [${TEST_SCOPE_OWNED}, ${TEST_SCOPE_FORBIDDEN}]
+---
+
+# Multi Scope Noop
+
+The scoped caller can edit because it shares one existing scope. Repeating the
+same full restrictedTags set is a no-op, not a new assignment.`,
+      },
+    ]);
+
+    const request = buildImportRequest(zipBuffer, rawKey, "true");
+    const response = await POST(request);
+    const body = (await response.json()) as {
+      summary: { imported: number; errors: number };
+      articles: Array<{ filename: string; error?: string }>;
+    };
+
+    assert.equal(body.summary.imported, 1, "same-set restrictedTags should import");
+    assert.equal(body.summary.errors, 0, body.articles[0]?.error ?? "no error expected");
+
+    const updated = await prisma.article.findFirstOrThrow({
+      where: { slug: "multi-scope-noop", topicId: topic.id },
+    });
+    assert.deepEqual(updated.restrictedTags, [
+      TEST_SCOPE_OWNED,
+      TEST_SCOPE_FORBIDDEN,
+    ]);
   } finally {
     await prisma.article.deleteMany({
       where: { topic: { slug: TEST_TOPIC_SLUG } },

--- a/src/__tests__/api/import-route-validation.test.ts
+++ b/src/__tests__/api/import-route-validation.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import crypto from "node:crypto";
 import JSZip from "jszip";
 import type { NextRequest } from "next/server";
+import type { PrismaClient } from "@prisma/client";
 
 // Connect to dev DB before any module that reads it loads.
 // This test requires the local dev stack: `docker compose up -d db redis`.
@@ -48,6 +49,35 @@ function buildImportRequest(
     body: formData,
   });
   return request as unknown as NextRequest;
+}
+
+async function upsertImportApiKey(
+  prisma: PrismaClient,
+  rawKey: string,
+  allowedScopes: string[],
+  permissions: "WRITE" | "ADMIN" = "WRITE",
+): Promise<void> {
+  const keyHash = crypto.createHash("sha256").update(rawKey).digest("hex");
+  const keyPrefix = rawKey.slice(0, 8);
+  const existingKey = await prisma.apiKey.findFirst({
+    where: { name: TEST_KEY_NAME },
+  });
+  if (existingKey) {
+    await prisma.apiKey.update({
+      where: { id: existingKey.id },
+      data: { keyHash, keyPrefix, permissions, allowedScopes },
+    });
+  } else {
+    await prisma.apiKey.create({
+      data: {
+        name: TEST_KEY_NAME,
+        keyHash,
+        keyPrefix,
+        permissions,
+        allowedScopes,
+      },
+    });
+  }
 }
 
 // ─── Issue #136: Import must validate caller can assign restrictedTags ─────
@@ -238,6 +268,260 @@ This assigns a scope the caller has.`,
     });
     await prisma.restrictedScope.deleteMany({
       where: { tag: { in: [TEST_SCOPE_OWNED, TEST_SCOPE_FORBIDDEN] } },
+    });
+  }
+});
+
+test("POST /api/import preserves existing restrictedTags when scoped overwrite omits them", async () => {
+  const { prisma } = await import("@/lib/prisma");
+  const { POST } = await import("@/app/api/import/route");
+
+  await prisma.restrictedScope.upsert({
+    where: { tag: TEST_SCOPE_OWNED },
+    create: { tag: TEST_SCOPE_OWNED, description: "Test owned scope" },
+    update: {},
+  });
+  const topic = await prisma.topic.upsert({
+    where: { slug: TEST_TOPIC_SLUG },
+    create: { name: "Test Import Validation", slug: TEST_TOPIC_SLUG },
+    update: {},
+  });
+
+  const rawKey = `noo_${crypto.randomBytes(32).toString("base64url")}`;
+  await upsertImportApiKey(prisma, rawKey, [TEST_SCOPE_OWNED]);
+
+  try {
+    await prisma.article.deleteMany({
+      where: { slug: "classified-article", topicId: topic.id },
+    });
+    await prisma.article.create({
+      data: {
+        title: "Classified Article",
+        slug: "classified-article",
+        topicId: topic.id,
+        content: "Old restricted content",
+        restrictedTags: [TEST_SCOPE_OWNED],
+      },
+    });
+
+    const zipBuffer = await buildZip([
+      {
+        filename: "classified-article.md",
+        content: `---
+title: Classified Article
+topic: ${TEST_TOPIC_SLUG}
+slug: classified-article
+---
+
+# Classified Article
+
+Updated content without restrictedTags frontmatter.`,
+      },
+    ]);
+
+    const request = buildImportRequest(zipBuffer, rawKey, "true");
+    const response = await POST(request);
+    const body = (await response.json()) as {
+      summary: { imported: number; errors: number };
+    };
+
+    assert.equal(body.summary.imported, 1, "article should be overwritten");
+    assert.equal(body.summary.errors, 0, "omitted restrictedTags should preserve, not error");
+
+    const updated = await prisma.article.findFirstOrThrow({
+      where: { slug: "classified-article", topicId: topic.id },
+    });
+    assert.deepEqual(
+      updated.restrictedTags,
+      [TEST_SCOPE_OWNED],
+      "omitted restrictedTags must preserve the existing classification",
+    );
+    assert.ok(updated.content.includes("Updated content"));
+  } finally {
+    await prisma.article.deleteMany({
+      where: { topic: { slug: TEST_TOPIC_SLUG } },
+    });
+    await prisma.topic.deleteMany({
+      where: { slug: TEST_TOPIC_SLUG },
+    });
+    await prisma.apiKey.deleteMany({
+      where: { name: TEST_KEY_NAME },
+    });
+    await prisma.restrictedScope.deleteMany({
+      where: { tag: { in: [TEST_SCOPE_OWNED, TEST_SCOPE_FORBIDDEN] } },
+    });
+  }
+});
+
+test("POST /api/import rejects scoped overwrite that declassifies an existing restricted article", async () => {
+  const { prisma } = await import("@/lib/prisma");
+  const { POST } = await import("@/app/api/import/route");
+
+  await prisma.restrictedScope.upsert({
+    where: { tag: TEST_SCOPE_OWNED },
+    create: { tag: TEST_SCOPE_OWNED, description: "Test owned scope" },
+    update: {},
+  });
+  const topic = await prisma.topic.upsert({
+    where: { slug: TEST_TOPIC_SLUG },
+    create: { name: "Test Import Validation", slug: TEST_TOPIC_SLUG },
+    update: {},
+  });
+
+  const rawKey = `noo_${crypto.randomBytes(32).toString("base64url")}`;
+  await upsertImportApiKey(prisma, rawKey, [TEST_SCOPE_OWNED]);
+
+  try {
+    await prisma.article.deleteMany({
+      where: { slug: "declassify-attempt", topicId: topic.id },
+    });
+    await prisma.article.create({
+      data: {
+        title: "Declassify Attempt",
+        slug: "declassify-attempt",
+        topicId: topic.id,
+        content: "Original restricted content",
+        restrictedTags: [TEST_SCOPE_OWNED],
+      },
+    });
+
+    const zipBuffer = await buildZip([
+      {
+        filename: "declassify-attempt.md",
+        content: `---
+title: Declassify Attempt
+topic: ${TEST_TOPIC_SLUG}
+slug: declassify-attempt
+restrictedTags: []
+---
+
+# Declassify Attempt
+
+This update tries to make restricted content public.`,
+      },
+    ]);
+
+    const request = buildImportRequest(zipBuffer, rawKey, "true");
+    const response = await POST(request);
+    const body = (await response.json()) as {
+      summary: { imported: number; errors: number };
+      articles: Array<{ filename: string; error?: string }>;
+    };
+
+    assert.equal(body.summary.imported, 0, "declassification must not import");
+    assert.equal(body.summary.errors, 1, "declassification should be an article error");
+    assert.match(
+      body.articles[0]?.error ?? "",
+      /requires ADMIN access/,
+      "error should name the required privilege",
+    );
+
+    const unchanged = await prisma.article.findFirstOrThrow({
+      where: { slug: "declassify-attempt", topicId: topic.id },
+    });
+    assert.deepEqual(unchanged.restrictedTags, [TEST_SCOPE_OWNED]);
+    assert.equal(unchanged.content, "Original restricted content");
+  } finally {
+    await prisma.article.deleteMany({
+      where: { topic: { slug: TEST_TOPIC_SLUG } },
+    });
+    await prisma.topic.deleteMany({
+      where: { slug: TEST_TOPIC_SLUG },
+    });
+    await prisma.apiKey.deleteMany({
+      where: { name: TEST_KEY_NAME },
+    });
+    await prisma.restrictedScope.deleteMany({
+      where: { tag: { in: [TEST_SCOPE_OWNED, TEST_SCOPE_FORBIDDEN] } },
+    });
+  }
+});
+
+test("POST /api/import allows ADMIN overwrite to declassify an existing restricted article", async () => {
+  const { prisma } = await import("@/lib/prisma");
+  const { POST } = await import("@/app/api/import/route");
+
+  await prisma.restrictedScope.upsert({
+    where: { tag: TEST_SCOPE_OWNED },
+    create: { tag: TEST_SCOPE_OWNED, description: "Test owned scope" },
+    update: {},
+  });
+  const topic = await prisma.topic.upsert({
+    where: { slug: TEST_TOPIC_SLUG },
+    create: { name: "Test Import Validation", slug: TEST_TOPIC_SLUG },
+    update: {},
+  });
+
+  const rawKey = `noo_${crypto.randomBytes(32).toString("base64url")}`;
+  await upsertImportApiKey(prisma, rawKey, ["*"], "ADMIN");
+
+  try {
+    await prisma.article.deleteMany({
+      where: { slug: "admin-declassify", topicId: topic.id },
+    });
+    await prisma.article.create({
+      data: {
+        title: "Admin Declassify",
+        slug: "admin-declassify",
+        topicId: topic.id,
+        content: "Original restricted content",
+        restrictedTags: [TEST_SCOPE_OWNED],
+      },
+    });
+
+    const zipBuffer = await buildZip([
+      {
+        filename: "admin-declassify.md",
+        content: `---
+title: Admin Declassify
+topic: ${TEST_TOPIC_SLUG}
+slug: admin-declassify
+restrictedTags: []
+---
+
+# Admin Declassify
+
+ADMIN explicitly makes this article public.`,
+      },
+    ]);
+
+    const request = buildImportRequest(zipBuffer, rawKey, "true");
+    const response = await POST(request);
+    const body = (await response.json()) as {
+      summary: { imported: number; errors: number };
+    };
+
+    assert.equal(body.summary.imported, 1, "ADMIN declassification should import");
+    assert.equal(body.summary.errors, 0, "ADMIN declassification should not error");
+
+    const updated = await prisma.article.findFirstOrThrow({
+      where: { slug: "admin-declassify", topicId: topic.id },
+    });
+    assert.deepEqual(updated.restrictedTags, []);
+
+    const logEntry = await prisma.activityLog.findFirst({
+      where: {
+        type: "update",
+        title: "Updated restrictedTags via import: Admin Declassify",
+      },
+      orderBy: { createdAt: "desc" },
+    });
+    assert.ok(logEntry, "classification changes should be audit logged");
+  } finally {
+    await prisma.article.deleteMany({
+      where: { topic: { slug: TEST_TOPIC_SLUG } },
+    });
+    await prisma.topic.deleteMany({
+      where: { slug: TEST_TOPIC_SLUG },
+    });
+    await prisma.apiKey.deleteMany({
+      where: { name: TEST_KEY_NAME },
+    });
+    await prisma.restrictedScope.deleteMany({
+      where: { tag: { in: [TEST_SCOPE_OWNED, TEST_SCOPE_FORBIDDEN] } },
+    });
+    await prisma.activityLog.deleteMany({
+      where: { title: "Updated restrictedTags via import: Admin Declassify" },
     });
   }
 });

--- a/src/__tests__/api/import-route-validation.test.ts
+++ b/src/__tests__/api/import-route-validation.test.ts
@@ -1,0 +1,243 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import crypto from "node:crypto";
+import JSZip from "jszip";
+import type { NextRequest } from "next/server";
+
+// Connect to dev DB before any module that reads it loads.
+// This test requires the local dev stack: `docker compose up -d db redis`.
+process.env.DATABASE_URL ??=
+  "postgresql://noosphere:noosphere_secret@127.0.0.1:5433/noosphere";
+
+const TEST_PREFIX = "test-issue136-";
+const TEST_SCOPE_OWNED = `${TEST_PREFIX}owned`;
+const TEST_SCOPE_FORBIDDEN = `${TEST_PREFIX}forbidden`;
+const TEST_TOPIC_SLUG = `${TEST_PREFIX}topic`;
+const TEST_KEY_NAME = `${TEST_PREFIX}key`;
+const TEST_CLIENT_IP = `10.99.${Math.floor(Math.random() * 254) + 1}.${Math.floor(Math.random() * 254) + 1}`;
+
+async function buildZip(
+  articles: Array<{ filename: string; content: string }>,
+): Promise<ArrayBuffer> {
+  const zip = new JSZip();
+  for (const article of articles) {
+    zip.file(article.filename, article.content);
+  }
+  return zip.generateAsync({ type: "arraybuffer" });
+}
+
+function buildImportRequest(
+  zipBuffer: ArrayBuffer,
+  rawKey: string,
+  overwrite: "true" | "false" = "false",
+): NextRequest {
+  const formData = new FormData();
+  formData.set(
+    "file",
+    new Blob([zipBuffer], { type: "application/zip" }),
+    "test.zip",
+  );
+  formData.set("overwrite", overwrite);
+
+  const request = new Request("http://localhost/api/import", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${rawKey}`,
+      "x-real-ip": TEST_CLIENT_IP,
+    },
+    body: formData,
+  });
+  return request as unknown as NextRequest;
+}
+
+// ─── Issue #136: Import must validate caller can assign restrictedTags ─────
+
+test("POST /api/import rejects articles with restrictedTags the caller cannot assign (issue #136)", async () => {
+  // Imports happen inside the test so DATABASE_URL is set first.
+  const { prisma } = await import("@/lib/prisma");
+  const { POST } = await import("@/app/api/import/route");
+
+  // Set up test data: restricted scopes, topic, and an API key that only has the "owned" scope.
+  await prisma.restrictedScope.upsert({
+    where: { tag: TEST_SCOPE_OWNED },
+    create: { tag: TEST_SCOPE_OWNED, description: "Test owned scope" },
+    update: {},
+  });
+  await prisma.restrictedScope.upsert({
+    where: { tag: TEST_SCOPE_FORBIDDEN },
+    create: { tag: TEST_SCOPE_FORBIDDEN, description: "Test forbidden scope" },
+    update: {},
+  });
+  await prisma.topic.upsert({
+    where: { slug: TEST_TOPIC_SLUG },
+    create: { name: "Test Import Validation", slug: TEST_TOPIC_SLUG },
+    update: {},
+  });
+
+  const rawKey = `noo_${crypto.randomBytes(32).toString("base64url")}`;
+  const keyHash = crypto.createHash("sha256").update(rawKey).digest("hex");
+  const keyPrefix = rawKey.slice(0, 8);
+  const existingKey = await prisma.apiKey.findFirst({
+    where: { name: TEST_KEY_NAME },
+  });
+  if (existingKey) {
+    await prisma.apiKey.update({
+      where: { id: existingKey.id },
+      data: { keyHash, keyPrefix, allowedScopes: [TEST_SCOPE_OWNED] },
+    });
+  } else {
+    await prisma.apiKey.create({
+      data: {
+        name: TEST_KEY_NAME,
+        keyHash,
+        keyPrefix,
+        permissions: "WRITE",
+        allowedScopes: [TEST_SCOPE_OWNED],
+      },
+    });
+  }
+
+  try {
+    const zipBuffer = await buildZip([
+      {
+        filename: "evil-article.md",
+        content: `---
+title: Evil Article
+topic: ${TEST_TOPIC_SLUG}
+slug: evil-article
+restrictedTags:
+  - ${TEST_SCOPE_FORBIDDEN}
+---
+
+# Evil Article
+
+This tries to assign a scope the caller does not have.`,
+      },
+    ]);
+
+    const request = buildImportRequest(zipBuffer, rawKey);
+    const response = await POST(request);
+    const body = (await response.json()) as {
+      success: boolean;
+      summary: { imported: number; errors: number };
+      articles: Array<{ filename: string; error?: string }>;
+    };
+
+    const evilArticle = body.articles.find(
+      (a) => a.filename === "evil-article.md",
+    );
+    assert.ok(evilArticle, "evil article should appear in the response");
+    assert.ok(
+      evilArticle.error,
+      `evil article should have an error, got: ${JSON.stringify(evilArticle)}`,
+    );
+    assert.ok(
+      evilArticle.error.includes(TEST_SCOPE_FORBIDDEN),
+      `error should mention the forbidden scope, got: ${evilArticle.error}`,
+    );
+    assert.equal(body.summary.imported, 0, "no articles should be imported");
+    assert.equal(body.summary.errors, 1, "summary should show 1 error");
+
+    // Confirm the article was not created in the DB
+    const created = await prisma.article.findFirst({
+      where: { slug: "evil-article", topic: { slug: TEST_TOPIC_SLUG } },
+    });
+    assert.equal(created, null, "evil article must not be persisted");
+  } finally {
+    // Clean up: reverse dependency order
+    await prisma.article.deleteMany({
+      where: { topic: { slug: TEST_TOPIC_SLUG } },
+    });
+    await prisma.topic.deleteMany({
+      where: { slug: TEST_TOPIC_SLUG },
+    });
+    await prisma.apiKey.deleteMany({
+      where: { name: TEST_KEY_NAME },
+    });
+    await prisma.restrictedScope.deleteMany({
+      where: { tag: { in: [TEST_SCOPE_OWNED, TEST_SCOPE_FORBIDDEN] } },
+    });
+  }
+});
+
+test("POST /api/import accepts articles with restrictedTags the caller can assign", async () => {
+  const { prisma } = await import("@/lib/prisma");
+  const { POST } = await import("@/app/api/import/route");
+
+  // Reuse the same setup as the first test (idempotent upserts).
+  await prisma.restrictedScope.upsert({
+    where: { tag: TEST_SCOPE_OWNED },
+    create: { tag: TEST_SCOPE_OWNED, description: "Test owned scope" },
+    update: {},
+  });
+  await prisma.topic.upsert({
+    where: { slug: TEST_TOPIC_SLUG },
+    create: { name: "Test Import Validation", slug: TEST_TOPIC_SLUG },
+    update: {},
+  });
+
+  const rawKey = `noo_${crypto.randomBytes(32).toString("base64url")}`;
+  const keyHash = crypto.createHash("sha256").update(rawKey).digest("hex");
+  const keyPrefix = rawKey.slice(0, 8);
+  const existingKey = await prisma.apiKey.findFirst({
+    where: { name: TEST_KEY_NAME },
+  });
+  if (existingKey) {
+    await prisma.apiKey.update({
+      where: { id: existingKey.id },
+      data: { keyHash, keyPrefix, allowedScopes: [TEST_SCOPE_OWNED] },
+    });
+  } else {
+    await prisma.apiKey.create({
+      data: {
+        name: TEST_KEY_NAME,
+        keyHash,
+        keyPrefix,
+        permissions: "WRITE",
+        allowedScopes: [TEST_SCOPE_OWNED],
+      },
+    });
+  }
+
+  try {
+    const zipBuffer = await buildZip([
+      {
+        filename: "good-article.md",
+        content: `---
+title: Good Article
+topic: ${TEST_TOPIC_SLUG}
+slug: good-article
+restrictedTags:
+  - ${TEST_SCOPE_OWNED}
+---
+
+# Good Article
+
+This assigns a scope the caller has.`,
+      },
+    ]);
+
+    const request = buildImportRequest(zipBuffer, rawKey);
+    const response = await POST(request);
+    const body = (await response.json()) as {
+      summary: { imported: number; errors: number };
+      articles: Array<{ filename: string; error?: string }>;
+    };
+
+    assert.equal(body.summary.imported, 1, "good article should be imported");
+    assert.equal(body.summary.errors, 0, "no errors expected");
+  } finally {
+    await prisma.article.deleteMany({
+      where: { topic: { slug: TEST_TOPIC_SLUG } },
+    });
+    await prisma.topic.deleteMany({
+      where: { slug: TEST_TOPIC_SLUG },
+    });
+    await prisma.apiKey.deleteMany({
+      where: { name: TEST_KEY_NAME },
+    });
+    await prisma.restrictedScope.deleteMany({
+      where: { tag: { in: [TEST_SCOPE_OWNED, TEST_SCOPE_FORBIDDEN] } },
+    });
+  }
+});

--- a/src/__tests__/api/restricted-scopes.test.ts
+++ b/src/__tests__/api/restricted-scopes.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test, { describe } from "node:test";
 import {
   normalizeRestrictedTagsForCaller,
+  resolveImportRestrictedTags,
   resolveRestrictedTagsForCaller,
   validateRestrictedTagsExist,
   type RestrictedScopeLookup,
@@ -216,5 +217,106 @@ describe("resolveRestrictedTagsForCaller", () => {
     assert.equal(result.ok, false);
     if (result.ok) return;
     assert.equal(result.status, 403);
+  });
+});
+
+// ─── resolveImportRestrictedTags ────────────────────────────────────────────
+
+describe("resolveImportRestrictedTags", () => {
+  const mockLookup: RestrictedScopeLookup = async (tags) => {
+    const existing = new Set(["scope-a", "scope-b"]);
+    return tags.filter((t) => existing.has(t));
+  };
+
+  test("returns empty array when value is undefined (does not auto-assign caller scopes)", async () => {
+    const result = await resolveImportRestrictedTags(undefined, ["scope-a"], mockLookup);
+    assert.ok(result.ok);
+    if (!result.ok) return;
+    assert.deepEqual(result.value, []);
+  });
+
+  test("returns empty array when value is null (does not auto-assign caller scopes)", async () => {
+    const result = await resolveImportRestrictedTags(null, ["scope-a"], mockLookup);
+    assert.ok(result.ok);
+    if (!result.ok) return;
+    assert.deepEqual(result.value, []);
+  });
+
+  test("returns empty array for empty array value (explicit no restricted tags)", async () => {
+    const result = await resolveImportRestrictedTags([], ["scope-a"], mockLookup);
+    assert.ok(result.ok);
+    if (!result.ok) return;
+    assert.deepEqual(result.value, []);
+  });
+
+  test("rejects non-array value", async () => {
+    const result = await resolveImportRestrictedTags("not-array", ["*"], mockLookup);
+    assert.equal(result.ok, false);
+    if (result.ok) return;
+    assert.equal(result.status, 400);
+  });
+
+  test("rejects array with non-string items", async () => {
+    const result = await resolveImportRestrictedTags([123], ["*"], mockLookup);
+    assert.equal(result.ok, false);
+    if (result.ok) return;
+    assert.equal(result.status, 400);
+  });
+
+  test("non-admin caller cannot assign scopes they do not have", async () => {
+    const result = await resolveImportRestrictedTags(
+      ["scope-b"],
+      ["scope-a"],
+      mockLookup,
+    );
+    assert.equal(result.ok, false);
+    if (result.ok) return;
+    assert.equal(result.status, 403);
+    assert.ok(result.error.includes("scope-b"));
+  });
+
+  test("non-admin caller can assign their own scopes", async () => {
+    const result = await resolveImportRestrictedTags(
+      ["scope-a"],
+      ["scope-a", "scope-b"],
+      mockLookup,
+    );
+    assert.ok(result.ok);
+    if (!result.ok) return;
+    assert.deepEqual(result.value, ["scope-a"]);
+  });
+
+  test("admin scope can assign any existing tag", async () => {
+    const result = await resolveImportRestrictedTags(
+      ["scope-a", "scope-b"],
+      ["*"],
+      mockLookup,
+    );
+    assert.ok(result.ok);
+    if (!result.ok) return;
+    assert.deepEqual(result.value, ["scope-a", "scope-b"]);
+  });
+
+  test("rejects tags that do not exist in the database", async () => {
+    const result = await resolveImportRestrictedTags(
+      ["nonexistent"],
+      ["*"],
+      mockLookup,
+    );
+    assert.equal(result.ok, false);
+    if (result.ok) return;
+    assert.equal(result.status, 400);
+    assert.ok(result.error.includes("nonexistent"));
+  });
+
+  test("deduplicates repeated tags", async () => {
+    const result = await resolveImportRestrictedTags(
+      ["scope-a", "scope-a", "scope-b"],
+      ["*"],
+      mockLookup,
+    );
+    assert.ok(result.ok);
+    if (!result.ok) return;
+    assert.deepEqual(result.value, ["scope-a", "scope-b"]);
   });
 });

--- a/src/app/api/import/route.ts
+++ b/src/app/api/import/route.ts
@@ -252,6 +252,29 @@ export async function POST(request: NextRequest) {
   // Validate that the caller is allowed to assign the requested restrictedTags.
   // Without this check, a scoped WRITE key could craft an import to add restricted
   // tags the caller does not have on existing or new articles. See issue #136.
+  //
+  // Batch the RestrictedScope existence check: collect every unique requested
+  // tag across the batch and resolve them in a single query, then validate
+  // each article against the in-memory set via the helper's injectable
+  // lookup. Avoids an N+1 query pattern for large imports.
+  const allRequestedTags = new Set<string>();
+  for (const article of toImport) {
+    if (article.error) continue;
+    for (const tag of article.restrictedTags ?? []) {
+      allRequestedTags.add(tag);
+    }
+  }
+  const existingScopes = new Set<string>();
+  if (allRequestedTags.size > 0) {
+    const rows = await prisma.restrictedScope.findMany({
+      where: { tag: { in: Array.from(allRequestedTags) } },
+      select: { tag: true },
+    });
+    for (const row of rows) existingScopes.add(row.tag);
+  }
+  const batchedLookup = async (tags: string[]): Promise<Iterable<string>> =>
+    tags.filter((t) => existingScopes.has(t));
+
   for (const article of toImport) {
     if (article.error) continue;
     const requested = article.restrictedTags ?? [];
@@ -259,6 +282,7 @@ export async function POST(request: NextRequest) {
     const result = await resolveImportRestrictedTags(
       requested,
       allowedScopes,
+      batchedLookup,
     );
     if (!result.ok) {
       article.error = result.error;

--- a/src/app/api/import/route.ts
+++ b/src/app/api/import/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import type { Role } from "@prisma/client";
 import { Permissions } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
 import { requirePermission, canAccessScopes } from "@/lib/api/auth";
@@ -26,6 +27,26 @@ function validatedStatus(v: string | undefined, fallback: string): string {
   return v && isValidStatus(v) ? v : fallback;
 }
 
+function hasRestrictedTagsField(frontmatter: Record<string, unknown>): boolean {
+  return Object.prototype.hasOwnProperty.call(frontmatter, "restrictedTags");
+}
+
+function sameRestrictedTags(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false;
+  const bSet = new Set(b);
+  return a.every((tag) => bSet.has(tag));
+}
+
+function canChangeExistingRestrictedTags(auth: {
+  allowedScopes?: string[];
+  keyId?: string;
+  permissions?: Permissions;
+  role?: Role;
+}): boolean {
+  if (auth.permissions === Permissions.ADMIN || auth.role === "ADMIN") return true;
+  return Boolean(auth.keyId && auth.allowedScopes?.includes("*"));
+}
+
 interface ImportArticle {
   filename: string;
   title: string;
@@ -39,6 +60,8 @@ interface ImportArticle {
   sourceUrl?: string;
   sourceType?: string;
   restrictedTags?: string[];
+  restrictedTagsInput?: unknown;
+  hasRestrictedTagsField: boolean;
   error?: string;
 }
 
@@ -181,7 +204,7 @@ export async function POST(request: NextRequest) {
     try {
       content = await entry.async("string");
     } catch {
-      toImport.push({ filename: entry.name, title: "", slug: "", topicSlug: "", content: "", tags: [], error: "Failed to read file" });
+      toImport.push({ filename: entry.name, title: "", slug: "", topicSlug: "", content: "", tags: [], hasRestrictedTagsField: false, error: "Failed to read file" });
       continue;
     }
 
@@ -190,7 +213,7 @@ export async function POST(request: NextRequest) {
 
     const parsed = parseNoosphereMarkdown(content);
     if (!parsed.ok) {
-      toImport.push({ filename: entry.name, title: "", slug: "", topicSlug: "", content: "", tags: [], error: parsed.error });
+      toImport.push({ filename: entry.name, title: "", slug: "", topicSlug: "", content: "", tags: [], hasRestrictedTagsField: false, error: parsed.error });
       continue;
     }
 
@@ -200,12 +223,12 @@ export async function POST(request: NextRequest) {
     const topicSlug = readMarkdownString(frontmatter, "topic") ?? topicPath.at(-1) ?? defaultTopicSlug ?? "";
 
     if (!title || !articleContent.trim()) {
-      toImport.push({ filename: entry.name, title, slug: "", topicSlug, content: articleContent, tags: [], error: "Missing required field: title or content" });
+      toImport.push({ filename: entry.name, title, slug: "", topicSlug, content: articleContent, tags: [], hasRestrictedTagsField: false, error: "Missing required field: title or content" });
       continue;
     }
 
     if (!topicSlug) {
-      toImport.push({ filename: entry.name, title, slug: "", topicSlug: "", content: articleContent, tags: [], error: "Missing required field: topic" });
+      toImport.push({ filename: entry.name, title, slug: "", topicSlug: "", content: articleContent, tags: [], hasRestrictedTagsField: false, error: "Missing required field: topic" });
       continue;
     }
 
@@ -219,12 +242,16 @@ export async function POST(request: NextRequest) {
       .slice(0, 80);
 
     if (!slug) {
-      toImport.push({ filename: entry.name, title, slug: "", topicSlug, content: articleContent, tags: [], error: "Could not derive valid slug from filename" });
+      toImport.push({ filename: entry.name, title, slug: "", topicSlug, content: articleContent, tags: [], hasRestrictedTagsField: false, error: "Could not derive valid slug from filename" });
       continue;
     }
 
     const tags = readMarkdownStringArray(frontmatter, "tags");
-    const restrictedTags = readMarkdownStringArray(frontmatter, "restrictedTags");
+    const hasRestrictedTags = hasRestrictedTagsField(frontmatter);
+    const restrictedTagsInput = hasRestrictedTags ? frontmatter.restrictedTags : undefined;
+    const restrictedTags = hasRestrictedTags
+      ? readMarkdownStringArray(frontmatter, "restrictedTags")
+      : undefined;
 
     toImport.push({
       filename: entry.name,
@@ -238,7 +265,9 @@ export async function POST(request: NextRequest) {
       status: readMarkdownString(frontmatter, "status"),
       sourceUrl: readMarkdownString(frontmatter, "sourceUrl"),
       sourceType: readMarkdownString(frontmatter, "sourceType"),
-      restrictedTags: restrictedTags.length > 0 ? restrictedTags : undefined,
+      restrictedTags,
+      restrictedTagsInput,
+      hasRestrictedTagsField: hasRestrictedTags,
     });
   }
 
@@ -277,21 +306,23 @@ export async function POST(request: NextRequest) {
 
   for (const article of toImport) {
     if (article.error) continue;
-    const requested = article.restrictedTags ?? [];
-    if (requested.length === 0) continue;
+    if (!article.hasRestrictedTagsField) continue;
     const result = await resolveImportRestrictedTags(
-      requested,
+      article.restrictedTagsInput,
       allowedScopes,
       batchedLookup,
     );
     if (!result.ok) {
       article.error = result.error;
+    } else {
+      article.restrictedTags = result.value;
     }
   }
 
   // Process imports
   const userId = auth.auth.userId ?? null;
   const userName = auth.auth.name ?? "Importer";
+  const canChangeClassification = canChangeExistingRestrictedTags(auth.auth);
 
   const results = { imported: 0, skipped: 0, errors: 0 };
 
@@ -317,6 +348,20 @@ export async function POST(request: NextRequest) {
             results.skipped++;
             continue;
           }
+
+          const existingRestrictedTags = existing.restrictedTags ?? [];
+          let nextRestrictedTags = article.restrictedTags ?? [];
+          if (existingRestrictedTags.length > 0) {
+            if (!article.hasRestrictedTagsField) {
+              nextRestrictedTags = existingRestrictedTags;
+            } else if (!sameRestrictedTags(existingRestrictedTags, nextRestrictedTags) && !canChangeClassification) {
+              article.error = "Changing restrictedTags on an existing restricted article requires ADMIN access";
+              results.errors++;
+              continue;
+            }
+          }
+          const restrictedTagsChanged = !sameRestrictedTags(existingRestrictedTags, nextRestrictedTags);
+
           // Update existing article
           await tx.article.update({
             where: { id: existing.id },
@@ -326,10 +371,27 @@ export async function POST(request: NextRequest) {
               excerpt: article.excerpt ?? article.content.slice(0, 160).replace(/[#*`_]/g, ""),
               confidence: validatedConfidence(article.confidence),
               status: validatedStatus(article.status, existing.status),
-              restrictedTags: article.restrictedTags ?? [],
+              restrictedTags: nextRestrictedTags,
               updatedAt: new Date(),
             },
           });
+          if (restrictedTagsChanged) {
+            await tx.activityLog.create({
+              data: {
+                type: "update",
+                title: `Updated restrictedTags via import: ${article.title}`,
+                authorName: userName,
+                details: {
+                  articleId: existing.id,
+                  slug: article.slug,
+                  topicSlug: article.topicSlug,
+                  previousRestrictedTags: existingRestrictedTags,
+                  restrictedTags: nextRestrictedTags,
+                  declassified: existingRestrictedTags.length > 0 && nextRestrictedTags.length === 0,
+                },
+              },
+            });
+          }
           results.imported++;
         } else {
           results.skipped++;

--- a/src/app/api/import/route.ts
+++ b/src/app/api/import/route.ts
@@ -61,6 +61,14 @@ export function canChangeExistingRestrictedTags(auth: {
   return Boolean(auth.allowedScopes?.includes("*"));
 }
 
+function restrictedTagsCallerCannotAssign(
+  restrictedTags: string[],
+  allowedScopes: string[] | undefined,
+): string[] {
+  if (allowedScopes?.includes("*")) return [];
+  return restrictedTags.filter((tag) => !(allowedScopes ?? []).includes(tag));
+}
+
 interface ImportArticle {
   filename: string;
   title: string;
@@ -292,9 +300,10 @@ export async function POST(request: NextRequest) {
     }
   }
 
-  // Validate that the caller is allowed to assign the requested restrictedTags.
-  // Without this check, a scoped WRITE key could craft an import to add restricted
-  // tags the caller does not have on existing or new articles. See issue #136.
+  // Validate the requested restrictedTags shape and database existence first.
+  // Authorization is decided later with the existing article in hand: an
+  // explicit same-set overwrite is a no-op, even if the caller only has one of
+  // several existing scopes. New articles still need caller-can-assign checks.
   //
   // Batch the RestrictedScope existence check: collect every unique requested
   // tag across the batch and resolve them in a single query, then validate
@@ -323,7 +332,7 @@ export async function POST(request: NextRequest) {
     if (!article.hasRestrictedTagsField) continue;
     const result = await resolveImportRestrictedTags(
       article.restrictedTagsInput,
-      allowedScopes,
+      ["*"],
       batchedLookup,
     );
     if (!result.ok) {
@@ -428,6 +437,16 @@ export async function POST(request: NextRequest) {
         } else {
           results.skipped++;
         }
+        continue;
+      }
+
+      const unauthorized = restrictedTagsCallerCannotAssign(
+        article.restrictedTags ?? [],
+        allowedScopes,
+      );
+      if (unauthorized.length > 0) {
+        article.error = `Cannot assign scope(s) you don't have: ${unauthorized.join(", ")}`;
+        results.errors++;
         continue;
       }
 

--- a/src/app/api/import/route.ts
+++ b/src/app/api/import/route.ts
@@ -37,14 +37,19 @@ function sameRestrictedTags(a: string[], b: string[]): boolean {
   return a.every((tag) => bSet.has(tag));
 }
 
-function canChangeExistingRestrictedTags(auth: {
+export function canChangeExistingRestrictedTags(auth: {
   allowedScopes?: string[];
   keyId?: string;
   permissions?: Permissions;
   role?: Role;
 }): boolean {
+  // Sessions and ADMIN permission both carry the full-access signal we care
+  // about here. Sessions (humans) get `allowedScopes: ["*"]` from
+  // checkRouteAuth and never set `keyId`; the previous API-key-only branch
+  // therefore blocked EDITOR sessions from reclassifying on overwrite even
+  // though they can already read every restricted article.
   if (auth.permissions === Permissions.ADMIN || auth.role === "ADMIN") return true;
-  return Boolean(auth.keyId && auth.allowedScopes?.includes("*"));
+  return Boolean(auth.allowedScopes?.includes("*"));
 }
 
 interface ImportArticle {

--- a/src/app/api/import/route.ts
+++ b/src/app/api/import/route.ts
@@ -31,10 +31,19 @@ function hasRestrictedTagsField(frontmatter: Record<string, unknown>): boolean {
   return Object.prototype.hasOwnProperty.call(frontmatter, "restrictedTags");
 }
 
-function sameRestrictedTags(a: string[], b: string[]): boolean {
-  if (a.length !== b.length) return false;
+export function sameRestrictedTags(a: string[], b: string[]): boolean {
+  // Compare as sets, not sequences: order-insensitive, duplicate-tolerant.
+  // The duplicate-tolerance is defence-in-depth: `resolveImportRestrictedTags`
+  // and `readMarkdownStringArray` already dedupe their inputs, but the
+  // comparison should not silently treat a de-duped set as equal to a
+  // superset just because both inputs happen to share the same length.
+  const aSet = new Set(a);
   const bSet = new Set(b);
-  return a.every((tag) => bSet.has(tag));
+  if (aSet.size !== bSet.size) return false;
+  for (const tag of aSet) {
+    if (!bSet.has(tag)) return false;
+  }
+  return true;
 }
 
 export function canChangeExistingRestrictedTags(auth: {
@@ -356,16 +365,29 @@ export async function POST(request: NextRequest) {
 
           const existingRestrictedTags = existing.restrictedTags ?? [];
           let nextRestrictedTags = article.restrictedTags ?? [];
-          if (existingRestrictedTags.length > 0) {
-            if (!article.hasRestrictedTagsField) {
-              nextRestrictedTags = existingRestrictedTags;
-            } else if (!sameRestrictedTags(existingRestrictedTags, nextRestrictedTags) && !canChangeClassification) {
-              article.error = "Changing restrictedTags on an existing restricted article requires ADMIN access";
-              results.errors++;
-              continue;
-            }
+          if (existingRestrictedTags.length > 0 && !article.hasRestrictedTagsField) {
+            // Omitted frontmatter on an already-restricted article preserves
+            // the existing classification. Explicit values still flow through
+            // the change-check below.
+            nextRestrictedTags = existingRestrictedTags;
           }
-          const restrictedTagsChanged = !sameRestrictedTags(existingRestrictedTags, nextRestrictedTags);
+          const restrictedTagsChanged = !sameRestrictedTags(
+            existingRestrictedTags,
+            nextRestrictedTags,
+          );
+          if (restrictedTagsChanged && !canChangeClassification) {
+            // Classification (unrestricted→restricted), declassification
+            // (restricted→unrestricted), and reclassification (restricted→a
+            // *different* restricted set) are all privileged operations. The
+            // import file is treated as content, not as an authorisation
+            // change, so any classification boundary crossing requires ADMIN
+            // (or session/["*"]) authority regardless of the caller's
+            // allowedScopes on the article.
+            article.error =
+              "Changing restrictedTags on an existing article requires ADMIN access";
+            results.errors++;
+            continue;
+          }
 
           // Update existing article
           await tx.article.update({
@@ -381,6 +403,8 @@ export async function POST(request: NextRequest) {
             },
           });
           if (restrictedTagsChanged) {
+            const wasUnrestricted = existingRestrictedTags.length === 0;
+            const isNowUnrestricted = nextRestrictedTags.length === 0;
             await tx.activityLog.create({
               data: {
                 type: "update",
@@ -392,7 +416,10 @@ export async function POST(request: NextRequest) {
                   topicSlug: article.topicSlug,
                   previousRestrictedTags: existingRestrictedTags,
                   restrictedTags: nextRestrictedTags,
-                  declassified: existingRestrictedTags.length > 0 && nextRestrictedTags.length === 0,
+                  classified: wasUnrestricted && !isNowUnrestricted,
+                  declassified: !wasUnrestricted && isNowUnrestricted,
+                  reclassified:
+                    !wasUnrestricted && !isNowUnrestricted,
                 },
               },
             });

--- a/src/app/api/import/route.ts
+++ b/src/app/api/import/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { Permissions } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
 import { requirePermission, canAccessScopes } from "@/lib/api/auth";
+import { resolveImportRestrictedTags } from "@/lib/api/restricted-scopes";
 import JSZip from "jszip";
 import { isValidConfidence, isValidStatus } from "@/lib/validation";
 import { rateLimit } from "@/lib/rate-limit";
@@ -245,6 +246,22 @@ export async function POST(request: NextRequest) {
   for (const article of toImport) {
     if (!article.error && !topicBySlug.has(article.topicSlug)) {
       article.error = `Topic "${article.topicSlug}" not found`;
+    }
+  }
+
+  // Validate that the caller is allowed to assign the requested restrictedTags.
+  // Without this check, a scoped WRITE key could craft an import to add restricted
+  // tags the caller does not have on existing or new articles. See issue #136.
+  for (const article of toImport) {
+    if (article.error) continue;
+    const requested = article.restrictedTags ?? [];
+    if (requested.length === 0) continue;
+    const result = await resolveImportRestrictedTags(
+      requested,
+      allowedScopes,
+    );
+    if (!result.ok) {
+      article.error = result.error;
     }
   }
 

--- a/src/lib/api/restricted-scopes.ts
+++ b/src/lib/api/restricted-scopes.ts
@@ -76,6 +76,12 @@ export async function resolveRestrictedTagsForCaller(
  * "no restricted tags" regardless of the caller's scopes.
  *
  * Otherwise, scope assignment and existence checks are identical.
+ *
+ * Design note: a flag parameter on `resolveRestrictedTagsForCaller` was
+ * considered and rejected. The two callers have different contracts
+ * (auto-assign vs. explicit) and conflating them behind a boolean makes
+ * both call sites harder to read. A named function keeps each contract
+ * visible at the call site.
  */
 export async function resolveImportRestrictedTags(
   value: unknown,

--- a/src/lib/api/restricted-scopes.ts
+++ b/src/lib/api/restricted-scopes.ts
@@ -67,6 +67,30 @@ export async function resolveRestrictedTagsForCaller(
   return validateRestrictedTagsExist(normalized.value, lookup);
 }
 
+/**
+ * Validates restrictedTags coming from a markdown import file.
+ *
+ * Unlike `resolveRestrictedTagsForCaller` (used by POST /api/articles), this
+ * does NOT default missing tags to the caller's scopes. Import files must
+ * explicitly declare their restricted tags; an omitted/empty value means
+ * "no restricted tags" regardless of the caller's scopes.
+ *
+ * Otherwise, scope assignment and existence checks are identical.
+ */
+export async function resolveImportRestrictedTags(
+  value: unknown,
+  allowedScopes: string[] | undefined,
+  lookup: RestrictedScopeLookup = findExistingRestrictedScopes,
+): Promise<RestrictedTagsResult> {
+  if (value === undefined || value === null) {
+    return { ok: true, value: [] };
+  }
+  if (Array.isArray(value) && value.length === 0) {
+    return { ok: true, value: [] };
+  }
+  return resolveRestrictedTagsForCaller(value, allowedScopes, lookup);
+}
+
 export async function validateRestrictedTagsExist(
   tags: string[],
   lookup: RestrictedScopeLookup = findExistingRestrictedScopes,


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request introduces comprehensive validation and permission checks for `restrictedTags` during bulk article imports via `POST /api/import`.

Key changes include:

*   **Restricted Tag Validation on Import**:
    *   **Caller Permissions**: Articles in an import file can only assign `restrictedTags` that the importing caller is authorized to assign. Attempts to assign unauthorized tags will result in an article-level error, skipping that specific article without aborting the entire batch.
    *   **Tag Existence**: All `restrictedTags` specified in the import frontmatter must exist in the system's `RestrictedScope` registry. Non-existent tags will also cause an article-level error.
    *   **No Auto-Assignment**: Unlike other article creation/update routes, `POST /api/import` does not automatically assign the caller's `allowedScopes` if `restrictedTags` are omitted or empty in the import frontmatter. An omitted or empty `restrictedTags` value explicitly means "no restricted tags" for that article.
    *   **Batch Optimization**: Validation for tag existence is optimized to collect all unique `restrictedTags` across the entire import batch and perform a single database query, preventing N+1 query issues.

*   **Overwrite Semantics for `restrictedTags`**: When `overwrite=true` is used:
    *   **Preservation of Existing Classification**: If an existing restricted article is updated and the `restrictedTags` field is *omitted* from the import frontmatter, the article's existing `restrictedTags` are preserved.
    *   **Privileged Classification Changes**: Any operation that changes an article's classification boundary (classifying a public article, declassifying a restricted article, or reclassifying a restricted article to a different set of tags) now explicitly requires ADMIN permissions or a session caller with `allowedScopes: ["*"]`. Scoped WRITE API keys cannot perform these operations, even if they possess the specific scopes involved.
    *   **No-Op Recognition**: The comparison logic for `restrictedTags` is now set-based (`sameRestrictedTags`), making it order-insensitive and duplicate-tolerant. This ensures that if the new set of tags is logically identical to the existing set (e.g., `[a, a]` in import vs. `[a]` existing), it's correctly identified as a no-op and allowed for scoped WRITE keys.

*   **Audit Logging**: Classification, declassification, and reclassification events performed during an import are now recorded in the activity log, including specific flags (`classified`, `declassified`, `reclassified`) to clearly indicate the type of change.

These changes enhance the security and data integrity of the import functionality by strictly enforcing restricted content policies and ensuring that classification changes are properly authorized and audited.

---

This pull request refines the validation process for `restrictedTags` during article import (`POST /api/import`).

Key changes include:

*   **Explicit Caller Permission Validation:** A new validation step is introduced to explicitly check if the importing caller (based on their `allowedScopes`) has permission to assign all `restrictedTags` specified in the import file for an article. If the caller lacks the necessary scopes for any of the requested tags, the article's import will fail with an article-level error in the import summary.
*   **"No-op" for Identical Restricted Tags:** The system now correctly identifies when an import attempts to set `restrictedTags` to an identical set of tags that an existing article already possesses. This is treated as a no-op, allowing the import to proceed even if the caller's `allowedScopes` do not cover every single tag in the existing set, as long as no actual change to the restricted tags is being made.
*   **Separation of Concerns:** The validation for the existence and format of `restrictedTags` is now separated from the caller's permission check, allowing for a more granular and robust validation flow.
*   **Documentation Update:** The `RESTRICTED-TAGS-SPEC.md` documentation is updated to clarify that restricted tag validation errors during import will be reported as article-level errors within the import summary, rather than a general 400 response.

This ensures that unauthorized assignment of restricted tags is prevented while allowing legitimate updates that do not alter an article's restricted access classification.
<!-- kody-pr-summary:end -->