### PR TITLE
test(cache): cover search invalidation versioning

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "next start",
     "test": "npm run test:memory && npm run test:cache && npm run test:api && npm run test:security",
     "test:memory": "node --env-file=.env.test --import tsx --test 'src/__tests__/memory/**/*.test.ts'",
-    "test:cache": "node --import tsx --test 'src/__tests__/cache/**/*.test.ts'",
+    "test:cache": "node --env-file=.env.test --import tsx --test 'src/__tests__/cache/**/*.test.ts'",
     "test:api": "node --import tsx --test 'src/__tests__/api/**/*.test.ts'",
     "test:security": "node --import tsx --test src/__tests__/security/uploads.test.ts src/__tests__/security/proxy.test.ts",
     "lint": "eslint",

--- a/src/__tests__/cache/search-cache.test.ts
+++ b/src/__tests__/cache/search-cache.test.ts
@@ -2,16 +2,24 @@ import { describe, it } from "node:test";
 import {
   buildSearchCacheKey,
   getCachedSearchResults,
+  getSearchCacheVersion,
   invalidateSearchCache,
   setCachedSearchResults,
 } from "@/lib/cache/search-cache";
 import { getRedisClient, _redisTestHooks } from "@/lib/cache/redis";
 import type { MemoryResult } from "@/lib/memory/types";
+import {
+  createMockPrisma,
+  createSequentialQueryRaw,
+  mockSearchRow,
+} from "../memory/noosphere-provider-helpers";
 import assert from "assert";
 
 class FakeRedisClient {
   status = "wait";
   private readonly store = new Map<string, string>();
+  private setexCalls = 0;
+  private readonly setexWaiters: (() => void)[] = [];
 
   async connect() {
     this.status = "ready";
@@ -29,6 +37,8 @@ class FakeRedisClient {
   async setex(key: string, _ttlSeconds: number, value: string) {
     this.assertReady();
     this.store.set(key, value);
+    this.setexCalls++;
+    this.setexWaiters.shift()?.();
     return "OK";
   }
 
@@ -39,9 +49,32 @@ class FakeRedisClient {
     return value;
   }
 
+  waitForSetexCall(expectedCalls = this.setexCalls + 1) {
+    if (this.setexCalls >= expectedCalls) {
+      return Promise.resolve();
+    }
+    return new Promise<void>((resolve) => {
+      this.setexWaiters.push(resolve);
+    });
+  }
+
   private assertReady() {
     if (this.status !== "ready") {
       throw new Error("Redis command executed before client was ready");
+    }
+  }
+}
+
+async function withRestoredDatabaseUrl<T>(fn: () => Promise<T>): Promise<T> {
+  const previousDatabaseUrl = process.env.DATABASE_URL;
+
+  try {
+    return await fn();
+  } finally {
+    if (previousDatabaseUrl === undefined) {
+      delete process.env.DATABASE_URL;
+    } else {
+      process.env.DATABASE_URL = previousDatabaseUrl;
     }
   }
 }
@@ -128,5 +161,70 @@ describe("Search Cache Redis Operations", () => {
     } finally {
       _redisTestHooks.reset();
     }
+  });
+
+  it("moves recall cache reads to a new key after invalidation", async () => {
+    const redis = new FakeRedisClient();
+    _redisTestHooks.setClientForTesting(redis as never);
+
+    try {
+      const initialVersion = await getSearchCacheVersion();
+      assert.strictEqual(initialVersion, "0");
+
+      const staleCacheKey = buildSearchCacheKey({
+        query: "versioned recall",
+        cacheVersion: initialVersion,
+      });
+      await setCachedSearchResults(staleCacheKey, [cachedResult], initialVersion);
+      assert.deepStrictEqual(await getCachedSearchResults(staleCacheKey), [
+        cachedResult,
+      ]);
+
+      await invalidateSearchCache();
+      const nextVersion = await getSearchCacheVersion();
+      assert.strictEqual(nextVersion, "1");
+
+      const nextCacheKey = buildSearchCacheKey({
+        query: "versioned recall",
+        cacheVersion: nextVersion,
+      });
+      assert.notStrictEqual(nextCacheKey, staleCacheKey);
+      assert.strictEqual(await getCachedSearchResults(nextCacheKey), null);
+    } finally {
+      _redisTestHooks.reset();
+    }
+  });
+
+  it("moves NoosphereProvider recall reads off stale cache entries after invalidation", async () => {
+    await withRestoredDatabaseUrl(async () => {
+      const redis = new FakeRedisClient();
+      _redisTestHooks.setClientForTesting(redis as never);
+
+      try {
+        const { NoosphereProvider } = await import("@/lib/memory/noosphere");
+        const provider = new NoosphereProvider({
+          prisma: createMockPrisma({
+            $queryRaw: createSequentialQueryRaw([
+              [mockSearchRow({ title: "Before invalidation" })],
+              [mockSearchRow({ title: "After invalidation" })],
+            ]),
+          }),
+        });
+
+        const initialResults = await provider.search("versioned recall");
+        assert.strictEqual(initialResults[0]?.title, "Before invalidation");
+        await redis.waitForSetexCall(1);
+
+        const cachedResults = await provider.search("versioned recall");
+        assert.strictEqual(cachedResults[0]?.title, "Before invalidation");
+
+        await invalidateSearchCache();
+        const refreshedResults = await provider.search("versioned recall");
+        assert.strictEqual(refreshedResults[0]?.title, "After invalidation");
+        await redis.waitForSetexCall(2);
+      } finally {
+        _redisTestHooks.reset();
+      }
+    });
   });
 });

