### PR TITLE
refactor: validate API keys by unique hash

### DIFF
--- a/src/__tests__/api/keys.test.ts
+++ b/src/__tests__/api/keys.test.ts
@@ -1,7 +1,19 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import test, { after } from "node:test";
 import crypto from "crypto";
-import { hashApiKey, generateApiKey } from "@/lib/api/keys";
+import { Permissions, type Prisma } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+import {
+  hashApiKey,
+  generateApiKey,
+  validateApiKey,
+  type ApiKeyValidationClient,
+  type ApiKeyValidationRecord,
+} from "@/lib/api/keys";
+
+after(async () => {
+  await prisma.$disconnect();
+});
 
 test("generateApiKey returns a noo_ prefixed key", () => {
   const key = generateApiKey("test-agent");
@@ -24,4 +36,182 @@ test("hashApiKey is deterministic", () => {
   const hash2 = hashApiKey(raw);
   assert.equal(hash1, hash2);
   assert.equal(hash1, crypto.createHash("sha256").update(raw).digest("hex"));
+});
+
+test("validateApiKey looks up by unique key hash and updates active keys", async () => {
+  const raw = "noo_test-key-active";
+  const expectedHash = hashApiKey(raw);
+  let findUniqueArgs: Prisma.ApiKeyFindUniqueArgs | undefined;
+  let updateManyArgs: Prisma.ApiKeyUpdateManyArgs | undefined;
+  const apiKeys: ApiKeyValidationClient = {
+    async findUnique(args) {
+      findUniqueArgs = args;
+      return {
+        id: "key-active",
+        permissions: Permissions.READ,
+        allowedScopes: ["scope-a"],
+        revokedAt: null,
+      };
+    },
+    async updateMany(args) {
+      updateManyArgs = args;
+      return { count: 1 };
+    },
+  };
+
+  const result = await validateApiKey(raw, apiKeys);
+
+  assert.deepEqual(findUniqueArgs, { where: { keyHash: expectedHash } });
+  assert.equal(result.valid, true);
+  if (!result.valid) return;
+  assert.equal(result.keyId, "key-active");
+  assert.equal(result.permissions, Permissions.READ);
+  assert.deepEqual(result.allowedScopes, ["scope-a"]);
+  assert.ok(updateManyArgs);
+  const updateWhere: Prisma.ApiKeyUpdateManyArgs["where"] = updateManyArgs.where;
+  assert.equal(updateWhere?.id, "key-active");
+  assert.ok(Array.isArray(updateWhere?.OR));
+  const [neverUsedBranch, staleBranch] = updateWhere.OR;
+  assert.deepEqual(neverUsedBranch, { lastUsedAt: null });
+  assert.ok(staleBranch?.lastUsedAt && typeof staleBranch.lastUsedAt === "object");
+  assert.ok("lt" in staleBranch.lastUsedAt);
+  assert.ok(staleBranch.lastUsedAt.lt instanceof Date);
+  assert.ok(updateManyArgs.data?.lastUsedAt instanceof Date);
+});
+
+test("validateApiKey rejects revoked records after unique hash lookup", async () => {
+  const raw = "noo_test-key-revoked";
+  const expectedHash = hashApiKey(raw);
+  let findUniqueArgs: Prisma.ApiKeyFindUniqueArgs | undefined;
+  let updateCalled = false;
+  const apiKeys: ApiKeyValidationClient = {
+    async findUnique(args) {
+      findUniqueArgs = args;
+      const record: ApiKeyValidationRecord = {
+        id: "key-revoked",
+        permissions: Permissions.ADMIN,
+        allowedScopes: ["*"],
+        revokedAt: new Date(),
+      };
+      return record;
+    },
+    async updateMany() {
+      updateCalled = true;
+      return { count: 1 };
+    },
+  };
+
+  const result = await validateApiKey(raw, apiKeys);
+
+  assert.deepEqual(findUniqueArgs, { where: { keyHash: expectedHash } });
+  assert.deepEqual(result, { valid: false });
+  assert.equal(updateCalled, false);
+});
+
+test("validateApiKey rejects missing key hashes without updating lastUsedAt", async () => {
+  const raw = "noo_test-key-missing";
+  const expectedHash = hashApiKey(raw);
+  let findUniqueArgs: Prisma.ApiKeyFindUniqueArgs | undefined;
+  let updateCalled = false;
+  const apiKeys: ApiKeyValidationClient = {
+    async findUnique(args) {
+      findUniqueArgs = args;
+      return null;
+    },
+    async updateMany() {
+      updateCalled = true;
+      return { count: 1 };
+    },
+  };
+
+  const result = await validateApiKey(raw, apiKeys);
+
+  assert.deepEqual(findUniqueArgs, { where: { keyHash: expectedHash } });
+  assert.deepEqual(result, { valid: false });
+  assert.equal(updateCalled, false);
+});
+
+test("validateApiKey propagates lookup errors", async () => {
+  const expected = new Error("lookup failed");
+  const apiKeys: ApiKeyValidationClient = {
+    async findUnique() {
+      throw expected;
+    },
+    async updateMany() {
+      return { count: 0 };
+    },
+  };
+
+  await assert.rejects(() => validateApiKey("noo_lookup-error", apiKeys), expected);
+});
+
+test("validateApiKey propagates last-used update errors", async () => {
+  const expected = new Error("update failed");
+  const apiKeys: ApiKeyValidationClient = {
+    async findUnique() {
+      return {
+        id: "key-update-error",
+        permissions: Permissions.READ,
+        allowedScopes: [],
+        revokedAt: null,
+      };
+    },
+    async updateMany() {
+      throw expected;
+    },
+  };
+
+  await assert.rejects(() => validateApiKey("noo_update-error", apiKeys), expected);
+});
+
+test("validateApiKey stays valid when last-used update is debounced", async () => {
+  const apiKeys: ApiKeyValidationClient = {
+    async findUnique() {
+      return {
+        id: "key-debounced",
+        permissions: Permissions.READ,
+        allowedScopes: [],
+        revokedAt: null,
+      };
+    },
+    async updateMany() {
+      return { count: 0 };
+    },
+  };
+
+  const result = await validateApiKey("noo_debounced", apiKeys);
+
+  assert.equal(result.valid, true);
+  if (!result.valid) return;
+  assert.equal(result.keyId, "key-debounced");
+});
+
+test("validateApiKey rejects a real key after it is revoked", async () => {
+  const runId = crypto.randomUUID();
+  const raw = `noo_${crypto.randomBytes(32).toString("base64url")}`;
+  const createdKey = await prisma.apiKey.create({
+    data: {
+      name: `test-issue193-${runId}`,
+      keyHash: hashApiKey(raw),
+      keyPrefix: raw.slice(0, 8),
+      permissions: Permissions.READ,
+      allowedScopes: [],
+    },
+  });
+
+  try {
+    const activeResult = await validateApiKey(raw);
+    assert.equal(activeResult.valid, true);
+    if (!activeResult.valid) return;
+    assert.equal(activeResult.keyId, createdKey.id);
+
+    await prisma.apiKey.update({
+      where: { id: createdKey.id },
+      data: { revokedAt: new Date() },
+    });
+
+    assert.deepEqual(await validateApiKey(raw), { valid: false });
+  } finally {
+    await prisma.apiKey.delete({ where: { id: createdKey.id } }).catch(() => undefined);
+  }
 });

--- a/src/lib/api/keys.ts
+++ b/src/lib/api/keys.ts
@@ -1,12 +1,24 @@
 import crypto from "crypto";
 import { prisma } from "@/lib/prisma";
-import type { Permissions } from "@prisma/client";
+import type { Permissions, Prisma } from "@prisma/client";
 
 const ALGORITHM = "sha256";
 const KEY_PREFIX_LENGTH = 8;
 
 /** How long to wait before re-recording a lastUsedAt timestamp (5 minutes). */
 const LAST_USED_DEBOUNCE_MS = 5 * 60 * 1000;
+
+export type ApiKeyValidationRecord = {
+  id: string;
+  permissions: Permissions;
+  allowedScopes: string[];
+  revokedAt: Date | null;
+};
+
+export type ApiKeyValidationClient = {
+  findUnique(args: Prisma.ApiKeyFindUniqueArgs): Promise<ApiKeyValidationRecord | null>;
+  updateMany(args: Prisma.ApiKeyUpdateManyArgs): Promise<Prisma.BatchPayload>;
+};
 
 /**
  * Hash an API key for storage.
@@ -40,30 +52,28 @@ export function generateApiKey(_name: string): {
  * Updates lastUsedAt on successful validation.
  */
 export async function validateApiKey(
-  rawKey: string
+  rawKey: string,
+  apiKeys: ApiKeyValidationClient = prisma.apiKey,
 ): Promise<
   | { valid: true; permissions: Permissions; keyId: string; allowedScopes: string[] }
   | { valid: false }
 > {
-  const prefix = rawKey.slice(0, KEY_PREFIX_LENGTH);
   const hash = hashApiKey(rawKey);
 
-  const record = await prisma.apiKey.findFirst({
-    where: {
-      keyPrefix: prefix,
-      keyHash: hash,
-      revokedAt: null,
-    },
+  // This is a normal indexed DB lookup, not a constant-time secret comparison.
+  // Missing and revoked keys are still collapsed to the same invalid response below.
+  const record = await apiKeys.findUnique({
+    where: { keyHash: hash },
   });
 
-  if (!record) {
+  if (!record || record.revokedAt !== null) {
     return { valid: false };
   }
 
   // Update last-used timestamp atomically and at most once per debounce window.
   const now = new Date();
   const cutoff = new Date(now.getTime() - LAST_USED_DEBOUNCE_MS);
-  await prisma.apiKey.updateMany({
+  await apiKeys.updateMany({
     where: {
       id: record.id,
       OR: [{ lastUsedAt: null }, { lastUsedAt: { lt: cutoff } }],


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## API Key Validation Refactor

This PR refactors `validateApiKey` to align with the database schema's unique constraint on `keyHash`, replacing the previous combined lookup with a two-step validation flow.

### Key Changes

**Lookup Strategy (`src/lib/api/keys.ts`)**
- Switched from `findFirst({ where: { keyPrefix, keyHash, revokedAt: null } })` to `findUnique({ where: { keyHash } })`
- Removed reliance on `keyPrefix` as a secondary matching field
- Removed the `revokedAt: null` filter from the database query
- Explicitly checks `record.revokedAt !== null` after the lookup, returning `{ valid: false }` for revoked records

This change ensures the query targets the unique index directly, eliminating unnecessary composite filtering and resolving the schema/query mismatch.

**Test Coverage (`src/__tests__/api/keys.test.ts`)**
- Added a test verifying that active keys are looked up by `keyHash` and that `updateMany` is called with the expected `lastUsedAt` condition
- Added a test verifying that revoked records are rejected after the unique lookup and that no `updateMany` is invoked
- Both tests mock `prisma.apiKey` methods, capture call arguments, and restore originals in a `finally` block

### Functional Impact

- Validation now matches the schema's `keyHash` uniqueness constraint, preventing the query from relying on a non-unique composite predicate
- Revoked keys continue to be rejected, but the rejection now happens after the lookup rather than being baked into the query filter
- The `lastUsedAt` timestamp update logic (previously part of the same patch context) is preserved and verified by the new active-key test

Closes #193.

---

**Summary**

Refactored `validateApiKey` to look up API keys by their unique `keyHash` only, instead of filtering by both `keyPrefix` and `keyHash`.

**Details**

- The lookup query changed from `findFirst` (with combined `keyPrefix` + `keyHash` filter) to `findUnique` using just `keyHash` as the unique key.
- Revocation status is now checked in application code after the lookup (`record.revokedAt !== null`) rather than in the database query.
- The function accepts an optional `apiKeys` client parameter (defaulting to `prisma.apiKey`), enabling dependency injection for testing.
- Added three unit tests covering: successful validation, revoked key rejection, and missing key rejection — all verifying that the unique hash lookup and conditional `lastUsedAt` update behave correctly.

---

### Summary

This change refactors `validateApiKey` to look up API key records by a unique `keyHash` rather than by a combined `keyPrefix` + `keyHash` query. This relies on `keyHash` being uniquely indexed in the database, which enables a single `findUnique` lookup instead of a broader `findFirst` scan.

### Functional changes

- **Lookup simplified to unique hash query**: `validateApiKey` now calls `apiKeys.findUnique({ where: { keyHash: hash } })`. The `keyPrefix` slice and the `revokedAt: null` filter were removed from the database query, and the revocation check is now performed in code after the lookup returns.
- **Dependency-injected Prisma client**: The function now accepts an optional `apiKeys` client parameter (defaulting to `prisma.apiKey`). This narrows the surface to just `findUnique` and `updateMany`, which simplifies testing and decouples the function from the full Prisma client.
- **Return shape unchanged**: The function still returns either `{ valid: true, permissions, keyId, allowedScopes }` or `{ valid: false }`.
- **`lastUsedAt` debounce update preserved**: The atomic, debounced `updateMany` that refreshes `lastUsedAt` at most once per 5 minutes continues to run only when the record is found and not revoked.

### Test updates

The test suite was extended with three new cases that exercise `validateApiKey` against a mock Prisma client:

- **Active key**: Confirms the lookup uses `where: { keyHash: expectedHash }`, returns the expected `keyId` / `permissions` / `allowedScopes`, and that `updateMany` is called with the debounce `OR` condition and a fresh `lastUsedAt` date.
- **Revoked key**: Confirms a record with a non-null `revokedAt` is rejected, and that `updateMany` is **not** called.
- **Missing key hash**: Confirms a `null` lookup result is rejected, and that `updateMany` is **not** called.

Existing tests for `generateApiKey` and `hashApiKey` remain unchanged.

---

## Summary

This PR refactors the API key validation logic to use a unique hash lookup, replacing the previous compound prefix-and-hash query, and makes the data access layer injectable for testability.

### Changes

- **`src/lib/api/keys.ts`**
  - Replaced `findFirst` with a `findUnique` query that looks up the API key solely by its `keyHash`. The key hash is now treated as the unique identifier for validation.
  - Removed the `keyPrefix` slice/match against the stored record; the prefix is no longer required for lookup.
  - Moved the `revokedAt !== null` check out of the database query and into application code so revoked keys can be inspected after the unique hash lookup.
  - Introduced a new `ApiKeyValidationClient` interface (with `findUnique` and `updateMany` methods) and `ApiKeyValidationRecord` type so the persistence layer can be substituted in tests. The `validateApiKey` function now accepts an optional client that defaults to `prisma.apiKey`.
  - Added a code comment documenting that the indexed lookup is intentionally not constant-time and that the same invalid response is returned for both missing and revoked keys to prevent API-key enumeration via response shape.

- **`src/__tests__/api/keys.test.ts`**
  - Added comprehensive test coverage for `validateApiKey`:
    - Verifies that active keys are looked up by unique hash, returned with their permissions/allowed scopes/key ID, and that `lastUsedAt` is updated using a debounce OR clause (`lastUsedAt: null` OR `lastUsedAt < cutoff`).
    - Confirms revoked records are rejected after the unique hash lookup without updating `lastUsedAt`.
    - Confirms missing keys are rejected without updating `lastUsedAt`.
    - Verifies that errors from the lookup and the last-used update are propagated to the caller.
    - Verifies that a key remains valid when the debounce window causes the last-used update to be skipped (`count: 0`).
    - Adds an integration test that creates a real API key in the database, validates it, revokes it, and confirms subsequent validation fails. Test data is cleaned up afterwards.

---

Refactor `validateApiKey` to look up API key records by their unique `keyHash` field instead of filtering on `keyPrefix` and `keyHash` together. The function now uses `findUnique` against the unique hash, then collapses both "record missing" and "record revoked" outcomes to the same `{ valid: false }` response, rather than baking the `revokedAt: null` check into the database query.

A new `ApiKeyValidationClient` interface (with `findUnique` and `updateMany` methods) is introduced, allowing the database client to be injected. This makes the validator testable with a mock client. The `lastUsedAt` debounce update remains, still scoped to never-used and stale records.

The test suite is expanded to cover the new behavior, including:

- Verifying the unique-hash lookup and successful validation updates the `lastUsedAt` timestamp with the correct debounce conditions.
- Rejecting revoked records returned from the hash lookup without updating `lastUsedAt`.
- Rejecting keys that don't exist in the database, again without any update call.
- Propagating errors from the lookup and the last-used update.
- Keeping validation successful when the debounced `updateMany` matches zero rows.
- An end-to-end test that creates a real API key in the database, validates it, revokes it, and confirms the next validation fails.
<!-- kody-pr-summary:end -->