### PR TITLE
fix(api): bound legacy JSON request bodies

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,10 @@ Common endpoints:
 | `POST` | `/api/memory/get` | Fetch one memory by canonical ref or ID |
 | `POST` | `/api/memory/save` | Save a draft memory candidate |
 
+JSON write endpoints reject malformed or excessively nested payloads and return
+`413` when their route-specific body-size limit is exceeded. Most routes allow
+64 KiB; article writes allow approximately 1 MiB, and batch ingest allows 4 MiB.
+
 Example recall request:
 
 ```bash

--- a/docs/NOOSPHERE-SKILL.md
+++ b/docs/NOOSPHERE-SKILL.md
@@ -232,7 +232,11 @@ Before implementing something, check what already exists:
 - **403 Forbidden**: Key lacks required scope for this operation (e.g., status check needs ADMIN)
 - **404 Not Found**: Topic or article doesn't exist — check slugs
 - **409 Conflict**: Article slug already exists in that topic — use a different slug or update existing
+- **413 Payload Too Large**: Request body exceeds the endpoint limit or JSON nesting exceeds 20 levels
 - **503 on /api/health**: Database connectivity issue — alert and retry
+
+JSON request limits are 64 KiB for standard write endpoints, approximately
+1 MiB for single-article writes, and 4 MiB for multi-article ingest batches.
 
 ---
 

--- a/src/__tests__/api/body.test.ts
+++ b/src/__tests__/api/body.test.ts
@@ -2,10 +2,12 @@ import assert from "node:assert/strict";
 import test, { describe } from "node:test";
 import {
   safeJsonParse,
+  getJsonBodyError,
   JsonDepthExceededError,
   RequestBodyTooLargeError,
   readBoundedJsonBody,
   readBoundedJson,
+  readBoundedJsonObject,
 } from "@/lib/api/body";
 import { NextRequest } from "next/server";
 
@@ -59,6 +61,29 @@ describe("safeJsonParse", () => {
     assert.doesNotThrow(() => safeJsonParse(json));
   });
 
+  test("allows flat objects with more fields than the nesting limit", () => {
+    const flatObject = Object.fromEntries(
+      Array.from({ length: 100 }, (_, index) => [`field${index}`, index]),
+    );
+
+    assert.deepEqual(safeJsonParse(JSON.stringify(flatObject)), flatObject);
+  });
+
+  test("ignores structural characters inside JSON strings", () => {
+    const value = { content: "[[[{{{ deeply-looking but still a string }}}]]]" };
+
+    assert.deepEqual(safeJsonParse(JSON.stringify(value)), value);
+  });
+
+  test("does not let unmatched closing delimiters offset later nesting", () => {
+    const nested = `${'{"value":'.repeat(21)}0${"}".repeat(21)}`;
+
+    assert.throws(
+      () => safeJsonParse(`}${nested}`),
+      JsonDepthExceededError,
+    );
+  });
+
   test("parses nested arrays", () => {
     const result = safeJsonParse('{"items":[{"name":"a"},{"name":"b"}]}');
     assert.deepEqual(result, { items: [{ name: "a" }, { name: "b" }] });
@@ -81,6 +106,24 @@ describe("Error classes", () => {
     assert.equal(err.message, "JSON nesting depth exceeds limit");
     assert.ok(err instanceof Error);
   });
+
+  test("getJsonBodyError maps body limits to 413", () => {
+    assert.deepEqual(getJsonBodyError(new RequestBodyTooLargeError()), {
+      message: "Request body is too large",
+      status: 413,
+    });
+    assert.deepEqual(getJsonBodyError(new JsonDepthExceededError()), {
+      message: "JSON nesting depth exceeds limit",
+      status: 413,
+    });
+  });
+
+  test("getJsonBodyError maps malformed JSON to 400", () => {
+    assert.deepEqual(getJsonBodyError(new SyntaxError("Unexpected token")), {
+      message: "Invalid JSON body",
+      status: 400,
+    });
+  });
 });
 
 // ─── readBoundedJsonBody ────────────────────────────────────────────────────
@@ -96,6 +139,16 @@ describe("readBoundedJsonBody", () => {
   test("throws RequestBodyTooLargeError when body exceeds maxBytes", async () => {
     const body = "x".repeat(100);
     const req = makeRequest(body);
+    await assert.rejects(
+      () => readBoundedJsonBody(req, 50),
+      RequestBodyTooLargeError,
+    );
+  });
+
+  test("rejects an oversized Content-Length before reading the stream", async () => {
+    const req = makeRequest("{}", "application/json");
+    req.headers.set("content-length", "100");
+
     await assert.rejects(
       () => readBoundedJsonBody(req, 50),
       RequestBodyTooLargeError,
@@ -138,5 +191,21 @@ describe("readBoundedJson", () => {
   test("throws SyntaxError on invalid JSON within size limit", async () => {
     const req = makeRequest("{not-json}");
     await assert.rejects(() => readBoundedJson(req), SyntaxError);
+  });
+});
+
+describe("readBoundedJsonObject", () => {
+  test("reads JSON objects", async () => {
+    const result = await readBoundedJsonObject(makeRequest('{"key":"value"}'));
+    assert.deepEqual(result, { key: "value" });
+  });
+
+  test("rejects null, arrays, and primitive JSON values", async () => {
+    for (const body of ["null", "[]", '"text"', "42"]) {
+      await assert.rejects(
+        () => readBoundedJsonObject(makeRequest(body)),
+        SyntaxError,
+      );
+    }
   });
 });

--- a/src/__tests__/api/bounded-json-routes.integration.test.ts
+++ b/src/__tests__/api/bounded-json-routes.integration.test.ts
@@ -1,0 +1,124 @@
+import assert from "node:assert/strict";
+import crypto from "node:crypto";
+import test from "node:test";
+import { NextRequest } from "next/server";
+import {
+  DEFAULT_JSON_BODY_MAX_BYTES,
+  MAX_JSON_DEPTH,
+} from "@/lib/api/body";
+import { ARTICLE_LIMITS } from "@/lib/validation";
+
+if (!process.env.DATABASE_URL) {
+  throw new Error("DATABASE_URL environment variable must be set for tests");
+}
+
+const TEST_PREFIX = "test-issue192-";
+const TEST_CLIENT_IP = `10.92.${Math.floor(Math.random() * 254) + 1}.${Math.floor(Math.random() * 254) + 1}`;
+
+function buildRequest(
+  rawKey: string,
+  pathname: string,
+  body?: string,
+  method = "POST",
+): NextRequest {
+  return new NextRequest(`http://localhost${pathname}`, {
+    method,
+    headers: {
+      Authorization: `Bearer ${rawKey}`,
+      "Content-Type": "application/json",
+      "x-real-ip": TEST_CLIENT_IP,
+    },
+    body,
+  });
+}
+
+test("legacy JSON routes enforce size and nesting limits (issue #192)", async () => {
+  const { prisma } = await import("@/lib/prisma");
+  const { POST: lint } = await import("@/app/api/lint/route");
+  const { POST: createArticle } = await import("@/app/api/articles/route");
+  const { PATCH: updateKey } = await import("@/app/api/keys/[id]/route");
+  const runId = crypto.randomUUID();
+  const rawKey = `noo_${crypto.randomBytes(32).toString("base64url")}`;
+  const keyHash = crypto.createHash("sha256").update(rawKey).digest("hex");
+
+  const apiKey = await prisma.apiKey.create({
+    data: {
+      name: `${TEST_PREFIX}${runId}`,
+      keyHash,
+      keyPrefix: rawKey.slice(0, 8),
+      permissions: "ADMIN",
+      allowedScopes: ["*"],
+    },
+  });
+
+  try {
+    const emptyResponse = await lint(buildRequest(rawKey, "/api/lint"));
+    assert.equal(emptyResponse.status, 200);
+
+    const malformedResponse = await lint(
+      buildRequest(rawKey, "/api/lint", "not-json"),
+    );
+    assert.equal(malformedResponse.status, 400);
+    assert.equal(
+      ((await malformedResponse.json()) as { error: string }).error,
+      "Invalid JSON body",
+    );
+
+    const nullObjectResponse = await updateKey(
+      buildRequest(rawKey, `/api/keys/${apiKey.id}`, "null", "PATCH"),
+      { params: Promise.resolve({ id: apiKey.id }) },
+    );
+    assert.equal(nullObjectResponse.status, 400);
+    assert.equal(
+      ((await nullObjectResponse.json()) as { error: string }).error,
+      "Invalid JSON body",
+    );
+
+    const oversizedDefaultBody = JSON.stringify({
+      padding: "x".repeat(DEFAULT_JSON_BODY_MAX_BYTES),
+    });
+    const oversizedResponse = await lint(
+      buildRequest(rawKey, "/api/lint", oversizedDefaultBody),
+    );
+    assert.equal(oversizedResponse.status, 413);
+    assert.equal(
+      ((await oversizedResponse.json()) as { error: string }).error,
+      "Request body is too large",
+    );
+
+    const deeplyNestedBody = `${'{"nested":'.repeat(MAX_JSON_DEPTH + 1)}0${"}".repeat(MAX_JSON_DEPTH + 1)}`;
+    const nestedResponse = await lint(
+      buildRequest(rawKey, "/api/lint", deeplyNestedBody),
+    );
+    assert.equal(nestedResponse.status, 413);
+    assert.equal(
+      ((await nestedResponse.json()) as { error: string }).error,
+      "JSON nesting depth exceeds limit",
+    );
+
+    const validLargeArticleBody = JSON.stringify({
+      title: "Large article",
+      slug: `large-article-${runId}`,
+      content: "x".repeat(DEFAULT_JSON_BODY_MAX_BYTES + 1),
+      topicId: `missing-${runId}`,
+    });
+    const validLargeResponse = await createArticle(
+      buildRequest(rawKey, "/api/articles", validLargeArticleBody),
+    );
+    assert.equal(validLargeResponse.status, 404);
+
+    const oversizedArticleBody = JSON.stringify({
+      // One byte beyond the route's documented content-plus-metadata allowance
+      // makes this a body-reader boundary assertion, not content validation.
+      content: "x".repeat(
+        ARTICLE_LIMITS.maxContentSize + DEFAULT_JSON_BODY_MAX_BYTES + 1,
+      ),
+    });
+    const oversizedArticleResponse = await createArticle(
+      buildRequest(rawKey, "/api/articles", oversizedArticleBody),
+    );
+    assert.equal(oversizedArticleResponse.status, 413);
+  } finally {
+    await prisma.apiKey.delete({ where: { id: apiKey.id } });
+  }
+});

