### PR TITLE
feat(wiki): address review quick wins

### DIFF
--- a/src/__tests__/api/wiki-search-results.test.ts
+++ b/src/__tests__/api/wiki-search-results.test.ts
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { buildSearchResultHydrationWhere } from "@/lib/wiki-search-results";
+
+describe("wiki search result hydration", () => {
+  it("keeps deleted articles out for human/admin sessions", () => {
+    assert.deepEqual(
+      buildSearchResultHydrationWhere(["article-a", "article-b"], ["*"]),
+      {
+        id: { in: ["article-a", "article-b"] },
+        deletedAt: null,
+      },
+    );
+  });
+
+  it("re-applies unrestricted filtering for anonymous users", () => {
+    assert.deepEqual(
+      buildSearchResultHydrationWhere(["article-a"], undefined),
+      {
+        id: { in: ["article-a"] },
+        deletedAt: null,
+        restrictedTags: { isEmpty: true },
+      },
+    );
+  });
+
+  it("re-applies scoped access for API callers", () => {
+    assert.deepEqual(
+      buildSearchResultHydrationWhere(["article-a"], ["scope-a"]),
+      {
+        id: { in: ["article-a"] },
+        deletedAt: null,
+        OR: [
+          { restrictedTags: { isEmpty: true } },
+          { restrictedTags: { hasSome: ["scope-a"] } },
+        ],
+      },
+    );
+  });
+});

--- a/src/app/api/articles/route.ts
+++ b/src/app/api/articles/route.ts
@@ -12,6 +12,7 @@ import { buildTagConnections, countSearchArticles, searchArticleIds } from "@/li
 import { detectSecretInInputs } from "@/lib/memory/api/save";
 import { invalidateSearchCache } from "@/lib/cache/search-cache";
 import { filterAccessibleRelatedTargets, filterVisibleRelatedArticleRows } from "@/lib/articles/relations";
