### PR TITLE
fix(security): harden remaining article write paths

### DIFF
--- a/src/__tests__/api/article-write-path-sanitizer-coverage.test.ts
+++ b/src/__tests__/api/article-write-path-sanitizer-coverage.test.ts
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const WRITE_PATHS = [
+  {
+    path: "src/app/wiki/[topicSlug]/new/actions.ts",
+    writes: ["tx.article.create"],
+  },
+  {
+    path: "src/app/wiki/[topicSlug]/[articleSlug]/edit/actions.ts",
+    writes: ["tx.article.update", "tx.articleRevision.create"],
+  },
+  {
+    path: "src/lib/markdown-sync/import-applier.ts",
+    writes: ["prisma.article.update", "prisma.article.create"],
+  },
+] as const;
+
+test("non-API article write paths sanitize content before persistence", async () => {
+  for (const writePath of WRITE_PATHS) {
+    const source = await readFile(writePath.path, "utf8");
+    const sanitizeIndex = source.indexOf("sanitizeArticleContent");
+    const secretScanIndex = source.indexOf("detectSecretInInputs");
+    const observationIndex = source.indexOf("buildArticleStripObservation");
+
+    assert.notEqual(sanitizeIndex, -1, `${writePath.path} must strip article content`);
+    assert.notEqual(secretScanIndex, -1, `${writePath.path} must scan sanitized inputs for secrets`);
+    assert.notEqual(observationIndex, -1, `${writePath.path} must build strip observability details`);
+
+    for (const writeNeedle of writePath.writes) {
+      const writeIndex = source.indexOf(writeNeedle);
+      assert.notEqual(writeIndex, -1, `${writePath.path} must still contain ${writeNeedle}`);
+      assert.ok(
+        sanitizeIndex < writeIndex,
+        `${writePath.path} must sanitize content before ${writeNeedle}`,
+      );
+      assert.ok(
+        secretScanIndex < writeIndex,
+        `${writePath.path} must scan secrets before ${writeNeedle}`,
+      );
+    }
+  }
+});

