### PR TITLE
fix(schema): declare GIN index on Article.restrictedTags (closes #143)

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -84,6 +84,11 @@ model Article {
   @@index([confidence])
   @@index([deletedAt])
   @@index([updatedAt(sort: Desc), id(sort: Asc)])
+  // GIN index for array-containment (`hasSome` / `&&`) queries on restrictedTags.
+  // The live DB index was hand-rolled in 20260514220000_add_restricted_tags_scope;
+  // declaring it here keeps `prisma migrate diff` from wanting to drop it on the
+  // next migration. See issue #143.
+  @@index([restrictedTags(ops: ArrayOps)], type: Gin, name: "Article_restrictedTags_idx")
 }
 
 // ─────────────────────────────────────────────


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request introduces a `@@index` declaration for the `restrictedTags` field within the `Article` model in `prisma/schema.prisma`.

**Key Changes and Functional Impact:**

*   **Schema Alignment:** The primary purpose of this change is to align the Prisma schema with the existing live database structure. A GIN index named `Article_restrictedTags_idx` already exists on the `restrictedTags` column in the production database, having been created by a prior hand-rolled migration (`20260514220000_add_restricted_tags_scope`). However, this index was never declared in the Prisma schema.
*   **Preventing Accidental Index Drops:** Without this declaration, `prisma migrate diff` would incorrectly identify the existing `Article_restrictedTags_idx` as an undeclared index and propose dropping it. This change prevents such an erroneous `DROP INDEX` operation during future migrations.
*   **Optimizing Array Queries:** The declared index is a `Gin` type index, specifically configured with `ops: ArrayOps`. This operator class is crucial for efficiently supporting array-containment queries (e.g., `hasSome` or PostgreSQL's `&&` operator) on the `restrictedTags` field, which is an array of strings. This ensures that queries filtering articles by multiple restricted tags can leverage the index for improved performance.
*   **Schema-Only Modification:** This PR does not create a new index in the database. It is a schema-only change that reflects the existing database state, ensuring `prisma migrate diff` produces a clean output for this specific index.
*   **Explicit Naming:** The `name: "Article_restrictedTags_idx"` attribute explicitly matches the name of the existing index in the database, which is critical for Prisma to correctly identify and reconcile the index.

This modification directly addresses issue #143 by resolving the schema drift for the `Article.restrictedTags` GIN index.
<!-- kody-pr-summary:end -->