### PR TITLE
chore(release): clarify injected-memory package policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,9 @@ jobs:
           node-version: 22
           cache: npm
 
+      - name: Check package publishing policy
+        run: npm run package-policy:check
+
       - name: Install dependencies
         run: npm ci
 

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - ".github/workflows/npm-publish.yml"
       - "VERSION"
+      - "scripts/check-package-policies.mjs"
       - "scripts/sync-version.mjs"
       - "package.json"
       - "package-lock.json"
@@ -75,6 +76,10 @@ jobs:
       - name: Validate release version metadata
         working-directory: .
         run: npm run version:check
+
+      - name: Validate package publishing policy
+        working-directory: .
+        run: npm run package-policy:check
 
       - name: Install dependencies
         run: npm ci

--- a/docs/OPENCLAW-OFFICIAL-PLUGIN-SETUP.md
+++ b/docs/OPENCLAW-OFFICIAL-PLUGIN-SETUP.md
@@ -300,6 +300,7 @@ memory capture instructions are not injected into prompts.
 - **Auto-recall fails open**. If Noosphere is unavailable, OpenClaw continues without injected memory.
 - **`noosphere_save` creates draft candidates only**. It never auto-publishes curated knowledge.
 - **Release tags are package-specific**. Use `v-openclaw-*` for `@sweetsophia/openclaw-noosphere-memory`, `v-opencode-*` for `@sweetsophia/opencode-noosphere-memory`, and `v-kilocode-*` for `@sweetsophia/kilocode-noosphere-memory`; add a new `v-{package}-*` CI prefix before introducing another package.
+- **Injected-memory stripping is bundled-only**. `@sweetsophia/noosphere-injected-memory` is a private internal helper package. It is still built and packed in CI, but it is not published under its own npm tag because the OpenClaw plugin bundles it.
 - **Prompt injection is explicit but broad by default in the installer**. OpenClaw requires `hooks.allowPromptInjection: true` before plugin hook text can enter the prompt; the installer enables it with no `enabledAgents` or `allowedChatTypes` allowlist.
 
 ## Restricting auto-recall scope

--- a/noosphere-injected-memory/README.md
+++ b/noosphere-injected-memory/README.md
@@ -1,7 +1,11 @@
 # Noosphere Injected Memory
 
-Shared helper package for removing transient injected-memory blocks before
+Internal helper package for removing transient injected-memory blocks before
 Noosphere persists agent-authored content.
 
-The package is intentionally adapter-neutral. The Noosphere server and agent
-plugins depend on this package instead of depending on each other.
+The package is intentionally adapter-neutral. The Noosphere server and OpenClaw
+plugin depend on this package instead of depending on each other.
+
+This package is not published independently to npm. It is consumed through local
+workspace file dependencies, and the OpenClaw plugin bundles it so installed
+plugin users do not need a separate package.

--- a/noosphere-injected-memory/package.json
+++ b/noosphere-injected-memory/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@sweetsophia/noosphere-injected-memory",
   "version": "1.10.2",
-  "private": false,
-  "description": "Shared injected-memory block stripping helpers for Noosphere server and agent adapters.",
+  "private": true,
+  "description": "Internal bundled injected-memory block stripping helpers for Noosphere server and agent adapters.",
   "type": "module",
   "license": "Apache-2.0",
   "main": "./dist/index.js",