+import { buildSearchResultHydrationWhere } from "@/lib/wiki-search-results";
 import {
   ARTICLE_LIMITS,
   QUERY_LIMITS,
@@ -109,7 +110,7 @@ export async function GET(request: NextRequest) {
       q
         ? articleIds.length
           ? prisma.article.findMany({
-            where: { id: { in: articleIds } },
+            where: buildSearchResultHydrationWhere(articleIds, auth.auth.allowedScopes),
             include: {
               topic: true,
               tags: { include: { tag: true } },

--- a/src/app/wiki/admin/keys/page.tsx
+++ b/src/app/wiki/admin/keys/page.tsx
@@ -52,6 +52,7 @@ export default async function ApiKeysPage({ searchParams }: Props) {
       <Breadcrumbs
         items={[
           { label: "Noosphere", href: "/wiki" },
+          { label: "Admin" },
           { label: "API Keys" },
         ]}
       />

--- a/src/app/wiki/admin/log/page.tsx
+++ b/src/app/wiki/admin/log/page.tsx
@@ -2,6 +2,8 @@ import type { CSSProperties } from "react";
 import Link from "next/link";
 import { redirect } from "next/navigation";
 import { AdminNav } from "@/components/wiki/AdminNav";
+import { Breadcrumbs } from "@/components/wiki/Breadcrumbs";
+import { PageHeader } from "@/components/wiki/PageHeader";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
@@ -46,11 +48,13 @@ export default async function ActivityLogPage({
 
   const params = await searchParams;
 
-  const where: Record<string, unknown> = {};
-  if (params.type) where.type = params.type;
-  if (params.author) where.authorName = { equals: params.author, mode: "insensitive" };
+  const authorWhere: Record<string, unknown> = {};
+  if (params.author) authorWhere.authorName = { equals: params.author, mode: "insensitive" };
 
-  const [entries, typeCounts] = await Promise.all([
+  const where: Record<string, unknown> = { ...authorWhere };
+  if (params.type) where.type = params.type;
+
+  const [entries, typeCounts, filteredCount] = await Promise.all([
     prisma.activityLog.findMany({
       where,
       orderBy: { createdAt: "desc" },
@@ -58,30 +62,49 @@ export default async function ActivityLogPage({
     }),
     prisma.activityLog.groupBy({
       by: ["type"],
+      where: authorWhere,
       _count: { type: true },
       orderBy: { _count: { type: "desc" } },
     }),
+    prisma.activityLog.count({ where }),
   ]);
 
   const totalCount = typeCounts.reduce((sum, item) => sum + item._count.type, 0);
+  const hasActiveFilters = Boolean(params.type || params.author);
+  const hasHiddenMatches = filteredCount > entries.length;
+  const metaCountLabel = hasHiddenMatches ? `${entries.length}/${filteredCount}` : String(filteredCount);
+  const metaDescription = hasActiveFilters
+    ? `matching event${filteredCount !== 1 ? "s" : ""}${hasHiddenMatches ? " shown" : ""}`
+    : `logged event${filteredCount !== 1 ? "s" : ""}${hasHiddenMatches ? " shown" : ""}`;
 
   return (
     <div className="wiki-content" style={{ maxWidth: 1040 }}>
-      <div className="page-toolbar">
-        <div>
-          <p className="page-eyebrow">Admin Console</p>
-          <h1>Activity Log</h1>
-          <p className="page-subtitle">
-            A rolling audit trail of ingests, edits, deletions, and maintenance events across the wiki.
-          </p>
-        </div>
+      <Breadcrumbs
+        items={[
+          { label: "Noosphere", href: "/wiki" },
+          { label: "Admin" },
+          { label: "Activity Log" },
+        ]}
+      />
 
-        <div className="page-actions">
+      <PageHeader
+        eyebrow="Admin Console"
+        title="Activity Log"
+        description="A rolling audit trail of ingests, edits, deletions, and maintenance events across the wiki."
+        meta={
+          <div className="page-meta-pills">
+            <span className="page-meta-pill">
+              <strong>{metaCountLabel}</strong>
+              <span>{metaDescription}</span>
+            </span>
+          </div>
+        }
+        actions={
           <Link href="/wiki" className="btn btn-secondary">
             Back to Wiki
           </Link>
-        </div>
-      </div>
+        }
+      />
 
       <AdminNav current="log" />
 

--- a/src/app/wiki/admin/trash/page.tsx
+++ b/src/app/wiki/admin/trash/page.tsx
@@ -35,6 +35,7 @@ export default async function TrashPage() {
       <Breadcrumbs
         items={[
           { label: "Noosphere", href: "/wiki" },
+          { label: "Admin" },
           { label: "Trash" },
         ]}
       />

--- a/src/app/wiki/layout.tsx
+++ b/src/app/wiki/layout.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
+import { SearchShortcut } from "@/components/wiki/SearchShortcut";
 import { SignOutButton } from "@/components/wiki/SignOutButton";
 import "./wiki.css";
 
@@ -52,12 +53,17 @@ export default async function WikiLayout({
                   ⌕
                 </span>
                 <input
+                  id="wiki-global-search"
                   type="search"
                   name="q"
                   placeholder="Search articles, excerpts, tags..."
                   aria-label="Search wiki"
+                  aria-keyshortcuts="Meta+K Control+K"
                   className="wiki-search-input"
                 />
+                <kbd className="wiki-search-shortcut" aria-hidden>
+                  ⌘/Ctrl K
+                </kbd>
               </label>
               <button type="submit" className="btn btn-secondary btn-sm">
                 Search
@@ -95,6 +101,7 @@ export default async function WikiLayout({
       <main className="wiki-main">
         <div className="wiki-main-inner">{children}</div>
       </main>
+      <SearchShortcut targetId="wiki-global-search" />
     </div>
   );
 }

--- a/src/app/wiki/search/page.tsx
+++ b/src/app/wiki/search/page.tsx
@@ -7,6 +7,7 @@ import { PageHeader } from "@/components/wiki/PageHeader";
 import { EmptyState } from "@/components/wiki/EmptyState";
 import { authOptions } from "@/lib/auth";
 import { buildScopeFilter } from "@/lib/api/auth";
+import { buildSearchResultHydrationWhere } from "@/lib/wiki-search-results";
 
 export const dynamic = "force-dynamic";
 
@@ -53,7 +54,7 @@ export default async function SearchPage({ searchParams }: Props) {
     q
       ? articleIds.length
         ? prisma.article.findMany({
-            where: { id: { in: articleIds } },
+            where: buildSearchResultHydrationWhere(articleIds, allowedScopes),
             include: {
               topic: true,
               tags: { include: { tag: true } },

--- a/src/app/wiki/wiki.css
+++ b/src/app/wiki/wiki.css
@@ -180,6 +180,7 @@
 }
 
 .wiki-search-input {
+  flex: 1;
   width: 100%;
   min-width: 0;
   padding: 0.85rem 0;
@@ -191,6 +192,22 @@
 .wiki-search-input:focus {
   outline: none;
   box-shadow: none;
+}
+
+.wiki-search-shortcut {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2.25rem;
+  padding: 0.18rem 0.45rem;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  background: var(--surface-inset);
+  color: var(--text-faint);
+  font-family: var(--font-noosphere-mono);
+  font-size: 0.72rem;
+  line-height: 1;
+  white-space: nowrap;
 }
 
 .wiki-nav {
@@ -824,6 +841,8 @@
 }
 
 .article-prose {
+  max-width: var(--reading-width);
+  margin-inline: auto;
   padding: clamp(1.1rem, 2vw, 1.6rem);
   border: 1px solid var(--border-color);
   border-radius: var(--radius-xl);
@@ -2122,6 +2141,10 @@ h2.activity-title {
   .wiki-search-shell,
   .wiki-search-form .btn {
     width: 100%;
+  }
+
+  .wiki-search-shortcut {
+    display: none;
   }
 
   .nav-link,

--- a/src/components/wiki/SearchShortcut.tsx
+++ b/src/components/wiki/SearchShortcut.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useEffect } from "react";
+
+interface SearchShortcutProps {
+  targetId: string;
+}
+
+function isEditableElement(element: Element | null) {
+  return (
+    element instanceof HTMLInputElement ||
+    element instanceof HTMLTextAreaElement ||
+    element instanceof HTMLSelectElement ||
+    (element instanceof HTMLElement && element.isContentEditable)
+  );
+}
+
+export function SearchShortcut({ targetId }: SearchShortcutProps) {
+  useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.defaultPrevented || event.key.toLowerCase() !== "k") return;
+
+      const hasPrimaryModifier = event.metaKey || event.ctrlKey;
+      const hasExtraModifiers = event.altKey || event.shiftKey;
+      if (!hasPrimaryModifier || hasExtraModifiers) return;
+
+      const target = document.getElementById(targetId);
+      if (!(target instanceof HTMLElement)) return;
+
+      if (document.activeElement !== target && isEditableElement(document.activeElement)) {
+        return;
+      }
+
+      event.preventDefault();
+      target.focus();
+
+      if (target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement) {
+        target.select();
+      }
+    }
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [targetId]);
+
+  return null;
+}

--- a/src/lib/wiki-search-results.ts
+++ b/src/lib/wiki-search-results.ts
@@ -1,0 +1,11 @@
+import { buildScopeFilter } from "@/lib/api/scope-filter";
+
+export function buildSearchResultHydrationWhere(
+  articleIds: string[],
+  allowedScopes: string[] | undefined,
+) {
+  return buildScopeFilter(allowedScopes, {
+    id: { in: articleIds },
+    deletedAt: null,
+  });
+}


### PR DESCRIPTION
## Summary

Second Noosphere review-list batch after F1. This PR keeps the scope to small UX/security polish from `REVIEW.md`:

- F2: constrain article prose to `var(--reading-width)` for better readability
- F3: add `Cmd/Ctrl+K` / `Ctrl+K` global search focus
- F26: standardize admin breadcrumbs and move Activity Log onto `PageHeader`
- B5: re-apply article scope filtering during the search result re-fetch

## What changed

- Added `SearchShortcut` client helper and wired it to the wiki header search input.
- Tightened the shortcut so extra modifiers are ignored and active editable fields keep focus.
- Added `max-width: var(--reading-width)` and centered `.article-prose`.
- Updated API Keys and Trash breadcrumbs to `Noosphere -> Admin -> <Page>`.
- Reworked Activity Log to use shared `Breadcrumbs` + `PageHeader` with an event-count meta pill.
- Moved search-result hydration filter construction into `buildSearchResultHydrationWhere`.
- Changed search result hydration from `where: { id: { in: articleIds } }` to a scope/deletion-filtered query.
- Added behavior-level regression coverage for admin, anonymous, and scoped search hydration filters.

## Test plan

- [x] `npm run typecheck`
- [x] `DATABASE_URL=... npm run build`
- [x] `npm run lint` — passes with 2 existing warnings outside this PR
- [x] `node --import tsx --test src/__tests__/api/scope-filter.test.ts`
- [x] `DATABASE_URL=... node --import tsx --test src/__tests__/api/wiki-home-scope.test.ts`
- [x] `node --import tsx --test src/__tests__/api/wiki-search-results.test.ts`
- [x] `DATABASE_URL=... npm run test:api` — 315/316 pass; the only failure is the known existing `sync-conflict-review.test.ts` mock issue
- [x] Browser probe: `Ctrl+K` on `/wiki` focuses `#wiki-global-search` and selects existing text
- [x] Browser probe: active editable fields keep focus, and `Ctrl+Shift+K` is ignored
- [x] Source/build check: admin breadcrumbs are `Noosphere -> Admin -> <Page>` for Activity Log, API Keys, and Trash
- [x] Source/build check: `.article-prose` is centered and constrained to `var(--reading-width)`

## Notes

F14 Write/Preview tabs and the deeper feature items are intentionally deferred because they change product behavior rather than applying low-risk polish.


<!-- kody-pr-summary:start -->
Here is a precise description of the changes in this pull request:

**Search & Filtering Improvements**
- **Keyboard Shortcut**: Added a `Cmd+K` (or `Ctrl+K`) keyboard shortcut to quickly focus the global search input.
- **Result Hydration**: Updated the search results query to properly filter out deleted articles and enforce access scope restrictions (restricted tags) based on the user's session (anonymous, API caller, or admin). Added unit tests to verify this filtering logic.

**UI & Navigation Enhancements**
- **Article Readability**: Constrained the maximum width of article content (`.article-prose`) and centered it to improve reading ergonomics.
- **Admin Breadcrumbs**: Added the missing "Admin" segment to the breadcrumb navigation across the API Keys, Activity Log, and Trash pages.
- **Activity Log Header**: Standardized the Activity Log page by replacing the custom HTML header with the shared `PageHeader` and `Breadcrumbs` components.

---

Based on the provided code changes, here is a precise description of the pull request:

**Search Improvements**
* **Global Search Shortcut**: Implemented a `Cmd+K` (or `Ctrl+K`) keyboard shortcut to quickly focus the global search input from anywhere in the wiki.
* **Search Result Permissions**: Fixed search result hydration to properly enforce user access scopes and exclude deleted articles, ensuring users only see search results they have permission to view.

**Admin Interface Enhancements**
* **Activity Log Updates**: Standardized the Activity Log page by implementing the shared `PageHeader` component and added dynamic metadata to display the count of filtered events versus total events.
* **Breadcrumb Navigation**: Fixed breadcrumbs across the Admin section (API Keys, Activity Log, and Trash pages) to correctly include the "Admin" parent level.

**UI & Readability**
* **Article Formatting**: Constrained the maximum width of article content (`.article-prose`) and centered it to improve reading ergonomics. 
* **Responsive Design**: Ensured the new search shortcut indicator is hidden on smaller screens to save space.

---

Here is a precise description of the changes in this pull request:

**Search & Access Control**
- **Search Result Filtering:** Fixed an issue where search results did not respect access scopes or deletion status. Introduced `buildSearchResultHydrationWhere` to ensure deleted articles are excluded and proper scope-based access controls are applied to both the API (`/api/articles`) and the web search page (`/wiki/search`).
- **Global Search Shortcut:** Added a `Cmd/Ctrl + K` keyboard shortcut to quickly focus the global wiki search input, along with a visual `<kbd>` hint in the search bar (hidden on mobile devices).

**Admin Interface Improvements**
- **Activity Log Enhancements:** Refactored the Activity Log page to use the standard `PageHeader` component. Added metadata to display the count of filtered events versus total events.
- **Breadcrumb Navigation:** Added the missing "Admin" level to the breadcrumb trails across the API Keys, Activity Log, and Trash pages for better navigational context.

**UI & Styling**
- **Article Readability:** Constrained the maximum width of article content (`.article-prose`) and centered it to improve reading ergonomics.
<!-- kody-pr-summary:end -->