### PR TITLE
fix(api): consolidate PATCH restricted-tags validation into shared helper

### DIFF
--- a/src/__tests__/api/articles-patch-restricted-tags.test.ts
+++ b/src/__tests__/api/articles-patch-restricted-tags.test.ts
@@ -1,0 +1,213 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import crypto from "node:crypto";
+import type { NextRequest } from "next/server";
+import type { PrismaClient } from "@prisma/client";
+
+// Route-level test for the PATCH /api/articles/[id] restricted-tags path.
+// Mirrors import-route-validation.test.ts: it needs a reachable DATABASE_URL
+// and the local dev stack, and exercises the real route handler end-to-end.
+if (!process.env.DATABASE_URL) {
+  throw new Error("DATABASE_URL environment variable must be set for tests");
+}
+
+const TEST_PREFIX = "test-issue182-";
+const TEST_SCOPE_OWNED = `${TEST_PREFIX}owned`;
+const TEST_SCOPE_FORBIDDEN = `${TEST_PREFIX}forbidden`;
+const TEST_TOPIC_SLUG = `${TEST_PREFIX}topic`;
+const TEST_KEY_NAME = `${TEST_PREFIX}key`;
+const TEST_CLIENT_IP = `10.77.${Math.floor(Math.random() * 254) + 1}.${Math.floor(Math.random() * 254) + 1}`;
+
+function buildPatchRequest(
+  articleId: string,
+  body: unknown,
+  rawKey: string,
+): NextRequest {
+  const request = new Request(`http://localhost/api/articles/${articleId}`, {
+    method: "PATCH",
+    headers: {
+      Authorization: `Bearer ${rawKey}`,
+      "Content-Type": "application/json",
+      "x-real-ip": TEST_CLIENT_IP,
+    },
+    body: JSON.stringify(body),
+  });
+  return request as unknown as NextRequest;
+}
+
+async function upsertScopedWriteKey(
+  prisma: PrismaClient,
+  rawKey: string,
+  allowedScopes: string[],
+): Promise<void> {
+  const keyHash = crypto.createHash("sha256").update(rawKey).digest("hex");
+  const keyPrefix = rawKey.slice(0, 8);
+  const existingKey = await prisma.apiKey.findFirst({
+    where: { name: TEST_KEY_NAME },
+  });
+  if (existingKey) {
+    await prisma.apiKey.update({
+      where: { id: existingKey.id },
+      data: { keyHash, keyPrefix, permissions: "WRITE", allowedScopes },
+    });
+  } else {
+    await prisma.apiKey.create({
+      data: {
+        name: TEST_KEY_NAME,
+        keyHash,
+        keyPrefix,
+        permissions: "WRITE",
+        allowedScopes,
+      },
+    });
+  }
+}
+
+async function setupSharedFixtures(prisma: PrismaClient): Promise<void> {
+  await prisma.restrictedScope.upsert({
+    where: { tag: TEST_SCOPE_OWNED },
+    create: { tag: TEST_SCOPE_OWNED, description: "Test owned scope" },
+    update: {},
+  });
+  await prisma.restrictedScope.upsert({
+    where: { tag: TEST_SCOPE_FORBIDDEN },
+    create: { tag: TEST_SCOPE_FORBIDDEN, description: "Test forbidden scope" },
+    update: {},
+  });
+  await prisma.topic.upsert({
+    where: { slug: TEST_TOPIC_SLUG },
+    create: { name: "Test Patch Validation", slug: TEST_TOPIC_SLUG },
+    update: {},
+  });
+}
+
+async function cleanupSharedFixtures(prisma: PrismaClient): Promise<void> {
+  await prisma.article.deleteMany({
+    where: { topic: { slug: TEST_TOPIC_SLUG } },
+  });
+  await prisma.topic.deleteMany({ where: { slug: TEST_TOPIC_SLUG } });
+  await prisma.apiKey.deleteMany({ where: { name: TEST_KEY_NAME } });
+  await prisma.restrictedScope.deleteMany({
+    where: { tag: { in: [TEST_SCOPE_OWNED, TEST_SCOPE_FORBIDDEN] } },
+  });
+}
+
+async function createArticle(
+  prisma: PrismaClient,
+  slug: string,
+  restrictedTags: string[] = [],
+) {
+  const topic = await prisma.topic.findUnique({
+    where: { slug: TEST_TOPIC_SLUG },
+  });
+  assert.ok(topic, "shared topic must exist");
+  return prisma.article.create({
+    data: {
+      title: `Patch Test ${slug}`,
+      slug,
+      content: "# Patch restricted-tags test",
+      topicId: topic.id,
+      authorName: TEST_KEY_NAME,
+      restrictedTags,
+    },
+  });
+}
+
+// ─── Issue #182: PATCH must reject restrictedTags the caller cannot assign ──
+
+test("PATCH /api/articles/[id] rejects restrictedTags the caller cannot assign (issue #182)", async () => {
+  const { prisma } = await import("@/lib/prisma");
+  const { PATCH } = await import("@/app/api/articles/[id]/route");
+
+  await setupSharedFixtures(prisma);
+
+  const rawKey = `noo_${crypto.randomBytes(32).toString("base64url")}`;
+  await upsertScopedWriteKey(prisma, rawKey, [TEST_SCOPE_OWNED]);
+
+  const article = await createArticle(prisma, "patch-unauthorized");
+
+  try {
+    const response = await PATCH(
+      buildPatchRequest(article.id, { restrictedTags: [TEST_SCOPE_FORBIDDEN] }, rawKey),
+      { params: Promise.resolve({ id: article.id }) },
+    );
+    const body = (await response.json()) as { error?: string };
+
+    assert.equal(response.status, 403, "non-admin key must be forbidden from assigning a scope it lacks");
+    assert.ok(body.error, "response should include an error message");
+    assert.ok(
+      body.error!.includes(TEST_SCOPE_FORBIDDEN),
+      `error should mention the forbidden scope, got: ${body.error}`,
+    );
+
+    // The article must be unchanged.
+    const after = await prisma.article.findUnique({ where: { id: article.id } });
+    assert.ok(after, "article must still exist");
+    assert.deepEqual(
+      after!.restrictedTags,
+      [],
+      "unauthorized PATCH must not mutate restrictedTags",
+    );
+  } finally {
+    await cleanupSharedFixtures(prisma);
+  }
+});
+
+test("PATCH /api/articles/[id] accepts restrictedTags the caller can assign", async () => {
+  const { prisma } = await import("@/lib/prisma");
+  const { PATCH } = await import("@/app/api/articles/[id]/route");
+
+  await setupSharedFixtures(prisma);
+
+  const rawKey = `noo_${crypto.randomBytes(32).toString("base64url")}`;
+  await upsertScopedWriteKey(prisma, rawKey, [TEST_SCOPE_OWNED]);
+
+  const article = await createArticle(prisma, "patch-authorized");
+
+  try {
+    const response = await PATCH(
+      buildPatchRequest(article.id, { restrictedTags: [TEST_SCOPE_OWNED] }, rawKey),
+      { params: Promise.resolve({ id: article.id }) },
+    );
+    const body = (await response.json()) as { restrictedTags?: string[] };
+
+    assert.equal(response.status, 200, "authorized PATCH should succeed");
+    assert.deepEqual(
+      body.restrictedTags,
+      [TEST_SCOPE_OWNED],
+      "restrictedTags should be persisted",
+    );
+  } finally {
+    await cleanupSharedFixtures(prisma);
+  }
+});
+
+test("PATCH /api/articles/[id] declassifies on explicit empty restrictedTags (no auto-assign)", async () => {
+  const { prisma } = await import("@/lib/prisma");
+  const { PATCH } = await import("@/app/api/articles/[id]/route");
+
+  await setupSharedFixtures(prisma);
+
+  const rawKey = `noo_${crypto.randomBytes(32).toString("base64url")}`;
+  // Key owns the scope the article is already classified under, so it can access it.
+  await upsertScopedWriteKey(prisma, rawKey, [TEST_SCOPE_OWNED]);
+
+  const article = await createArticle(prisma, "patch-declassify", [TEST_SCOPE_OWNED]);
+
+  try {
+    const response = await PATCH(
+      buildPatchRequest(article.id, { restrictedTags: [] }, rawKey),
+      { params: Promise.resolve({ id: article.id }) },
+    );
+    const body = (await response.json()) as { restrictedTags?: string[] };
+
+    assert.equal(response.status, 200, "explicit [] should declassify");
+    assert.deepEqual(
+      body.restrictedTags,
+      [],
+      "empty array must declassify, not auto-inherit the caller's scopes",
+    );
+  } finally {
+    await cleanupSharedFixtures(prisma);
+  }
+});