@@ -26,9 +26,6 @@
   "devDependencies": {
     "@types/node": "^20",
     "typescript": "^5"
-  },
-  "publishConfig": {
-    "access": "public"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "deploy:verify": "bash scripts/verify-deploy.sh",
     "memory:scheduler": "tsx scripts/memory-scheduler.ts",
     "db:studio": "prisma studio",
+    "package-policy:check": "node scripts/check-package-policies.mjs",
     "version:sync": "node scripts/sync-version.mjs",
     "version:check": "node scripts/sync-version.mjs --check",
     "test:persistence-layer": "node --env-file=.env.test --import tsx --test 'src/__tests__/persistence-layer/**/*.test.ts'"

--- a/scripts/check-package-policies.mjs
+++ b/scripts/check-package-policies.mjs
@@ -1,0 +1,294 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const failures = [];
+const policy = {
+  helper: {
+    name: "@sweetsophia/noosphere-injected-memory",
+    dir: "noosphere-injected-memory",
+    rootDependency: "file:./noosphere-injected-memory",
+    openclawDependency: "file:../noosphere-injected-memory",
+    rootLockLinkPath: "node_modules/@sweetsophia/noosphere-injected-memory",
+    rootLockPackagePath: "noosphere-injected-memory",
+    openclawLockLinkPath: "node_modules/@sweetsophia/noosphere-injected-memory",
+    openclawLockPackagePath: "../noosphere-injected-memory",
+    allowedRootResolved: new Set([
+      "noosphere-injected-memory",
+      "file:noosphere-injected-memory",
+      "file:./noosphere-injected-memory",
+    ]),
+    allowedOpenclawResolved: new Set([
+      "../noosphere-injected-memory",
+      "file:../noosphere-injected-memory",
+    ]),
+  },
+  openclaw: {
+    dir: "openclaw-noosphere-memory",
+    packageName: "@sweetsophia/openclaw-noosphere-memory",
+  },
+  npmPublishWorkflow: ".github/workflows/npm-publish.yml",
+  forbiddenPublishSignals: ["injectedmemory", "noosphereinjectedmemory"],
+};
+
+function readText(relativePath) {
+  try {
+    return readFileSync(resolve(root, relativePath), "utf8");
+  } catch (error) {
+    failures.push(`Failed to read ${relativePath}: ${error.message}`);
+    return "";
+  }
+}
+
+function readJson(relativePath) {
+  try {
+    return JSON.parse(readText(relativePath));
+  } catch (error) {
+    failures.push(`Failed to parse ${relativePath}: ${error.message}`);
+    return {};
+  }
+}
+
+function expect(condition, message) {
+  if (!condition) {
+    failures.push(message);
+  }
+}
+
+function getLockPackage(lock, packagePath) {
+  return lock.packages?.[packagePath];
+}
+
+function isLocalLockLink(entry, allowedResolvedValues) {
+  return entry?.link === true && allowedResolvedValues.has(entry.resolved);
+}
+
+function bundledDependencyNames(pkg) {
+  const bundled = [
+    ...(Array.isArray(pkg.bundledDependencies) ? pkg.bundledDependencies : []),
+    ...(Array.isArray(pkg.bundleDependencies) ? pkg.bundleDependencies : []),
+  ];
+
+  if (pkg.bundleDependencies === true || pkg.bundledDependencies === true) {
+    bundled.push(...Object.keys(pkg.dependencies ?? {}));
+  }
+
+  return Array.from(new Set(bundled));
+}
+
+function workflowLines(workflowText) {
+  return workflowText
+    .split(/\r?\n/)
+    .map(stripYamlComment)
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+function stripYamlComment(line) {
+  let quote = null;
+
+  for (let index = 0; index < line.length; index += 1) {
+    const char = line[index];
+
+    if ((char === '"' || char === "'") && line[index - 1] !== "\\") {
+      quote = quote === char ? null : quote ?? char;
+      continue;
+    }
+
+    if (char === "#" && quote === null) {
+      return line.slice(0, index);
+    }
+  }
+
+  return line;
+}
+
+function parseYamlScalar(value) {
+  const trimmed = value.trim();
+  const quote = trimmed[0];
+
+  if ((quote === '"' || quote === "'") && trimmed.endsWith(quote)) {
+    return trimmed.slice(1, -1);
+  }
+
+  return trimmed;
+}
+
+function yamlKeyValue(line) {
+  const match = line.match(/^(?:-\s*)?(?:"([^"]+)"|'([^']+)'|([A-Za-z_][A-Za-z0-9_-]*)):\s*(.*)$/);
+
+  if (!match) {
+    return null;
+  }
+
+  return {
+    key: match[1] ?? match[2] ?? match[3],
+    value: parseYamlScalar(match[4]),
+  };
+}
+
+function yamlListValue(line) {
+  const match = line.match(/^-\s+(.+)$/);
+
+  if (!match || yamlKeyValue(line)) {
+    return null;
+  }
+
+  return parseYamlScalar(match[1]);
+}
+
+function hasPathTrigger(lines, path) {
+  return lines.some((line) => yamlListValue(line) === path);
+}
+
+function hasMatrixPackage(lines, packageDir, packageName) {
+  for (let index = 0; index < lines.length; index += 1) {
+    const entry = yamlKeyValue(lines[index]);
+
+    if (entry?.key !== "dir" || entry.value !== packageDir) {
+      continue;
+    }
+
+    for (let lookahead = index + 1; lookahead < lines.length; lookahead += 1) {
+      if (lines[lookahead].startsWith("- ")) {
+        break;
+      }
+
+      const nextEntry = yamlKeyValue(lines[lookahead]);
+
+      if (nextEntry?.key === "name" && nextEntry.value === packageName) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+function hasWorkflowInput(lines, inputName) {
+  return lines.some((line) => {
+    const entry = yamlKeyValue(line);
+
+    return entry?.key === inputName;
+  });
+}
+
+function normalizeSignal(value) {
+  return value.toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
+function hasForbiddenHelperPublishKey(lines, forbiddenSignals) {
+  return lines.some((line) => {
+    const entry = yamlKeyValue(line);
+
+    if (!entry) {
+      return false;
+    }
+
+    const key = normalizeSignal(entry.key);
+
+    return key.startsWith("publish") && forbiddenSignals.some((signal) => key.includes(signal));
+  });
+}
+
+function hasForbiddenHelperTag(lines, forbiddenSignals) {
+  for (const line of lines) {
+    const tagMatches = line.matchAll(/["'\s[]?(v-[A-Za-z0-9_*.-]+)/g);
+
+    for (const match of tagMatches) {
+      const tag = normalizeSignal(match[1]);
+
+      if (forbiddenSignals.some((signal) => tag.includes(signal))) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+const rootPackage = readJson("package.json");
+const rootLock = readJson("package-lock.json");
+const injectedPackage = readJson(`${policy.helper.dir}/package.json`);
+const injectedLock = readJson(`${policy.helper.dir}/package-lock.json`);
+const openclawPackage = readJson(`${policy.openclaw.dir}/package.json`);
+const openclawLock = readJson(`${policy.openclaw.dir}/package-lock.json`);
+const npmPublishWorkflow = readText(policy.npmPublishWorkflow);
+const npmPublishWorkflowLines = workflowLines(npmPublishWorkflow);
+
+expect(
+  injectedPackage.private === true,
+  `${policy.helper.name} must stay private because it is an internal bundled helper, not an independently published npm package.`,
+);
+expect(
+  !Object.hasOwn(injectedPackage, "publishConfig"),
+  `${policy.helper.name} must not define publishConfig while the policy is bundled-only.`,
+);
+expect(
+  rootPackage.dependencies?.[policy.helper.name] === policy.helper.rootDependency,
+  `The app must consume ${policy.helper.name} through the local file dependency.`,
+);
+expect(
+  isLocalLockLink(
+    getLockPackage(rootLock, policy.helper.rootLockLinkPath),
+    policy.helper.allowedRootResolved,
+  ),
+  `The root lockfile must resolve ${policy.helper.name} from the local helper directory.`,
+);
+expect(
+  getLockPackage(rootLock, policy.helper.rootLockPackagePath)?.name === policy.helper.name,
+  `The root lockfile must include the local ${policy.helper.name} package entry.`,
+);
+expect(
+  getLockPackage(injectedLock, "")?.name === policy.helper.name,
+  `${policy.helper.name}/package-lock.json must describe the helper package.`,
+);
+expect(
+  openclawPackage.dependencies?.[policy.helper.name] === policy.helper.openclawDependency,
+  `The OpenClaw plugin must depend on the local ${policy.helper.name} helper.`,
+);
+expect(
+  bundledDependencyNames(openclawPackage).includes(policy.helper.name),
+  `The OpenClaw plugin must bundle ${policy.helper.name} so npm consumers do not need a separate helper package.`,
+);
+expect(
+  isLocalLockLink(
+    getLockPackage(openclawLock, policy.helper.openclawLockLinkPath),
+    policy.helper.allowedOpenclawResolved,
+  ),
+  `The OpenClaw lockfile must resolve ${policy.helper.name} from the local helper directory.`,
+);
+expect(
+  getLockPackage(openclawLock, policy.helper.openclawLockPackagePath)?.name === policy.helper.name,
+  `The OpenClaw lockfile must include the local ${policy.helper.name} helper package entry.`,
+);
+expect(
+  hasPathTrigger(npmPublishWorkflowLines, `${policy.helper.dir}/**`),
+  "The npm publish workflow must keep checking helper package source changes.",
+);
+expect(
+  hasMatrixPackage(npmPublishWorkflowLines, policy.helper.dir, policy.helper.name),
+  "The npm publish workflow package-check matrix must keep building the helper package from the helper directory.",
+);
+expect(
+  !hasForbiddenHelperTag(npmPublishWorkflowLines, policy.forbiddenPublishSignals),
+  "The npm publish workflow must not define a release tag prefix for the bundled-only helper.",
+);
+expect(
+  !hasWorkflowInput(npmPublishWorkflowLines, "publish_injected") &&
+    !hasForbiddenHelperPublishKey(npmPublishWorkflowLines, policy.forbiddenPublishSignals),
+  "The npm publish workflow must not expose a publish_injected* dispatch input/job for the bundled-only helper.",
+);
+
+if (failures.length > 0) {
+  console.error("Package policy check failed:");
+  for (const failure of failures) {
+    console.error(`- ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log("Package policy check passed.");


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## What changed

- **Added `scripts/check-package-policies.mjs`** — a new policy-enforcement script that validates the bundled-only status of `@sweetsophia/noosphere-injected-memory` by asserting:
  - The helper package is `private: true` and has no `publishConfig`.
  - The root app and OpenClaw plugin both depend on it via `file:` references, and corresponding entries exist in their lockfiles.
  - The OpenClaw plugin lists the helper in `bundledDependencies`.
  - The npm publish workflow still triggers builds on changes to the helper, includes the helper in its package-check matrix, and does **not** define a `v-injected-memory-` release tag prefix or any `publish_injected*` dispatch input/job.

- **Wired the check into CI and release**:
  - `.github/workflows/ci.yml` runs `npm run package-policy:check` after `npm ci`.
  - `.github/workflows/npm-publish.yml` runs the same check before install, and the script path (`scripts/check-package-policies.mjs`) is added to the `paths` trigger so policy changes also retrigger the publish workflow.

- **Added the `package-policy:check` script** (via the new file) so the check is exposed as a single npm command and can be run locally and in CI.

- **Updated documentation to reflect the policy**:
  - `noosphere-injected-memory/README.md` reframes the package as an *internal* helper, clarifies that it is consumed via local workspace file dependencies, and states that the OpenClaw plugin bundles it so end users do not need a separate npm package.
  - `docs/OPENCLAW-OFFICIAL-PLUGIN-SETUP.md` adds a note in the design constraints that injected-memory stripping is **bundled-only** — the helper is built and packed in CI but not published under its own npm tag.

## Why

The helper package was at risk of being accidentally exposed as a public npm dependency. The changes make the bundled-only policy explicit in metadata (`private: true`, no `publishConfig`), codify it in the publish workflow (no release tag, no publish input for it), and enforce it with a script that fails CI/npm-publish if any of those invariants regress. Documentation is updated to match so contributors understand the helper is meant to be bundled into the OpenClaw plugin rather than consumed as a standalone npm package.

## Functional impact

- No runtime behavior changes for end users — plugin users still receive the stripping logic, now via bundling rather than a separate install.
- A new gate now blocks future PRs that would (a) republish the helper to npm, (b) remove it from the OpenClaw bundle, or (c) change the local file-dependency wiring between the app/plugin and the helper.

---

This PR clarifies and enforces the publishing policy for the `@sweetsophia/noosphere-injected-memory` helper package, codifying that it is an internal, bundled-only dependency rather than an independently published npm package.

Key changes:

- **Documentation update**: The `noosphere-injected-memory/README.md` and `docs/OPENCLAW-OFFICIAL-PLUGIN-SETUP.md` explicitly state that the helper package is not published to npm on its own. Instead, it is consumed via local workspace file dependencies, and the OpenClaw plugin bundles it so end users of the plugin do not need to install the helper separately.

- **New policy check script (`scripts/check-package-policies.mjs`)**: A new script that enforces the bundled-only policy by validating:
  - The helper's `package.json` is marked `private: true` and has no `publishConfig`.
  - The root and OpenClaw packages depend on the helper through local `file:` references.
  - The root and OpenClaw lockfiles resolve the helper from the local directory and include the appropriate workspace package entries.
  - The OpenClaw plugin lists the helper in `bundledDependencies` so npm consumers do not need a separate install.
  - The npm publish workflow still watches helper source changes and includes the helper in the build matrix, but contains no release tag prefix (e.g. `v-injected-memory-*`) and no `publish_injected*` dispatch input or job.

- **CI integration**: The `ci.yml` and `npm-publish.yml` workflows now run `npm run package-policy:check`, and `npm-publish.yml` additionally triggers on changes to `scripts/check-package-policies.mjs` so the policy guard itself stays covered.

In short, the change documents and programmatically protects the rule that the injected-memory helper is built and bundled inside the OpenClaw plugin instead of being released as its own npm package.

---

This pull request establishes and enforces a policy clarifying that `@sweetsophia/noosphere-injected-memory` is a private, bundled-only helper package rather than an independently published npm package.

**Summary of changes:**

1. **New policy validation script** (`scripts/check-package-policies.mjs`): Adds an automated checker that enforces the bundled-only publishing policy for the injected-memory helper package. It verifies that:
   - The helper package remains marked as `private: true` in its `package.json`
   - No `publishConfig` is defined for the helper package
   - The root app and OpenClaw plugin consume the helper via local file dependencies (`file:./noosphere-injected-memory` and `file:../noosphere-injected-memory`)
   - The OpenClaw plugin bundles the helper via `bundledDependencies`/`bundleDependencies` so npm consumers don't need a separate package
   - The lockfiles correctly link to the local helper directories
   - The npm publish workflow continues to build/package the helper but does not define a release tag prefix (e.g., `v-injected-memory-*`) or expose a `publish_injected*` dispatch input

2. **CI integration** (`.github/workflows/ci.yml`): Adds a `package-policy:check` step to the CI pipeline to catch policy violations on every build.

3. **Publish workflow guard** (`.github/workflows/npm-publish.yml`): Adds the policy script itself and the helper source path to the publish workflow triggers, and runs the policy check before publishing to prevent accidental independent publication.

4. **Documentation updates**:
   - `noosphere-injected-memory/README.md`: Clarifies that the package is "internal" (not "shared"), and explicitly states it is not published independently—it is consumed through local workspace file dependencies and bundled into the OpenClaw plugin.
   - `docs/OPENCLAW-OFFICIAL-PLUGIN-SETUP.md`: Adds a release-notes bullet documenting that injected-memory stripping is bundled-only and explains why the package isn't published under its own npm tag.

Together, these changes codify and protect the decision that the injected-memory helper travels only as a bundled dependency of the OpenClaw plugin, ensuring the helper's private/internal status is maintained across CI and release processes.

---

This pull request clarifies and enforces the publishing policy for the `@sweetsophia/noosphere-injected-memory` package, establishing it as an internal bundled-only helper rather than an independently published npm package.

### Key Changes

**1. New policy validation script** (`scripts/check-package-policies.mjs`)
- Verifies that `@sweetsophia/noosphere-injected-memory` remains marked as private with no `publishConfig`
- Confirms the root app and OpenClaw plugin consume the helper via local `file:` dependencies
- Ensures the helper is listed as a `bundledDependency` in the OpenClaw plugin's `package.json` so npm consumers don't need to install it separately
- Validates lockfile entries for both root and OpenClaw workspaces
- Enforces that the npm publish workflow does not define a release tag prefix or dispatch input for publishing the helper independently

**2. CI integration**
- The `ci.yml` workflow now runs the package policy check before dependency installation
- The `npm-publish.yml` workflow also runs the check, and triggers on changes to the new script

**3. Documentation updates**
- `noosphere-injected-memory/README.md`: Clarifies the package is "internal" (not "shared") and explicitly states it is not published to npm independently; it's consumed via workspace file dependencies and bundled into the OpenClaw plugin
- `docs/OPENCLAW-OFFICIAL-PLUGIN-SETUP.md`: Adds a note that injected-memory stripping is bundled-only and the helper package is still built/packed in CI but not published under its own npm tag

### Purpose

This change formalizes the architectural decision that the injected-memory helper is a private internal package. By encoding this policy as an automated check, the PR prevents accidental independent publication of the helper, ensures the OpenClaw plugin always bundles it for end users, and keeps CI build/pack steps intact while blocking npm release tags or workflow inputs that would publish it on its own.
<!-- kody-pr-summary:end -->