### PR TITLE
chore: ignore local review artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,9 @@ uploads/
 
 # review artifacts
 CODE_REVIEW.md
+REVIEW.md
+.codegraph/
+.opencode/
 
 # agent instructions (personal)
 AGENTS.md


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Chore: Ignore Local Review Artifacts

This PR expands the `.gitignore` to exclude additional local review and tooling artifacts from version control.

### Changes

Added the following entries to the `.gitignore` under the "review artifacts" section:

- **`REVIEW.md`** — A local review notes file, complementing the already-ignored `CODE_REVIEW.md`
- **`.codegraph/`** — Local directory likely used for code graph analysis or visualization tooling
- **`.opencode/`** — Local directory likely associated with OpenCode or similar development tooling

### Context

The repository already had a "review artifacts" section that excluded `CODE_REVIEW.md`. This change broadens that policy to cover:
1. An alternative/additional review documentation file (`REVIEW.md`)
2. Tooling-specific directories (`.codegraph/` and `.opencode/`) that appear to be local development aids rather than project source

These additions keep the working tree clean from personal or machine-local review outputs and tool caches without affecting shared project files.

### Verification

The ignore rules were confirmed working via `git check-ignore -v` against each newly-added path.
<!-- kody-pr-summary:end -->