### PR TITLE
fix(api): strip injected memory on article writes

### DIFF
--- a/src/__tests__/api/articles-patch-injected-memory.test.ts
+++ b/src/__tests__/api/articles-patch-injected-memory.test.ts
@@ -1,0 +1,205 @@
+import assert from "node:assert/strict";
+import crypto from "node:crypto";
+import test from "node:test";
+import type { NextRequest } from "next/server";
+import type { PrismaClient } from "@prisma/client";
+
+if (!process.env.DATABASE_URL) {
+  throw new Error("DATABASE_URL environment variable must be set for tests");
+}
+
+const TEST_RUN_ID = crypto.randomUUID();
+const TEST_PREFIX = `test-issue208-patch-${TEST_RUN_ID}`;
+const TEST_TOPIC_SLUG = `${TEST_PREFIX}-topic`;
+const TEST_KEY_NAME = `${TEST_PREFIX}-key`;
+const TEST_CLIENT_IP = `10.209.${Math.floor(Math.random() * 254) + 1}.${Math.floor(Math.random() * 254) + 1}`;
+
+function buildPatchRequest(
+  articleId: string,
+  body: unknown,
+  rawKey: string,
+): NextRequest {
+  const request = new Request(`http://localhost/api/articles/${articleId}`, {
+    method: "PATCH",
+    headers: {
+      Authorization: `Bearer ${rawKey}`,
+      "Content-Type": "application/json",
+      "x-real-ip": TEST_CLIENT_IP,
+    },
+    body: JSON.stringify(body),
+  });
+  return request as unknown as NextRequest;
+}
+
+async function createWriteKey(
+  prisma: PrismaClient,
+  rawKey: string,
+): Promise<void> {
+  await prisma.apiKey.create({
+    data: {
+      name: TEST_KEY_NAME,
+      keyHash: crypto.createHash("sha256").update(rawKey).digest("hex"),
+      keyPrefix: rawKey.slice(0, 8),
+      permissions: "WRITE",
+      allowedScopes: ["*"],
+    },
+  });
+}
+
+async function setupTopic(prisma: PrismaClient): Promise<{ id: string }> {
+  return prisma.topic.create({
+    data: { name: "Test Issue 208 Patch", slug: TEST_TOPIC_SLUG },
+    select: { id: true },
+  });
+}
+
+async function createArticle(
+  prisma: PrismaClient,
+  topicId: string,
+  slug: string,
+  content = "Original durable content.",
+) {
+  return prisma.article.create({
+    data: {
+      title: `Patch ${slug}`,
+      slug,
+      content,
+      excerpt: "Original excerpt.",
+      topicId,
+      authorName: TEST_KEY_NAME,
+    },
+  });
+}
+
+async function cleanupFixtures(prisma: PrismaClient): Promise<void> {
+  await prisma.article.deleteMany({
+    where: { topic: { slug: TEST_TOPIC_SLUG } },
+  });
+  await prisma.topic.deleteMany({ where: { slug: TEST_TOPIC_SLUG } });
+  await prisma.apiKey.deleteMany({ where: { name: TEST_KEY_NAME } });
+}
+
+test("PATCH /api/articles/[id] strips injected memory blocks before persistence", async () => {
+  const { prisma } = await import("@/lib/prisma");
+  const { PATCH } = await import("@/app/api/articles/[id]/route");
+  const rawKey = `noo_${crypto.randomBytes(32).toString("base64url")}`;
+
+  await cleanupFixtures(prisma);
+  const topic = await setupTopic(prisma);
+  await createWriteKey(prisma, rawKey);
+  const article = await createArticle(prisma, topic.id, "patch-strip");
+
+  try {
+    const content = [
+      "Visible preamble.",
+      "<recall>hidden recall sk-abcdefghijklmnopqrstuvwxyz</recall>",
+      "Visible middle.",
+      "<hindsight_memories>hidden hindsight</hindsight_memories>",
+      "<noosphere_auto_recall>hidden auto</noosphere_auto_recall>",
+      "Visible ending.",
+    ].join("\n");
+
+    const response = await PATCH(
+      buildPatchRequest(article.id, {
+        content,
+        excerpt: "Visible patch summary. <recall>hidden excerpt</recall>",
+      }, rawKey),
+      { params: Promise.resolve({ id: article.id }) },
+    );
+    const body = (await response.json()) as { error?: string };
+
+    assert.equal(response.status, 200, body.error);
+
+    const after = await prisma.article.findUnique({
+      where: { id: article.id },
+      include: { revisions: true },
+    });
+    assert.ok(after, "article must still exist");
+    assert.match(after.content, /Visible preamble/);
+    assert.match(after.content, /Visible middle/);
+    assert.match(after.content, /Visible ending/);
+    assert.doesNotMatch(after.content, /<recall|<hindsight_memories|<noosphere_auto_recall/);
+    assert.doesNotMatch(after.content, /hidden recall|hidden hindsight|hidden auto|sk-abcdefghijklmnopqrstuvwxyz/);
+    assert.match(after.excerpt ?? "", /Visible patch summary/);
+    assert.doesNotMatch(after.excerpt ?? "", /<recall|hidden excerpt/);
+    assert.equal(after.revisions.length, 1, "content PATCH should create one revision");
+    assert.equal(
+      after.revisions[0].content,
+      after.content,
+      "revision content must match stripped article content",
+    );
+  } finally {
+    await cleanupFixtures(prisma);
+  }
+});
+
+test("PATCH /api/articles/[id] rejects content made only of injected memory blocks", async () => {
+  const { prisma } = await import("@/lib/prisma");
+  const { PATCH } = await import("@/app/api/articles/[id]/route");
+  const rawKey = `noo_${crypto.randomBytes(32).toString("base64url")}`;
+
+  await cleanupFixtures(prisma);
+  const topic = await setupTopic(prisma);
+  await createWriteKey(prisma, rawKey);
+  const article = await createArticle(prisma, topic.id, "patch-empty");
+
+  try {
+    const response = await PATCH(
+      buildPatchRequest(article.id, {
+        content: "<recall>hidden only</recall>",
+      }, rawKey),
+      { params: Promise.resolve({ id: article.id }) },
+    );
+    const body = (await response.json()) as { error?: string };
+
+    assert.equal(response.status, 400);
+    assert.equal(
+      body.error,
+      "Content must include durable text outside injected memory blocks",
+    );
+
+    const after = await prisma.article.findUnique({
+      where: { id: article.id },
+      include: { revisions: true },
+    });
+    assert.ok(after, "article must still exist");
+    assert.equal(after.content, article.content);
+    assert.equal(after.revisions.length, 0, "rejected content must not create a revision");
+  } finally {
+    await cleanupFixtures(prisma);
+  }
+});
+
+test("PATCH /api/articles/[id] rejects visible secrets after stripping", async () => {
+  const { prisma } = await import("@/lib/prisma");
+  const { PATCH } = await import("@/app/api/articles/[id]/route");
+  const rawKey = `noo_${crypto.randomBytes(32).toString("base64url")}`;
+
+  await cleanupFixtures(prisma);
+  const topic = await setupTopic(prisma);
+  await createWriteKey(prisma, rawKey);
+  const article = await createArticle(prisma, topic.id, "patch-secret");
+
+  try {
+    const response = await PATCH(
+      buildPatchRequest(article.id, {
+        content: "Visible content with api_key=abcdefghijklmnop",
+      }, rawKey),
+      { params: Promise.resolve({ id: article.id }) },
+    );
+    const body = (await response.json()) as { error?: string };
+
+    assert.equal(response.status, 400);
+    assert.match(body.error ?? "", /secret/);
+
+    const after = await prisma.article.findUnique({
+      where: { id: article.id },
+      include: { revisions: true },
+    });
+    assert.ok(after, "article must still exist");
+    assert.equal(after.content, article.content);
+    assert.equal(after.revisions.length, 0, "secret rejection must not create a revision");
+  } finally {
+    await cleanupFixtures(prisma);
+  }
+});

