### PR TITLE
chore(deps): bump hono override from 4.12.18 to 4.12.25 (resolves 4 CVEs)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5509,9 +5509,9 @@
       "license": "CC0-1.0"
     },
     "node_modules/hono": {
-      "version": "4.12.18",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
-      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
+      "version": "4.12.25",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
+      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/package.json
+++ b/package.json
@@ -59,6 +59,6 @@
   "overrides": {
     "@hono/node-server": "1.19.13",
     "postcss": "8.5.14",
-    "hono": "4.12.18"
+    "hono": "4.12.25"
   }
 }


### PR DESCRIPTION
## Summary

Bumps the `hono` npm override from `4.12.18` to `4.12.25` (latest patch in the 4.12.x line), which resolves all four related Hono CVEs reported by Snyk.

- **Before:** `npm audit` reported 4 moderate-severity Hono advisories
- **After:** `npm audit` reports 0 Hono advisories (4 → 3 total moderate vulns, only `brace-expansion` and `uuid` remain)

## CVEs resolved (all fixed in `hono >= 4.12.21`)

| Snyk ID | CVE | What it does | CVSS |
|---------|-----|--------------|------|
| `SNYK-JS-HONO-17055751` | CVE-2026-47673 | JWT middleware accepts any Authorization scheme, not just Bearer | 6.3 (M) |
| `SNYK-JS-HONO-17055743` | CVE-2026-47676 | `app.mount()` strips mount prefix without decoding, causing wrong routing for percent-encoded paths | 6.9 (M) |
| `SNYK-JS-HONO-17055753` | CVE-2026-47675 | `serialize()` does not sanitize `sameSite` / `priority`, allowing Set-Cookie injection | 5.3 (M) |
| `SNYK-JS-HONO-17055760` | CVE-2026-47674 | `ip-restriction` regex bypass via non-canonical IPv6 forms | 6.9 (M) |

## Why `4.12.25` and not the minimum fix (`4.12.21`)

`4.12.25` is the latest patch in the 4.12.x line (per the `latest` npm dist-tag). Same minor, no API break, picks up any subsequent security or stability fixes between 4.12.21 and 4.12.25. There's no reason to under-bump and then re-bump later.

## Reachability assessment

**None of the four vulnerable code paths are invoked in Noosphere's own source code.** Hono enters the dependency tree only via a Prisma dev dependency:

```
noosphere
└─ prisma@7.7.0 (devDependency)
   └─ @prisma/dev@0.24.3
      ├─ @hono/node-server@1.19.13
      │  └─ hono@4.12.25
      └─ hono@4.12.25
```

Specifically:

- Noosphere uses **Next.js App Router with NextAuth.js**, not Hono. The `jwt({ token, user })` callback in `src/lib/auth/index.ts` is NextAuth's API, not Hono's `jwt()` middleware.
- No Hono routes are mounted anywhere. All HTTP routing is via Next.js App Router.
- `sameSite: "lax"` calls in `src/app/wiki/admin/keys/actions.ts` and `src/app/wiki/admin/settings/actions.ts` are Next.js `cookies().set()` calls, not Hono's `c.serialize()` helper.
- No IP-restriction middleware is used anywhere in the codebase.

So this is a **transitive dev-dependency CVE** — Hono is used by Prisma's local dev tooling, not by Noosphere's production runtime. The bump is still worth doing because:

1. It removes the advisories from the Snyk dashboard and `npm audit` output (less noise, fewer false-positives to triage)
2. It provides defense-in-depth if future code changes ever introduce a Hono usage
3. The cost is one line in `package.json` plus a lockfile regeneration

## Change

```diff
   "overrides": {
     "@hono/node-server": "1.19.13",
     "postcss": "8.5.14",
-    "hono": "4.12.18"
+    "hono": "4.12.25"
   }
```

`package-lock.json` regenerated by `npm install`. No source code changes.

## Verification

### Before

```
$ npm audit
4 moderate severity vulnerabilities
  hono <=4.12.20  →  4 advisories
  brace-expansion 5.0.2-5.0.5  →  1 advisory
  uuid <11.1.1  →  1 advisory
```

### After

```
$ npm audit
3 moderate severity vulnerabilities
  (Hono cluster removed; brace-expansion and uuid remain — see follow-up issues)
```

### Other checks

- `npm run typecheck` ✅ clean
- `npm run lint` ✅ 0 errors (2 pre-existing warnings, unrelated)
- `npm run test:memory` ✅ 186/186 pass
- `npm run version:check` ✅ "already synchronized to VERSION=1.9.1" (no version change in this PR)

## Follow-up issues

The remaining 2 advisories in `npm audit` are out of scope for this PR per the agreed-upon split:

1. `uuid` < 11.1.1 — buffer bounds check missing in v3/v5/v6 (CVE-2026-41907 / `SNYK-JS-UUID-16133035`). Transitive via `next-auth@4.24.14` → `uuid@8.3.2`. Will need an `overrides` pin or a `next-auth` upgrade. Tracked separately.
2. `brace-expansion` 5.0.2-5.0.5 — ReDoS via large numeric ranges. Transitive via `@typescript-eslint/typescript-estree` (dev-only, no runtime exposure). Will need an `@typescript-eslint` bump. Tracked separately.

## References

- [Snyk advisory: SNYK-JS-HONO-17055751](https://security.snyk.io/vuln/SNYK-JS-HONO-17055751)
- [Snyk advisory: SNYK-JS-HONO-17055743](https://security.snyk.io/vuln/SNYK-JS-HONO-17055743)
- [Snyk advisory: SNYK-JS-HONO-17055753](https://security.snyk.io/vuln/SNYK-JS-HONO-17055753)
- [Snyk advisory: SNYK-JS-HONO-17055760](https://security.snyk.io/vuln/SNYK-JS-HONO-17055760)
- [Hono npm package](https://www.npmjs.com/package/hono) — latest = 4.12.25

## Summary by Sourcery

Update the Hono npm override to the latest 4.12.x patch release and refresh the lockfile to resolve reported Hono security advisories in a transitive dev dependency.

Bug Fixes:
- Resolve four Snyk-reported Hono CVEs by bumping the overridden Hono version from 4.12.18 to 4.12.25 in the dependency tree.

Build:
- Regenerate package-lock.json to reflect the updated Hono override version used via Prisma's dev tooling.