### PR TITLE
docs(opencode,kilocode): add 'Before you start' section

### DIFF
--- a/kilocode-noosphere-memory/README.md
+++ b/kilocode-noosphere-memory/README.md
@@ -8,6 +8,42 @@ It provides:
 - optional idle auto-save through `POST /api/memory/save`
 - manual tools for status, recall, topic lookup, and draft memory saving
 
+## Before you start
+
+You need two things before this plugin will do anything useful:
+
+1. **A reachable Noosphere instance.** The plugin defaults to
+   `http://127.0.0.1:6578`. For a local install, the easiest path is the
+   repository's one-shot installer:
+
+   ```bash
+   curl -fsSL https://raw.githubusercontent.com/SweetSophia/noosphere/master/install-openclaw.sh | bash
+   ```
+
+   It provisions Docker, Redis, the Noosphere container, and a bootstrap API key.
+   To point at an existing Noosphere instead, set `baseUrl` in the plugin
+   options (see [Configuration](#configuration)).
+
+2. **A Noosphere API key for this tool.** The plugin will refuse to start
+   without one. Create it in the Noosphere admin UI:
+
+   ```text
+   <NOOSPHERE_URL>/wiki/admin/keys
+   ```
+
+   (Admin login is required. The local installer creates an `admin@noosphere.local`
+   admin account whose password is in `~/.noosphere/.env` as
+   `NOOSPHERE_ADMIN_PASSWORD`.) Use a **tool-scoped key** rather than the
+   bootstrap key for production installs — name it after the tool
+   (e.g. `kilocode`) and grant the permissions you need:
+
+   - `READ` for prompt-time recall and topic lookup
+   - `WRITE` for manual saves and idle auto-save
+   - `ADMIN` for full `noosphere_status` output (the plugin falls back to
+     `/api/health` automatically if the key lacks `ADMIN`)
+
+   See [Secrets](#secrets) below for where to put the key once you have it.
+
 ## Install
 
 ```bash

--- a/kilocode-noosphere-memory/README.md
+++ b/kilocode-noosphere-memory/README.md
@@ -13,36 +13,41 @@ It provides:
 You need two things before this plugin will do anything useful:
 
 1. **A reachable Noosphere instance.** The plugin defaults to
-   `http://127.0.0.1:6578`. For a local install, the easiest path is the
-   repository's one-shot installer:
+   `http://127.0.0.1:6578`. For a local install, the cleanest path is the
+   repository's Docker Compose stack — it provisions just Noosphere, without
+   pulling in any other plugin:
 
    ```bash
-   curl -fsSL https://raw.githubusercontent.com/SweetSophia/noosphere/master/install-openclaw.sh | bash
+   git clone https://github.com/SweetSophia/noosphere.git
+   cd noosphere
+   cp noosphere.env.example .env
+   # Edit .env: POSTGRES_PASSWORD, NEXTAUTH_SECRET, NOOSPHERE_ADMIN_PASSWORD,
+   # and NOOSPHERE_BOOTSTRAP_API_KEY. Generate strong values, for example:
+   # openssl rand -hex 32
+   # printf 'noo_%s\n' "$(openssl rand -hex 32)"
+   docker compose -f docker-compose.noosphere.yml up -d
    ```
 
-   It provisions Docker, Redis, the Noosphere container, and a bootstrap API key.
-   To point at an existing Noosphere instead, set `baseUrl` in the plugin
-   options (see [Configuration](#configuration)).
+   The bootstrap key is whatever you put in `NOOSPHERE_BOOTSTRAP_API_KEY` and
+   has full `ADMIN` scope. To point at an existing Noosphere instead, set
+   `baseUrl` in the plugin options (see [Configuration](#configuration)).
+
+   > **Note:** the repository also ships `install-openclaw.sh`, a one-shot
+   > installer that provisions Noosphere *plus* the OpenClaw plugin. Use it
+   > if you intend to run both tools; skip it if you only want Kilo Code.
 
 2. **A Noosphere API key for this tool.** The plugin will refuse to start
-   without one. Create it in the Noosphere admin UI:
+   without one. Create a **tool-scoped** key (named after the tool, e.g.
+   `kilocode`) in the Noosphere admin UI at:
 
    ```text
-   <NOOSPHERE_URL>/wiki/admin/keys
+   https://<your-noosphere-host>/wiki/admin/keys
    ```
 
-   (Admin login is required. The local installer creates an `admin@noosphere.local`
-   admin account whose password is in `~/.noosphere/.env` as
-   `NOOSPHERE_ADMIN_PASSWORD`.) Use a **tool-scoped key** rather than the
-   bootstrap key for production installs — name it after the tool
-   (e.g. `kilocode`) and grant the permissions you need:
-
-   - `READ` for prompt-time recall and topic lookup
-   - `WRITE` for manual saves and idle auto-save
-   - `ADMIN` for full `noosphere_status` output (the plugin falls back to
-     `/api/health` automatically if the key lacks `ADMIN`)
-
-   See [Secrets](#secrets) below for where to put the key once you have it.
+   Admin login is required. The local Docker Compose install creates an
+   `admin@noosphere.local` admin account whose password is in `.env` as
+   `NOOSPHERE_ADMIN_PASSWORD`. See [Secrets](#secrets) below for which
+   permissions the key needs and where to put it.
 
 ## Install
 

--- a/opencode-noosphere-memory/README.md
+++ b/opencode-noosphere-memory/README.md
@@ -13,36 +13,41 @@ It provides:
 You need two things before this plugin will do anything useful:
 
 1. **A reachable Noosphere instance.** The plugin defaults to
-   `http://127.0.0.1:6578`. For a local install, the easiest path is the
-   repository's one-shot installer:
+   `http://127.0.0.1:6578`. For a local install, the cleanest path is the
+   repository's Docker Compose stack — it provisions just Noosphere, without
+   pulling in any other plugin:
 
    ```bash
-   curl -fsSL https://raw.githubusercontent.com/SweetSophia/noosphere/master/install-openclaw.sh | bash
+   git clone https://github.com/SweetSophia/noosphere.git
+   cd noosphere
+   cp noosphere.env.example .env
+   # Edit .env: POSTGRES_PASSWORD, NEXTAUTH_SECRET, NOOSPHERE_ADMIN_PASSWORD,
+   # and NOOSPHERE_BOOTSTRAP_API_KEY. Generate strong values, for example:
+   # openssl rand -hex 32
+   # printf 'noo_%s\n' "$(openssl rand -hex 32)"
+   docker compose -f docker-compose.noosphere.yml up -d
    ```
 
-   It provisions Docker, Redis, the Noosphere container, and a bootstrap API key.
-   To point at an existing Noosphere instead, set `baseUrl` in the plugin
-   options (see [Configuration](#configuration)).
+   The bootstrap key is whatever you put in `NOOSPHERE_BOOTSTRAP_API_KEY` and
+   has full `ADMIN` scope. To point at an existing Noosphere instead, set
+   `baseUrl` in the plugin options (see [Configuration](#configuration)).
+
+   > **Note:** the repository also ships `install-openclaw.sh`, a one-shot
+   > installer that provisions Noosphere *plus* the OpenClaw plugin. Use it
+   > if you intend to run both tools; skip it if you only want opencode.
 
 2. **A Noosphere API key for this tool.** The plugin will refuse to start
-   without one. Create it in the Noosphere admin UI:
+   without one. Create a **tool-scoped** key (named after the tool, e.g.
+   `opencode`) in the Noosphere admin UI at:
 
    ```text
-   <NOOSPHERE_URL>/wiki/admin/keys
+   https://<your-noosphere-host>/wiki/admin/keys
    ```
 
-   (Admin login is required. The local installer creates an `admin@noosphere.local`
-   admin account whose password is in `~/.noosphere/.env` as
-   `NOOSPHERE_ADMIN_PASSWORD`.) Use a **tool-scoped key** rather than the
-   bootstrap key for production installs — name it after the tool
-   (e.g. `opencode`) and grant the permissions you need:
-
-   - `READ` for prompt-time recall and topic lookup
-   - `WRITE` for manual saves and idle auto-save
-   - `ADMIN` for full `noosphere_status` output (the plugin falls back to
-     `/api/health` automatically if the key lacks `ADMIN`)
-
-   See [Secrets](#secrets) below for where to put the key once you have it.
+   Admin login is required. The local Docker Compose install creates an
+   `admin@noosphere.local` admin account whose password is in `.env` as
+   `NOOSPHERE_ADMIN_PASSWORD`. See [Secrets](#secrets) below for which
+   permissions the key needs and where to put it.
 
 ## Install
 

--- a/opencode-noosphere-memory/README.md
+++ b/opencode-noosphere-memory/README.md
@@ -8,6 +8,42 @@ It provides:
 - optional idle auto-save through `POST /api/memory/save`
 - manual tools for status, recall, topic lookup, and draft memory saving
 
+## Before you start
+
+You need two things before this plugin will do anything useful:
+
+1. **A reachable Noosphere instance.** The plugin defaults to
+   `http://127.0.0.1:6578`. For a local install, the easiest path is the
+   repository's one-shot installer:
+
+   ```bash
+   curl -fsSL https://raw.githubusercontent.com/SweetSophia/noosphere/master/install-openclaw.sh | bash
+   ```
+
+   It provisions Docker, Redis, the Noosphere container, and a bootstrap API key.
+   To point at an existing Noosphere instead, set `baseUrl` in the plugin
+   options (see [Configuration](#configuration)).
+
+2. **A Noosphere API key for this tool.** The plugin will refuse to start
+   without one. Create it in the Noosphere admin UI:
+
+   ```text
+   <NOOSPHERE_URL>/wiki/admin/keys
+   ```
+
+   (Admin login is required. The local installer creates an `admin@noosphere.local`
+   admin account whose password is in `~/.noosphere/.env` as
+   `NOOSPHERE_ADMIN_PASSWORD`.) Use a **tool-scoped key** rather than the
+   bootstrap key for production installs — name it after the tool
+   (e.g. `opencode`) and grant the permissions you need:
+
+   - `READ` for prompt-time recall and topic lookup
+   - `WRITE` for manual saves and idle auto-save
+   - `ADMIN` for full `noosphere_status` output (the plugin falls back to
+     `/api/health` automatically if the key lacks `ADMIN`)
+
+   See [Secrets](#secrets) below for where to put the key once you have it.
+
 ## Install
 
 Add it to `~/.config/opencode/opencode.json`. Opencode can auto-install scoped


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
The pull request introduces a new "Before you start" section to the `README.md` files of both the `kilocode-noosphere-memory` and `opencode-noosphere-memory` plugins. This documentation enhancement aims to proactively guide users through the essential prerequisites for these plugins to function correctly, thereby preventing common runtime errors related to missing dependencies.

Specifically, the added sections provide:

1.  **Guidance on Noosphere Instance Setup**: It clarifies that a reachable Noosphere instance is required, defaulting to `http://127.0.0.1:6578`. For local development, it provides a `curl` command to execute the `install-openclaw.sh` script, which automates the provisioning of Docker, Redis, the Noosphere container, and a bootstrap API key. It also advises users on how to configure a custom `baseUrl` for existing Noosphere instances.

2.  **Detailed API Key Creation Instructions**: The documentation emphasizes that a Noosphere API key is mandatory for the plugin to start. It provides the exact URL (`<NOOSPHERE_URL>/wiki/admin/keys`) within the Noosphere admin UI for key creation. For local installations, it specifies that the admin password can be found in `~/.noosphere/.env` under `NOOSPHERE_ADMIN_PASSWORD`.

3.  **API Key Best Practices and Permissions**: The new section recommends using a dedicated "tool-scoped" API key (e.g., named `kilocode` or `opencode`) for production environments instead of the bootstrap key. It meticulously outlines the specific permissions required for various plugin functionalities:
    *   `READ` for prompt-time recall and topic lookup.
    *   `WRITE` for manual and idle auto-saves.
    *   `ADMIN` for full `noosphere_status` output, noting that the plugin will gracefully fall back to `/api/health` if the `ADMIN` permission is absent.

This change significantly improves the developer experience by providing clear, actionable steps and technical context upfront, ensuring users can successfully set up and utilize the Noosphere memory plugins without encountering initial configuration hurdles.

---

This pull request updates the "Before you start" section in the `README.md` files for both `kilocode-noosphere-memory` and `opencode-noosphere-memory`.

The changes aim to provide clearer and more specific instructions for setting up a local Noosphere instance and obtaining the required API keys:

*   **Noosphere Instance Setup:** The recommended method for a local Noosphere instance has been updated from a one-shot `install-openclaw.sh` script to a more controlled Docker Compose setup. This includes detailed steps for cloning the repository, configuring environment variables, and starting the Noosphere service. A note has been added to clarify when to use the `install-openclaw.sh` script (for Noosphere *plus* OpenClaw).
*   **Noosphere API Key Creation:** Instructions for creating a Noosphere API key have been refined to emphasize creating **tool-scoped** keys (e.g., `kilocode` or `opencode`). The location of the admin password for the Docker Compose setup is now correctly referenced, and detailed API key permission requirements are now deferred to the "Secrets" section for better documentation structure.
<!-- kody-pr-summary:end -->