--- a/src/__tests__/api/article-write-paths-injected-memory.test.ts
+++ b/src/__tests__/api/article-write-paths-injected-memory.test.ts
@@ -1,0 +1,414 @@
+import assert from "node:assert/strict";
+import crypto from "node:crypto";
+import test from "node:test";
+import JSZip from "jszip";
+import type { NextRequest } from "next/server";
+import type { PrismaClient } from "@prisma/client";
+
+if (!process.env.DATABASE_URL) {
+  throw new Error("DATABASE_URL environment variable must be set for tests");
+}
+
+const TEST_RUN_ID = crypto.randomUUID();
+const TEST_PREFIX = `test-issue211-${TEST_RUN_ID}`;
+const TEST_TITLE_PREFIX = `Issue 211 ${TEST_RUN_ID}`;
+const TEST_TOPIC_SLUG = `${TEST_PREFIX}-topic`;
+const TEST_KEY_NAME = `${TEST_PREFIX}-key`;
+const TEST_CLIENT_IP = `10.211.${Math.floor(Math.random() * 254) + 1}.${Math.floor(Math.random() * 254) + 1}`;
+
+function buildJsonRequest(
+  path: string,
+  rawKey: string,
+  body: unknown,
+): NextRequest {
+  const request = new Request(`http://localhost${path}`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${rawKey}`,
+      "Content-Type": "application/json",
+      "x-real-ip": TEST_CLIENT_IP,
+    },
+    body: JSON.stringify(body),
+  });
+  return request as unknown as NextRequest;
+}
+
+async function buildZip(
+  articles: Array<{ filename: string; content: string }>,
+): Promise<ArrayBuffer> {
+  const zip = new JSZip();
+  for (const article of articles) {
+    zip.file(article.filename, article.content);
+  }
+  return zip.generateAsync({ type: "arraybuffer" });
+}
+
+function buildImportRequest(
+  zipBuffer: ArrayBuffer,
+  rawKey: string,
+): NextRequest {
+  const formData = new FormData();
+  formData.set(
+    "file",
+    new Blob([zipBuffer], { type: "application/zip" }),
+    "issue-211.zip",
+  );
+
+  const request = new Request("http://localhost/api/import", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${rawKey}`,
+      "x-real-ip": TEST_CLIENT_IP,
+    },
+    body: formData,
+  });
+  return request as unknown as NextRequest;
+}
+
+async function createWriteKey(
+  prisma: PrismaClient,
+  rawKey: string,
+): Promise<void> {
+  await prisma.apiKey.create({
+    data: {
+      name: `${TEST_KEY_NAME}-${crypto.randomUUID()}`,
+      keyHash: crypto.createHash("sha256").update(rawKey).digest("hex"),
+      keyPrefix: rawKey.slice(0, 8),
+      permissions: "WRITE",
+      allowedScopes: ["*"],
+    },
+  });
+}
+
+async function setupTopic(prisma: PrismaClient): Promise<{ id: string }> {
+  return prisma.topic.upsert({
+    where: { slug: TEST_TOPIC_SLUG },
+    create: { name: `Test ${TEST_TITLE_PREFIX}`, slug: TEST_TOPIC_SLUG },
+    update: {},
+    select: { id: true },
+  });
+}
+
+async function cleanupFixtures(prisma: PrismaClient): Promise<void> {
+  await prisma.activityLog.deleteMany({
+    where: {
+      OR: [
+        { authorName: { startsWith: TEST_KEY_NAME } },
+        { title: { contains: TEST_TITLE_PREFIX } },
+      ],
+    },
+  });
+  await prisma.article.deleteMany({
+    where: { topic: { slug: TEST_TOPIC_SLUG } },
+  });
+  await prisma.topic.deleteMany({ where: { slug: TEST_TOPIC_SLUG } });
+  await prisma.apiKey.deleteMany({
+    where: { name: { startsWith: TEST_KEY_NAME } },
+  });
+}
+
+test("POST /api/answer strips injected blocks from content and excerpt", async () => {
+  const { prisma } = await import("@/lib/prisma");
+  const { POST } = await import("@/app/api/answer/route");
+  const rawKey = `noo_${crypto.randomBytes(32).toString("base64url")}`;
+
+  await cleanupFixtures(prisma);
+  const topic = await setupTopic(prisma);
+  await createWriteKey(prisma, rawKey);
+
+  try {
+    const response = await POST(buildJsonRequest("/api/answer", rawKey, {
+      title: `${TEST_TITLE_PREFIX} Answer`,
+      topicId: topic.id,
+      content: [
+        "Visible answer before.",
+        "<recall>hidden recall sk-abcdefghijklmnopqrstuvwxyz</recall>",
+        "Visible answer middle.",
+        "<hindsight_memories>hidden hindsight</hindsight_memories>",
+        "<noosphere_auto_recall>hidden auto</noosphere_auto_recall>",
+        "Visible answer after.",
+      ].join("\n"),
+      excerpt: "Visible answer summary. <recall>hidden excerpt</recall>",
+    }));
+    const body = (await response.json()) as {
+      article?: { id: string };
+      error?: string;
+    };
+
+    assert.equal(response.status, 201, body.error);
+    assert.ok(body.article?.id, "response should include created article id");
+
+    const article = await prisma.article.findUnique({
+      where: { id: body.article.id },
+      include: { revisions: true },
+    });
+    assert.ok(article, "created answer article must exist");
+    assert.match(article.content, /Visible answer before/);
+    assert.match(article.content, /Visible answer middle/);
+    assert.match(article.content, /Visible answer after/);
+    assert.doesNotMatch(article.content, /<recall|<hindsight_memories|<noosphere_auto_recall/);
+    assert.doesNotMatch(article.content, /hidden recall|hidden hindsight|hidden auto|sk-abcdefghijklmnopqrstuvwxyz/);
+    assert.match(article.excerpt ?? "", /Visible answer summary/);
+    assert.doesNotMatch(article.excerpt ?? "", /hidden excerpt|<recall/);
+    assert.equal(article.revisions[0].content, article.content);
+
+    const log = await prisma.activityLog.findFirst({
+      where: {
+        type: "article_content_stripped",
+        title: { contains: `${TEST_TITLE_PREFIX} Answer` },
+      },
+    });
+    assert.ok(log, "answer strip activity log should exist");
+    assert.match(JSON.stringify(log.details), /POST \/api\/answer/);
+    assert.match(JSON.stringify(log.details), /strippedBlockCount/);
+    assert.match(JSON.stringify(log.details), /recall/);
+  } finally {
+    await cleanupFixtures(prisma);
+  }
+});
+
+test("POST /api/answer rejects visible secrets after stripping injected blocks", async () => {
+  const { prisma } = await import("@/lib/prisma");
+  const { POST } = await import("@/app/api/answer/route");
+  const rawKey = `noo_${crypto.randomBytes(32).toString("base64url")}`;
+
+  await cleanupFixtures(prisma);
+  const topic = await setupTopic(prisma);
+  await createWriteKey(prisma, rawKey);
+
+  try {
+    const response = await POST(buildJsonRequest("/api/answer", rawKey, {
+      title: `${TEST_TITLE_PREFIX} Answer Secret`,
+      topicId: topic.id,
+      content: "Visible answer content with api_key=abcdefghijklmnop",
+    }));
+    const body = (await response.json()) as { error?: string };
+
+    assert.equal(response.status, 400);
+    assert.match(body.error ?? "", /secret/);
+
+    const article = await prisma.article.findFirst({
+      where: { topicId: topic.id, title: `${TEST_TITLE_PREFIX} Answer Secret` },
+    });
+    assert.equal(article, null, "secret-bearing answer must not create an article");
+  } finally {
+    await cleanupFixtures(prisma);
+  }
+});
+
+test("POST /api/answer rejects injected-only excerpts", async () => {
+  const { prisma } = await import("@/lib/prisma");
+  const { POST } = await import("@/app/api/answer/route");
+  const rawKey = `noo_${crypto.randomBytes(32).toString("base64url")}`;
+
+  await cleanupFixtures(prisma);
+  const topic = await setupTopic(prisma);
+  await createWriteKey(prisma, rawKey);
+
+  try {
+    const response = await POST(buildJsonRequest("/api/answer", rawKey, {
+      title: `${TEST_TITLE_PREFIX} Answer Empty Excerpt`,
+      topicId: topic.id,
+      content: "Visible answer content.",
+      excerpt: "<recall>hidden only</recall>",
+    }));
+    const body = (await response.json()) as { error?: string };
+
+    assert.equal(response.status, 400);
+    assert.equal(
+      body.error,
+      "Excerpt must include durable text outside injected memory blocks",
+    );
+
+    const article = await prisma.article.findFirst({
+      where: { topicId: topic.id, title: `${TEST_TITLE_PREFIX} Answer Empty Excerpt` },
+    });
+    assert.equal(article, null, "injected-only excerpt must not create an article");
+  } finally {
+    await cleanupFixtures(prisma);
+  }
+});
+
+test("POST /api/ingest strips malformed injected tails before batch persistence", async () => {
+  const { prisma } = await import("@/lib/prisma");
+  const { POST } = await import("@/app/api/ingest/route");
+  const rawKey = `noo_${crypto.randomBytes(32).toString("base64url")}`;
+
+  await cleanupFixtures(prisma);
+  const topic = await setupTopic(prisma);
+  await createWriteKey(prisma, rawKey);
+
+  try {
+    const response = await POST(buildJsonRequest("/api/ingest", rawKey, {
+      source: { type: "text", title: `${TEST_TITLE_PREFIX} Ingest Source` },
+      articles: [
+        {
+          title: `${TEST_TITLE_PREFIX} Ingest`,
+          slug: "issue-211-ingest",
+          topicId: topic.id,
+          content: [
+            "Visible ingest content.",
+            "<recall>hidden malformed tail",
+            "This tail must not persist.",
+          ].join("\n"),
+          excerpt: "Visible ingest summary. <hindsight_memories>hidden excerpt</hindsight_memories>",
+        },
+      ],
+    }));
+    const body = (await response.json()) as { error?: string; created?: number };
+
+    assert.equal(response.status, 201, body.error);
+    assert.equal(body.created, 1);
+
+    const article = await prisma.article.findFirst({
+      where: { topicId: topic.id, slug: "issue-211-ingest" },
+      include: { revisions: true },
+    });
+    assert.ok(article, "ingested article should exist");
+    assert.match(article.content, /Visible ingest content/);
+    assert.doesNotMatch(article.content, /hidden malformed tail|This tail must not persist|<recall/);
+    assert.match(article.excerpt ?? "", /Visible ingest summary/);
+    assert.doesNotMatch(article.excerpt ?? "", /hidden excerpt|<hindsight_memories/);
+    assert.equal(article.revisions[0].content, article.content);
+
+    const log = await prisma.activityLog.findFirst({
+      where: {
+        type: "article_content_stripped",
+        title: { contains: `${TEST_TITLE_PREFIX} Ingest Source` },
+      },
+    });
+    assert.ok(log, "ingest strip activity log should exist");
+    assert.match(JSON.stringify(log.details), /POST \/api\/ingest/);
+    assert.match(JSON.stringify(log.details), /recall/);
+  } finally {
+    await cleanupFixtures(prisma);
+  }
+});
+
+test("POST /api/ingest rejects the whole batch when one article is injected-only", async () => {
+  const { prisma } = await import("@/lib/prisma");
+  const { POST } = await import("@/app/api/ingest/route");
+  const rawKey = `noo_${crypto.randomBytes(32).toString("base64url")}`;
+
+  await cleanupFixtures(prisma);
+  const topic = await setupTopic(prisma);
+  await createWriteKey(prisma, rawKey);
+
+  try {
+    const response = await POST(buildJsonRequest("/api/ingest", rawKey, {
+      source: { type: "text", title: `${TEST_TITLE_PREFIX} Ingest Reject Source` },
+      articles: [
+        {
+          title: `${TEST_TITLE_PREFIX} Ingest Clean`,
+          slug: "issue-211-ingest-clean",
+          topicId: topic.id,
+          content: "Visible clean content.",
+        },
+        {
+          title: `${TEST_TITLE_PREFIX} Ingest Injected Only`,
+          slug: "issue-211-ingest-injected-only",
+          topicId: topic.id,
+          content: "<recall>hidden only</recall>",
+        },
+      ],
+    }));
+    const body = (await response.json()) as { error?: string };
+
+    assert.equal(response.status, 400);
+    assert.match(body.error ?? "", /Article \[1\].*durable text/);
+
+    const articles = await prisma.article.findMany({
+      where: { topicId: topic.id },
+    });
+    assert.equal(articles.length, 0, "rejected ingest batch must not persist earlier clean articles");
+  } finally {
+    await cleanupFixtures(prisma);
+  }
+});
+
+test("POST /api/import strips valid files and reports injected-only or secret files as errors", async () => {
+  const { prisma } = await import("@/lib/prisma");
+  const { POST } = await import("@/app/api/import/route");
+  const rawKey = `noo_${crypto.randomBytes(32).toString("base64url")}`;
+
+  await cleanupFixtures(prisma);
+  await setupTopic(prisma);
+  await createWriteKey(prisma, rawKey);
+
+  try {
+    const zipBuffer = await buildZip([
+      {
+        filename: "good.md",
+        content: `---
+title: ${TEST_TITLE_PREFIX} Import Good
+topic: ${TEST_TOPIC_SLUG}
+slug: issue-211-import-good
+excerpt: "Visible import summary. <recall>hidden excerpt</recall>"
+---
+Visible import content.
+<recall>hidden malformed tail
+This tail must not persist.`,
+      },
+      {
+        filename: "injected-only.md",
+        content: `---
+title: ${TEST_TITLE_PREFIX} Import Empty
+topic: ${TEST_TOPIC_SLUG}
+slug: issue-211-import-empty
+---
+<recall>hidden only</recall>`,
+      },
+      {
+        filename: "secret.md",
+        content: `---
+title: ${TEST_TITLE_PREFIX} Import Secret
+topic: ${TEST_TOPIC_SLUG}
+slug: issue-211-import-secret
+---
+Visible import content with api_key=abcdefghijklmnop`,
+      },
+    ]);
+
+    const response = await POST(buildImportRequest(zipBuffer, rawKey));
+    const body = (await response.json()) as {
+      summary?: { imported: number; errors: number };
+      articles?: Array<{ filename: string; error?: string }>;
+      error?: string;
+    };
+
+    assert.equal(response.status, 200, body.error);
+    assert.equal(body.summary?.imported, 1);
+    assert.equal(body.summary?.errors, 2);
+    assert.match(
+      body.articles?.find((article) => article.filename === "injected-only.md")?.error ?? "",
+      /durable text/,
+    );
+    assert.match(
+      body.articles?.find((article) => article.filename === "secret.md")?.error ?? "",
+      /secret/,
+    );
+
+    const article = await prisma.article.findFirst({
+      where: { slug: "issue-211-import-good" },
+      include: { revisions: true },
+    });
+    assert.ok(article, "good import should create an article");
+    assert.match(article.content, /Visible import content/);
+    assert.doesNotMatch(article.content, /hidden malformed tail|This tail must not persist|<recall/);
+    assert.match(article.excerpt ?? "", /Visible import summary/);
+    assert.doesNotMatch(article.excerpt ?? "", /hidden excerpt|<recall/);
+    assert.equal(article.revisions[0].content, article.content);
+
+    const log = await prisma.activityLog.findFirst({
+      where: {
+        type: "article_content_stripped",
+        title: { contains: `${TEST_TITLE_PREFIX} Import Good` },
+      },
+    });
+    assert.ok(log, "import strip activity log should exist");
+    assert.match(JSON.stringify(log.details), /good.md/);
+    assert.match(JSON.stringify(log.details), /recall/);
+  } finally {
+    await cleanupFixtures(prisma);
+  }
+});