--- a/src/__tests__/memory/noosphere-provider-helpers.ts
+++ b/src/__tests__/memory/noosphere-provider-helpers.ts
@@ -1,0 +1,76 @@
+import type { PrismaClient } from "@prisma/client";
+
+export function createMockPrisma(
+  overrides: Record<string, unknown> = {},
+): PrismaClient {
+  return {
+    article: {
+      findFirst: (() =>
+        Promise.resolve(null)) as unknown as PrismaClient["article"]["findFirst"],
+      findMany: (() =>
+        Promise.resolve(
+          [],
+        )) as unknown as PrismaClient["article"]["findMany"],
+    },
+    $queryRaw: (() =>
+      Promise.resolve([])) as unknown as PrismaClient["$queryRaw"],
+    ...overrides,
+  } as unknown as PrismaClient;
+}
+
+export function createSequentialQueryRaw(rowsByCall: unknown[][]) {
+  let callIndex = 0;
+  return () => {
+    const rows = rowsByCall[Math.min(callIndex, rowsByCall.length - 1)] ?? [];
+    callIndex++;
+    return Promise.resolve(rows);
+  };
+}
+
+export function mockArticle(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "test-id",
+    title: "Test Article",
+    slug: "test-article",
+    content: "Test content body",
+    excerpt: "Test excerpt",
+    status: "published",
+    confidence: "high",
+    sourceUrl: null,
+    sourceType: null,
+    createdAt: new Date("2026-01-01"),
+    updatedAt: new Date("2026-04-01"),
+    lastReviewed: null,
+    authorId: null,
+    authorName: null,
+    topicId: "topic-1",
+    topic: { id: "topic-1", slug: "engineering", name: "Engineering" },
+    tags: [],
+    ...overrides,
+  };
+}
+
+export function mockSearchRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "article-1",
+    rank: 1,
+    title: "Article",
+    slug: "article",
+    content: "Article content",
+    excerpt: "Article excerpt",
+    status: "published",
+    confidence: "high",
+    sourceUrl: null,
+    sourceType: null,
+    createdAt: new Date("2026-01-01"),
+    updatedAt: new Date("2026-01-02"),
+    lastReviewed: null,
+    authorId: null,
+    authorName: null,
+    topicId: "topic-1",
+    topicSlug: "engineering",
+    topicName: "Engineering",
+    tagName: null,
+    ...overrides,
+  };
+}

--- a/src/__tests__/memory/noosphere-provider.test.ts
+++ b/src/__tests__/memory/noosphere-provider.test.ts
@@ -12,19 +12,15 @@
  * 6. Descriptor metadata
  */
 
-// Set DATABASE_URL before importing modules that may create Prisma client at load time.
-// Static imports are evaluated before module body code, so we must set this first.
-// Tests inject their own mock Prisma, so this connection string is never used.
-process.env.DATABASE_URL = "postgresql://test:test@localhost:5432/test";
-
-import type { PrismaClient } from "@prisma/client";
 import {
   NoosphereProvider,
   createNoosphereProvider,
 } from "@/lib/memory/noosphere";
 import type { MemoryCurationLevel } from "@/lib/memory/types";
-
-// ─── Test helpers ────────────────────────────────────────────────────────────
+import {
+  createMockPrisma,
+  mockArticle,
+} from "./noosphere-provider-helpers";
 
 let testCounter = 0;
 let passCount = 0;
@@ -71,51 +67,6 @@ function assertApprox(
       `${label}: expected ~${expected} (±${tolerance}), got ${actual}`,
     );
   }