--- a/src/__tests__/api/bounded-json-routes.test.ts
+++ b/src/__tests__/api/bounded-json-routes.test.ts
@@ -28,3 +28,22 @@ for (const routePath of JSON_BODY_ROUTES) {
     assert.match(source, /readBoundedJson(?:Object)?(?:<[^>]+>)?\s*\(/);
   });
 }
+
+// Sync routes read the body as text (they run domain-specific text validators
+// before parsing), so they use the depth-guarded `safeJsonParse` rather than
+// the streaming `readBoundedJson` reader. Guard against regression to a raw
+// `JSON.parse`, which would skip the nesting-depth check.
+const SYNC_JSON_ROUTES = [
+  "src/app/api/sync/import-apply/route.ts",
+  "src/app/api/sync/import-scan/route.ts",
+  "src/app/api/sync/conflict-preferences/route.ts",
+] as const;
+
+for (const routePath of SYNC_JSON_ROUTES) {
+  test(`${routePath} uses the depth-guarded JSON parser`, async () => {
+    const source = await readFile(path.join(process.cwd(), routePath), "utf8");
+
+    assert.doesNotMatch(source, /JSON\.parse\s*\(/);
+    assert.match(source, /safeJsonParse\s*\(/);
+  });
+}

--- a/src/__tests__/api/bounded-json-routes.test.ts
+++ b/src/__tests__/api/bounded-json-routes.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+
+const JSON_BODY_ROUTES = [
+  "src/app/api/tags/route.ts",
+  "src/app/api/tags/[id]/route.ts",
+  "src/app/api/answer/route.ts",
+  "src/app/api/scopes/route.ts",
+  "src/app/api/keys/route.ts",
+  "src/app/api/ingest/route.ts",
+  "src/app/api/keys/[id]/route.ts",
+  "src/app/api/lint/route.ts",
+  "src/app/api/memory/settings/route.ts",
+  "src/app/api/sync/obsidian/route.ts",
+  "src/app/api/topics/route.ts",
+  "src/app/api/articles/route.ts",
+  "src/app/api/topics/[id]/route.ts",
+  "src/app/api/articles/[id]/route.ts",
+] as const;
+
+for (const routePath of JSON_BODY_ROUTES) {
+  test(`${routePath} uses the bounded JSON parser`, async () => {
+    const source = await readFile(path.join(process.cwd(), routePath), "utf8");
+
+    assert.doesNotMatch(source, /request\.json\s*\(/);
+    assert.match(source, /readBoundedJson(?:Object)?(?:<[^>]+>)?\s*\(/);
+  });
+}

--- a/src/app/api/answer/route.ts
+++ b/src/app/api/answer/route.ts
@@ -2,8 +2,14 @@ import { NextRequest, NextResponse } from "next/server";
 import { Permissions } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
 import { requirePermission } from "@/lib/api/auth";
+import {
+  DEFAULT_JSON_BODY_MAX_BYTES,
+  getJsonBodyError,
+  readBoundedJsonObject,
+} from "@/lib/api/body";
 import { apiError } from "@/lib/api/errors";
 import {
+  ARTICLE_LIMITS,
   deriveExcerpt,
   isValidConfidence,
   isValidStatus,
@@ -15,6 +21,8 @@ import { invalidateSearchCache } from "@/lib/cache/search-cache";
 import { slugify } from "@/lib/wiki";
 
 const ANSWER_SLUG_MAX_LENGTH = 80;
+const ANSWER_JSON_BODY_MAX_BYTES =
+  ARTICLE_LIMITS.maxContentSize + DEFAULT_JSON_BODY_MAX_BYTES;
 
 // POST /api/answer — Save a synthesized answer as a new wiki article
 // Auth: API key (WRITE/ADMIN) or session (EDITOR/ADMIN)
@@ -58,9 +66,13 @@ export async function POST(request: NextRequest) {
   };
 
   try {
-    body = await request.json();
-  } catch {
-    return apiError("Invalid JSON body", 400);
+    body = await readBoundedJsonObject<typeof body>(
+      request,
+      ANSWER_JSON_BODY_MAX_BYTES,
+    );
+  } catch (error) {
+    const bodyError = getJsonBodyError(error);
+    return apiError(bodyError.message, bodyError.status);
   }
 
   const { title, content, topicId, excerpt, tags, sourceQuery, confidence, status, authorName: rawAuthorName } = body;

--- a/src/app/api/articles/[id]/route.ts
+++ b/src/app/api/articles/[id]/route.ts
@@ -2,6 +2,11 @@ import { NextRequest, NextResponse } from "next/server";
 import { Permissions } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
 import { requirePermission, canAccessScopes } from "@/lib/api/auth";
+import {
+  DEFAULT_JSON_BODY_MAX_BYTES,
+  getJsonBodyError,
+  readBoundedJsonObject,
+} from "@/lib/api/body";
 import { buildTagConnections } from "@/lib/wiki";
 import {
   syncArticleRelations,
@@ -18,6 +23,9 @@ import {
 import { invalidateSearchCache } from "@/lib/cache/search-cache";
 import { rateLimit } from "@/lib/rate-limit";
 import { resolvePatchRestrictedTags } from "@/lib/api/restricted-scopes";
+
+const ARTICLE_JSON_BODY_MAX_BYTES =
+  ARTICLE_LIMITS.maxContentSize + DEFAULT_JSON_BODY_MAX_BYTES;
 
 // PATCH /api/articles/[id] — Update article
 // Auth: API key (WRITE/ADMIN) or session (EDITOR/ADMIN)
@@ -50,7 +58,31 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
       return NextResponse.json({ error: "Article not found" }, { status: 404 });
     }
 
-    const body = await request.json();
+    let body: {
+      title?: string;
+      slug?: string;
+      content?: string;
+      excerpt?: string | null;
+      topicId?: string;
+      tags?: string[];
+      confidence?: string;
+      status?: string;
+      relatedArticleIds?: string[];
+      lastReviewed?: string | number | null;
+      restrictedTags?: unknown;
+    };
+    try {
+      body = await readBoundedJsonObject<typeof body>(
+        request,
+        ARTICLE_JSON_BODY_MAX_BYTES,
+      );
+    } catch (error) {
+      const bodyError = getJsonBodyError(error);
+      return NextResponse.json(
+        { error: bodyError.message },
+        { status: bodyError.status },
+      );
+    }
     const {
       title,
       slug,

--- a/src/app/api/articles/route.ts
+++ b/src/app/api/articles/route.ts
@@ -2,6 +2,11 @@ import { NextRequest, NextResponse } from "next/server";
 import { Permissions } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
 import { requirePermission, buildScopeFilter } from "@/lib/api/auth";
+import {
+  DEFAULT_JSON_BODY_MAX_BYTES,
+  getJsonBodyError,
+  readBoundedJsonObject,
+} from "@/lib/api/body";
 import { resolveRestrictedTagsForCaller } from "@/lib/api/restricted-scopes";
 import { buildTagConnections, countSearchArticles, searchArticleIds } from "@/lib/wiki";
 import { detectSecretInInputs } from "@/lib/memory/api/save";
@@ -19,6 +24,9 @@ import {
 } from "@/lib/validation";
 import { parsePagination } from "@/lib/pagination";
 import { rateLimit } from "@/lib/rate-limit";
+
+const ARTICLE_JSON_BODY_MAX_BYTES =
+  ARTICLE_LIMITS.maxContentSize + DEFAULT_JSON_BODY_MAX_BYTES;
 
 // GET /api/articles — List articles (with filters)
 // Auth: API key (READ/WRITE/ADMIN) or session (human)
@@ -191,7 +199,31 @@ export async function POST(request: NextRequest) {
   }
 
   try {
-    const body = await request.json();
+    let body: {
+      title?: string;
+      slug?: string;
+      content?: string;
+      topicId?: string;
+      tags?: string[];
+      excerpt?: string | null;
+      authorName?: string;
+      confidence?: string;
+      status?: string;
+      relatedArticleIds?: string[];
+      restrictedTags?: unknown;
+    };
+    try {
+      body = await readBoundedJsonObject<typeof body>(
+        request,
+        ARTICLE_JSON_BODY_MAX_BYTES,
+      );
+    } catch (error) {
+      const bodyError = getJsonBodyError(error);
+      return NextResponse.json(
+        { error: bodyError.message },
+        { status: bodyError.status },
+      );
+    }
     const { title, slug, content, topicId, tags, excerpt, authorName, confidence, status, relatedArticleIds, restrictedTags } = body;
 
     // Validate relatedArticleIds is an array of valid CUIDs
@@ -266,7 +298,7 @@ export async function POST(request: NextRequest) {
     const secretError = detectSecretInInputs([
       { field: "title", value: title },
       { field: "content", value: content },
-      { field: "excerpt", value: excerpt },
+      { field: "excerpt", value: excerpt ?? undefined },
       { field: "authorName", value: authorName },
       ...(Array.isArray(tags)
         ? tags.map((value) => ({ field: "tags", value: typeof value === "string" ? value : undefined }))

--- a/src/app/api/ingest/route.ts
+++ b/src/app/api/ingest/route.ts
@@ -2,11 +2,21 @@ import { NextRequest, NextResponse } from "next/server";
 import { Permissions } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
 import { requirePermission } from "@/lib/api/auth";
+import {
+  DEFAULT_JSON_BODY_MAX_BYTES,
+  getJsonBodyError,
+  readBoundedJsonObject,
+} from "@/lib/api/body";
 import { apiError } from "@/lib/api/errors";
 import { ARTICLE_LIMITS, deriveExcerpt, sanitizeAuthorName } from "@/lib/validation";
 import { rateLimit } from "@/lib/rate-limit";
 import { invalidateSearchCache } from "@/lib/cache/search-cache";
 import { filterAccessibleRelatedTargets } from "@/lib/articles/relations";
+
+// Ingest is a multi-article batch endpoint, so it needs more headroom than a
+// single article while still rejecting payloads large enough to amplify work.
+const INGEST_JSON_BODY_MAX_BYTES =
+  ARTICLE_LIMITS.maxContentSize * 4 + DEFAULT_JSON_BODY_MAX_BYTES;
 
 // POST /api/ingest — Process a source into multiple wiki articles
 // Auth: API key (WRITE/ADMIN) or session (EDITOR/ADMIN)
@@ -63,9 +73,13 @@ export async function POST(request: NextRequest) {
   };
 
   try {
-    body = await request.json();
-  } catch {
-    return apiError("Invalid JSON body", 400);
+    body = await readBoundedJsonObject<typeof body>(
+      request,
+      INGEST_JSON_BODY_MAX_BYTES,
+    );
+  } catch (error) {
+    const bodyError = getJsonBodyError(error);
+    return apiError(bodyError.message, bodyError.status);
   }
 
   const { source, articles, tags: globalTags } = body;

--- a/src/app/api/keys/[id]/route.ts
+++ b/src/app/api/keys/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { Permissions } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
 import { requirePermission } from "@/lib/api/auth";
+import { getJsonBodyError, readBoundedJsonObject } from "@/lib/api/body";
 import { rateLimit } from "@/lib/rate-limit";
 
 // GET /api/keys/[id] — Get a single key's metadata
@@ -55,7 +56,16 @@ export async function PATCH(
   }
 
   try {
-    const body = await request.json();
+    let body: Record<string, unknown>;
+    try {
+      body = await readBoundedJsonObject(request);
+    } catch (error) {
+      const bodyError = getJsonBodyError(error);
+      return NextResponse.json(
+        { error: bodyError.message },
+        { status: bodyError.status },
+      );
+    }
     const { allowedScopes, permissions, name } = body;
 
     const existing = await prisma.apiKey.findFirst({
@@ -79,10 +89,13 @@ export async function PATCH(
     }
 
     if (permissions !== undefined) {
-      if (!["READ", "WRITE", "ADMIN"].includes(permissions)) {
+      if (
+        typeof permissions !== "string" ||
+        !["READ", "WRITE", "ADMIN"].includes(permissions)
+      ) {
         return NextResponse.json({ error: "permissions must be READ, WRITE, or ADMIN" }, { status: 400 });
       }
-      updateData.permissions = permissions;
+      updateData.permissions = permissions as Permissions;
     }
 
     if (allowedScopes !== undefined) {
@@ -103,7 +116,7 @@ export async function PATCH(
           );
         }
       }
-      updateData.allowedScopes = allowedScopes;
+      updateData.allowedScopes = allowedScopes as string[];
     }
 
     if (Object.keys(updateData).length === 0) {

--- a/src/app/api/keys/route.ts
+++ b/src/app/api/keys/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { Permissions } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
 import { requirePermission } from "@/lib/api/auth";
+import { getJsonBodyError, readBoundedJsonObject } from "@/lib/api/body";
 import { generateApiKey } from "@/lib/api/keys";
 import { rateLimit } from "@/lib/rate-limit";
 
@@ -45,7 +46,17 @@ export async function POST(request: NextRequest) {
   }
 
   try {
-    const { name, permissions, allowedScopes } = await request.json();
+    let body: Record<string, unknown>;
+    try {
+      body = await readBoundedJsonObject(request);
+    } catch (error) {
+      const bodyError = getJsonBodyError(error);
+      return NextResponse.json(
+        { error: bodyError.message },
+        { status: bodyError.status },
+      );
+    }
+    const { name, permissions, allowedScopes } = body;
 
     if (!name || typeof name !== "string" || !name.trim()) {
       return NextResponse.json({ error: "name is required and must be a non-empty string" }, { status: 400 });
@@ -58,7 +69,10 @@ export async function POST(request: NextRequest) {
     }
 
     if (permissions !== undefined) {
-      if (!["READ", "WRITE", "ADMIN"].includes(permissions)) {
+      if (
+        typeof permissions !== "string" ||
+        !["READ", "WRITE", "ADMIN"].includes(permissions)
+      ) {
         return NextResponse.json({ error: "permissions must be READ, WRITE, or ADMIN" }, { status: 400 });
       }
     }
@@ -92,7 +106,7 @@ export async function POST(request: NextRequest) {
         keyHash: hash,
         keyPrefix: prefix,
         permissions: (permissions as Permissions) ?? Permissions.WRITE,
-        allowedScopes: allowedScopes ?? [],
+        allowedScopes: (allowedScopes as string[] | undefined) ?? [],
       },
       select: {
         id: true,

--- a/src/app/api/lint/route.ts
+++ b/src/app/api/lint/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { Permissions } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
 import { requirePermission, buildScopeFilter } from "@/lib/api/auth";
+import { getJsonBodyError, readBoundedJsonObject } from "@/lib/api/body";
 import { rateLimit } from "@/lib/rate-limit";
 import { parseLintOptions } from "@/lib/lint-options";
 
@@ -44,10 +45,16 @@ export async function POST(request: NextRequest) {
 
   // --- Parse options ---
   let body: { staleDays?: unknown; tagMin?: unknown; maxArticles?: unknown } = {};
-  try {
-    body = await request.json();
-  } catch {
-    // No body — use defaults
+  if (request.body) {
+    try {
+      body = await readBoundedJsonObject<typeof body>(request);
+    } catch (error) {
+      const bodyError = getJsonBodyError(error);
+      return NextResponse.json(
+        { error: bodyError.message },
+        { status: bodyError.status },
+      );
+    }
   }
 
   const lintOptions = parseLintOptions(body);

--- a/src/app/api/memory/settings/route.ts
+++ b/src/app/api/memory/settings/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { Permissions } from "@prisma/client";
 import { requirePermission } from "@/lib/api/auth";
+import { getJsonBodyError, readBoundedJson } from "@/lib/api/body";
 import { getRecallSettingsFromDB, upsertRecallSettings } from "@/lib/memory/api/settings";
 import type { RecallSettings } from "@/lib/memory/settings";
 import { rateLimit } from "@/lib/rate-limit";
@@ -68,11 +69,12 @@ export async function POST(request: NextRequest) {
 
   let body: unknown;
   try {
-    body = await request.json();
-  } catch {
+    body = await readBoundedJson(request, SETTINGS_MAX_BODY_BYTES);
+  } catch (error) {
+    const bodyError = getJsonBodyError(error);
     return NextResponse.json(
-      { error: "Invalid JSON body" },
-      { status: 400 },
+      { error: bodyError.message },
+      { status: bodyError.status },
     );
   }
 

--- a/src/app/api/memory/settings/route.ts
+++ b/src/app/api/memory/settings/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { Permissions } from "@prisma/client";
 import { requirePermission } from "@/lib/api/auth";
-import { getJsonBodyError, readBoundedJson } from "@/lib/api/body";
+import { getJsonBodyError, readBoundedJsonObject } from "@/lib/api/body";
 import { getRecallSettingsFromDB, upsertRecallSettings } from "@/lib/memory/api/settings";
 import type { RecallSettings } from "@/lib/memory/settings";
 import { rateLimit } from "@/lib/rate-limit";
@@ -53,35 +53,14 @@ export async function POST(request: NextRequest) {
     return auth.response;
   }
 
-  // Reject oversized bodies
-  const contentLength = request.headers.get("content-length");
-  if (
-    contentLength !== null &&
-    parseInt(contentLength, 10) > SETTINGS_MAX_BODY_BYTES
-  ) {
-    return NextResponse.json(
-      {
-        error: `Request body too large. Maximum size is ${SETTINGS_MAX_BODY_BYTES} bytes.`,
-      },
-      { status: 413 },
-    );
-  }
-
-  let body: unknown;
+  let body: Record<string, unknown>;
   try {
-    body = await readBoundedJson(request, SETTINGS_MAX_BODY_BYTES);
+    body = await readBoundedJsonObject(request, SETTINGS_MAX_BODY_BYTES);
   } catch (error) {
     const bodyError = getJsonBodyError(error);
     return NextResponse.json(
       { error: bodyError.message },
       { status: bodyError.status },
-    );
-  }
-
-  if (typeof body !== "object" || body === null || Array.isArray(body)) {
-    return NextResponse.json(
-      { error: "Body must be a JSON object" },
-      { status: 400 },
     );
   }
 

--- a/src/app/api/scopes/route.ts
+++ b/src/app/api/scopes/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { Permissions } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
 import { requirePermission } from "@/lib/api/auth";
+import { getJsonBodyError, readBoundedJsonObject } from "@/lib/api/body";
 import { rateLimit } from "@/lib/rate-limit";
 
 // GET /api/scopes — List all available restricted scopes
@@ -35,7 +36,17 @@ export async function POST(request: NextRequest) {
   }
 
   try {
-    const { tag, description } = await request.json();
+    let body: Record<string, unknown>;
+    try {
+      body = await readBoundedJsonObject(request);
+    } catch (error) {
+      const bodyError = getJsonBodyError(error);
+      return NextResponse.json(
+        { error: bodyError.message },
+        { status: bodyError.status },
+      );
+    }
+    const { tag, description } = body;
 
     if (!tag || typeof tag !== "string") {
       return NextResponse.json({ error: "tag is required and must be a string" }, { status: 400 });

--- a/src/app/api/sync/conflict-preferences/route.ts
+++ b/src/app/api/sync/conflict-preferences/route.ts
@@ -22,6 +22,7 @@ import {
   validateSyncConflictPreferencesUpdate,
 } from "@/lib/markdown-sync/conflict-preferences";
 import { rateLimit } from "@/lib/rate-limit";
+import { JsonDepthExceededError, safeJsonParse } from "@/lib/api/body";
 
 export async function GET(request: NextRequest) {
   const rl = await rateLimit(request, { windowMs: 60_000, maxRequests: 60, keyPrefix: "sync-conflict-preferences-get" });
@@ -64,8 +65,14 @@ export async function POST(request: NextRequest) {
         { status: 413 },
       );
     }
-    body = JSON.parse(bodyText);
-  } catch {
+    body = safeJsonParse(bodyText);
+  } catch (error) {
+    if (error instanceof JsonDepthExceededError) {
+      return NextResponse.json(
+        { error: error.message },
+        { status: 413 },
+      );
+    }
     return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
   }
 

--- a/src/app/api/sync/import-apply/route.ts
+++ b/src/app/api/sync/import-apply/route.ts
@@ -14,6 +14,7 @@ import { requirePermission } from "@/lib/api/auth";
 import { getObsidianSyncConfig } from "@/lib/obsidian-sync/config";
 import { rateLimit } from "@/lib/rate-limit";
 import { prisma } from "@/lib/prisma";
+import { JsonDepthExceededError, safeJsonParse } from "@/lib/api/body";
 import { loadManifest } from "@/lib/markdown-sync/manifest";
 import {
   applyMarkdownImports,
@@ -55,11 +56,17 @@ export async function POST(request: NextRequest) {
         { status: 413 }
       );
     }
-    body = JSON.parse(rawBody);
-  } catch {
+    body = safeJsonParse(rawBody) as ImportApplyRequestBody;
+  } catch (error) {
+    if (error instanceof JsonDepthExceededError) {
+      return NextResponse.json(
+        { success: false, error: error.message },
+        { status: 413 },
+      );
+    }
     return NextResponse.json(
       { success: false, error: "Invalid JSON body." },
-      { status: 400 }
+      { status: 400 },
     );
   }
 

--- a/src/app/api/sync/import-scan/route.ts
+++ b/src/app/api/sync/import-scan/route.ts
@@ -19,6 +19,7 @@ import {
   validateMarkdownImportScanRequestBody,
 } from "@/lib/markdown-sync/import-scanner";
 import { rateLimit } from "@/lib/rate-limit";
+import { JsonDepthExceededError, safeJsonParse } from "@/lib/api/body";
 
 export async function POST(request: NextRequest) {
   const rl = await rateLimit(request, { windowMs: 60_000, maxRequests: 20, keyPrefix: "sync-import-scan-post" });
@@ -56,9 +57,15 @@ export async function POST(request: NextRequest) {
       if (!bodyTextValidation.ok) {
         return NextResponse.json({ error: bodyTextValidation.error }, { status: bodyTextValidation.status });
       }
-      body = JSON.parse(bodyText);
+      body = safeJsonParse(bodyText);
     }
-  } catch {
+  } catch (error) {
+    if (error instanceof JsonDepthExceededError) {
+      return NextResponse.json(
+        { error: error.message },
+        { status: 413 },
+      );
+    }
     return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
   }
 

--- a/src/app/api/sync/obsidian/route.ts
+++ b/src/app/api/sync/obsidian/route.ts
@@ -10,6 +10,7 @@ export const dynamic = "force-dynamic";
 import { NextRequest, NextResponse } from "next/server";
 import { Permissions } from "@prisma/client";
 import { requirePermission } from "@/lib/api/auth";
+import { getJsonBodyError, readBoundedJsonObject } from "@/lib/api/body";
 import { getObsidianSyncConfig } from "@/lib/obsidian-sync/config";
 import { runObsidianSync, SyncConflictError } from "@/lib/obsidian-sync";
 import type { SyncOptions } from "@/lib/obsidian-sync";
@@ -77,9 +78,13 @@ export async function POST(request: NextRequest) {
   // Parse request body
   let body: Record<string, unknown>;
   try {
-    body = await request.json();
-  } catch {
-    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+    body = await readBoundedJsonObject(request);
+  } catch (error) {
+    const bodyError = getJsonBodyError(error);
+    return NextResponse.json(
+      { error: bodyError.message },
+      { status: bodyError.status },
+    );
   }
 
   const mode = body["mode"] === "full" || body["full"] === true ? "full" : "incremental";

--- a/src/app/api/tags/[id]/route.ts
+++ b/src/app/api/tags/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { slugify } from "@/lib/wiki";
 import { checkRouteAuth } from "@/lib/api/auth";
+import { getJsonBodyError, readBoundedJsonObject } from "@/lib/api/body";
 import { rateLimit } from "@/lib/rate-limit";
 import { invalidateSearchCache } from "@/lib/cache/search-cache";
 
@@ -25,7 +26,16 @@ export async function PATCH(request: NextRequest, { params }: Props) {
   const { id } = await params;
 
   try {
-    const body = await request.json();
+    let body: Record<string, unknown>;
+    try {
+      body = await readBoundedJsonObject(request);
+    } catch (error) {
+      const bodyError = getJsonBodyError(error);
+      return NextResponse.json(
+        { error: bodyError.message },
+        { status: bodyError.status },
+      );
+    }
     const { name } = body;
 
     if (!name || typeof name !== "string" || !name.trim()) {

--- a/src/app/api/tags/route.ts
+++ b/src/app/api/tags/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { slugify } from "@/lib/wiki";
 import { checkRouteAuth } from "@/lib/api/auth";
+import { getJsonBodyError, readBoundedJsonObject } from "@/lib/api/body";
 import { rateLimit } from "@/lib/rate-limit";
 
 // GET /api/tags — List all tags with article counts
@@ -46,7 +47,16 @@ export async function POST(request: NextRequest) {
   }
 
   try {
-    const body = await request.json();
+    let body: Record<string, unknown>;
+    try {
+      body = await readBoundedJsonObject(request);
+    } catch (error) {
+      const bodyError = getJsonBodyError(error);
+      return NextResponse.json(
+        { error: bodyError.message },
+        { status: bodyError.status },
+      );
+    }
     const { name } = body;
 
     if (!name || typeof name !== "string" || !name.trim()) {

--- a/src/app/api/topics/[id]/route.ts
+++ b/src/app/api/topics/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { slugify } from "@/lib/wiki";
 import { checkRouteAuth } from "@/lib/api/auth";
+import { getJsonBodyError, readBoundedJsonObject } from "@/lib/api/body";
 import { rateLimit } from "@/lib/rate-limit";
 import { invalidateSearchCache } from "@/lib/cache/search-cache";
 
@@ -40,7 +41,21 @@ export async function PATCH(request: NextRequest, { params }: Props) {
   const { id } = await params;
 
   try {
-    const body = await request.json();
+    let body: {
+      name?: string;
+      slug?: string;
+      parentId?: string | null;
+      description?: unknown;
+    };
+    try {
+      body = await readBoundedJsonObject<typeof body>(request);
+    } catch (error) {
+      const bodyError = getJsonBodyError(error);
+      return NextResponse.json(
+        { error: bodyError.message },
+        { status: bodyError.status },
+      );
+    }
     const { name, slug, parentId, description } = body;
 
     const existing = await prisma.topic.findUnique({ where: { id } });

--- a/src/app/api/topics/route.ts
+++ b/src/app/api/topics/route.ts
@@ -3,6 +3,7 @@ import { Permissions, type Topic } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
 import { slugify } from "@/lib/wiki";
 import { buildScopeFilter, checkRouteAuth, hasPermission, requirePermission } from "@/lib/api/auth";
+import { getJsonBodyError, readBoundedJsonObject } from "@/lib/api/body";
 import { rateLimit } from "@/lib/rate-limit";
 
 const TOPIC_TREE_MAX_TOPICS = 500;
@@ -166,7 +167,21 @@ export async function POST(request: NextRequest) {
       return topicTreeLimitExceededResponse();
     }
 
-    const body = await request.json();
+    let body: {
+      name?: unknown;
+      slug?: string;
+      parentId?: string | null;
+      description?: unknown;
+    };
+    try {
+      body = await readBoundedJsonObject<typeof body>(request);
+    } catch (error) {
+      const bodyError = getJsonBodyError(error);
+      return NextResponse.json(
+        { error: bodyError.message },
+        { status: bodyError.status },
+      );
+    }
     const { name, slug, parentId, description } = body;
 
     if (!name || typeof name !== "string" || !name.trim()) {

--- a/src/lib/api/body.ts
+++ b/src/lib/api/body.ts
@@ -63,15 +63,11 @@ export function getJsonBodyError(error: unknown): {
   message: string;
   status: 400 | 413;
 } {
-  // Match by `name` rather than `instanceof` so the 413 mapping survives
-  // module-duplication or realm boundaries that break instanceof identity.
   if (
-    typeof error === "object" &&
-    error !== null &&
-    ((error as { name?: string }).name === "RequestBodyTooLargeError" ||
-      (error as { name?: string }).name === "JsonDepthExceededError")
+    error instanceof RequestBodyTooLargeError ||
+    error instanceof JsonDepthExceededError
   ) {
-    return { message: (error as Error).message, status: 413 };
+    return { message: error.message, status: 413 };
   }
 
   return { message: "Invalid JSON body", status: 400 };

--- a/src/lib/api/body.ts
+++ b/src/lib/api/body.ts
@@ -1,5 +1,7 @@
 import { NextRequest } from "next/server";
 
+export const DEFAULT_JSON_BODY_MAX_BYTES = 64 * 1024;
+
 export class RequestBodyTooLargeError extends Error {
   constructor() {
     super("Request body is too large");
@@ -19,8 +21,13 @@ function concatChunks(chunks: Uint8Array[], totalBytes: number): Uint8Array {
 
 export async function readBoundedJsonBody(
   request: NextRequest,
-  maxBytes: number = 64 * 1024,
+  maxBytes: number = DEFAULT_JSON_BODY_MAX_BYTES,
 ): Promise<string> {
+  const contentLength = Number(request.headers.get("content-length"));
+  if (Number.isFinite(contentLength) && contentLength > maxBytes) {
+    throw new RequestBodyTooLargeError();
+  }
+
   const reader = request.body?.getReader();
   if (!reader) return "";
 
@@ -32,7 +39,7 @@ export async function readBoundedJsonBody(
     if (done) break;
     totalBytes += value.byteLength;
     if (totalBytes > maxBytes) {
-      await reader.cancel();
+      await reader.cancel().catch(() => undefined);
       throw new RequestBodyTooLargeError();
     }
     chunks.push(value);
@@ -41,7 +48,7 @@ export async function readBoundedJsonBody(
   return new TextDecoder().decode(concatChunks(chunks, totalBytes));
 }
 
-const MAX_JSON_DEPTH = 20;
+export const MAX_JSON_DEPTH = 20;
 
 export class JsonDepthExceededError extends Error {
   constructor() {
@@ -50,18 +57,59 @@ export class JsonDepthExceededError extends Error {
   }
 }
 
+export function getJsonBodyError(error: unknown): {
+  message: string;
+  status: 400 | 413;
+} {
+  if (
+    error instanceof RequestBodyTooLargeError ||
+    error instanceof JsonDepthExceededError
+  ) {
+    return { message: error.message, status: 413 };
+  }
+
+  return { message: "Invalid JSON body", status: 400 };
+}
+
+function assertJsonDepth(raw: string): void {
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+
+  for (const character of raw) {
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (character === "\\") {
+        escaped = true;
+      } else if (character === '"') {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (character === '"') {
+      inString = true;
+    } else if (character === "{" || character === "[") {
+      depth += 1;
+      if (depth > MAX_JSON_DEPTH) {
+        throw new JsonDepthExceededError();
+      }
+    } else if (character === "}" || character === "]") {
+      // Malformed closing delimiters must not offset later nesting and weaken
+      // the guard. JSON.parse will still report the malformed payload.
+      depth = Math.max(0, depth - 1);
+    }
+  }
+}
+
 /**
  * Parse JSON with a nesting-depth guard to prevent CPU exhaustion
  * from deeply nested payloads (e.g. 30KB of brackets).
  */
 export function safeJsonParse(raw: string): unknown {
-  let depth = 0;
-  return JSON.parse(raw, (_key, value: unknown) => {
-    if (depth++ > MAX_JSON_DEPTH) {
-      throw new JsonDepthExceededError();
-    }
-    return value;
-  });
+  assertJsonDepth(raw);
+  return JSON.parse(raw);
 }
 
 /**
@@ -70,8 +118,19 @@ export function safeJsonParse(raw: string): unknown {
  */
 export async function readBoundedJson(
   request: NextRequest,
-  maxBytes: number = 64 * 1024,
+  maxBytes: number = DEFAULT_JSON_BODY_MAX_BYTES,
 ): Promise<unknown> {
   const rawBody = await readBoundedJsonBody(request, maxBytes);
   return safeJsonParse(rawBody);
+}
+
+export async function readBoundedJsonObject<T extends object = Record<string, unknown>>(
+  request: NextRequest,
+  maxBytes: number = DEFAULT_JSON_BODY_MAX_BYTES,
+): Promise<T> {
+  const body = await readBoundedJson(request, maxBytes);
+  if (typeof body !== "object" || body === null || Array.isArray(body)) {
+    throw new SyntaxError("JSON body must be an object");
+  }
+  return body as T;
 }

--- a/src/lib/api/body.ts
+++ b/src/lib/api/body.ts
@@ -23,6 +23,8 @@ export async function readBoundedJsonBody(
   request: NextRequest,
   maxBytes: number = DEFAULT_JSON_BODY_MAX_BYTES,
 ): Promise<string> {
+  // Missing/empty header → Number(null)===0; the streaming cap below is the
+  // authoritative bound, so the absent-header path falls through safely.
   const contentLength = Number(request.headers.get("content-length"));
   if (Number.isFinite(contentLength) && contentLength > maxBytes) {
     throw new RequestBodyTooLargeError();
@@ -37,11 +39,11 @@ export async function readBoundedJsonBody(
   while (true) {
     const { done, value } = await reader.read();
     if (done) break;
-    totalBytes += value.byteLength;
-    if (totalBytes > maxBytes) {
+    if (totalBytes + value.byteLength > maxBytes) {
       await reader.cancel().catch(() => undefined);
       throw new RequestBodyTooLargeError();
     }
+    totalBytes += value.byteLength;
     chunks.push(value);
   }
 
@@ -61,11 +63,15 @@ export function getJsonBodyError(error: unknown): {
   message: string;
   status: 400 | 413;
 } {
+  // Match by `name` rather than `instanceof` so the 413 mapping survives
+  // module-duplication or realm boundaries that break instanceof identity.
   if (
-    error instanceof RequestBodyTooLargeError ||
-    error instanceof JsonDepthExceededError
+    typeof error === "object" &&
+    error !== null &&
+    ((error as { name?: string }).name === "RequestBodyTooLargeError" ||
+      (error as { name?: string }).name === "JsonDepthExceededError")
   ) {
-    return { message: error.message, status: 413 };
+    return { message: (error as Error).message, status: 413 };
   }
 
   return { message: "Invalid JSON body", status: 400 };


### PR DESCRIPTION
## Summary

- replace unbounded `request.json()` calls in all 14 legacy JSON routes with the shared streaming body reader
- enforce early `Content-Length` checks, streaming byte limits, and a real structural JSON depth limit of 20
- return `413` for oversized/deep payloads while preserving `400` for malformed JSON
- require object-shaped JSON before route destructuring, so `null`, arrays, and primitives fail safely with `400`
- preserve larger legitimate payloads with route-specific limits: 64 KiB standard, approximately 1 MiB single-article writes, and 4 MiB batch ingest
- add static coverage for every affected route plus authenticated integration coverage for empty, malformed, null, oversized, deeply nested, and valid large article requests
- document the body-limit contract

## Root cause

The legacy handlers called `request.json()` directly, allowing the runtime to buffer and parse attacker-controlled bodies before application validation. The existing `safeJsonParse()` depth guard also counted every parsed value instead of structural nesting, so flat objects with more than 20 fields could be rejected while deeply nested input was not measured correctly.

## Verification

- focused bounded-body suite: 39/39 passed
- API suite: 311/312 passed; only the unchanged `sync-conflict-review.test.ts` Prisma mock baseline failed
- memory suite: 186/186 passed
- cache suite: 8/8 passed
- security suite: 14/15 baseline; unchanged proxy rate-limit test still expects 429 but receives 200
- `npm run typecheck`: passed
- full ESLint: 0 errors, 2 pre-existing unrelated warnings
- production `npm run build`: passed
- `git diff --check` and secret scan: passed
- no dependency manifests changed; npm audit remains at the existing single moderate dev-only advisory

## Review follow-up

Valid automated findings were addressed through `ccfda6a`: unmatched closing delimiters cannot offset nesting; `/api/lint` distinguishes an absent body from malformed JSON; object-body routes reject `null`, arrays, and primitives before destructuring; the integration test does not disconnect the shared Prisma pool; and the article overflow assertion is explicitly above the transport boundary. All review threads are resolved.

Closes #192

<!-- kody-pr-summary:start -->
This pull request introduces robust validation and bounding for JSON request bodies across all API write endpoints to prevent resource exhaustion and improve API stability.

Key changes include:

*   **Bounded JSON Parsing:** All API endpoints that accept JSON payloads now utilize custom `readBoundedJson` and `readBoundedJsonObject` utilities. These utilities enforce limits on both the total size of the request body and the nesting depth of the JSON structure.
*   **Early Request Rejection:** Requests with a `Content-Length` header exceeding the configured limit are now rejected immediately (HTTP 413) before the entire body is read, conserving server resources and bandwidth.
*   **JSON Nesting Depth Limit:** A maximum JSON nesting depth of 20 levels is enforced to prevent CPU exhaustion from maliciously crafted deeply nested payloads.
*   **Specific Error Responses:**
    *   Requests exceeding body size or JSON nesting limits will now return a `413 Payload Too Large` status with a descriptive error message.
    *   Malformed JSON payloads or those not conforming to the expected root type (e.g., an array where an object is expected) will return a `400 Bad Request` status.
*   **Route-Specific Body Limits:**
    *   Most standard write endpoints are limited to 64 KiB.
    *   Endpoints for creating or updating single articles (`/api/articles`, `/api/articles/[id]`, `/api/answer`) allow approximately 1 MiB to accommodate article content.
    *   The batch ingest endpoint (`/api/ingest`) allows up to 4 MiB for multiple articles.
*   **Documentation Updates:** The `README.md` and `docs/NOOSPHERE-SKILL.md` files have been updated to clearly document these new JSON body limits and the corresponding `413` error code.
*   **Integration Tests:** New integration tests confirm that API routes correctly enforce these size and nesting limits, returning the expected HTTP status codes and error messages.

---

This pull request enhances the robustness and security of API request body parsing by implementing stricter bounds and depth checks for JSON payloads.

Key changes include:

*   **Introduced Depth-Guarded JSON Parsing:** Several API routes (`/api/sync/conflict-preferences`, `/api/sync/import-apply`, `/api/sync/import-scan`) that previously used `JSON.parse` now utilize `safeJsonParse`. This change protects against excessively nested JSON structures, which can be exploited for denial-of-service attacks, by throwing a `JsonDepthExceededError` for overly complex bodies.
*   **Refined Bounded JSON Body Reading:** The `readBoundedJsonBody` function (used by `readBoundedJsonObject`) now employs a more precise byte-counting mechanism to strictly enforce maximum body size limits, preventing requests from exceeding the allowed payload size.
*   **Consolidated Body Validation:** The `/api/memory/settings` route now uses `readBoundedJsonObject`, which streamlines the process of reading and validating JSON object bodies, incorporating both size bounding and type validation.
*   **Improved Error Handling:** The `getJsonBodyError` utility has been updated to use string-based name checks for `RequestBodyTooLargeError` and `JsonDepthExceededError` instead of `instanceof`. This makes error identification more resilient across different JavaScript execution contexts.
*   **Added Regression Tests:** New tests have been introduced to ensure that the affected sync routes consistently use the depth-guarded `safeJsonParse` and do not revert to the less secure `JSON.parse`.

---

Refactored the `getJsonBodyError` function to simplify the identification of `RequestBodyTooLargeError` and `JsonDepthExceededError`. The error checking now uses direct `instanceof` comparisons instead of relying on string-based `name` property checks, streamlining the logic for handling oversized or excessively deep JSON request bodies and ensuring they correctly return a 413 status.
<!-- kody-pr-summary:end -->