--- a/src/__tests__/api/articles-patch-injected-memory.test.ts
+++ b/src/__tests__/api/articles-patch-injected-memory.test.ts
@@ -72,6 +72,9 @@ async function createArticle(
 }
 
 async function cleanupFixtures(prisma: PrismaClient): Promise<void> {
+  await prisma.activityLog.deleteMany({
+    where: { authorName: TEST_KEY_NAME },
+  });
   await prisma.article.deleteMany({
     where: { topic: { slug: TEST_TOPIC_SLUG } },
   });
@@ -199,6 +202,43 @@ test("PATCH /api/articles/[id] rejects visible secrets after stripping", async (
     assert.ok(after, "article must still exist");
     assert.equal(after.content, article.content);
     assert.equal(after.revisions.length, 0, "secret rejection must not create a revision");
+  } finally {
+    await cleanupFixtures(prisma);
+  }
+});
+
+test("PATCH /api/articles/[id] rejects caller excerpts made only of injected memory blocks", async () => {
+  const { prisma } = await import("@/lib/prisma");
+  const { PATCH } = await import("@/app/api/articles/[id]/route");
+  const rawKey = `noo_${crypto.randomBytes(32).toString("base64url")}`;
+
+  await cleanupFixtures(prisma);
+  const topic = await setupTopic(prisma);
+  await createWriteKey(prisma, rawKey);
+  const article = await createArticle(prisma, topic.id, "patch-empty-excerpt");
+
+  try {
+    const response = await PATCH(
+      buildPatchRequest(article.id, {
+        excerpt: "<recall>hidden excerpt only</recall>",
+      }, rawKey),
+      { params: Promise.resolve({ id: article.id }) },
+    );
+    const body = (await response.json()) as { error?: string };
+
+    assert.equal(response.status, 400);
+    assert.equal(
+      body.error,
+      "Excerpt must include durable text outside injected memory blocks",
+    );
+
+    const after = await prisma.article.findUnique({
+      where: { id: article.id },
+      include: { revisions: true },
+    });
+    assert.ok(after, "article must still exist");
+    assert.equal(after.excerpt, article.excerpt);
+    assert.equal(after.revisions.length, 0, "rejected excerpt must not create a revision");
   } finally {
     await cleanupFixtures(prisma);
   }

--- a/src/__tests__/api/articles-post-injected-memory.test.ts
+++ b/src/__tests__/api/articles-post-injected-memory.test.ts
@@ -55,6 +55,9 @@ async function setupTopic(prisma: PrismaClient): Promise<{ id: string }> {
 }
 
 async function cleanupFixtures(prisma: PrismaClient): Promise<void> {
+  await prisma.activityLog.deleteMany({
+    where: { authorName: { startsWith: TEST_KEY_NAME } },
+  });
   await prisma.article.deleteMany({
     where: { topic: { slug: TEST_TOPIC_SLUG } },
   });
@@ -180,6 +183,40 @@ test("POST /api/articles rejects content made only of injected memory blocks", a
       where: { topicId: topic.id, slug: "issue-208-empty" },
     });
     assert.equal(article, null, "invalid content must not create an article");
+  } finally {
+    await cleanupFixtures(prisma);
+  }
+});
+
+test("POST /api/articles rejects caller excerpts made only of injected memory blocks", async () => {
+  const { prisma } = await import("@/lib/prisma");
+  const { POST } = await import("@/app/api/articles/route");
+  const rawKey = `noo_${crypto.randomBytes(32).toString("base64url")}`;
+
+  await cleanupFixtures(prisma);
+  const topic = await setupTopic(prisma);
+  await createWriteKey(prisma, rawKey);
+
+  try {
+    const response = await POST(buildPostRequest(rawKey, {
+      title: "Issue 208 Empty Excerpt",
+      slug: "issue-208-empty-excerpt",
+      content: "Visible durable content.",
+      excerpt: "<recall>hidden excerpt only</recall>",
+      topicId: topic.id,
+    }));
+    const body = (await response.json()) as { error?: string };
+
+    assert.equal(response.status, 400);
+    assert.equal(
+      body.error,
+      "Excerpt must include durable text outside injected memory blocks",
+    );
+
+    const article = await prisma.article.findFirst({
+      where: { topicId: topic.id, slug: "issue-208-empty-excerpt" },
+    });
+    assert.equal(article, null, "invalid excerpt must not create an article");
   } finally {
     await cleanupFixtures(prisma);
   }

--- a/src/__tests__/api/markdown-import-apply.test.ts
+++ b/src/__tests__/api/markdown-import-apply.test.ts
@@ -1,9 +1,17 @@
 import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import test from "node:test";
 import {
+  applyMarkdownImports,
   MARKDOWN_IMPORT_APPLY_MAX_BODY_BYTES,
   MARKDOWN_IMPORT_APPLY_PERMISSIONS,
 } from "@/lib/markdown-sync/import-applier";
+import type { MarkdownImportCandidate } from "@/lib/markdown-sync/import-scanner";
+import type { Manifest } from "@/lib/obsidian-sync";
+import type { ObsidianSyncConfig } from "@/lib/obsidian-sync/config";
 
 test("import-apply exports correct constants", () => {
   // 256KB max body size
@@ -82,4 +90,122 @@ test("max body bytes is 256KB", () => {
   assert.equal(MARKDOWN_IMPORT_APPLY_MAX_BODY_BYTES, 262144);
   // Verify it's exactly 256KB
   assert.equal(MARKDOWN_IMPORT_APPLY_MAX_BODY_BYTES, 256 * 1024);
+});
+
+test("applyMarkdownImports strips injected blocks before markdown-sync persistence", {
+  skip: !process.env.DATABASE_URL,
+}, async () => {
+  const { prisma } = await import("@/lib/prisma");
+  const testRunId = randomUUID();
+  const testPrefix = `test-issue211-applier-${testRunId}`;
+  const topicSlug = `${testPrefix}-topic`;
+  const articleSlug = `${testPrefix}-article`;
+  const articleTitle = `Issue 211 ${testRunId} Markdown Sync`;
+  const vaultPath = await mkdtemp(join(tmpdir(), "noosphere-import-applier-"));
+  const relativePath = "articles/issue-211-markdown-sync.md";
+  const markdownPath = join(vaultPath, relativePath);
+
+  const topic = await prisma.topic.create({
+    data: { name: `Test ${articleTitle}`, slug: topicSlug },
+    select: { id: true },
+  });
+
+  try {
+    await mkdir(join(vaultPath, "articles"), { recursive: true });
+    await writeFile(markdownPath, `---
+title: ${articleTitle}
+topic: ${topicSlug}
+slug: ${articleSlug}
+excerpt: "Visible markdown summary. <recall>hidden excerpt</recall>"
+tags:
+  - clean-tag
+---
+Visible markdown content.
+<recall>hidden markdown tail
+This tail must not persist.`);
+
+    const manifest: Manifest = {
+      version: 1,
+      vaultPath,
+      lastRunAt: new Date().toISOString(),
+      articles: {},
+    };
+    const config: ObsidianSyncConfig = {
+      enabled: true,
+      vaultPath,
+      gitEnabled: false,
+      autoClean: true,
+      preserveLocalChanges: true,
+      trashDeletions: true,
+      publish: false,
+      manifestPath: ".noosphere-sync/manifest.json",
+      lastRunPath: ".noosphere-sync/last-run.json",
+      timeoutMs: 60_000,
+    };
+    const candidate: MarkdownImportCandidate = {
+      kind: "untracked",
+      relativePath,
+      articleId: null,
+      manifestPath: null,
+      baselineHash: null,
+      markdownHash: testRunId,
+      sizeBytes: 1,
+      metadata: {
+        id: null,
+        slug: articleSlug,
+        title: articleTitle,
+        topic: topicSlug,
+        topicPath: [],
+        tags: ["clean-tag"],
+        restrictedTags: [],
+        updatedAt: null,
+        noosphere: {
+          schemaVersion: null,
+          contentHash: null,
+          syncedAt: null,
+          sourceOfTruth: null,
+        },
+      },
+      parseError: null,
+    };
+
+    const result = await applyMarkdownImports(prisma, {
+      vaultPath,
+      manifest,
+      config,
+      candidates: [candidate],
+      mode: "create",
+      forceOverwrite: false,
+      dryRun: false,
+      performedBy: testPrefix,
+    });
+
+    assert.equal(result.success, true);
+    assert.equal(result.stats.created, 1);
+
+    const article = await prisma.article.findFirst({
+      where: { topicId: topic.id, slug: articleSlug },
+    });
+    assert.ok(article, "markdown-sync import should create an article");
+    assert.match(article.content, /Visible markdown content/);
+    assert.doesNotMatch(article.content, /hidden markdown tail|This tail must not persist|<recall/);
+    assert.match(article.excerpt ?? "", /Visible markdown summary/);
+    assert.doesNotMatch(article.excerpt ?? "", /hidden excerpt|<recall/);
+
+    const log = await prisma.activityLog.findFirst({
+      where: {
+        type: "article_content_stripped",
+        authorName: testPrefix,
+        title: { contains: articleTitle },
+      },
+    });
+    assert.ok(log, "markdown-sync strip activity log should exist");
+    assert.match(JSON.stringify(log.details), /markdown-sync import-applier/);
+    assert.match(JSON.stringify(log.details), /strippedBlockCount/);
+  } finally {
+    await prisma.activityLog.deleteMany({ where: { authorName: testPrefix } });
+    await prisma.article.deleteMany({ where: { topicId: topic.id } });
+    await prisma.topic.deleteMany({ where: { id: topic.id } });
+    await rm(vaultPath, { recursive: true, force: true });
+  }
 });

--- a/src/app/api/answer/route.ts
+++ b/src/app/api/answer/route.ts
@@ -19,6 +19,12 @@ import {
 import { rateLimit } from "@/lib/rate-limit";
 import { invalidateSearchCache } from "@/lib/cache/search-cache";
 import { slugify } from "@/lib/wiki";
+import {
+  buildArticleStripObservation,
+  sanitizeArticleContent,
+  sanitizeArticleExcerpt,
+} from "@/lib/api/article-content";
+import { detectSecretInInputs } from "@/lib/memory/api/save";
 
 const ANSWER_SLUG_MAX_LENGTH = 80;
 const ANSWER_JSON_BODY_MAX_BYTES =
@@ -87,6 +93,9 @@ export async function POST(request: NextRequest) {
       { status: 400 }
     );
   }
+  if (excerpt !== undefined && typeof excerpt !== "string") {
+    return NextResponse.json({ error: "excerpt must be a string" }, { status: 400 });
+  }
 
   // Validate enums
   if (status && !isValidStatus(status)) {
@@ -119,6 +128,45 @@ export async function POST(request: NextRequest) {
     );
   }
 
+  const contentSanitization = sanitizeArticleContent(content);
+  if (!contentSanitization.ok) {
+    return NextResponse.json(
+      { error: contentSanitization.error },
+      { status: contentSanitization.status },
+    );
+  }
+  const sanitizedContent = contentSanitization.content;
+  const excerptSanitization =
+    typeof excerpt === "string" ? sanitizeArticleExcerpt(excerpt) : undefined;
+  if (excerptSanitization && !excerptSanitization.ok) {
+    return NextResponse.json(
+      { error: excerptSanitization.error },
+      { status: excerptSanitization.status },
+    );
+  }
+  const sanitizedExcerpt = excerptSanitization?.excerpt;
+  const stripObservation = buildArticleStripObservation([
+    { field: "content", strippedBlocks: contentSanitization.strippedBlocks },
+    {
+      field: "excerpt",
+      strippedBlocks: excerptSanitization?.strippedBlocks ?? [],
+    },
+  ]);
+
+  const secretError = detectSecretInInputs([
+    { field: "title", value: title },
+    { field: "content", value: sanitizedContent },
+    { field: "excerpt", value: sanitizedExcerpt },
+    { field: "sourceQuery", value: sourceQuery },
+    { field: "authorName", value: rawAuthorName },
+    ...(Array.isArray(tags)
+      ? tags.map((value) => ({ field: "tags", value: typeof value === "string" ? value : undefined }))
+      : []),
+  ]);
+  if (secretError) {
+    return NextResponse.json({ error: secretError.error }, { status: secretError.status });
+  }
+
   // Build tag connections
   const tagConnections = tags?.length
     ? await Promise.all(
@@ -135,14 +183,14 @@ export async function POST(request: NextRequest) {
     : [];
 
   // Derive excerpt if not provided
-  const derivedExcerpt = excerpt || deriveExcerpt(content, 200);
+  const derivedExcerpt = sanitizedExcerpt || deriveExcerpt(sanitizedContent, 200);
 
   const article = await prisma.$transaction(async (tx) => {
     const created = await tx.article.create({
       data: {
         title,
         slug: slug.slug,
-        content,
+        content: sanitizedContent,
         excerpt: derivedExcerpt,
         topicId,
         authorId: userId,
@@ -156,7 +204,7 @@ export async function POST(request: NextRequest) {
           create: {
             authorId: userId,
             title,
-            content,
+            content: sanitizedContent,
           },
         },
       },
@@ -175,13 +223,31 @@ export async function POST(request: NextRequest) {
         details: {
           articleId: created.id,
           topic: topic.name,
-          sourceQuery,
           tagCount: tagConnections.length,
-          confidence,
           status: status || "published",
+          ...(sourceQuery ? { sourceQuery } : {}),
+          ...(confidence ? { confidence } : {}),
         },
       },
     });
+
+    if (stripObservation) {
+      await tx.activityLog.create({
+        data: {
+          type: "article_content_stripped",
+          title: `Injected memory stripped from answer save: ${title}`,
+          authorName,
+          details: {
+            route: "POST /api/answer",
+            kind: "single",
+            articleId: created.id,
+            topicId,
+            slug: slug.slug,
+            ...stripObservation,
+          },
+        },
+      });
+    }
 
     return created;
   });

--- a/src/app/api/articles/[id]/route.ts
+++ b/src/app/api/articles/[id]/route.ts
@@ -8,6 +8,7 @@ import {
   readBoundedJsonObject,
 } from "@/lib/api/body";
 import {
+  buildArticleStripObservation,
   sanitizeArticleContent,
   sanitizeArticleExcerpt,
 } from "@/lib/api/article-content";
@@ -106,6 +107,8 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
     const updateData: Record<string, unknown> = { updatedAt: new Date() };
     let sanitizedContent: string | undefined;
     let sanitizedExcerpt: string | undefined;
+    let contentStrippedBlocks: string[] = [];
+    let excerptStrippedBlocks: string[] = [];
 
     // title
     if (title !== undefined) {
@@ -160,6 +163,7 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
       }
 
       sanitizedContent = contentSanitization.content;
+      contentStrippedBlocks = contentSanitization.strippedBlocks;
       updateData.content = sanitizedContent;
 
       // Auto-update excerpt if content changed and no explicit excerpt provided
@@ -176,8 +180,19 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
       if (excerpt && excerpt.length > ARTICLE_LIMITS.maxExcerptLength) {
         return NextResponse.json({ error: `excerpt exceeds maximum length of ${ARTICLE_LIMITS.maxExcerptLength} characters` }, { status: 400 });
       }
-      sanitizedExcerpt =
-        excerpt === null ? "" : sanitizeArticleExcerpt(excerpt).excerpt;
+      if (excerpt === null) {
+        sanitizedExcerpt = "";
+      } else {
+        const excerptSanitization = sanitizeArticleExcerpt(excerpt);
+        if (!excerptSanitization.ok) {
+          return NextResponse.json(
+            { error: excerptSanitization.error },
+            { status: excerptSanitization.status },
+          );
+        }
+        sanitizedExcerpt = excerptSanitization.excerpt;
+        excerptStrippedBlocks = excerptSanitization.strippedBlocks;
+      }
       updateData.excerpt = sanitizedExcerpt;
     }
 
@@ -281,6 +296,11 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
       };
     }
 
+    const stripObservation = buildArticleStripObservation([
+      { field: "content", strippedBlocks: contentStrippedBlocks },
+      { field: "excerpt", strippedBlocks: excerptStrippedBlocks },
+    ]);
+
     // Execute update in transaction: article update + tag reconnect + relation sync
     const updatedArticle = await prisma.$transaction(async (tx) => {
       // Update article fields
@@ -288,6 +308,24 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
         where: { id },
         data: updateData,
       });
+
+      if (stripObservation) {
+        await tx.activityLog.create({
+          data: {
+            type: "article_content_stripped",
+            title: `Injected memory stripped from article update: ${String(updateData.title ?? existing.title)}`,
+            authorName: auth.auth.name ?? "API",
+            details: {
+              route: "PATCH /api/articles/[id]",
+              kind: "single",
+              articleId: id,
+              topicId: (updateData.topicId as string | undefined) ?? existing.topicId,
+              slug: (updateData.slug as string | undefined) ?? existing.slug,
+              ...stripObservation,
+            },
+          },
+        });
+      }
 
       // Reconnect tags if changed
       if (tags !== undefined) {

--- a/src/app/api/articles/route.ts
+++ b/src/app/api/articles/route.ts
@@ -14,6 +14,7 @@ import { invalidateSearchCache } from "@/lib/cache/search-cache";
 import { filterAccessibleRelatedTargets, filterVisibleRelatedArticleRows } from "@/lib/articles/relations";
 import { buildSearchResultHydrationWhere } from "@/lib/wiki-search-results";
 import {
+  buildArticleStripObservation,
   sanitizeArticleContent,
   sanitizeArticleExcerpt,
 } from "@/lib/api/article-content";
@@ -308,10 +309,22 @@ export async function POST(request: NextRequest) {
       );
     }
     const sanitizedContent = contentSanitization.content;
-    const sanitizedExcerpt =
-      typeof excerpt === "string"
-        ? sanitizeArticleExcerpt(excerpt).excerpt
-        : undefined;
+    const excerptSanitization =
+      typeof excerpt === "string" ? sanitizeArticleExcerpt(excerpt) : undefined;
+    if (excerptSanitization && !excerptSanitization.ok) {
+      return NextResponse.json(
+        { error: excerptSanitization.error },
+        { status: excerptSanitization.status },
+      );
+    }
+    const sanitizedExcerpt = excerptSanitization?.excerpt;
+    const stripObservation = buildArticleStripObservation([
+      { field: "content", strippedBlocks: contentSanitization.strippedBlocks },
+      {
+        field: "excerpt",
+        strippedBlocks: excerptSanitization?.strippedBlocks ?? [],
+      },
+    ]);
 
     const secretError = detectSecretInInputs([
       { field: "title", value: title },
@@ -399,6 +412,24 @@ export async function POST(request: NextRequest) {
           tags: { include: { tag: true } },
         },
       });
+
+      if (stripObservation) {
+        await tx.activityLog.create({
+          data: {
+            type: "article_content_stripped",
+            title: `Injected memory stripped from article create: ${title}`,
+            authorName: sanitizeAuthorName(authorName) || (auth.auth.name ?? "API"),
+            details: {
+              route: "POST /api/articles",
+              kind: "single",
+              articleId: created.id,
+              topicId,
+              slug: slugValidation.slug,
+              ...stripObservation,
+            },
+          },
+        });
+      }
 
       // Filter against the caller's scopes so a scoped key cannot link an
       // unrestricted source to a restricted target the caller cannot see —

--- a/src/app/api/import/route.ts
+++ b/src/app/api/import/route.ts
@@ -13,6 +13,13 @@ import {
   readMarkdownString,
   readMarkdownStringArray,
 } from "@/lib/markdown/noosphere-markdown";
+import {
+  type ArticleStripObservation,
+  buildArticleStripObservation,
+  sanitizeArticleContent,
+  sanitizeArticleExcerpt,
+} from "@/lib/api/article-content";
+import { detectSecretInInputs } from "@/lib/memory/api/save";
 
 // Disable Next.js body parsing for file uploads
 export const dynamic = "force-dynamic";
@@ -84,6 +91,7 @@ interface ImportArticle {
   restrictedTags?: string[];
   restrictedTagsInput?: unknown;
   hasRestrictedTagsField: boolean;
+  stripObservation?: ArticleStripObservation;
   error?: string;
 }
 
@@ -269,20 +277,72 @@ export async function POST(request: NextRequest) {
     }
 
     const tags = readMarkdownStringArray(frontmatter, "tags");
+    const rawExcerpt = readMarkdownString(frontmatter, "excerpt");
     const hasRestrictedTags = hasRestrictedTagsField(frontmatter);
     const restrictedTagsInput = hasRestrictedTags ? frontmatter.restrictedTags : undefined;
     const restrictedTags = hasRestrictedTags
       ? readMarkdownStringArray(frontmatter, "restrictedTags")
       : undefined;
+    const contentSanitization = sanitizeArticleContent(articleContent);
+    if (!contentSanitization.ok) {
+      toImport.push({
+        filename: entry.name,
+        title,
+        slug,
+        topicSlug,
+        content: articleContent,
+        tags,
+        hasRestrictedTagsField: hasRestrictedTags,
+        error: contentSanitization.error,
+      });
+      continue;
+    }
+    const excerptSanitization =
+      typeof rawExcerpt === "string"
+        ? sanitizeArticleExcerpt(rawExcerpt)
+        : undefined;
+    if (excerptSanitization && !excerptSanitization.ok) {
+      toImport.push({
+        filename: entry.name,
+        title,
+        slug,
+        topicSlug,
+        content: contentSanitization.content,
+        tags,
+        hasRestrictedTagsField: hasRestrictedTags,
+        error: excerptSanitization.error,
+      });
+      continue;
+    }
+    const secretError = detectSecretInInputs([
+      { field: `${entry.name}.title`, value: title },
+      { field: `${entry.name}.content`, value: contentSanitization.content },
+      { field: `${entry.name}.excerpt`, value: excerptSanitization?.excerpt },
+      { field: `${entry.name}.sourceUrl`, value: readMarkdownString(frontmatter, "sourceUrl") },
+      ...tags.map((value) => ({ field: `${entry.name}.tags`, value })),
+    ]);
+    if (secretError) {
+      toImport.push({
+        filename: entry.name,
+        title,
+        slug,
+        topicSlug,
+        content: contentSanitization.content,
+        tags,
+        hasRestrictedTagsField: hasRestrictedTags,
+        error: secretError.error,
+      });
+      continue;
+    }
 
     toImport.push({
       filename: entry.name,
       title,
       topicSlug,
       slug,
-      content: articleContent,
+      content: contentSanitization.content,
       tags,
-      excerpt: readMarkdownString(frontmatter, "excerpt"),
+      excerpt: excerptSanitization?.excerpt,
       confidence: readMarkdownString(frontmatter, "confidence"),
       status: readMarkdownString(frontmatter, "status"),
       sourceUrl: readMarkdownString(frontmatter, "sourceUrl"),
@@ -290,6 +350,13 @@ export async function POST(request: NextRequest) {
       restrictedTags,
       restrictedTagsInput,
       hasRestrictedTagsField: hasRestrictedTags,
+      stripObservation: buildArticleStripObservation([
+        { field: "content", strippedBlocks: contentSanitization.strippedBlocks },
+        {
+          field: "excerpt",
+          strippedBlocks: excerptSanitization?.strippedBlocks ?? [],
+        },
+      ]),
     });
   }
 
@@ -348,6 +415,14 @@ export async function POST(request: NextRequest) {
   const canChangeClassification = canChangeExistingRestrictedTags(auth.auth);
 
   const results = { imported: 0, skipped: 0, errors: 0 };
+  const strippedImports: Array<{
+    filename: string;
+    title: string;
+    slug: string;
+    topicSlug: string;
+    articleId: string;
+    observation: ArticleStripObservation;
+  }> = [];
 
   await prisma.$transaction(async (tx) => {
     for (const article of toImport) {
@@ -411,6 +486,16 @@ export async function POST(request: NextRequest) {
               updatedAt: new Date(),
             },
           });
+          if (article.stripObservation) {
+            strippedImports.push({
+              filename: article.filename,
+              title: article.title,
+              slug: article.slug,
+              topicSlug: article.topicSlug,
+              articleId: existing.id,
+              observation: article.stripObservation,
+            });
+          }
           if (restrictedTagsChanged) {
             const wasUnrestricted = existingRestrictedTags.length === 0;
             const isNowUnrestricted = nextRestrictedTags.length === 0;
@@ -467,7 +552,7 @@ export async function POST(request: NextRequest) {
         })
       );
 
-      await tx.article.create({
+      const created = await tx.article.create({
         data: {
           title: article.title,
           slug: article.slug,
@@ -490,9 +575,38 @@ export async function POST(request: NextRequest) {
             },
           },
         },
+        select: { id: true },
       });
+      if (article.stripObservation) {
+        strippedImports.push({
+          filename: article.filename,
+          title: article.title,
+          slug: article.slug,
+          topicSlug: article.topicSlug,
+          articleId: created.id,
+          observation: article.stripObservation,
+        });
+      }
 
       results.imported++;
+    }
+
+    if (strippedImports.length > 0) {
+      await tx.activityLog.create({
+        data: {
+          type: "article_content_stripped",
+          title: `Injected memory stripped from import: ${strippedImports
+            .map((article) => article.title)
+            .slice(0, 2)
+            .join(", ")}`,
+          authorName: userName,
+          details: {
+            route: "POST /api/import",
+            kind: "batch",
+            articles: strippedImports,
+          },
+        },
+      });
     }
   });
 

--- a/src/app/api/ingest/route.ts
+++ b/src/app/api/ingest/route.ts
@@ -12,6 +12,13 @@ import { ARTICLE_LIMITS, deriveExcerpt, sanitizeAuthorName } from "@/lib/validat
 import { rateLimit } from "@/lib/rate-limit";
 import { invalidateSearchCache } from "@/lib/cache/search-cache";
 import { filterAccessibleRelatedTargets } from "@/lib/articles/relations";
+import {
+  type ArticleStripObservation,
+  buildArticleStripObservation,
+  sanitizeArticleContent,
+  sanitizeArticleExcerpt,
+} from "@/lib/api/article-content";
+import { detectSecretInInputs } from "@/lib/memory/api/save";
 
 // Ingest is a multi-article batch endpoint, so it needs more headroom than a
 // single article while still rejecting payloads large enough to amplify work.
@@ -52,6 +59,7 @@ interface IngestArticle {
   confidence?: string;
   status?: string;
   relatedArticleIds?: string[];
+  stripObservation?: ArticleStripObservation;
 }
 
 export async function POST(request: NextRequest) {
@@ -102,10 +110,22 @@ export async function POST(request: NextRequest) {
 
   // Validate each article has required fields
   for (const [i, article] of articles.entries()) {
-    if (!article.title || !article.slug || !article.content || !article.topicId) {
+    if (
+      typeof article.title !== "string" || !article.title ||
+      typeof article.slug !== "string" || !article.slug ||
+      typeof article.content !== "string" || !article.content ||
+      typeof article.topicId !== "string" || !article.topicId
+    ) {
       return NextResponse.json(
         { error: `Article [${i}] missing required fields: title, slug, content, topicId` },
         { status: 400 }
+      );
+    }
+
+    if (article.excerpt !== undefined && typeof article.excerpt !== "string") {
+      return NextResponse.json(
+        { error: `Article [${i}] excerpt must be a string` },
+        { status: 400 },
       );
     }
 
@@ -134,21 +154,77 @@ export async function POST(request: NextRequest) {
   // --- Create articles ---
   const sourceUrl = source.type === "url" ? source.url : null;
   const createdArticles: { id: string; title: string; slug: string; topic: string }[] = [];
+  const strippedIngestArticles: Array<{
+    index: number;
+    articleId: string;
+    title: string;
+    slug: string;
+    observation: ArticleStripObservation;
+  }> = [];
   let totalTagsApplied = 0;
 
   // Validate content sizes before entering transaction — throws are not caught inside $transaction
-  for (const article of articles) {
+  for (const [i, article] of articles.entries()) {
     if (new TextEncoder().encode(article.content).length > ARTICLE_LIMITS.maxContentSize) {
       return NextResponse.json(
-        { error: `Article [${articles.indexOf(article)}] content exceeds ${ARTICLE_LIMITS.maxContentSize} bytes` },
+        { error: `Article [${i}] content exceeds ${ARTICLE_LIMITS.maxContentSize} bytes` },
         { status: 400 }
       );
     }
+
+    const contentSanitization = sanitizeArticleContent(article.content);
+    if (!contentSanitization.ok) {
+      return NextResponse.json(
+        { error: `Article [${i}] ${contentSanitization.error}` },
+        { status: contentSanitization.status },
+      );
+    }
+
+    const excerptSanitization =
+      typeof article.excerpt === "string"
+        ? sanitizeArticleExcerpt(article.excerpt)
+        : undefined;
+    if (excerptSanitization && !excerptSanitization.ok) {
+      return NextResponse.json(
+        { error: `Article [${i}] ${excerptSanitization.error}` },
+        { status: excerptSanitization.status },
+      );
+    }
+
+    const secretError = detectSecretInInputs([
+      { field: `articles[${i}].title`, value: article.title },
+      { field: `articles[${i}].content`, value: contentSanitization.content },
+      { field: `articles[${i}].excerpt`, value: excerptSanitization?.excerpt },
+      { field: `articles[${i}].sourceUrl`, value: article.sourceUrl },
+      { field: `articles[${i}].authorName`, value: article.authorName },
+      ...[...(article.tags ?? []), ...(globalTags ?? [])].map((value) => ({
+        field: `articles[${i}].tags`,
+        value,
+      })),
+    ]);
+    if (secretError) {
+      return NextResponse.json(
+        { error: secretError.error },
+        { status: secretError.status },
+      );
+    }
+
+    // Intentional in-place rewrite: after this pre-transaction pass, the
+    // transaction only sees sanitized article payloads.
+    article.content = contentSanitization.content;
+    article.excerpt = excerptSanitization?.excerpt;
+    article.stripObservation = buildArticleStripObservation([
+      { field: "content", strippedBlocks: contentSanitization.strippedBlocks },
+      {
+        field: "excerpt",
+        strippedBlocks: excerptSanitization?.strippedBlocks ?? [],
+      },
+    ]);
   }
 
   // Use a transaction to keep everything consistent
   const result = await prisma.$transaction(async (tx) => {
-    for (const article of articles) {
+    for (const [index, article] of articles.entries()) {
       // Check slug uniqueness within topic
       const existing = await tx.article.findUnique({
         where: { topicId_slug: { topicId: article.topicId, slug: article.slug } },
@@ -220,6 +296,15 @@ export async function POST(request: NextRequest) {
         slug: article.slug,
         topic: topic.name,
       });
+      if (article.stripObservation) {
+        strippedIngestArticles.push({
+          index,
+          articleId: created.id,
+          title: article.title,
+          slug: article.slug,
+          observation: article.stripObservation,
+        });
+      }
 
       // Filter against the caller's scopes (and skip non-existent /
       // soft-deleted targets) so a scoped key cannot link an unrestricted
@@ -264,6 +349,22 @@ export async function POST(request: NextRequest) {
         },
       },
     });
+
+    if (strippedIngestArticles.length > 0) {
+      await tx.activityLog.create({
+        data: {
+          type: "article_content_stripped",
+          title: `Injected memory stripped from ingest: ${source.title}`,
+          sourceUrl,
+          authorName: sanitizedAuthorName,
+          details: {
+            route: "POST /api/ingest",
+            kind: "batch",
+            articles: strippedIngestArticles,
+          },
+        },
+      });
+    }
 
     return { logId: logEntry.id };
   });

--- a/src/app/wiki/[topicSlug]/[articleSlug]/edit/actions.ts
+++ b/src/app/wiki/[topicSlug]/[articleSlug]/edit/actions.ts
@@ -7,6 +7,12 @@ import { authOptions } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { buildTagConnections, parseTagInput } from "@/lib/wiki";
 import { invalidateSearchCache } from "@/lib/cache/search-cache";
+import {
+  buildArticleStripObservation,
+  sanitizeArticleContent,
+  sanitizeArticleExcerpt,
+} from "@/lib/api/article-content";
+import { detectSecretInInputs } from "@/lib/memory/api/save";
 
 async function requireEditorSession() {
   const session = await getServerSession(authOptions);
@@ -47,6 +53,10 @@ export async function saveArticle(
   if (!content.trim()) {
     throw new Error("Content cannot be empty.");
   }
+  const contentSanitization = sanitizeArticleContent(content.trim());
+  if (!contentSanitization.ok) {
+    throw new Error(contentSanitization.error);
+  }
 
   const topic = await prisma.topic.findUnique({ where: { slug: topicSlug } });
   if (!topic) throw new Error("Topic not found.");
@@ -58,8 +68,31 @@ export async function saveArticle(
   if (!article) throw new Error("Article not found.");
 
   const nextTitle = title.trim() || article.title;
-  const nextContent = content.trim();
-  const nextExcerpt = excerpt.trim() || nextContent.slice(0, 160).replace(/[#*`_]/g, "");
+  const nextContent = contentSanitization.content.trim();
+  const rawExcerpt = excerpt.trim();
+  const excerptSanitization = rawExcerpt
+    ? sanitizeArticleExcerpt(rawExcerpt)
+    : undefined;
+  if (excerptSanitization && !excerptSanitization.ok) {
+    throw new Error(excerptSanitization.error);
+  }
+  const nextExcerpt = excerptSanitization?.excerpt.trim() || nextContent.slice(0, 160).replace(/[#*`_]/g, "");
+  const stripObservation = buildArticleStripObservation([
+    { field: "content", strippedBlocks: contentSanitization.strippedBlocks },
+    {
+      field: "excerpt",
+      strippedBlocks: excerptSanitization?.strippedBlocks ?? [],
+    },
+  ]);
+  const secretError = detectSecretInInputs([
+    { field: "title", value: title.trim() ? nextTitle : undefined },
+    { field: "content", value: nextContent },
+    { field: "excerpt", value: rawExcerpt ? nextExcerpt : undefined },
+    ...tags.map((value) => ({ field: "tags", value })),
+  ]);
+  if (secretError) {
+    throw new Error(secretError.error);
+  }
   const tagConnections = await buildTagConnections(tags);
 
   // Collect restricted tags from form
@@ -83,8 +116,8 @@ export async function saveArticle(
     }
   }
 
-  await prisma.$transaction([
-    prisma.article.update({
+  await prisma.$transaction(async (tx) => {
+    await tx.article.update({
       where: { id: article.id },
       data: {
         content: nextContent,
@@ -93,17 +126,34 @@ export async function saveArticle(
         restrictedTags,
         updatedAt: new Date(),
       },
-    }),
-    prisma.articleTag.deleteMany({ where: { articleId: article.id } }),
-    prisma.articleRevision.create({
+    });
+    await tx.articleTag.deleteMany({ where: { articleId: article.id } });
+    await tx.articleRevision.create({
       data: {
         articleId: article.id,
         authorId: session.user.id,
         content: nextContent,
         title: nextTitle,
       },
-    }),
-  ]);
+    });
+    if (stripObservation) {
+      await tx.activityLog.create({
+        data: {
+          type: "article_content_stripped",
+          title: `Injected memory stripped from wiki article update: ${nextTitle}`,
+          authorName: session.user.name ?? session.user.email ?? "Web UI",
+          details: {
+            route: "wiki saveArticle",
+            kind: "single",
+            articleId: article.id,
+            topicId: topic.id,
+            slug: article.slug,
+            ...stripObservation,
+          },
+        },
+      });
+    }
+  });
 
   if (tagConnections.length > 0) {
     await prisma.articleTag.createMany({

--- a/src/app/wiki/[topicSlug]/new/actions.ts
+++ b/src/app/wiki/[topicSlug]/new/actions.ts
@@ -7,6 +7,12 @@ import { authOptions } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { buildTagConnections, parseTagInput, slugify } from "@/lib/wiki";
 import { invalidateSearchCache } from "@/lib/cache/search-cache";
+import {
+  buildArticleStripObservation,
+  sanitizeArticleContent,
+  sanitizeArticleExcerpt,
+} from "@/lib/api/article-content";
+import { detectSecretInInputs } from "@/lib/memory/api/save";
 
 async function requireEditorSession() {
   const session = await getServerSession(authOptions);
@@ -32,18 +38,49 @@ export async function createArticle(
   const content = String(formData.get("content") ?? "");
   const excerpt = String(formData.get("excerpt") ?? "");
   const tags = parseTagInput(String(formData.get("tags") ?? ""));
+  const normalizedTitle = title.trim();
 
-  if (!title.trim()) {
+  if (!normalizedTitle) {
     throw new Error("Title is required.");
   }
   if (!content.trim()) {
     throw new Error("Content cannot be empty.");
   }
 
+  const contentSanitization = sanitizeArticleContent(content.trim());
+  if (!contentSanitization.ok) {
+    throw new Error(contentSanitization.error);
+  }
+  const sanitizedContent = contentSanitization.content.trim();
+  const rawExcerpt = excerpt.trim();
+  const excerptSanitization = rawExcerpt
+    ? sanitizeArticleExcerpt(rawExcerpt)
+    : undefined;
+  if (excerptSanitization && !excerptSanitization.ok) {
+    throw new Error(excerptSanitization.error);
+  }
+  const sanitizedExcerpt = excerptSanitization?.excerpt.trim();
+  const stripObservation = buildArticleStripObservation([
+    { field: "content", strippedBlocks: contentSanitization.strippedBlocks },
+    {
+      field: "excerpt",
+      strippedBlocks: excerptSanitization?.strippedBlocks ?? [],
+    },
+  ]);
+  const secretError = detectSecretInInputs([
+    { field: "title", value: normalizedTitle },
+    { field: "content", value: sanitizedContent },
+    { field: "excerpt", value: sanitizedExcerpt },
+    ...tags.map((value) => ({ field: "tags", value })),
+  ]);
+  if (secretError) {
+    throw new Error(secretError.error);
+  }
+
   const topic = await prisma.topic.findUnique({ where: { slug: topicSlug } });
   if (!topic) throw new Error("Topic not found.");
 
-  let slug = slugify(title) || "untitled";
+  let slug = slugify(normalizedTitle) || "untitled";
   const existing = await prisma.article.findFirst({
     where: { topicId: topic.id, slug, deletedAt: null },
   });
@@ -74,24 +111,46 @@ export async function createArticle(
     }
   }
 
-  const article = await prisma.article.create({
-    data: {
-      title: title.trim(),
-      slug,
-      content: content.trim(),
-      excerpt: excerpt.trim() || content.trim().slice(0, 160).replace(/[#*`_]/g, ""),
-      topicId: topic.id,
-      authorId: session.user.id,
-      tags: { create: tagConnections },
-      restrictedTags,
-      revisions: {
-        create: {
-          authorId: session.user.id,
-          title: title.trim(),
-          content: content.trim(),
+  const article = await prisma.$transaction(async (tx) => {
+    const created = await tx.article.create({
+      data: {
+        title: normalizedTitle,
+        slug,
+        content: sanitizedContent,
+        excerpt: sanitizedExcerpt || sanitizedContent.slice(0, 160).replace(/[#*`_]/g, ""),
+        topicId: topic.id,
+        authorId: session.user.id,
+        tags: { create: tagConnections },
+        restrictedTags,
+        revisions: {
+          create: {
+            authorId: session.user.id,
+            title: normalizedTitle,
+            content: sanitizedContent,
+          },
         },
       },
-    },
+    });
+
+    if (stripObservation) {
+      await tx.activityLog.create({
+        data: {
+          type: "article_content_stripped",
+          title: `Injected memory stripped from wiki article create: ${normalizedTitle}`,
+          authorName: session.user.name ?? session.user.email ?? "Web UI",
+          details: {
+            route: "wiki createArticle",
+            kind: "single",
+            articleId: created.id,
+            topicId: topic.id,
+            slug,
+            ...stripObservation,
+          },
+        },
+      });
+    }
+
+    return created;
   });
 
   await invalidateSearchCache();

--- a/src/lib/api/article-content.ts
+++ b/src/lib/api/article-content.ts
@@ -2,13 +2,20 @@ import {
   SERVER_MEMORY_SAVE_STRIP_MODE,
   stripInjectedMemoryBlocks,
 } from "@sweetsophia/noosphere-injected-memory";
+import type { Prisma } from "@prisma/client";
 
 export const ARTICLE_CONTENT_INJECTED_ONLY_ERROR =
   "Content must include durable text outside injected memory blocks";
+export const ARTICLE_EXCERPT_INJECTED_ONLY_ERROR =
+  "Excerpt must include durable text outside injected memory blocks";
 
 export type ArticleContentSanitizationResult =
   | { ok: true; content: string; strippedBlocks: string[] }
   | { ok: false; status: 400; error: string };
+
+export type ArticleExcerptSanitizationResult =
+  | { ok: true; excerpt: string; strippedBlocks: string[] }
+  | { ok: false; status: 400; error: string; strippedBlocks: string[] };
 
 export function sanitizeArticleContent(
   content: string,
@@ -32,20 +39,55 @@ export function sanitizeArticleContent(
   };
 }
 
-export function sanitizeArticleExcerpt(excerpt: string): {
-  excerpt: string;
-  strippedBlocks: string[];
-} {
+export function sanitizeArticleExcerpt(
+  excerpt: string,
+): ArticleExcerptSanitizationResult {
   const stripped = stripInjectedMemoryBlocks(
     excerpt,
     SERVER_MEMORY_SAVE_STRIP_MODE,
   );
+  if (stripped.strippedBlocks.length > 0 && !stripped.content.trim()) {
+    return {
+      ok: false,
+      status: 400,
+      error: ARTICLE_EXCERPT_INJECTED_ONLY_ERROR,
+      strippedBlocks: stripped.strippedBlocks,
+    };
+  }
 
   return {
-    excerpt:
-      stripped.strippedBlocks.length > 0 && !stripped.content.trim()
-        ? ""
-        : stripped.content,
+    ok: true,
+    excerpt: stripped.content,
     strippedBlocks: stripped.strippedBlocks,
+  };
+}
+
+export type ArticleStripObservationField = Prisma.InputJsonObject & {
+  field: string;
+  strippedBlocks: string[];
+};
+
+export type ArticleStripObservation = Prisma.InputJsonObject;
+
+export function buildArticleStripObservation(
+  fields: ArticleStripObservationField[],
+): Prisma.InputJsonObject | undefined {
+  const activeFields = fields.filter((field) => field.strippedBlocks.length > 0);
+  if (activeFields.length === 0) return undefined;
+
+  const strippedBlocks: Record<string, number> = {};
+  for (const field of activeFields) {
+    for (const blockName of field.strippedBlocks) {
+      strippedBlocks[blockName] = (strippedBlocks[blockName] ?? 0) + 1;
+    }
+  }
+
+  return {
+    strippedBlockCount: activeFields.reduce(
+      (count, field) => count + field.strippedBlocks.length,
+      0,
+    ),
+    strippedBlocks,
+    fields: activeFields,
   };
 }

--- a/src/lib/markdown-sync/import-applier.ts
+++ b/src/lib/markdown-sync/import-applier.ts
@@ -20,6 +20,12 @@ import type {
 import { resolveExistingVaultFilePath } from "@/lib/markdown-sync/import-scanner";
 import { parseNoosphereMarkdown } from "@/lib/markdown/noosphere-markdown";
 import { invalidateSearchCache } from "@/lib/cache/search-cache";
+import {
+  buildArticleStripObservation,
+  sanitizeArticleContent,
+  sanitizeArticleExcerpt,
+} from "@/lib/api/article-content";
+import { detectSecretInInputs } from "@/lib/memory/api/save";
 import { isValidConfidence, isValidStatus } from "@/lib/validation";
 import type { Manifest, ManifestEntry } from "@/lib/obsidian-sync";
 import type { ObsidianSyncConfig } from "@/lib/obsidian-sync/config";
@@ -355,7 +361,7 @@ async function applyCreateOrUpdate(
   prisma: PrismaClient,
   options: ApplyCreateOrUpdateOptions
 ): Promise<ImportApplyCandidateResult> {
-  const { candidate, absolutePath, vaultPath, manifest, mode, forceOverwrite, dryRun, performedBy } = options;
+  const { candidate, absolutePath, manifest, mode, forceOverwrite, dryRun, performedBy } = options;
 
   // ── Read and parse the markdown file ─────────────────────────────────────
   let markdownContent: string;
@@ -495,14 +501,118 @@ async function applyCreateOrUpdate(
   const rawStatus = typeof frontmatter.status === "string" ? frontmatter.status : null;
   const confidence = rawConfidence && isValidConfidence(rawConfidence) ? rawConfidence : "medium";
   const status = rawStatus && isValidStatus(rawStatus) ? rawStatus : "published";
+  const articleTitle = (frontmatter.title as string | null) ?? metadata?.title ?? slug;
+  const articleAuthorName =
+    typeof frontmatter.authorName === "string" ? frontmatter.authorName : null;
+  const rawTags = (frontmatter.tags as unknown[] | undefined) ?? metadata?.tags ?? [];
+  // Validate tags before the article write so secret-like tag names cannot be
+  // persisted after the content has already been sanitized.
+  const validTags: string[] = [];
+  const seenSlugs = new Set<string>();
+  for (const tag of rawTags) {
+    if (typeof tag !== "string" || tag.trim().length === 0) continue;
+    const tagSlug = slugify(tag);
+    if (tagSlug.length === 0 || seenSlugs.has(tagSlug)) continue;
+    seenSlugs.add(tagSlug);
+    validTags.push(tag);
+  }
+  const contentSanitization = sanitizeArticleContent(body);
+  if (!contentSanitization.ok) {
+    await recordAudit(prisma, {
+      articleId: candidate.articleId ?? null,
+      relativePath: candidate.relativePath,
+      action: "skipped",
+      kind: candidate.kind,
+      dryRun,
+      mode,
+      forceOverwrite,
+      markdownHash: candidate.markdownHash ?? null,
+      noosphereHash: null,
+      conflictReason: contentSanitization.error,
+      performedBy,
+    });
+
+    return {
+      candidate,
+      action: "skipped",
+      articleId: candidate.articleId ?? null,
+      conflictReason: contentSanitization.error,
+      warning: null,
+    };
+  }
+  const rawExcerpt =
+    typeof frontmatter.excerpt === "string" ? frontmatter.excerpt : null;
+  const excerptSanitization = rawExcerpt
+    ? sanitizeArticleExcerpt(rawExcerpt)
+    : undefined;
+  if (excerptSanitization && !excerptSanitization.ok) {
+    await recordAudit(prisma, {
+      articleId: candidate.articleId ?? null,
+      relativePath: candidate.relativePath,
+      action: "skipped",
+      kind: candidate.kind,
+      dryRun,
+      mode,
+      forceOverwrite,
+      markdownHash: candidate.markdownHash ?? null,
+      noosphereHash: null,
+      conflictReason: excerptSanitization.error,
+      performedBy,
+    });
+
+    return {
+      candidate,
+      action: "skipped",
+      articleId: candidate.articleId ?? null,
+      conflictReason: excerptSanitization.error,
+      warning: null,
+    };
+  }
+  const secretError = detectSecretInInputs([
+    { field: `${candidate.relativePath}.title`, value: articleTitle },
+    { field: `${candidate.relativePath}.content`, value: contentSanitization.content },
+    { field: `${candidate.relativePath}.excerpt`, value: excerptSanitization?.excerpt },
+    { field: `${candidate.relativePath}.authorName`, value: articleAuthorName ?? undefined },
+    ...validTags.map((value) => ({ field: `${candidate.relativePath}.tags`, value })),
+  ]);
+  if (secretError) {
+    await recordAudit(prisma, {
+      articleId: candidate.articleId ?? null,
+      relativePath: candidate.relativePath,
+      action: "skipped",
+      kind: candidate.kind,
+      dryRun,
+      mode,
+      forceOverwrite,
+      markdownHash: candidate.markdownHash ?? null,
+      noosphereHash: null,
+      conflictReason: secretError.error,
+      performedBy,
+    });
+
+    return {
+      candidate,
+      action: "skipped",
+      articleId: candidate.articleId ?? null,
+      conflictReason: secretError.error,
+      warning: null,
+    };
+  }
+  const stripObservation = buildArticleStripObservation([
+    { field: "content", strippedBlocks: contentSanitization.strippedBlocks },
+    {
+      field: "excerpt",
+      strippedBlocks: excerptSanitization?.strippedBlocks ?? [],
+    },
+  ]);
 
   // ── Build article data ─────────────────────────────────────────────────────
   const articleData = {
-    title: (frontmatter.title as string | null) ?? metadata?.title ?? slug,
+    title: articleTitle,
     slug,
-    content: body,
-    excerpt: (frontmatter.excerpt as string | null) ?? null,
-    authorName: (frontmatter.authorName as string | null) ?? null,
+    content: contentSanitization.content,
+    excerpt: excerptSanitization?.excerpt ?? null,
+    authorName: articleAuthorName,
     topicId: topic.id,
     sourceType: "markdown-import" as const,
     sourceUrl: null,
@@ -588,18 +698,27 @@ async function applyCreateOrUpdate(
     }
   }
 
-  // ── Handle tags ────────────────────────────────────────────────────────────
-  const rawTags = (frontmatter.tags as unknown[] | undefined) ?? metadata?.tags ?? [];
-  // Validate: keep only non-empty strings, then deduplicate by slug
-  const validTags: string[] = [];
-  const seenSlugs = new Set<string>();
-  for (const tag of rawTags) {
-    if (typeof tag !== "string" || tag.trim().length === 0) continue;
-    const tagSlug = slugify(tag);
-    if (tagSlug.length === 0 || seenSlugs.has(tagSlug)) continue;
-    seenSlugs.add(tagSlug);
-    validTags.push(tag);
+  if (!dryRun && stripObservation) {
+    await prisma.activityLog.create({
+      data: {
+        type: "article_content_stripped",
+        title: `Injected memory stripped from markdown sync import: ${articleData.title}`,
+        authorName: performedBy,
+        details: {
+          route: "markdown-sync import-applier",
+          kind: "single",
+          articleId,
+          topicId: topic.id,
+          slug,
+          relativePath: candidate.relativePath,
+          action,
+          ...stripObservation,
+        },
+      },
+    });
   }
+
+  // ── Handle tags ────────────────────────────────────────────────────────────
   if (!dryRun && articleId) {
     await syncArticleTags(prisma, articleId, validTags);
   }


### PR DESCRIPTION
## Summary

Closes #211 by hardening all article write paths that persist durable article content outside the already-fixed direct `/api/articles` create/update path. The patch strips injected memory blocks, rejects injected-only payloads, rejects visible secrets after stripping, and records queryable strip observations before durable content is written.

## What Changed

### Shared sanitization utilities
- Extended `src/lib/api/article-content.ts` with shared content/excerpt sanitizers and `buildArticleStripObservation`.
- `sanitizeArticleContent` rejects injected-only content.
- `sanitizeArticleExcerpt` now rejects injected-only caller excerpts instead of storing a blank excerpt.
- `buildArticleStripObservation` returns a Prisma JSON-compatible object so callers no longer need repeated casts.

### API write paths
- `POST /api/answer`: sanitizes content/excerpt, scans sanitized fields for secrets, writes stripped content to the article and revision, and logs strip events as `article_content_stripped`.
- `POST /api/ingest`: validates and sanitizes each batch article before the transaction, rejects the whole batch on injected-only or visible-secret input, and logs batch strip events as `article_content_stripped`.
- `POST /api/import`: sanitizes parsed markdown content/excerpts per file, preserves the per-file error contract, and logs batch strip events as `article_content_stripped`.
- `POST /api/articles` and `PATCH /api/articles/[id]`: tightened excerpt handling and strip-log shape while preserving the PR #210 protections.

### Non-API write paths
- Web UI create action `src/app/wiki/[topicSlug]/new/actions.ts` now sanitizes content/excerpt and scans secrets before article/revision creation.
- Web UI edit action `src/app/wiki/[topicSlug]/[articleSlug]/edit/actions.ts` now sanitizes content/excerpt and scans secrets before article update and revision creation.
- Markdown sync import applier `src/lib/markdown-sync/import-applier.ts` now sanitizes imported markdown content/excerpts, scans secrets before create/update/tag sync, skips unsafe candidates with audit records, and logs strip events.

### Observability and tests
- Strip events now use the unified `article_content_stripped` activity-log type with route and kind metadata.
- Added regression tests for answer, ingest, import, direct POST/PATCH excerpts, markdown-sync import application, and static coverage for non-API write-path sanitizer use.

## Verification

- Focused injected-memory tests: 27/27 passed
- `npm run test:api`: 339/341 passed; the 2 failures are unchanged known baseline failures in `bounded-json-routes.integration.test.ts` and `sync-conflict-review.test.ts`
- `npm run typecheck`: passed
- `npm run lint`: passed with 1 existing warning in `src/app/wiki/admin/topics/actions.ts`
- `DATABASE_URL='postgresql://placeholder:placeholder@localhost:5432/placeholder' npm run build`: passed


<!-- kody-pr-summary:start -->
## Summary

This PR hardens the remaining article write paths (`POST /api/answer`, `POST /api/ingest`, `POST /api/import`, the wiki web `createArticle`/`saveArticle` server actions, and the markdown-sync `import-applier`) to strip injected memory blocks from content and excerpts, scan sanitized inputs for secrets, and reject excerpts that consist entirely of stripped blocks — bringing them in line with the existing `POST /api/articles` and `PATCH /api/articles/[id]` protections.

### Behavior added to every write path
- `sanitizeArticleContent` is run on body/content before persistence; inputs made only of injected memory blocks are rejected with HTTP 400.
- `sanitizeArticleExcerpt` is run on excerpts; an excerpt that becomes empty after stripping is now rejected with `"Excerpt must include durable text outside injected memory blocks"` instead of being silently coerced to `""`.
- `detectSecretInInputs` scans sanitized content, sanitized excerpt, title, tags, and author/source metadata; a detected secret aborts the write.
- When stripping actually occurred, an `article_content_stripped` `ActivityLog` entry is written inside the same transaction (with a per-route title and `kind: "single"` or `"batch"`).
- The persisted `Article` content, the created `ArticleRevision` content, and the persisted excerpt are all guaranteed to be the sanitized values.

### Path-specific changes
- `POST /api/answer`: also validates that optional `excerpt` is a string when present, and only logs `sourceQuery`/`confidence` when supplied.
- `POST /api/ingest`: now pre-validates each article's required fields with explicit string checks, runs size, sanitize, and secret checks per article, rewrites `article.content`/`article.excerpt` in place before the transaction, and rejects the entire batch if any one article fails — using stable `[i]` indexing rather than the prior `articles.indexOf(article)`.
- `POST /api/import`: parses frontmatter excerpts up front, sanitizes each file individually, surfaces injected-only and secret failures as per-file errors in the response summary, and writes a single batch `article_content_stripped` log when any file in the ZIP was stripped.
- Wiki `createArticle`/`saveArticle` server actions: trim the title once, sanitize content and excerpt, run the secret scan against title/content/excerpt/tags, persist inside `prisma.$transaction`, and emit `article_content_stripped` entries attributed to the web user.
- `markdown-sync/import-applier`: sanitizes content and excerpt, scans sanitized inputs (title, content, excerpt, authorName, tags) for secrets, records an `article_content_stripped` log on the markdown-sync route when stripping happened, and now skips candidates that fail sanitization or the secret scan — recording an audit entry with the conflict reason rather than persisting. Tag dedupe/validation is hoisted above the sanitization step so secret-like tag names cannot survive sanitization.

### Shared helper changes (`src/lib/api/article-content.ts`)
- `sanitizeArticleExcerpt` returns a result type that distinguishes ok/failure and exposes `strippedBlocks` on failure; it now rejects excerpts that are entirely made of injected blocks instead of returning `""`.
- New `buildArticleStripObservation` aggregates per-field stripped blocks into a `strippedBlockCount`/`strippedBlocks`/`fields` JSON object, returning `undefined` when nothing was stripped.

### Test coverage
- New `article-write-path-sanitizer-coverage.test.ts` static-greps every non-API write path to assert `sanitizeArticleContent`, `detectSecretInInputs`, and `buildArticleStripObservation` are invoked before the database write call.
- New `article-write-paths-injected-memory.test.ts` exercises `POST /api/answer`, `POST /api/ingest`, and `POST /api/import` end-to-end, asserting that injected blocks are stripped, that injected-only excerpts and visible secrets are rejected, that an injected-only article in a batch fails the whole batch, and that the per-route `article_content_stripped` activity logs are written.
- `articles-post-injected-memory.test.ts` and `articles-patch-injected-memory.test.ts` gain matching coverage for caller excerpts that are only injected memory blocks, and now clean up `activityLog` fixtures alongside articles.
- `markdown-import-apply.test.ts` gains an integration test (skipped without `DATABASE_URL`) that runs `applyMarkdownImports` against a temp vault and asserts the persisted article and excerpt are stripped, the activity log is written under the markdown-sync route, and the temp vault is torn down.
<!-- kody-pr-summary:end -->