--- a/src/__tests__/api/articles-post-injected-memory.test.ts
+++ b/src/__tests__/api/articles-post-injected-memory.test.ts
@@ -1,0 +1,186 @@
+import assert from "node:assert/strict";
+import crypto from "node:crypto";
+import test from "node:test";
+import type { NextRequest } from "next/server";
+import type { PrismaClient } from "@prisma/client";
+
+// Route-level test for issue #208. It exercises the real POST /api/articles
+// handler so direct HTTP callers get the same injected-memory protection as
+// agent adapters.
+if (!process.env.DATABASE_URL) {
+  throw new Error("DATABASE_URL environment variable must be set for tests");
+}
+
+const TEST_RUN_ID = crypto.randomUUID();
+const TEST_PREFIX = `test-issue208-${TEST_RUN_ID}`;
+const TEST_TOPIC_SLUG = `${TEST_PREFIX}-topic`;
+const TEST_KEY_NAME = `${TEST_PREFIX}-key`;
+const TEST_CLIENT_IP = `10.208.${Math.floor(Math.random() * 254) + 1}.${Math.floor(Math.random() * 254) + 1}`;
+
+function buildPostRequest(rawKey: string, body: unknown): NextRequest {
+  const request = new Request("http://localhost/api/articles", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${rawKey}`,
+      "Content-Type": "application/json",
+      "x-real-ip": TEST_CLIENT_IP,
+    },
+    body: JSON.stringify(body),
+  });
+  return request as unknown as NextRequest;
+}
+
+async function createWriteKey(
+  prisma: PrismaClient,
+  rawKey: string,
+): Promise<void> {
+  await prisma.apiKey.create({
+    data: {
+      name: `${TEST_KEY_NAME}-${crypto.randomUUID()}`,
+      keyHash: crypto.createHash("sha256").update(rawKey).digest("hex"),
+      keyPrefix: rawKey.slice(0, 8),
+      permissions: "WRITE",
+      allowedScopes: ["*"],
+    },
+  });
+}
+
+async function setupTopic(prisma: PrismaClient): Promise<{ id: string }> {
+  return prisma.topic.upsert({
+    where: { slug: TEST_TOPIC_SLUG },
+    create: { name: "Test Issue 208", slug: TEST_TOPIC_SLUG },
+    update: {},
+    select: { id: true },
+  });
+}
+
+async function cleanupFixtures(prisma: PrismaClient): Promise<void> {
+  await prisma.article.deleteMany({
+    where: { topic: { slug: TEST_TOPIC_SLUG } },
+  });
+  await prisma.topic.deleteMany({ where: { slug: TEST_TOPIC_SLUG } });
+  await prisma.apiKey.deleteMany({
+    where: { name: { startsWith: TEST_KEY_NAME } },
+  });
+}
+
+test("POST /api/articles strips injected memory blocks before persistence (issue #208)", async () => {
+  const { prisma } = await import("@/lib/prisma");
+  const { POST } = await import("@/app/api/articles/route");
+  const rawKey = `noo_${crypto.randomBytes(32).toString("base64url")}`;
+
+  await cleanupFixtures(prisma);
+  const topic = await setupTopic(prisma);
+  await createWriteKey(prisma, rawKey);
+
+  try {
+    const content = [
+      "Visible before.",
+      "<recall>hidden recall</recall>",
+      "Visible middle.",
+      "<hindsight_memories>hidden hindsight</hindsight_memories>",
+      "<noosphere_auto_recall>hidden auto</noosphere_auto_recall>",
+      "Visible after.",
+    ].join("\n");
+
+    const response = await POST(buildPostRequest(rawKey, {
+      title: "Issue 208 Article",
+      slug: "issue-208-article",
+      content,
+      excerpt: "Visible summary. <recall>hidden excerpt</recall>",
+      topicId: topic.id,
+    }));
+    const body = (await response.json()) as { id?: string; error?: string };
+
+    assert.equal(response.status, 201, body.error);
+    assert.ok(body.id, "response should include created article id");
+
+    const article = await prisma.article.findUnique({
+      where: { id: body.id },
+      include: { revisions: true },
+    });
+    assert.ok(article, "created article must exist");
+    assert.match(article.content, /Visible before/);
+    assert.match(article.content, /Visible middle/);
+    assert.match(article.content, /Visible after/);
+    assert.doesNotMatch(article.content, /<recall|<hindsight_memories|<noosphere_auto_recall/);
+    assert.doesNotMatch(article.content, /hidden recall|hidden hindsight|hidden auto/);
+    assert.match(article.excerpt ?? "", /Visible summary/);
+    assert.doesNotMatch(article.excerpt ?? "", /<recall|hidden excerpt/);
+    assert.equal(article.revisions.length, 1, "initial revision should be created");
+    assert.equal(
+      article.revisions[0].content,
+      article.content,
+      "initial revision must store the same stripped content",
+    );
+  } finally {
+    await cleanupFixtures(prisma);
+  }
+});
+
+test("POST /api/articles truncates malformed injected memory tails before persistence", async () => {
+  const { prisma } = await import("@/lib/prisma");
+  const { POST } = await import("@/app/api/articles/route");
+  const rawKey = `noo_${crypto.randomBytes(32).toString("base64url")}`;
+
+  await cleanupFixtures(prisma);
+  const topic = await setupTopic(prisma);
+  await createWriteKey(prisma, rawKey);
+
+  try {
+    const response = await POST(buildPostRequest(rawKey, {
+      title: "Issue 208 Malformed",
+      slug: "issue-208-malformed",
+      content: [
+        "Visible durable content.",
+        "<recall>hidden tail",
+        "This should not persist.",
+      ].join("\n"),
+      topicId: topic.id,
+    }));
+    const body = (await response.json()) as { id?: string; error?: string };
+
+    assert.equal(response.status, 201, body.error);
+    assert.ok(body.id, "response should include created article id");
+
+    const article = await prisma.article.findUnique({ where: { id: body.id } });
+    assert.ok(article, "created article must exist");
+    assert.match(article.content, /Visible durable content/);
+    assert.doesNotMatch(article.content, /hidden tail|This should not persist/);
+  } finally {
+    await cleanupFixtures(prisma);
+  }
+});
+
+test("POST /api/articles rejects content made only of injected memory blocks", async () => {
+  const { prisma } = await import("@/lib/prisma");
+  const { POST } = await import("@/app/api/articles/route");
+  const rawKey = `noo_${crypto.randomBytes(32).toString("base64url")}`;
+
+  await cleanupFixtures(prisma);
+  const topic = await setupTopic(prisma);
+  await createWriteKey(prisma, rawKey);
+
+  try {
+    const response = await POST(buildPostRequest(rawKey, {
+      title: "Issue 208 Empty",
+      slug: "issue-208-empty",
+      content: "<recall>hidden only</recall>",
+      topicId: topic.id,
+    }));
+    const body = (await response.json()) as { error?: string };
+
+    assert.equal(response.status, 400);
+    assert.equal(
+      body.error,
+      "Content must include durable text outside injected memory blocks",
+    );
+
+    const article = await prisma.article.findFirst({
+      where: { topicId: topic.id, slug: "issue-208-empty" },
+    });
+    assert.equal(article, null, "invalid content must not create an article");
+  } finally {
+    await cleanupFixtures(prisma);
+  }
+});

--- a/src/app/api/articles/[id]/route.ts
+++ b/src/app/api/articles/[id]/route.ts
@@ -7,6 +7,10 @@ import {
   getJsonBodyError,
   readBoundedJsonObject,
 } from "@/lib/api/body";
+import {
+  sanitizeArticleContent,
+  sanitizeArticleExcerpt,
+} from "@/lib/api/article-content";
 import { buildTagConnections } from "@/lib/wiki";
 import {
   syncArticleRelations,
@@ -23,6 +27,7 @@ import {
 import { invalidateSearchCache } from "@/lib/cache/search-cache";
 import { rateLimit } from "@/lib/rate-limit";
 import { resolvePatchRestrictedTags } from "@/lib/api/restricted-scopes";
+import { detectSecretInInputs } from "@/lib/memory/api/save";
 
 const ARTICLE_JSON_BODY_MAX_BYTES =
   ARTICLE_LIMITS.maxContentSize + DEFAULT_JSON_BODY_MAX_BYTES;
@@ -99,6 +104,8 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
 
     // Build update data — all fields optional
     const updateData: Record<string, unknown> = { updatedAt: new Date() };
+    let sanitizedContent: string | undefined;
+    let sanitizedExcerpt: string | undefined;
 
     // title
     if (title !== undefined) {
@@ -144,11 +151,20 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
       if (encoded.length > ARTICLE_LIMITS.maxContentSize) {
         return NextResponse.json({ error: `content exceeds maximum size of ${ARTICLE_LIMITS.maxContentSize} bytes` }, { status: 400 });
       }
-      updateData.content = content;
+      const contentSanitization = sanitizeArticleContent(content);
+      if (!contentSanitization.ok) {
+        return NextResponse.json(
+          { error: contentSanitization.error },
+          { status: contentSanitization.status },
+        );
+      }
+
+      sanitizedContent = contentSanitization.content;
+      updateData.content = sanitizedContent;
 
       // Auto-update excerpt if content changed and no explicit excerpt provided
       if (excerpt === undefined) {
-        updateData.excerpt = deriveExcerpt(content);
+        updateData.excerpt = deriveExcerpt(sanitizedContent);
       }
     }
 
@@ -160,7 +176,9 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
       if (excerpt && excerpt.length > ARTICLE_LIMITS.maxExcerptLength) {
         return NextResponse.json({ error: `excerpt exceeds maximum length of ${ARTICLE_LIMITS.maxExcerptLength} characters` }, { status: 400 });
       }
-      updateData.excerpt = excerpt ?? "";
+      sanitizedExcerpt =
+        excerpt === null ? "" : sanitizeArticleExcerpt(excerpt).excerpt;
+      updateData.excerpt = sanitizedExcerpt;
     }
 
     // topicId
@@ -230,6 +248,18 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
       }
     }
 
+    const secretError = detectSecretInInputs([
+      { field: "title", value: title },
+      { field: "content", value: sanitizedContent },
+      { field: "excerpt", value: sanitizedExcerpt },
+      ...(Array.isArray(tags)
+        ? tags.map((value) => ({ field: "tags", value: typeof value === "string" ? value : undefined }))
+        : []),
+    ]);
+    if (secretError) {
+      return NextResponse.json({ error: secretError.error }, { status: secretError.status });
+    }
+
     // Build tag connections if tags are being updated
     let newTagConnections: { tagId: string }[] = [];
     if (tags !== undefined) {
@@ -238,14 +268,15 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
 
     // Create revision if content or title changed
     const titleChanged = title !== undefined && title !== existing.title;
-    const contentChanged = content !== undefined && content !== existing.content;
+    const contentChanged =
+      sanitizedContent !== undefined && sanitizedContent !== existing.content;
 
     if (titleChanged || contentChanged) {
       updateData.revisions = {
         create: {
           authorId: auth.auth.userId ?? null,
           title: (title ?? existing.title) as string,
-          content: (content ?? existing.content) as string,
+          content: (sanitizedContent ?? existing.content) as string,
         },
       };
     }

--- a/src/app/api/articles/route.ts
+++ b/src/app/api/articles/route.ts
@@ -14,6 +14,10 @@ import { invalidateSearchCache } from "@/lib/cache/search-cache";
 import { filterAccessibleRelatedTargets, filterVisibleRelatedArticleRows } from "@/lib/articles/relations";
 import { buildSearchResultHydrationWhere } from "@/lib/wiki-search-results";
 import {
+  sanitizeArticleContent,
+  sanitizeArticleExcerpt,
+} from "@/lib/api/article-content";
+import {
   ARTICLE_LIMITS,
   QUERY_LIMITS,
   deriveExcerpt,
@@ -296,10 +300,23 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    const contentSanitization = sanitizeArticleContent(content);
+    if (!contentSanitization.ok) {
+      return NextResponse.json(
+        { error: contentSanitization.error },
+        { status: contentSanitization.status },
+      );
+    }
+    const sanitizedContent = contentSanitization.content;
+    const sanitizedExcerpt =
+      typeof excerpt === "string"
+        ? sanitizeArticleExcerpt(excerpt).excerpt
+        : undefined;
+
     const secretError = detectSecretInInputs([
       { field: "title", value: title },
-      { field: "content", value: content },
-      { field: "excerpt", value: excerpt ?? undefined },
+      { field: "content", value: sanitizedContent },
+      { field: "excerpt", value: sanitizedExcerpt },
       { field: "authorName", value: authorName },
       ...(Array.isArray(tags)
         ? tags.map((value) => ({ field: "tags", value: typeof value === "string" ? value : undefined }))
@@ -360,8 +377,8 @@ export async function POST(request: NextRequest) {
         data: {
           title,
           slug: slugValidation.slug,
-          content,
-          excerpt: excerpt || deriveExcerpt(content),
+          content: sanitizedContent,
+          excerpt: sanitizedExcerpt || deriveExcerpt(sanitizedContent),
           topicId,
           authorId: auth.auth.userId ?? null,
           authorName: sanitizeAuthorName(authorName) || (auth.auth.name ?? null),
@@ -373,7 +390,7 @@ export async function POST(request: NextRequest) {
             create: {
               authorId: auth.auth.userId ?? null,
               title,
-              content,
+              content: sanitizedContent,
             },
           },
         },

--- a/src/lib/api/article-content.ts
+++ b/src/lib/api/article-content.ts
@@ -1,0 +1,51 @@
+import {
+  SERVER_MEMORY_SAVE_STRIP_MODE,
+  stripInjectedMemoryBlocks,
+} from "@sweetsophia/noosphere-injected-memory";
+
+export const ARTICLE_CONTENT_INJECTED_ONLY_ERROR =
+  "Content must include durable text outside injected memory blocks";
+
+export type ArticleContentSanitizationResult =
+  | { ok: true; content: string; strippedBlocks: string[] }
+  | { ok: false; status: 400; error: string };
+
+export function sanitizeArticleContent(
+  content: string,
+): ArticleContentSanitizationResult {
+  const stripped = stripInjectedMemoryBlocks(
+    content,
+    SERVER_MEMORY_SAVE_STRIP_MODE,
+  );
+  if (!stripped.content.trim()) {
+    return {
+      ok: false,
+      status: 400,
+      error: ARTICLE_CONTENT_INJECTED_ONLY_ERROR,
+    };
+  }
+
+  return {
+    ok: true,
+    content: stripped.content,
+    strippedBlocks: stripped.strippedBlocks,
+  };
+}
+
+export function sanitizeArticleExcerpt(excerpt: string): {
+  excerpt: string;
+  strippedBlocks: string[];
+} {
+  const stripped = stripInjectedMemoryBlocks(
+    excerpt,
+    SERVER_MEMORY_SAVE_STRIP_MODE,
+  );
+
+  return {
+    excerpt:
+      stripped.strippedBlocks.length > 0 && !stripped.content.trim()
+        ? ""
+        : stripped.content,
+    strippedBlocks: stripped.strippedBlocks,
+  };
+}


### PR DESCRIPTION
Closes #208.

## Summary

Hardens direct article create/update API writes so injected-memory blocks cannot be persisted by bypassing the agent adapter layer.

## What Changed

- Added shared article API sanitization in `src/lib/api/article-content.ts`.
- `POST /api/articles` now strips injected-memory blocks from `content` and caller-supplied `excerpt` before secret detection, derived excerpt fallback, article persistence, and initial revision creation.
- `PATCH /api/articles/[id]` now strips injected-memory blocks from updated `content` and explicit `excerpt` before persistence and revision creation.
- `PATCH /api/articles/[id]` now runs secret detection on sanitized title/content/excerpt/tags input, closing the update-path bypass found in review.
- Content that becomes empty after stripping is rejected with HTTP 400 instead of creating or updating durable articles with injected-only text.
- Added focused route-level tests for POST and PATCH, including all supported injected block tags, malformed tails, caller-supplied excerpts, injected-only rejection, revision persistence, and visible-secret rejection after stripping.

## Review Follow-Up

The severe review findings were valid for two blocking cases and are addressed here:

- PATCH could previously persist injected-memory blocks and raw revision content.
- POST could previously persist caller-supplied `excerpt` containing injected-memory blocks.

The broader findings for `POST /api/ingest`, `POST /api/answer`, `POST /api/import`, and stripping observability are valid but wider than #208's direct `/api/articles` scope. I opened follow-up issue #211 for those remaining write paths.

## Verification

- Focused route tests: 6/6 passed
  - `articles-post-injected-memory.test.ts`
  - `articles-patch-injected-memory.test.ts`
- `npm run typecheck`: passed
- `npm run lint`: passed with the same 2 pre-existing unused-variable warnings
- `npm run build`: passed
- `npm run test:api`: 329/331 passed
  - Existing unrelated `sync-conflict-review.test.ts` Prisma mock failure reproduced in isolation
  - `bounded-json-routes.integration.test.ts` failed only in the full shared-DB suite and passed in isolation


<!-- kody-pr-summary:start -->
## Summary

This pull request implements server-side sanitization to strip injected memory blocks (`<recall>`, `<hindsight_memories>`, `<noosphere_auto_recall>`, and malformed tails) from article content and excerpts before they are persisted, addressing issue #208. Previously, this stripping only happened in agent adapters; now it also applies to direct HTTP callers of the article API.

## Changes

### New utility: `src/lib/api/article-content.ts`
Introduces two helpers:
- **`sanitizeArticleContent`** – Strips injected memory blocks from article body content. Returns a 400 error result (`"Content must include durable text outside injected memory blocks"`) when no durable text remains after stripping.
- **`sanitizeArticleExcerpt`** – Strips injected memory blocks from excerpts, returning an empty string if only injected content was present.

Both reuse the existing `stripInjectedMemoryBlocks` helper from `@sweetsophia/noosphere-injected-memory` with the server-save strip mode.

### Modified: `POST /api/articles` (`src/app/api/articles/route.ts`)
- Sanitizes incoming `content` and `excerpt` before secret detection, persistence, initial revision creation, and excerpt derivation.
- Rejects requests whose content consists entirely of injected memory blocks (HTTP 400).

### Modified: `PATCH /api/articles/[id]` (`src/app/api/articles/[id]/route.ts`)
- Sanitizes incoming `content` and `excerpt` on partial updates before storing them, running secret detection, auto-deriving excerpts from the cleaned text, and creating revisions from the stripped content.
- Rejects content-only-injected-memory payloads and runs secret detection against sanitized fields.
- Revision creation now keys off the sanitized content, so revision history matches what's actually persisted.

### New tests
- **`src/__tests__/api/articles-post-injected-memory.test.ts`** – Verifies POST strips `<recall>`, `<hindsight_memories>`, and `<noosphere_auto_recall>` blocks (and the secrets they contain) from both content and excerpts; truncates malformed (unterminated) injected memory tails; persists stripped content in the initial revision; and rejects content that is entirely injected memory.
- **`src/__tests__/api/articles-patch-injected-memory.test.ts`** – Verifies PATCH applies the same stripping, matches the stripped content in newly created revisions, rejects injected-only updates, and rejects visible secrets that survive stripping.
<!-- kody-pr-summary:end -->