-}
-
-// ─── Mock Prisma ─────────────────────────────────────────────────────────────
-
-function createMockPrisma(
-  overrides: Record<string, unknown> = {},
-): PrismaClient {
-  return {
-    article: {
-      findFirst: (() =>
-        Promise.resolve(null)) as unknown as PrismaClient["article"]["findFirst"],
-      findMany: (() =>
-        Promise.resolve(
-          [],
-        )) as unknown as PrismaClient["article"]["findMany"],
-    },
-    $queryRaw: (() =>
-      Promise.resolve([])) as unknown as PrismaClient["$queryRaw"],
-    ...overrides,
-  } as unknown as PrismaClient;
-}
-
-// ─── Shared mock article factory ────────────────────────────────────────────
-
-function mockArticle(overrides: Record<string, unknown> = {}) {
-  return {
-    id: "test-id",
-    title: "Test Article",
-    slug: "test-article",
-    content: "Test content body",
-    excerpt: "Test excerpt",
-    status: "published",
-    confidence: "high",
-    sourceUrl: null,
-    sourceType: null,
-    createdAt: new Date("2026-01-01"),
-    updatedAt: new Date("2026-04-01"),
-    lastReviewed: null,
-    authorId: null,
-    authorName: null,
-    topicId: "topic-1",
-    topic: { id: "topic-1", slug: "engineering", name: "Engineering" },
-    tags: [],
-    ...overrides,
-  };
 }
 
 // ─── Tests ───────────────────────────────────────────────────────────────────


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request introduces a new test utility file, `src/__tests__/memory/noosphere-provider-helpers.ts`, to centralize and enhance mocking capabilities for `NoosphereProvider` tests.

**Key Changes and Functional Impact:**

1.  **New Prisma Mocking Helpers:**
    *   `createMockPrisma`: A flexible factory function to generate a mock `PrismaClient` instance. This allows tests to precisely control the behavior of Prisma methods like `article.findFirst`, `article.findMany`, and `$queryRaw`, ensuring test isolation from actual database interactions.
    *   `createSequentialQueryRaw`: A specialized helper for `$queryRaw` that returns different sets of rows on successive calls. This is crucial for simulating dynamic database states, such as when data changes after an update or cache invalidation, allowing tests to verify that subsequent reads fetch fresh data.

2.  **New Test Data Factories:**
    *   `mockArticle`: A factory to create mock `Article` objects with predefined default values, simplifying the generation of consistent article data for various test scenarios.
    *   `mockSearchRow`: A factory specifically designed to create mock search result rows, including fields like `id`, `rank`, `title`, `slug`, and topic information. This streamlines the creation of expected search query outputs.

3.  **Test Code Refactoring:**
    *   The existing `createMockPrisma` and `mockArticle` functions were moved from `src/__tests__/memory/noosphere-provider.test.ts` into the new `noosphere-provider-helpers.ts` file. This refactoring improves code organization, reduces duplication, and makes these common test utilities reusable across multiple test files within the `memory` test suite.

**Technical Context and Complementary Information:**

These changes lay the foundational infrastructure for robust regression testing of search cache invalidation. The `createSequentialQueryRaw` function is particularly significant as it enables the simulation of a "stale" cache scenario followed by a "fresh" data retrieval, directly addressing the need to prove that `NoosphereProvider.search()` does not return stale results after invalidation. The `mockSearchRow` factory ensures that the structure of the mocked search results accurately reflects what the `NoosphereProvider` expects, allowing for precise verification of search logic and cache interactions. This approach leverages advanced mocking techniques to create highly controlled and repeatable test environments, which is essential for verifying complex caching behaviors.

---

This pull request refactors and enhances the test suite for the `NoosphereProvider` by extracting common test helper functions into a new dedicated file.

Key changes include:
- **Refactored Test Helpers:** Moved `createMockPrisma` and `mockArticle` functions from `noosphere-provider.test.ts` to `src/__tests__/memory/noosphere-provider-helpers.ts` to improve test code organization and reusability.
- **New Mocking Capabilities:** Introduced `createSequentialQueryRaw` to enable mocking Prisma's `$queryRaw` method to return different results on successive calls, facilitating tests for scenarios where database data changes over time.
- **Search Result Mocks:** Added `mockSearchRow` to simplify the creation of mock data for search query results.

These changes lay the groundwork for comprehensive testing of search cache invalidation and versioning, allowing the test suite to simulate dynamic database states and verify that cached search results are correctly updated.

---

Refactored test helper functions by extracting `createMockPrisma` and `mockArticle` into a new dedicated file, `src/__tests__/memory/noosphere-provider-helpers.ts`.

This change also introduces new test helpers:
- `createSequentialQueryRaw`: A utility to simulate sequential database query results, useful for testing scenarios involving data changes over time.
- `mockSearchRow`: A factory for creating mock search result objects.

The refactoring improves test code organization and reusability, and prepares the testing environment for future tests, particularly those related to search cache invalidation versioning. The `DATABASE_URL` environment variable setup was also removed from the test file, streamlining the test configuration.
<!-- kody-pr-summary:end -->