### PR TITLE
Fix sync-conflict-review test and restore strict API CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,4 +82,3 @@ jobs:
 
       - name: Run API tests
         run: npm run test:api
-        continue-on-error: true # TODO: fix sync-conflict-review test (Node mock API issue)

--- a/src/__tests__/api/lint.test.ts
+++ b/src/__tests__/api/lint.test.ts
@@ -161,3 +161,51 @@ test.describe("staleDays and tagMin parsing logic", () => {
     assert.equal(tagMin.error, "tagMin must be a finite number");
   });
 });
+
+test("buildLintIssues handles null topic and tag joins defensively", async () => {
+  process.env.DATABASE_URL ??= "postgresql://test:test@localhost:5432/test";
+  const { buildLintIssues } = await import("@/app/api/lint/route");
+  const now = new Date("2026-06-24T12:00:00.000Z");
+  const content =
+    "This article has enough plain text content to avoid the near-empty lint rule.";
+  const sharedTag = { id: "tag-shared", name: "Shared", slug: "shared" };
+
+  const issues = buildLintIssues(
+    [
+      {
+        id: "null-only",
+        title: "Null Only",
+        slug: "null-only",
+        content,
+        updatedAt: now,
+        topic: null,
+        tags: [{ tag: null }],
+      },
+      {
+        id: "mixed-tag",
+        title: "Mixed Tag",
+        slug: "mixed-tag",
+        content,
+        updatedAt: now,
+        topic: { slug: "mixed-topic", name: "Mixed Topic" },
+        tags: [{ tag: null }, { tag: sharedTag }],
+      },
+      {
+        id: "shared-tag",
+        title: "Shared Tag",
+        slug: "shared-tag",
+        content,
+        updatedAt: now,
+        topic: { slug: "other-topic", name: "Other Topic" },
+        tags: [{ tag: sharedTag }],
+      },
+    ],
+    { staleDays: 90, tagMin: 2, now },
+  );
+
+  const orphanIssues = issues.filter((issue) => issue.type === "orphan");
+  assert.deepEqual(
+    orphanIssues.map((issue) => [issue.articleId, issue.severity]),
+    [["null-only", "high"]],
+  );
+});

--- a/src/__tests__/api/sync-conflict-review.test.ts
+++ b/src/__tests__/api/sync-conflict-review.test.ts
@@ -222,17 +222,39 @@ test("runObsidianSync keeps local markdown visible when conflict review persiste
       tags: [],
     };
 
-    const { mock } = await import("node:test");
+    const client = prisma as unknown as {
+      $queryRaw: (query: TemplateStringsArray, ...values: unknown[]) => Promise<unknown>;
+    };
+    const topicDelegate = prisma.topic as unknown as {
+      findMany: (args?: unknown) => Promise<unknown>;
+    };
+    const articleDelegate = prisma.article as unknown as {
+      findMany: (args?: unknown) => Promise<unknown>;
+    };
+    const reviewDelegate = prisma.syncConflictReview as unknown as {
+      findFirst: (args?: unknown) => Promise<unknown>;
+      create: (args?: unknown) => Promise<unknown>;
+    };
+    const activityDelegate = prisma.activityLog as unknown as {
+      create: (args?: unknown) => Promise<unknown>;
+    };
+    const originalQueryRaw = client.$queryRaw;
+    const originalTopicFindMany = topicDelegate.findMany;
+    const originalArticleFindMany = articleDelegate.findMany;
+    const originalReviewFindFirst = reviewDelegate.findFirst;
+    const originalReviewCreate = reviewDelegate.create;
+    const originalActivityCreate = activityDelegate.create;
+    const originalConsoleError = console.error;
 