--- a/src/__tests__/api/articles-patch-restricted-tags.test.ts
+++ b/src/__tests__/api/articles-patch-restricted-tags.test.ts
@@ -177,6 +177,14 @@ test("PATCH /api/articles/[id] accepts restrictedTags the caller can assign", as
       [TEST_SCOPE_OWNED],
       "restrictedTags should be persisted",
     );
+
+    const after = await prisma.article.findUnique({ where: { id: article.id } });
+    assert.ok(after, "article must still exist");
+    assert.deepEqual(
+      after.restrictedTags,
+      [TEST_SCOPE_OWNED],
+      "authorized PATCH must persist restrictedTags",
+    );
   } finally {
     await cleanupSharedFixtures(prisma);
   }
@@ -206,6 +214,76 @@ test("PATCH /api/articles/[id] declassifies on explicit empty restrictedTags (no
       body.restrictedTags,
       [],
       "empty array must declassify, not auto-inherit the caller's scopes",
+    );
+  } finally {
+    await cleanupSharedFixtures(prisma);
+  }
+});
+
+test("PATCH /api/articles/[id] rejects null restrictedTags without declassifying", async () => {
+  const { prisma } = await import("@/lib/prisma");
+  const { PATCH } = await import("@/app/api/articles/[id]/route");
+
+  await setupSharedFixtures(prisma);
+
+  const rawKey = `noo_${crypto.randomBytes(32).toString("base64url")}`;
+  await upsertScopedWriteKey(prisma, rawKey, [TEST_SCOPE_OWNED]);
+
+  const article = await createArticle(prisma, "patch-null", [TEST_SCOPE_OWNED]);
+
+  try {
+    const response = await PATCH(
+      buildPatchRequest(article.id, { restrictedTags: null }, rawKey),
+      { params: Promise.resolve({ id: article.id }) },
+    );
+    const body = (await response.json()) as { error?: string };
+
+    assert.equal(response.status, 400, "null must retain the previous validation error");
+    assert.equal(
+      body.error,
+      "restrictedTags must be an array of non-empty strings",
+    );
+
+    const after = await prisma.article.findUnique({ where: { id: article.id } });
+    assert.ok(after, "article must still exist");
+    assert.deepEqual(
+      after.restrictedTags,
+      [TEST_SCOPE_OWNED],
+      "invalid null input must not declassify the article",
+    );
+  } finally {
+    await cleanupSharedFixtures(prisma);
+  }
+});
+
+test("PATCH /api/articles/[id] preserves duplicate restrictedTags", async () => {
+  const { prisma } = await import("@/lib/prisma");
+  const { PATCH } = await import("@/app/api/articles/[id]/route");
+
+  await setupSharedFixtures(prisma);
+
+  const rawKey = `noo_${crypto.randomBytes(32).toString("base64url")}`;
+  await upsertScopedWriteKey(prisma, rawKey, [TEST_SCOPE_OWNED]);
+
+  const article = await createArticle(prisma, "patch-duplicates");
+  const duplicateTags = [TEST_SCOPE_OWNED, TEST_SCOPE_OWNED];
+
+  try {
+    const response = await PATCH(
+      buildPatchRequest(article.id, { restrictedTags: duplicateTags }, rawKey),
+      { params: Promise.resolve({ id: article.id }) },
+    );
+    const body = (await response.json()) as { restrictedTags?: string[] };
+
+    assert.equal(response.status, 200, "duplicate tags remain valid PATCH input");
+    assert.deepEqual(body.restrictedTags, duplicateTags);
+
+    const after = await prisma.article.findUnique({ where: { id: article.id } });
+    assert.ok(after, "article must still exist");
+    assert.deepEqual(
+      after.restrictedTags,
+      duplicateTags,
+      "PATCH must not silently normalize stored tags",
     );
   } finally {
     await cleanupSharedFixtures(prisma);

--- a/src/__tests__/api/restricted-scopes.test.ts
+++ b/src/__tests__/api/restricted-scopes.test.ts
@@ -3,6 +3,7 @@ import test, { describe } from "node:test";
 import {
   normalizeRestrictedTagsForCaller,
   resolveImportRestrictedTags,
+  resolvePatchRestrictedTags,
   resolveRestrictedTagsForCaller,
   validateRestrictedTagsExist,
   type RestrictedScopeLookup,
@@ -311,6 +312,107 @@ describe("resolveImportRestrictedTags", () => {
 
   test("deduplicates repeated tags", async () => {
     const result = await resolveImportRestrictedTags(
+      ["scope-a", "scope-a", "scope-b"],
+      ["*"],
+      mockLookup,
+    );
+    assert.ok(result.ok);
+    if (!result.ok) return;
+    assert.deepEqual(result.value, ["scope-a", "scope-b"]);
+  });
+});
+
+// ─── resolvePatchRestrictedTags ─────────────────────────────────────────────
+
+describe("resolvePatchRestrictedTags", () => {
+  const mockLookup: RestrictedScopeLookup = async (tags) => {
+    const existing = new Set(["scope-a", "scope-b"]);
+    return tags.filter((t) => existing.has(t));
+  };
+
+  test("returns empty array when value is undefined (no auto-assign)", async () => {
+    const result = await resolvePatchRestrictedTags(undefined, ["scope-a"], mockLookup);
+    assert.ok(result.ok);
+    if (!result.ok) return;
+    assert.deepEqual(result.value, []);
+  });
+
+  test("returns empty array when value is null (no auto-assign)", async () => {
+    const result = await resolvePatchRestrictedTags(null, ["scope-a"], mockLookup);
+    assert.ok(result.ok);
+    if (!result.ok) return;
+    assert.deepEqual(result.value, []);
+  });
+
+  test("returns empty array for empty array value (explicit declassify, no auto-assign)", async () => {
+    const result = await resolvePatchRestrictedTags([], ["scope-a"], mockLookup);
+    assert.ok(result.ok);
+    if (!result.ok) return;
+    assert.deepEqual(result.value, []);
+  });
+
+  test("rejects non-array value", async () => {
+    const result = await resolvePatchRestrictedTags("not-array", ["*"], mockLookup);
+    assert.equal(result.ok, false);
+    if (result.ok) return;
+    assert.equal(result.status, 400);
+  });
+
+  test("rejects array with non-string items", async () => {
+    const result = await resolvePatchRestrictedTags([123], ["*"], mockLookup);
+    assert.equal(result.ok, false);
+    if (result.ok) return;
+    assert.equal(result.status, 400);
+  });
+
+  test("non-admin caller cannot assign scopes they do not have", async () => {
+    const result = await resolvePatchRestrictedTags(
+      ["scope-b"],
+      ["scope-a"],
+      mockLookup,
+    );
+    assert.equal(result.ok, false);
+    if (result.ok) return;
+    assert.equal(result.status, 403);
+    assert.ok(result.error.includes("scope-b"));
+  });
+
+  test("non-admin caller can assign their own scopes", async () => {
+    const result = await resolvePatchRestrictedTags(
+      ["scope-a"],
+      ["scope-a", "scope-b"],
+      mockLookup,
+    );
+    assert.ok(result.ok);
+    if (!result.ok) return;
+    assert.deepEqual(result.value, ["scope-a"]);
+  });
+
+  test("admin scope can assign any existing tag", async () => {
+    const result = await resolvePatchRestrictedTags(
+      ["scope-a", "scope-b"],
+      ["*"],
+      mockLookup,
+    );
+    assert.ok(result.ok);
+    if (!result.ok) return;
+    assert.deepEqual(result.value, ["scope-a", "scope-b"]);
+  });
+
+  test("rejects tags that do not exist in the database", async () => {
+    const result = await resolvePatchRestrictedTags(
+      ["nonexistent"],
+      ["*"],
+      mockLookup,
+    );
+    assert.equal(result.ok, false);
+    if (result.ok) return;
+    assert.equal(result.status, 400);
+    assert.ok(result.error.includes("nonexistent"));
+  });
+
+  test("deduplicates repeated tags", async () => {
+    const result = await resolvePatchRestrictedTags(
       ["scope-a", "scope-a", "scope-b"],
       ["*"],
       mockLookup,

--- a/src/__tests__/api/restricted-scopes.test.ts
+++ b/src/__tests__/api/restricted-scopes.test.ts
@@ -330,18 +330,18 @@ describe("resolvePatchRestrictedTags", () => {
     return tags.filter((t) => existing.has(t));
   };
 
-  test("returns empty array when value is undefined (no auto-assign)", async () => {
+  test("rejects undefined because PATCH only resolves present fields", async () => {
     const result = await resolvePatchRestrictedTags(undefined, ["scope-a"], mockLookup);
-    assert.ok(result.ok);
-    if (!result.ok) return;
-    assert.deepEqual(result.value, []);
+    assert.equal(result.ok, false);
+    if (result.ok) return;
+    assert.equal(result.status, 400);
   });
 
-  test("returns empty array when value is null (no auto-assign)", async () => {
+  test("rejects null to preserve the PATCH API contract", async () => {
     const result = await resolvePatchRestrictedTags(null, ["scope-a"], mockLookup);
-    assert.ok(result.ok);
-    if (!result.ok) return;
-    assert.deepEqual(result.value, []);
+    assert.equal(result.ok, false);
+    if (result.ok) return;
+    assert.equal(result.status, 400);
   });
 
   test("returns empty array for empty array value (explicit declassify, no auto-assign)", async () => {
@@ -408,10 +408,13 @@ describe("resolvePatchRestrictedTags", () => {
     assert.equal(result.ok, false);
     if (result.ok) return;
     assert.equal(result.status, 400);
-    assert.ok(result.error.includes("nonexistent"));
+    assert.equal(
+      result.error,
+      "Unknown restricted tag(s): nonexistent. Valid tags: ",
+    );
   });
 
-  test("deduplicates repeated tags", async () => {
+  test("preserves repeated tags to keep PATCH storage behavior unchanged", async () => {
     const result = await resolvePatchRestrictedTags(
       ["scope-a", "scope-a", "scope-b"],
       ["*"],
@@ -419,6 +422,21 @@ describe("resolvePatchRestrictedTags", () => {
     );
     assert.ok(result.ok);
     if (!result.ok) return;
-    assert.deepEqual(result.value, ["scope-a", "scope-b"]);
+    assert.deepEqual(result.value, ["scope-a", "scope-a", "scope-b"]);
+  });
+
+  test("does not trim whitespace before validating tags", async () => {
+    const result = await resolvePatchRestrictedTags(
+      [" scope-a "],
+      ["*"],
+      mockLookup,
+    );
+    assert.equal(result.ok, false);
+    if (result.ok) return;
+    assert.equal(result.status, 400);
+    assert.equal(
+      result.error,
+      "Unknown restricted tag(s):  scope-a . Valid tags: ",
+    );
   });
 });

--- a/src/app/api/articles/[id]/route.ts
+++ b/src/app/api/articles/[id]/route.ts
@@ -17,6 +17,7 @@ import {
 } from "@/lib/validation";
 import { invalidateSearchCache } from "@/lib/cache/search-cache";
 import { rateLimit } from "@/lib/rate-limit";
+import { resolvePatchRestrictedTags } from "@/lib/api/restricted-scopes";
 
 // PATCH /api/articles/[id] — Update article
 // Auth: API key (WRITE/ADMIN) or session (EDITOR/ADMIN)
@@ -173,39 +174,21 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
       updateData.lastReviewed = lastReviewed ? new Date(lastReviewed) : null;
     }
 
-    // restrictedTags — validate and apply
+    // restrictedTags — validate via the shared scope helper (issue #182).
+    // PATCH semantics: an explicit [] declassifies and never auto-inherits the
+    // caller's scopes; only present tags are type/existence/membership-checked.
     if (restrictedTags !== undefined) {
-      if (!Array.isArray(restrictedTags) || !(restrictedTags as unknown[]).every((t) => typeof t === "string" && t.length > 0)) {
-        return NextResponse.json({ error: "restrictedTags must be an array of non-empty strings" }, { status: 400 });
+      const restrictedTagsResult = await resolvePatchRestrictedTags(
+        restrictedTags,
+        auth.auth.allowedScopes,
+      );
+      if (!restrictedTagsResult.ok) {
+        return NextResponse.json(
+          { error: restrictedTagsResult.error },
+          { status: restrictedTagsResult.status },
+        );
       }
-      if (restrictedTags.length > 0) {
-        const validScopes = await prisma.restrictedScope.findMany({
-          where: { tag: { in: restrictedTags } },
-          select: { tag: true },
-        });
-        const validSet = new Set(validScopes.map((s) => s.tag));
-        const invalid = (restrictedTags as string[]).filter((t) => !validSet.has(t));
-        if (invalid.length > 0) {
-          return NextResponse.json(
-            { error: `Unknown restricted tag(s): ${invalid.join(", ")}. Valid tags: ${validScopes.map((s) => s.tag).join(", ")}` },
-            { status: 400 }
-          );
-        }
-
-        // Security: WRITE keys can only assign scopes that are in their allowedScopes.
-        // ADMIN (*) bypasses this check.
-        const callerScopes = auth.auth.allowedScopes;
-        if (!callerScopes?.includes("*")) {
-          const unauthorized = (restrictedTags as string[]).filter((t) => !(callerScopes ?? []).includes(t));
-          if (unauthorized.length > 0) {
-            return NextResponse.json(
-              { error: `Cannot assign scope(s) you don't have: ${unauthorized.join(", ")}` },
-              { status: 403 }
-            );
-          }
-        }
-      }
-      updateData.restrictedTags = restrictedTags;
+      updateData.restrictedTags = restrictedTagsResult.value;
     }
 
     // tags — validate early if provided

--- a/src/lib/api/restricted-scopes.ts
+++ b/src/lib/api/restricted-scopes.ts
@@ -4,6 +4,32 @@ export type RestrictedTagsResult =
 
 export type RestrictedScopeLookup = (tags: string[]) => Promise<Iterable<string>>;
 
+type UnknownRestrictedTagsError = (
+  invalidTags: string[],
+  validTags: string[],
+) => string;
+
+function authorizeRestrictedTags(
+  tags: string[],
+  allowedScopes: string[] | undefined,
+): RestrictedTagsResult {
+  const callerScopes = allowedScopes ?? [];
+  if (callerScopes.includes("*")) {
+    return { ok: true, value: tags };
+  }
+
+  const unauthorized = tags.filter((tag) => !callerScopes.includes(tag));
+  if (unauthorized.length > 0) {
+    return {
+      ok: false,
+      status: 403,
+      error: `Cannot assign scope(s) you don't have: ${unauthorized.join(", ")}`,
+    };
+  }
+
+  return { ok: true, value: tags };
+}
+
 export function normalizeRestrictedTagsForCaller(
   value: unknown,
   allowedScopes: string[] | undefined,
@@ -42,18 +68,7 @@ export function normalizeRestrictedTagsForCaller(
     requestedTags = [...callerScopes];
   }
 
-  if (!isAdminScope) {
-    const unauthorized = requestedTags.filter((tag) => !callerScopes.includes(tag));
-    if (unauthorized.length > 0) {
-      return {
-        ok: false,
-        status: 403,
-        error: `Cannot assign scope(s) you don't have: ${unauthorized.join(", ")}`,
-      };
-    }
-  }
-
-  return { ok: true, value: requestedTags };
+  return authorizeRestrictedTags(requestedTags, allowedScopes);
 }
 
 export async function resolveRestrictedTagsForCaller(
@@ -100,45 +115,55 @@ export async function resolveImportRestrictedTags(
 /**
  * Validates restrictedTags on PATCH /api/articles/[id].
  *
- * Shares the same "explicit" contract as `resolveImportRestrictedTags`: an
- * omitted or empty value declassifies (means "no restricted tags") and never
- * auto-inherits the caller's scopes. Only present tags are type-checked,
- * existence-checked, and scope-membership-checked — all via the shared
- * `resolveRestrictedTagsForCaller` core so a fix to the access-control logic
- * reaches the create, import, and PATCH paths together (see issue #182).
- *
- * This is intentionally a separate, PATCH-named entry point rather than a flag
- * on the create helper: the create path auto-assigns caller scopes on omission,
- * whereas PATCH must not. Keeping the contracts in named functions makes the
- * divergence visible at each call site.
+ * PATCH only calls this helper when the field is present. Its input and error
+ * behavior intentionally match the previous inline route validation: null and
+ * non-array values are rejected, whitespace and duplicates are not normalized,
+ * and unknown-tag errors retain their legacy response text. The sensitive
+ * scope-membership check is shared with the create/import paths.
  */
 export async function resolvePatchRestrictedTags(
   value: unknown,
   allowedScopes: string[] | undefined,
   lookup: RestrictedScopeLookup = findExistingRestrictedScopes,
 ): Promise<RestrictedTagsResult> {
-  if (value === undefined || value === null) {
-    return { ok: true, value: [] };
+  if (
+    !Array.isArray(value) ||
+    !value.every((tag) => typeof tag === "string" && tag.length > 0)
+  ) {
+    return {
+      ok: false,
+      status: 400,
+      error: "restrictedTags must be an array of non-empty strings",
+    };
   }
-  if (Array.isArray(value) && value.length === 0) {
-    return { ok: true, value: [] };
-  }
-  return resolveRestrictedTagsForCaller(value, allowedScopes, lookup);
+
+  const existing = await validateRestrictedTagsExist(
+    value,
+    lookup,
+    (invalidTags, validTags) =>
+      `Unknown restricted tag(s): ${invalidTags.join(", ")}. Valid tags: ${validTags.join(", ")}`,
+  );
+  if (!existing.ok) return existing;
+
+  return authorizeRestrictedTags(existing.value, allowedScopes);
 }
 
 export async function validateRestrictedTagsExist(
   tags: string[],
   lookup: RestrictedScopeLookup = findExistingRestrictedScopes,
+  formatError: UnknownRestrictedTagsError = (invalidTags) =>
+    `Unknown restricted tag(s): ${invalidTags.join(", ")}`,
 ): Promise<RestrictedTagsResult> {
   if (tags.length === 0) return { ok: true, value: [] };
 
-  const validSet = new Set(await lookup(tags));
+  const validTags = Array.from(await lookup(tags));
+  const validSet = new Set(validTags);
   const invalid = tags.filter((tag) => !validSet.has(tag));
   if (invalid.length > 0) {
     return {
       ok: false,
       status: 400,
-      error: `Unknown restricted tag(s): ${invalid.join(", ")}`,
+      error: formatError(invalid, validTags),
     };
   }
 

--- a/src/lib/api/restricted-scopes.ts
+++ b/src/lib/api/restricted-scopes.ts
@@ -97,6 +97,35 @@ export async function resolveImportRestrictedTags(
   return resolveRestrictedTagsForCaller(value, allowedScopes, lookup);
 }
 
+/**
+ * Validates restrictedTags on PATCH /api/articles/[id].
+ *
+ * Shares the same "explicit" contract as `resolveImportRestrictedTags`: an
+ * omitted or empty value declassifies (means "no restricted tags") and never
+ * auto-inherits the caller's scopes. Only present tags are type-checked,
+ * existence-checked, and scope-membership-checked — all via the shared
+ * `resolveRestrictedTagsForCaller` core so a fix to the access-control logic
+ * reaches the create, import, and PATCH paths together (see issue #182).
+ *
+ * This is intentionally a separate, PATCH-named entry point rather than a flag
+ * on the create helper: the create path auto-assigns caller scopes on omission,
+ * whereas PATCH must not. Keeping the contracts in named functions makes the
+ * divergence visible at each call site.
+ */
+export async function resolvePatchRestrictedTags(
+  value: unknown,
+  allowedScopes: string[] | undefined,
+  lookup: RestrictedScopeLookup = findExistingRestrictedScopes,
+): Promise<RestrictedTagsResult> {
+  if (value === undefined || value === null) {
+    return { ok: true, value: [] };
+  }
+  if (Array.isArray(value) && value.length === 0) {
+    return { ok: true, value: [] };
+  }
+  return resolveRestrictedTagsForCaller(value, allowedScopes, lookup);
+}
+
 export async function validateRestrictedTagsExist(
   tags: string[],
   lookup: RestrictedScopeLookup = findExistingRestrictedScopes,


### PR DESCRIPTION
## Summary

- move PATCH `restrictedTags` validation out of the route and into `resolvePatchRestrictedTags`
- share the scope-membership authorization check with create/import paths
- preserve the existing PATCH API contract byte-for-byte
- add focused unit and route-level regression coverage

## Preserved PATCH behavior

- omitted `restrictedTags` leaves the existing classification unchanged
- `null` and non-array values return HTTP 400
- explicit `[]` declassifies without auto-inheriting caller scopes
- whitespace and duplicate values are not silently normalized
- unknown-tag errors retain the legacy response text
- unauthorized scope assignment returns HTTP 403 without mutating the article

## Verification

- `node --import tsx --test src/__tests__/api/restricted-scopes.test.ts` (42/42)
- `node --import tsx --test src/__tests__/api/articles-patch-restricted-tags.test.ts` (5/5)
- `node --import tsx --test src/__tests__/api/import-route-validation.test.ts` (10/10)
- `npm run typecheck`
- focused ESLint
- `git diff --check`

Closes #182

<!-- kody-pr-summary:start -->
This pull request consolidates the validation logic for `restrictedTags` on the `PATCH /api/articles/[id]` endpoint into a shared helper function, ensuring consistent authorization checks across article creation, import, and update operations.

Key changes include:

*   **Consolidated Authorization**: Extracted the logic for checking if a caller is authorized to assign specific restricted tags into a new `authorizeRestrictedTags` helper, which is now used by both `normalizeRestrictedTagsForCaller` (for create/import) and `resolvePatchRestrictedTags` (for PATCH).
*   **Stricter PATCH Input Validation**:
    *   `PATCH /api/articles/[id]` now explicitly rejects `null` or `undefined` values for `restrictedTags` with a `400 Bad Request` error, instead of implicitly declassifying the article. Declassification still occurs when an empty array (`[]`) is provided.
    *   The validation ensures that `restrictedTags` is an array containing only non-empty strings.
    *   Tags with leading or trailing whitespace are no longer implicitly trimmed and will be considered invalid if they do not exactly match an existing tag.
*   **Preservation of Duplicate Tags**: The `PATCH` endpoint will now preserve duplicate tags in the `restrictedTags` array as provided by the caller, rather than silently deduplicating them.
*   **Enhanced Error Messages**: Error messages for unknown restricted tags now include a list of valid tags, providing more informative feedback to API consumers.
<!-- kody-pr-summary:end -->