### PR TITLE
fix(api): bound topic tree queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Common endpoints:
 | Method | Endpoint | Purpose |
 | --- | --- | --- |
 | `GET` | `/api/health` | Service health check |
-| `GET` | `/api/topics` | List topics |
+| `GET` | `/api/topics` | List the complete topic tree (maximum 500 topics; returns `409` above the limit) |
 | `GET` | `/api/articles` | Search/list articles |
 | `POST` | `/api/articles` | Create an article |
 | `PATCH` | `/api/articles/:id` | Update an article |

--- a/src/__tests__/api/topics-list-limit.test.ts
+++ b/src/__tests__/api/topics-list-limit.test.ts
@@ -22,9 +22,22 @@ function buildGetRequest(rawKey: string): NextRequest {
   return request as unknown as NextRequest;
 }
 
+function buildPostRequest(rawKey: string, body: unknown): NextRequest {
+  const request = new Request("http://localhost/api/topics", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${rawKey}`,
+      "Content-Type": "application/json",
+      "x-real-ip": TEST_CLIENT_IP,
+    },
+    body: JSON.stringify(body),
+  });
+  return request as unknown as NextRequest;
+}
+
 test("GET /api/topics rejects oversized trees instead of returning a partial hierarchy (issue #144)", async () => {
   const { prisma } = await import("@/lib/prisma");
-  const { GET } = await import("@/app/api/topics/route");
+  const { GET, POST } = await import("@/app/api/topics/route");
   const runId = crypto.randomUUID();
   const rawKey = `noo_${crypto.randomBytes(32).toString("base64url")}`;
   const keyHash = crypto.createHash("sha256").update(rawKey).digest("hex");
@@ -88,6 +101,24 @@ test("GET /api/topics rejects oversized trees instead of returning a partial hie
     assert.equal(overflowBody.maxTopics, TOPIC_TREE_MAX_TOPICS);
     assert.equal(overflowBody.topics, undefined, "overflow must not expose a partial topic tree");
     assert.match(overflowBody.error ?? "", /supported limit of 500 topics/);
+
+    await prisma.apiKey.update({
+      where: { id: apiKey.id },
+      data: { permissions: "WRITE" },
+    });
+    const blockedSlug = `${TEST_PREFIX}${runId}-blocked`;
+    const createResponse = await POST(buildPostRequest(rawKey, {
+      name: "Blocked topic beyond limit",
+      slug: blockedSlug,
+    }));
+    const createBody = (await createResponse.json()) as { code?: string };
+    assert.equal(createResponse.status, 409);
+    assert.equal(createBody.code, "TOPIC_TREE_LIMIT_EXCEEDED");
+    assert.equal(
+      await prisma.topic.count({ where: { slug: blockedSlug } }),
+      0,
+      "POST must not create topics after the global ceiling is reached",
+    );
   } finally {
     await prisma.topic.deleteMany({
       where: { slug: { startsWith: `${TEST_PREFIX}${runId}` } },

--- a/src/__tests__/api/topics-list-limit.test.ts
+++ b/src/__tests__/api/topics-list-limit.test.ts
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import crypto from "node:crypto";
+import test from "node:test";
+import type { NextRequest } from "next/server";
+
+if (!process.env.DATABASE_URL) {
+  throw new Error("DATABASE_URL environment variable must be set for tests");
+}
+
+const TOPIC_TREE_MAX_TOPICS = 500;
+const TEST_PREFIX = "test-issue144-";
+const TEST_CLIENT_IP = `10.78.${Math.floor(Math.random() * 254) + 1}.${Math.floor(Math.random() * 254) + 1}`;
+
+function buildGetRequest(rawKey: string): NextRequest {
+  const request = new Request("http://localhost/api/topics", {
+    method: "GET",
+    headers: {
+      Authorization: `Bearer ${rawKey}`,
+      "x-real-ip": TEST_CLIENT_IP,
+    },
+  });
+  return request as unknown as NextRequest;
+}
+
+test("GET /api/topics rejects oversized trees instead of returning a partial hierarchy (issue #144)", async () => {
+  const { prisma } = await import("@/lib/prisma");
+  const { GET } = await import("@/app/api/topics/route");
+  const runId = crypto.randomUUID();
+  const rawKey = `noo_${crypto.randomBytes(32).toString("base64url")}`;
+  const keyHash = crypto.createHash("sha256").update(rawKey).digest("hex");
+
+  const apiKey = await prisma.apiKey.create({
+    data: {
+      name: `${TEST_PREFIX}${runId}`,
+      keyHash,
+      keyPrefix: rawKey.slice(0, 8),
+      permissions: "READ",
+      allowedScopes: ["*"],
+    },
+  });
+
+  try {
+    const initialCount = await prisma.topic.count();
+    assert.ok(
+      initialCount <= TOPIC_TREE_MAX_TOPICS,
+      `test database already exceeds the ${TOPIC_TREE_MAX_TOPICS}-topic contract`,
+    );
+
+    const normalResponse = await GET(buildGetRequest(rawKey));
+    const normalBody = (await normalResponse.json()) as { topics?: unknown[] };
+    assert.equal(normalResponse.status, 200);
+    assert.ok(Array.isArray(normalBody.topics), "normal datasets should retain the topic-tree response");
+
+    const topicsNeeded = TOPIC_TREE_MAX_TOPICS + 1 - initialCount;
+    await prisma.topic.createMany({
+      data: Array.from({ length: topicsNeeded }, (_, index) => ({
+        name: `${TEST_PREFIX}${runId}-${index}`,
+        slug: `${TEST_PREFIX}${runId}-${index}`,
+      })),
+    });
+
+    const overflowResponse = await GET(buildGetRequest(rawKey));
+    const overflowBody = (await overflowResponse.json()) as {
+      error?: string;
+      code?: string;
+      maxTopics?: number;
+      topics?: unknown[];
+    };
+
+    assert.equal(overflowResponse.status, 409);
+    assert.equal(overflowBody.code, "TOPIC_TREE_LIMIT_EXCEEDED");
+    assert.equal(overflowBody.maxTopics, TOPIC_TREE_MAX_TOPICS);
+    assert.equal(overflowBody.topics, undefined, "overflow must not expose a partial topic tree");
+    assert.match(overflowBody.error ?? "", /supported limit of 500 topics/);
+  } finally {
+    await prisma.topic.deleteMany({
+      where: { slug: { startsWith: `${TEST_PREFIX}${runId}` } },
+    });
+    await prisma.apiKey.delete({ where: { id: apiKey.id } });
+  }
+});

--- a/src/__tests__/api/topics-list-limit.test.ts
+++ b/src/__tests__/api/topics-list-limit.test.ts
@@ -41,22 +41,38 @@ test("GET /api/topics rejects oversized trees instead of returning a partial hie
 
   try {
     const initialCount = await prisma.topic.count();
-    assert.ok(
-      initialCount <= TOPIC_TREE_MAX_TOPICS,
-      `test database already exceeds the ${TOPIC_TREE_MAX_TOPICS}-topic contract`,
+    if (initialCount <= TOPIC_TREE_MAX_TOPICS) {
+      const normalResponse = await GET(buildGetRequest(rawKey));
+      const normalBody = (await normalResponse.json()) as { topics?: unknown[] };
+      assert.equal(normalResponse.status, 200);
+      assert.ok(Array.isArray(normalBody.topics), "normal datasets should retain the topic-tree response");
+
+      const topicsNeeded = TOPIC_TREE_MAX_TOPICS + 1 - initialCount;
+      await prisma.topic.createMany({
+        data: Array.from({ length: topicsNeeded }, (_, index) => ({
+          name: `${TEST_PREFIX}${runId}-${index}`,
+          slug: `${TEST_PREFIX}${runId}-${index}`,
+        })),
+      });
+    }
+
+    await prisma.apiKey.update({
+      where: { id: apiKey.id },
+      data: { allowedScopes: [] },
+    });
+    const scopedResponse = await GET(buildGetRequest(rawKey));
+    const scopedBody = (await scopedResponse.json()) as { topics?: unknown[] };
+    assert.equal(scopedResponse.status, 200, "hidden topics must not count against a scoped caller");
+    assert.ok(Array.isArray(scopedBody.topics));
+    assert.equal(
+      JSON.stringify(scopedBody.topics).includes(`${TEST_PREFIX}${runId}`),
+      false,
+      "empty topics outside the caller's visible tree must remain hidden",
     );
 
-    const normalResponse = await GET(buildGetRequest(rawKey));
-    const normalBody = (await normalResponse.json()) as { topics?: unknown[] };
-    assert.equal(normalResponse.status, 200);
-    assert.ok(Array.isArray(normalBody.topics), "normal datasets should retain the topic-tree response");
-
-    const topicsNeeded = TOPIC_TREE_MAX_TOPICS + 1 - initialCount;
-    await prisma.topic.createMany({
-      data: Array.from({ length: topicsNeeded }, (_, index) => ({
-        name: `${TEST_PREFIX}${runId}-${index}`,
-        slug: `${TEST_PREFIX}${runId}-${index}`,
-      })),
+    await prisma.apiKey.update({
+      where: { id: apiKey.id },
+      data: { allowedScopes: ["*"] },
     });
 
     const overflowResponse = await GET(buildGetRequest(rawKey));

--- a/src/app/api/topics/route.ts
+++ b/src/app/api/topics/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { Permissions } from "@prisma/client";
+import { Permissions, type Topic } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
 import { slugify } from "@/lib/wiki";
 import { buildScopeFilter, checkRouteAuth, hasPermission, requirePermission } from "@/lib/api/auth";
@@ -18,35 +18,75 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    const allTopics = await prisma.topic.findMany({
-      take: TOPIC_TREE_MAX_TOPICS + 1,
-      orderBy: { name: "asc" },
-    });
-
-    if (allTopics.length > TOPIC_TREE_MAX_TOPICS) {
-      return NextResponse.json(
-        {
-          error: `Topic tree exceeds the supported limit of ${TOPIC_TREE_MAX_TOPICS} topics`,
-          code: "TOPIC_TREE_LIMIT_EXCEEDED",
-          maxTopics: TOPIC_TREE_MAX_TOPICS,
-        },
-        { status: 409 },
-      );
-    }
-
-    const counts = await prisma.article.groupBy({
-      by: ["topicId"],
-      _count: { id: true },
-      where: buildScopeFilter(auth.auth.allowedScopes, {
-        topicId: { in: allTopics.map((t) => t.id) },
-        deletedAt: null,
-      }),
-    });
-    const countMap = new Map(counts.map((c) => [c.topicId, c._count.id]));
     const fullAccess = auth.auth.allowedScopes?.includes("*") ?? false;
-    const visibleTopicIds = fullAccess
-      ? new Set(allTopics.map((topic) => topic.id))
-      : collectVisibleTopicIds(allTopics, countMap);
+    let allTopics: Topic[];
+    let countMap: Map<string, number>;
+
+    if (fullAccess) {
+      allTopics = await prisma.topic.findMany({
+        take: TOPIC_TREE_MAX_TOPICS + 1,
+        orderBy: { name: "asc" },
+      });
+      if (allTopics.length > TOPIC_TREE_MAX_TOPICS) {
+        return topicTreeLimitExceededResponse();
+      }
+
+      const counts = await prisma.article.groupBy({
+        by: ["topicId"],
+        _count: { id: true },
+        where: {
+          topicId: { in: allTopics.map((topic) => topic.id) },
+          deletedAt: null,
+        },
+      });
+      countMap = new Map(counts.map((count) => [count.topicId, count._count.id]));
+    } else {
+      const counts = await prisma.article.groupBy({
+        by: ["topicId"],
+        _count: { id: true },
+        where: buildScopeFilter(auth.auth.allowedScopes, { deletedAt: null }),
+        orderBy: { topicId: "asc" },
+        take: TOPIC_TREE_MAX_TOPICS + 1,
+      });
+      if (counts.length > TOPIC_TREE_MAX_TOPICS) {
+        return topicTreeLimitExceededResponse();
+      }
+
+      countMap = new Map(counts.map((count) => [count.topicId, count._count.id]));
+      const visibleTopicIds = new Set<string>();
+      let pendingIds = [...countMap.keys()];
+
+      while (pendingIds.length > 0) {
+        const remaining = TOPIC_TREE_MAX_TOPICS - visibleTopicIds.size;
+        const topics = await prisma.topic.findMany({
+          where: { id: { in: pendingIds } },
+          select: { id: true, parentId: true },
+          orderBy: { id: "asc" },
+          take: remaining + 1,
+        });
+
+        if (topics.length > remaining) {
+          return topicTreeLimitExceededResponse();
+        }
+
+        const nextIds = new Set<string>();
+        for (const topic of topics) {
+          visibleTopicIds.add(topic.id);
+          if (topic.parentId && !visibleTopicIds.has(topic.parentId)) {
+            nextIds.add(topic.parentId);
+          }
+        }
+        pendingIds = [...nextIds];
+      }
+
+      allTopics = visibleTopicIds.size === 0
+        ? []
+        : await prisma.topic.findMany({
+            where: { id: { in: [...visibleTopicIds] } },
+            orderBy: { name: "asc" },
+            take: TOPIC_TREE_MAX_TOPICS,
+          });
+    }
 
     type TopicTree = {
       id: string;
@@ -61,7 +101,6 @@ export async function GET(request: NextRequest) {
     const roots: TopicTree[] = [];
 
     for (const topic of allTopics) {
-      if (!visibleTopicIds.has(topic.id)) continue;
       topicMap.set(topic.id, {
         id: topic.id,
         name: topic.name,
@@ -89,23 +128,15 @@ export async function GET(request: NextRequest) {
   }
 }
 
-function collectVisibleTopicIds(
-  topics: Array<{ id: string; parentId: string | null }>,
-  countMap: Map<string, number>,
-): Set<string> {
-  const byId = new Map(topics.map((topic) => [topic.id, topic]));
-  const visible = new Set<string>();
-
-  for (const topicId of countMap.keys()) {
-    let current = byId.get(topicId);
-    while (current) {
-      if (visible.has(current.id)) break;
-      visible.add(current.id);
-      current = current.parentId ? byId.get(current.parentId) : undefined;
-    }
-  }
-
-  return visible;
+function topicTreeLimitExceededResponse() {
+  return NextResponse.json(
+    {
+      error: `Topic tree exceeds the supported limit of ${TOPIC_TREE_MAX_TOPICS} topics`,
+      code: "TOPIC_TREE_LIMIT_EXCEEDED",
+      maxTopics: TOPIC_TREE_MAX_TOPICS,
+    },
+    { status: 409 },
+  );
 }
 
 // POST /api/topics — Create a topic or subtopic

--- a/src/app/api/topics/route.ts
+++ b/src/app/api/topics/route.ts
@@ -5,6 +5,8 @@ import { slugify } from "@/lib/wiki";
 import { buildScopeFilter, checkRouteAuth, hasPermission, requirePermission } from "@/lib/api/auth";
 import { rateLimit } from "@/lib/rate-limit";
 
+const TOPIC_TREE_MAX_TOPICS = 500;
+
 // GET /api/topics — List all topics (existing)
 export async function GET(request: NextRequest) {
   const rl = await rateLimit(request, { windowMs: 60_000, maxRequests: 60, keyPrefix: "topics-get" });
@@ -17,8 +19,20 @@ export async function GET(request: NextRequest) {
 
   try {
     const allTopics = await prisma.topic.findMany({
+      take: TOPIC_TREE_MAX_TOPICS + 1,
       orderBy: { name: "asc" },
     });
+
+    if (allTopics.length > TOPIC_TREE_MAX_TOPICS) {
+      return NextResponse.json(
+        {
+          error: `Topic tree exceeds the supported limit of ${TOPIC_TREE_MAX_TOPICS} topics`,
+          code: "TOPIC_TREE_LIMIT_EXCEEDED",
+          maxTopics: TOPIC_TREE_MAX_TOPICS,
+        },
+        { status: 409 },
+      );
+    }
 
     const counts = await prisma.article.groupBy({
       by: ["topicId"],

--- a/src/app/api/topics/route.ts
+++ b/src/app/api/topics/route.ts
@@ -157,6 +157,15 @@ export async function POST(request: NextRequest) {
   }
 
   try {
+    const topicAtLimit = await prisma.topic.findFirst({
+      orderBy: { id: "asc" },
+      skip: TOPIC_TREE_MAX_TOPICS - 1,
+      select: { id: true },
+    });
+    if (topicAtLimit) {
+      return topicTreeLimitExceededResponse();
+    }
+
     const body = await request.json();
     const { name, slug, parentId, description } = body;
 


### PR DESCRIPTION
## Summary

- bound full-access `GET /api/topics` reads at 501 rows (500 supported topics plus one overflow sentinel)
- preserve scope filtering by bounding scoped callers against only visible article topics plus their ancestor chain
- return an explicit `409 TOPIC_TREE_LIMIT_EXCEEDED` response instead of silently emitting an incomplete hierarchy
- prevent `POST /api/topics` from creating topics after the global 500-topic ceiling is reached
- preserve the existing full-tree response for supported datasets and document the endpoint limit
- add route-level regression coverage for normal, scoped, overflow, and blocked-create behavior

## Why reject instead of truncate

A plain `take: 500` can omit a parent or descendant and produce a structurally incomplete topic tree. Sentinel queries bound database work while allowing the route to reject oversized visible trees deterministically. Scoped callers are not penalized for empty or inaccessible topics outside their visible tree.

## Verification

- focused route regression: 1/1 passed
- API suite: 288/289 passed; the only failure is the pre-existing `sync-conflict-review.test.ts` Prisma mock failure, unchanged by this PR
- `npm run typecheck`
- focused ESLint
- production `npm run build`
- `git diff --check`
- temporary database fixtures after tests: 0

Closes #144


<!-- kody-pr-summary:start -->
This pull request refines the `/api/topics` endpoint to more effectively manage and enforce the `TOPIC_TREE_MAX_TOPICS` limit, improving performance and resource utilization, especially for users with restricted access.

Specifically:
*   **Scoped Access Optimization:** For users with specific access scopes, the topic tree limit is now applied only to the topics visible within their assigned scopes and their necessary parent topics. This prevents the API from attempting to build or count an entire topic tree if only a subset is relevant to the user's permissions, ensuring that hidden topics do not contribute to the limit or resource consumption for scoped requests.
*   **Full Access Enforcement:** For users with full access, the API now immediately returns an HTTP 409 error if the total number of topics in the database exceeds the configured `TOPIC_TREE_MAX_TOPICS` limit, preventing the generation of overly large topic trees.
*   **Standardized Error Response:** A consistent error response is provided when the topic tree limit is exceeded.
*   **Robust Testing:** New tests validate that the topic limit is correctly applied for both full and scoped access scenarios, confirming that hidden topics do not affect the limit for scoped users.
<!-- kody-pr-summary:end -->