-    mock.method(prisma, "$queryRaw", async () => [{ acquire: true }]);
-    mock.method(prisma.topic, "findMany", async () => [topic]);
-    mock.method(prisma.article, "findMany", async () => [syncArticle]);
-    mock.method(prisma.syncConflictReview, "findFirst", async () => null);
-    mock.method(prisma.syncConflictReview, "create", async () => {
+    client.$queryRaw = async () => [{ acquire: true }];
+    topicDelegate.findMany = async () => [topic];
+    articleDelegate.findMany = async () => [syncArticle];
+    reviewDelegate.findFirst = async () => null;
+    reviewDelegate.create = async () => {
       throw new Error("database unavailable");
-    });
-    mock.method(prisma.activityLog, "create", async () => ({}));
-    mock.method(console, "error", () => {});
+    };
+    activityDelegate.create = async () => ({});
+    console.error = () => {};
 
     try {
       const result = await runObsidianSync({ mode: "full", clean: false, git: false, dryRun: false });
@@ -246,7 +268,13 @@ test("runObsidianSync keeps local markdown visible when conflict review persiste
       );
       assert.equal(existsSync(join(vaultPath, ".noosphere-sync", "conflicts")), true);
     } finally {
-      mock.restoreAll();
+      client.$queryRaw = originalQueryRaw;
+      topicDelegate.findMany = originalTopicFindMany;
+      articleDelegate.findMany = originalArticleFindMany;
+      reviewDelegate.findFirst = originalReviewFindFirst;
+      reviewDelegate.create = originalReviewCreate;
+      activityDelegate.create = originalActivityCreate;
+      console.error = originalConsoleError;
     }
   } finally {
     if (oldEnabled === undefined) delete process.env.OBSIDIAN_SYNC_ENABLED;

--- a/src/app/api/lint/route.ts
+++ b/src/app/api/lint/route.ts
@@ -32,75 +32,56 @@ interface LintIssue {
   details: string;
 }
 
-export async function POST(request: NextRequest) {
-  const rl = await rateLimit(request, { windowMs: 60_000, maxRequests: 10, keyPrefix: "lint" });
-  if (!rl.allowed) return rl.response;
+interface LintArticle {
+  id: string;
+  title: string;
+  slug: string;
+  content: string;
+  updatedAt: Date;
+  topic: { slug: string; name?: string } | null;
+  tags: Array<{
+    tag: { id: string; name: string; slug?: string } | null;
+  }>;
+}
 
-  const auth = await requirePermission(request, [Permissions.WRITE]);
-  if (!auth.success) {
-    return auth.response;
-  }
+function hasTag(
+  entry: LintArticle["tags"][number],
+): entry is { tag: { id: string; name: string; slug?: string } } {
+  return Boolean(entry.tag);
+}
 
-  const scopeWhere = buildScopeFilter(auth.auth.allowedScopes, { deletedAt: null });
-
-  // --- Parse options ---
-  let body: { staleDays?: unknown; tagMin?: unknown; maxArticles?: unknown } = {};
-  if (request.body) {
-    try {
-      body = await readBoundedJsonObject<typeof body>(request);
-    } catch (error) {
-      const bodyError = getJsonBodyError(error);
-      return NextResponse.json(
-        { error: bodyError.message },
-        { status: bodyError.status },
-      );
-    }
-  }
-
-  const lintOptions = parseLintOptions(body);
-  if (!lintOptions.ok) {
-    return NextResponse.json({ error: lintOptions.error }, { status: 400 });
-  }
-  const { staleDays, tagMin, maxArticles } = lintOptions.options;
-  const staleThreshold = new Date(Date.now() - staleDays * 24 * 60 * 60 * 1000);
-
+export function buildLintIssues(
+  articles: LintArticle[],
+  options: { staleDays: number; tagMin: number; now?: Date },
+): LintIssue[] {
+  const { staleDays, tagMin, now = new Date() } = options;
+  const staleThreshold = new Date(now.getTime() - staleDays * 24 * 60 * 60 * 1000);
   const issues: LintIssue[] = [];
-
-  // ── Fetch non-deleted articles (capped for performance) ──
-  const articles = await prisma.article.findMany({
-    where: scopeWhere,
-    take: maxArticles,
-    orderBy: [{ updatedAt: "desc" }, { id: "asc" }],
-    select: {
-      id: true,
-      title: true,
-      slug: true,
-      content: true,
-      updatedAt: true,
-      topic: { select: { slug: true, name: true } },
-      tags: { select: { tag: { select: { id: true, name: true, slug: true } } } },
-    },
-  });
 
   const articleMap = new Map(articles.map((a) => [a.slug, a]));
 
-  const topicSlugSet = new Set(articles.map((a) => a.topic.slug));
+  const topicSlugSet = new Set(
+    articles
+      .map((a) => a.topic?.slug)
+      .filter((slug): slug is string => typeof slug === "string" && slug.length > 0),
+  );
 
   // ── 1. Orphan articles ──
-  // An orphan has no topic-edge (same-topic) and no tag-edge and no cross_ref
-  // We check this by building inbound connection sets
+  // An orphan has no topic-edge (same-topic) and no tag-edge and no cross_ref.
 
-  // Build tag → article mapping
+  // Build tag → article mapping. Null joins are ignored defensively so a bad
+  // relation payload cannot crash the lint endpoint.
   const tagToArticles = new Map<string, string[]>();
   for (const a of articles) {
     for (const { tag } of a.tags) {
+      if (!tag) continue;
       const list = tagToArticles.get(tag.id) ?? [];
       list.push(a.id);
       tagToArticles.set(tag.id, list);
     }
   }
 
-  // Build cross_ref edges from content
+  // Build cross_ref edges from content.
   const crossRefTargets = new Map<string, Set<string>>();
   for (const a of articles) {
     const targets = new Set<string>();
@@ -132,16 +113,18 @@ export async function POST(request: NextRequest) {
   }
 
   for (const a of articles) {
-    const hasTopicEdge = articles.some(
-      (b) => b.id !== a.id && b.topic.slug === a.topic.slug
+    const validTags = a.tags.filter(hasTag);
+    const topicSlug = a.topic?.slug;
+    const hasTopicEdge = Boolean(topicSlug) && articles.some(
+      (b) => b.id !== a.id && b.topic?.slug === topicSlug
     );
-    const hasTagEdge = a.tags.some(({ tag }) => (tagToArticles.get(tag.id)?.length ?? 0) > 1);
+    const hasTagEdge = validTags.some(({ tag }) => (tagToArticles.get(tag.id)?.length ?? 0) > 1);
     const hasCrossRef = (crossRefTargets.get(a.id)?.size ?? 0) > 0;
 
     if (!hasTopicEdge && !hasTagEdge && !hasCrossRef) {
       issues.push({
         type: "orphan",
-        severity: a.tags.length === 0 ? "high" : "medium",
+        severity: validTags.length === 0 ? "high" : "medium",
         articleId: a.id,
         title: a.title,
         details: `No topic siblings, no shared tags, and no cross-references to or from other articles.`,
@@ -153,7 +136,7 @@ export async function POST(request: NextRequest) {
   for (const a of articles) {
     if (a.updatedAt < staleThreshold) {
       const daysSince = Math.floor(
-        (Date.now() - a.updatedAt.getTime()) / (24 * 60 * 60 * 1000)
+        (now.getTime() - a.updatedAt.getTime()) / (24 * 60 * 60 * 1000)
       );
       issues.push({
         type: "stale",
@@ -196,7 +179,7 @@ export async function POST(request: NextRequest) {
   for (const [tagId, articleIds] of tagOrphanTags) {
     const tagName = articles
       .flatMap((a) => a.tags)
-      .find((t) => t.tag.id === tagId)?.tag.name;
+      .find((t) => t.tag?.id === tagId)?.tag?.name;
     issues.push({
       type: "tag_orphan",
       severity: "low",
@@ -253,6 +236,58 @@ export async function POST(request: NextRequest) {
       });
     }
   }
+
+  return issues;
+}
+
+export async function POST(request: NextRequest) {
+  const rl = await rateLimit(request, { windowMs: 60_000, maxRequests: 10, keyPrefix: "lint" });
+  if (!rl.allowed) return rl.response;
+
+  const auth = await requirePermission(request, [Permissions.WRITE]);
+  if (!auth.success) {
+    return auth.response;
+  }
+
+  const scopeWhere = buildScopeFilter(auth.auth.allowedScopes, { deletedAt: null });
+
+  // --- Parse options ---
+  let body: { staleDays?: unknown; tagMin?: unknown; maxArticles?: unknown } = {};
+  if (request.body) {
+    try {
+      body = await readBoundedJsonObject<typeof body>(request);
+    } catch (error) {
+      const bodyError = getJsonBodyError(error);
+      return NextResponse.json(
+        { error: bodyError.message },
+        { status: bodyError.status },
+      );
+    }
+  }
+
+  const lintOptions = parseLintOptions(body);
+  if (!lintOptions.ok) {
+    return NextResponse.json({ error: lintOptions.error }, { status: 400 });
+  }
+  const { staleDays, tagMin, maxArticles } = lintOptions.options;
+
+  // ── Fetch non-deleted articles (capped for performance) ──
+  const articles = await prisma.article.findMany({
+    where: scopeWhere,
+    take: maxArticles,
+    orderBy: [{ updatedAt: "desc" }, { id: "asc" }],
+    select: {
+      id: true,
+      title: true,
+      slug: true,
+      content: true,
+      updatedAt: true,
+      topic: { select: { slug: true, name: true } },
+      tags: { select: { tag: { select: { id: true, name: true, slug: true } } } },
+    },
+  });
+
+  const issues = buildLintIssues(articles, { staleDays, tagMin });
 
   // ── Summary ──
   const summary = {


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary

This PR resolves issue #215 by fixing the broken `sync-conflict-review` failure-path test and restoring strict CI enforcement, while also extracting and hardening the lint issue generation logic.

### Key Changes

**1. Replaced fragile `node:test` mocking with explicit Prisma delegate restoration**

The `sync-conflict-review` failure-path test previously used `mock.method()` / `mock.restoreAll()`, which interacted poorly with the shared Prisma client across tests. The test now directly captures the original delegate methods (`$queryRaw`, `topic.findMany`, `article.findMany`, `syncConflictReview.findFirst`/`create`, `activityLog.create`, and `console.error`) and restores them in a `finally` block. This guarantees deterministic state restoration regardless of which other tests have run.

**2. Restored strict `npm run test:api` enforcement in CI**

The `continue-on-error: true` annotation on the API test step (a known TODO for the sync-conflict-review mock issue) is removed, so failures in the API test suite now correctly block CI.

**3. Extracted `buildLintIssues` as a pure, testable function**

The lint issue computation in `src/app/api/lint/route.ts` was previously inlined inside the `POST` handler, making it untestable in isolation. It is now factored out into an exported `buildLintIssues(articles, options)` function that:
- Accepts an injectable `now` timestamp for deterministic testing (no more `Date.now()` non-determinism in stale-date calculations)
- Returns a `LintIssue[]` independent of HTTP/auth concerns
- Keeps the `POST` handler responsible only for rate limiting, auth, option parsing, fetching, and response shaping

**4. Hardened against null topic/tag joins**

A defensive review surfaced that if Prisma ever returns a `null` for `topic` or `tag` (e.g., from a dangling relation), the lint endpoint would crash on `a.topic.slug` access. The refactor:
- Treats `topic` as `{ slug; name? } | null` and skips nulls in the topic-sibling check and topic-slug set
- Filters out null tag entries via a new `hasTag` type guard before counting tags and building the tag-to-article map
- Updates the `tag_orphan` name lookup to safely chain through the optional `tag` field

The severity calculation for orphans now uses the filtered `validTags` length rather than the raw `a.tags.length`, so an article with only null tag joins is correctly classified as "high" severity (truly disconnected) rather than "medium".

**5. Added regression test for null join payloads**

A new test in `src/__tests__/api/lint.test.ts` exercises `buildLintIssues` directly with three article fixtures:
- `null-only`: both `topic: null` and a tag with `tag: null` — verifies it survives and is classified as a "high" orphan
- `mixed-tag`: has a valid topic but mixes a null tag with a valid shared tag — verifies shared-tag counting still works
- `shared-tag`: shares a tag with `mixed-tag` — verifies the cross-article tag-edge detection

The test asserts that only the genuinely disconnected article is flagged as an orphan at "high" severity, proving the defensive code preserves correct lint semantics.

### Functional Impact

- **CI**: API tests are now a hard gate again; the sync-conflict-review test is reliable.
- **Reliability**: The lint endpoint no longer throws on malformed relation data.
- **Testability**: `buildLintIssues` is now pure and unit-testable without spinning up Prisma.
- **No behavior change for valid data**: Articles with well-formed topics and tags produce identical lint results as before.
<!-- kody-pr-summary:end -->