### PR TITLE
refine wiki home page

### DIFF
--- a/src/app/wiki/page.tsx
+++ b/src/app/wiki/page.tsx
@@ -19,6 +19,7 @@ interface ArticleCountMap {
 
 interface TopicRenderNode {
   node: TopicNode;
+  directArticleCount: number;
   articleCount: number;
   descendantCount: number;
   children: TopicRenderNode[];
@@ -33,32 +34,69 @@ type WikiHomeArticle = Prisma.ArticleGetPayload<{
 
 function buildTopicRenderNode(node: TopicNode, countMap: ArticleCountMap): TopicRenderNode {
   const children = node.children.map((child) => buildTopicRenderNode(child, countMap));
+  const directArticleCount = countMap[node.id] ?? 0;
 
   return {
     node,
-    articleCount:
-      (countMap[node.id] ?? 0) + children.reduce((total, child) => total + child.articleCount, 0),
+    directArticleCount,
+    articleCount: directArticleCount + children.reduce((total, child) => total + child.articleCount, 0),
     descendantCount:
       node.children.length + children.reduce((total, child) => total + child.descendantCount, 0),
     children,
   };
 }
 
-function TopicTreeNode({ tree }: { tree: TopicRenderNode }) {
-  const { node, articleCount, descendantCount, children } = tree;
+const homeDateFormatter = new Intl.DateTimeFormat(undefined, {
+  month: "short",
+  day: "numeric",
+  year: "numeric",
+});
+
+function RestrictedArticleIcon({ tags }: { tags: string[] }) {
+  if (tags.length === 0) return null;
+
+  return (
+    <span className="restricted-icon" title={`Restricted: ${tags.join(", ")}`}>
+      <svg
+        width="12"
+        height="12"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+      >
+        <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+        <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+      </svg>
+    </span>
+  );
+}
+
+function TopicTreeNode({ tree, depth = 0 }: { tree: TopicRenderNode; depth?: number }) {
+  const { node, directArticleCount, articleCount, descendantCount, children } = tree;
   const hasChildren = children.length > 0;
 
   return (
-    <div className="topic-tree-node">
-      <div className="topic-card topic-tree-card">
+    <div className="topic-tree-node" data-depth={depth}>
+      <Link href={`/wiki/${node.slug}`} className="topic-card topic-tree-card">
         <div className="topic-tree-copy">
-          <p className="topic-tree-kind">{hasChildren ? "Topic cluster" : "Leaf topic"}</p>
+          <p className="topic-tree-kind">
+            {hasChildren ? "Topic cluster" : "Leaf topic"}
+            {depth > 0 ? <span>Level {depth}</span> : null}
+          </p>
           <h2 className="topic-tree-title">
-            <Link href={`/wiki/${node.slug}`}>{node.name}</Link>
+            <span>{node.name}</span>
           </h2>
           <p className="topic-tree-description">
             {node.description ?? "A focused pocket of the wiki ready for articles, references, and linked subtopics."}
           </p>
+          <div className="topic-tree-meta meta-row">
+            <span>{directArticleCount} direct article{directArticleCount !== 1 ? "s" : ""}</span>
+            <span>{descendantCount} nested topic{descendantCount !== 1 ? "s" : ""}</span>
+          </div>
         </div>
 
         <div className="topic-tree-metrics" aria-label={`${node.name} metrics`}>
@@ -71,12 +109,12 @@ function TopicTreeNode({ tree }: { tree: TopicRenderNode }) {
             <span>subtopic{descendantCount !== 1 ? "s" : ""}</span>
           </div>
         </div>
-      </div>
+      </Link>
 
       {hasChildren && (
         <div className="topic-tree-children">
           {children.map((child) => (
-            <TopicTreeNode key={child.node.id} tree={child} />
+            <TopicTreeNode key={child.node.id} tree={child} depth={depth + 1} />
           ))}
         </div>
       )}
@@ -115,13 +153,17 @@ export default async function WikiHomePage() {
 
   const totalArticles = Object.values(countMap).reduce((total, count) => total + count, 0);
   const topicTree = roots.map((topic) => buildTopicRenderNode(topic, countMap));
+  const topicClusters = topicTree.filter((topic) => topic.children.length > 0).length;
+  const latestArticle = recentArticles[0];
+  const secondaryArticles = recentArticles.slice(1);
 
   return (
     <div className="wiki-content wiki-home">
       <PageHeader
         eyebrow="Knowledge atlas"
         title="Noosphere"
-        description="Agent-authored documentation with a calmer information hierarchy: browse live updates, scan topic clusters, and dive straight into the wiki's deepest branches."
+        description="Agent-authored documentation with clear topic paths, readable update trails, and fewer dead ends between question and answer."
+        className="wiki-home-hero"
         meta={
           <div className="page-meta-pills">
             <span className="page-meta-pill">
@@ -133,14 +175,14 @@ export default async function WikiHomePage() {
               <span>topics mapped</span>
             </span>
             <span className="page-meta-pill">
-              <strong>{recentArticles.length}</strong>
-              <span>recent updates surfaced</span>
+              <strong>{topicClusters}</strong>
+              <span>topic clusters</span>
             </span>
           </div>
         }
         actions={
           isAdmin ? (
-            <div style={{ display: "flex", gap: "0.5rem", flexWrap: "wrap" }}>
+            <div className="cluster">
               <Link href="/wiki/admin/topics" className="btn btn-secondary btn-sm">
                 New Topic
               </Link>
@@ -153,12 +195,12 @@ export default async function WikiHomePage() {
       />
 
       {recentArticles.length > 0 && (
-        <section className="browse-section">
+        <section className="browse-section wiki-home-section wiki-home-recent">
           <div className="section-header">
             <div className="section-header-copy">
               <p className="page-eyebrow">Fresh signal</p>
               <h2 className="section-title">Recently updated</h2>
-              <p className="section-subtitle">The newest edits, additions, and refinements across the wiki.</p>
+              <p className="section-subtitle">The newest edits, additions, and refinements are separated from the topic map so the landing page stays easy to scan.</p>
             </div>
             <div className="section-actions">
               <Link href="/wiki/search" className="btn btn-secondary btn-sm">
@@ -167,34 +209,26 @@ export default async function WikiHomePage() {
             </div>
           </div>
 
-          <div className="recent-updates-grid">
-            {recentArticles.map((article) => (
+          <div className="home-updates-layout">
+            {latestArticle ? (
               <Link
-                key={article.id}
-                href={`/wiki/${article.topic.slug}/${article.slug}`}
-                className="article-card article-card-grid"
+                href={`/wiki/${latestArticle.topic.slug}/${latestArticle.slug}`}
+                className="article-card article-card-featured home-featured-update"
               >
                 <div className="article-card-header-row">
-                  <span className="article-kicker">{article.topic.name}</span>
-                  <span className="article-date">{new Date(article.updatedAt).toLocaleDateString()}</span>
+                  <span className="article-kicker">{latestArticle.topic.name}</span>
+                  <span className="article-date">{homeDateFormatter.format(new Date(latestArticle.updatedAt))}</span>
                 </div>
                 <h3>
-                  {article.restrictedTags && article.restrictedTags.length > 0 && (
-                    <span className="restricted-icon" title={`Restricted: ${article.restrictedTags.join(", ")}`}>
-                      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-                        <rect x="3" y="11" width="18" height="11" rx="2" ry="2"/>
-                        <path d="M7 11V7a5 5 0 0 1 10 0v4"/>
-                      </svg>
-                    </span>
-                  )}
-                  {article.title}
+                  <RestrictedArticleIcon tags={latestArticle.restrictedTags ?? []} />
+                  {latestArticle.title}
                 </h3>
                 <p>
-                  {article.excerpt ?? "Open the latest revision to read the current summary and linked references."}
+                  {latestArticle.excerpt ?? "Open the latest revision to read the current summary and linked references."}
                 </p>
-                {article.tags.length > 0 ? (
+                {latestArticle.tags.length > 0 ? (
                   <div className="article-tag-row article-tag-row-muted">
-                    {article.tags.slice(0, 3).map((tag) => (
+                    {latestArticle.tags.slice(0, 4).map((tag) => (
                       <span key={tag.tag.id} className="tag-badge">
                         {tag.tag.name}
                       </span>
@@ -202,17 +236,39 @@ export default async function WikiHomePage() {
                   </div>
                 ) : null}
               </Link>
-            ))}
+            ) : null}
+
+            {secondaryArticles.length > 0 ? (
+              <div className="home-update-list" aria-label="Additional recent updates">
+                {secondaryArticles.map((article) => (
+                  <Link
+                    key={article.id}
+                    href={`/wiki/${article.topic.slug}/${article.slug}`}
+                    className="article-card article-card-compact home-update-card"
+                  >
+                    <div className="article-card-header-row">
+                      <span className="article-kicker">{article.topic.name}</span>
+                      <span className="article-date">{homeDateFormatter.format(new Date(article.updatedAt))}</span>
+                    </div>
+                    <h3>
+                      <RestrictedArticleIcon tags={article.restrictedTags ?? []} />
+                      {article.title}
+                    </h3>
+                    <p>{article.excerpt ?? "Open the latest revision to read the current summary and linked references."}</p>
+                  </Link>
+                ))}
+              </div>
+            ) : null}
           </div>
         </section>
       )}
 
-      <section className="browse-section">
+      <section className="browse-section wiki-home-section wiki-home-topics">
         <div className="section-header">
           <div className="section-header-copy">
             <p className="page-eyebrow">Topic map</p>
             <h2 className="section-title">Browse the knowledge tree</h2>
-            <p className="section-subtitle">Follow parent-to-child branches to see how subjects cluster and where the richest pockets of documentation live.</p>
+            <p className="section-subtitle">Parent topics stay visually anchored while child topics step inward, making the tree readable without turning it into a wall of tags.</p>
           </div>
         </div>
 

--- a/src/app/wiki/page.tsx
+++ b/src/app/wiki/page.tsx
@@ -56,7 +56,7 @@ function RestrictedArticleIcon({ tags }: { tags: string[] }) {
   if (tags.length === 0) return null;
 
   return (
-    <span className="restricted-icon" role="img" aria-label="Restricted">
+    <span className="restricted-icon" role="img" aria-label={`Restricted: ${tags.join(", ")}`}>
       <svg
         width="12"
         height="12"
@@ -88,7 +88,12 @@ function pluralize(count: number, singular: string, plural = `${singular}s`) {
 }
 
 function articleCardLabel(article: WikiHomeArticle) {
-  return `${article.restrictedTags.length > 0 ? "Restricted article" : "Article"}: ${article.title} in ${article.topic.name}`;
+  const restriction =
+    article.restrictedTags.length > 0
+      ? `Restricted article (${article.restrictedTags.join(", ")})`
+      : "Article";
+
+  return `${restriction}: ${article.title} in ${article.topic.name}`;
 }
 
 function TopicTreeNode({ tree, depth = 0 }: { tree: TopicRenderNode; depth?: number }) {

--- a/src/app/wiki/page.tsx
+++ b/src/app/wiki/page.tsx
@@ -56,7 +56,7 @@ function RestrictedArticleIcon({ tags }: { tags: string[] }) {
   if (tags.length === 0) return null;
 
   return (
-    <span className="restricted-icon" role="img" aria-label={`Restricted: ${tags.join(", ")}`}>
+    <span className="restricted-icon" role="img" aria-label="Restricted">
       <svg
         width="12"
         height="12"
@@ -75,12 +75,20 @@ function RestrictedArticleIcon({ tags }: { tags: string[] }) {
   );
 }
 
-function countTopicClusters(nodes: TopicRenderNode[]): number {
+function countBranchTopics(nodes: TopicRenderNode[]): number {
   return nodes.reduce(
     (total, topic) =>
-      total + (topic.children.length > 0 ? 1 : 0) + countTopicClusters(topic.children),
+      total + (topic.children.length > 0 ? 1 : 0) + countBranchTopics(topic.children),
     0,
   );
+}
+
+function pluralize(count: number, singular: string, plural = `${singular}s`) {
+  return count === 1 ? singular : plural;
+}
+
+function articleCardLabel(article: WikiHomeArticle) {
+  return `${article.restrictedTags.length > 0 ? "Restricted article" : "Article"}: ${article.title} in ${article.topic.name}`;
 }
 
 function TopicTreeNode({ tree, depth = 0 }: { tree: TopicRenderNode; depth?: number }) {
@@ -89,11 +97,15 @@ function TopicTreeNode({ tree, depth = 0 }: { tree: TopicRenderNode; depth?: num
 
   return (
     <div className="topic-tree-node" data-depth={depth}>
-      <Link href={`/wiki/${node.slug}`} className="topic-card topic-tree-card">
+      <Link
+        href={`/wiki/${node.slug}`}
+        className="topic-card topic-tree-card"
+        aria-label={`${node.name}: ${directArticleCount} direct ${pluralize(directArticleCount, "article")}, ${articleCount} total ${pluralize(articleCount, "article")} in tree, ${descendantCount} ${pluralize(descendantCount, "subtopic")}`}
+      >
         <div className="topic-tree-copy">
-          <p className="topic-tree-kind">
+          <p className="topic-tree-kind" aria-hidden="true">
             {hasChildren ? "Topic cluster" : "Leaf topic"}
-            {depth > 0 ? <span>Level {depth}</span> : null}
+            {depth > 0 ? <span aria-hidden="true">Level {depth}</span> : null}
           </p>
           <h2 className="topic-tree-title">
             <span>{node.name}</span>
@@ -106,10 +118,10 @@ function TopicTreeNode({ tree, depth = 0 }: { tree: TopicRenderNode; depth?: num
           </div>
         </div>
 
-        <div className="topic-tree-metrics" aria-label={`${node.name} metrics`}>
+        <div className="topic-tree-metrics" aria-hidden="true">
           <div className="topic-tree-stat">
             <strong>{articleCount}</strong>
-            <span>article{articleCount !== 1 ? "s" : ""}</span>
+            <span>total article{articleCount !== 1 ? "s" : ""}</span>
           </div>
           <div className="topic-tree-stat">
             <strong>{descendantCount}</strong>
@@ -160,7 +172,7 @@ export default async function WikiHomePage() {
 
   const totalArticles = Object.values(countMap).reduce((total, count) => total + count, 0);
   const topicTree = roots.map((topic) => buildTopicRenderNode(topic, countMap));
-  const topicClusters = countTopicClusters(topicTree);
+  const branchTopics = countBranchTopics(topicTree);
   const latestArticle = recentArticles[0];
   const secondaryArticles = recentArticles.slice(1);
 
@@ -182,8 +194,8 @@ export default async function WikiHomePage() {
               <span>topics mapped</span>
             </span>
             <span className="page-meta-pill">
-              <strong>{topicClusters}</strong>
-              <span>topic clusters</span>
+              <strong>{branchTopics}</strong>
+              <span>branch topics</span>
             </span>
           </div>
         }
@@ -221,13 +233,14 @@ export default async function WikiHomePage() {
               <Link
                 href={`/wiki/${latestArticle.topic.slug}/${latestArticle.slug}`}
                 className="article-card article-card-featured home-featured-update"
+                aria-label={articleCardLabel(latestArticle)}
               >
                 <div className="article-card-header-row">
-                  <span className="article-kicker">{latestArticle.topic.name}</span>
-                  <span className="article-date">{homeDateFormatter.format(new Date(latestArticle.updatedAt))}</span>
+                  <span className="article-kicker" aria-hidden="true">{latestArticle.topic.name}</span>
+                  <span className="article-date" aria-hidden="true">{homeDateFormatter.format(new Date(latestArticle.updatedAt))}</span>
                 </div>
                 <h3>
-                  <RestrictedArticleIcon tags={latestArticle.restrictedTags ?? []} />
+                  <RestrictedArticleIcon tags={latestArticle.restrictedTags} />
                   {latestArticle.title}
                 </h3>
                 <p>
@@ -246,19 +259,20 @@ export default async function WikiHomePage() {
             ) : null}
 
             {secondaryArticles.length > 0 ? (
-              <div className="home-update-list" aria-label="Additional recent updates">
+              <div className="home-update-list">
                 {secondaryArticles.map((article) => (
                   <Link
                     key={article.id}
                     href={`/wiki/${article.topic.slug}/${article.slug}`}
                     className="article-card article-card-compact home-update-card"
+                    aria-label={articleCardLabel(article)}
                   >
                     <div className="article-card-header-row">
-                      <span className="article-kicker">{article.topic.name}</span>
-                      <span className="article-date">{homeDateFormatter.format(new Date(article.updatedAt))}</span>
+                      <span className="article-kicker" aria-hidden="true">{article.topic.name}</span>
+                      <span className="article-date" aria-hidden="true">{homeDateFormatter.format(new Date(article.updatedAt))}</span>
                     </div>
                     <h3>
-                      <RestrictedArticleIcon tags={article.restrictedTags ?? []} />
+                      <RestrictedArticleIcon tags={article.restrictedTags} />
                       {article.title}
                     </h3>
                     <p>{article.excerpt ?? "Open the latest revision to read the current summary and linked references."}</p>

--- a/src/app/wiki/page.tsx
+++ b/src/app/wiki/page.tsx
@@ -46,7 +46,7 @@ function buildTopicRenderNode(node: TopicNode, countMap: ArticleCountMap): Topic
   };
 }
 
-const homeDateFormatter = new Intl.DateTimeFormat(undefined, {
+const homeDateFormatter = new Intl.DateTimeFormat("en-GB", {
   month: "short",
   day: "numeric",
   year: "numeric",
@@ -56,7 +56,7 @@ function RestrictedArticleIcon({ tags }: { tags: string[] }) {
   if (tags.length === 0) return null;
 
   return (
-    <span className="restricted-icon" title={`Restricted: ${tags.join(", ")}`}>
+    <span className="restricted-icon" role="img" aria-label={`Restricted: ${tags.join(", ")}`}>
       <svg
         width="12"
         height="12"
@@ -72,6 +72,14 @@ function RestrictedArticleIcon({ tags }: { tags: string[] }) {
         <path d="M7 11V7a5 5 0 0 1 10 0v4" />
       </svg>
     </span>
+  );
+}
+
+function countTopicClusters(nodes: TopicRenderNode[]): number {
+  return nodes.reduce(
+    (total, topic) =>
+      total + (topic.children.length > 0 ? 1 : 0) + countTopicClusters(topic.children),
+    0,
   );
 }
 
@@ -95,7 +103,6 @@ function TopicTreeNode({ tree, depth = 0 }: { tree: TopicRenderNode; depth?: num
           </p>
           <div className="topic-tree-meta meta-row">
             <span>{directArticleCount} direct article{directArticleCount !== 1 ? "s" : ""}</span>
-            <span>{descendantCount} nested topic{descendantCount !== 1 ? "s" : ""}</span>
           </div>
         </div>
 
@@ -153,7 +160,7 @@ export default async function WikiHomePage() {
 
   const totalArticles = Object.values(countMap).reduce((total, count) => total + count, 0);
   const topicTree = roots.map((topic) => buildTopicRenderNode(topic, countMap));
-  const topicClusters = topicTree.filter((topic) => topic.children.length > 0).length;
+  const topicClusters = countTopicClusters(topicTree);
   const latestArticle = recentArticles[0];
   const secondaryArticles = recentArticles.slice(1);
 

--- a/src/app/wiki/wiki.css
+++ b/src/app/wiki/wiki.css
@@ -567,18 +567,13 @@
   min-height: 100%;
   padding: 1.5rem;
   background:
-    radial-gradient(circle at top right, rgba(95, 115, 255, 0.18), transparent 34%),
+    radial-gradient(circle at top right, var(--accent-glow), transparent 34%),
     linear-gradient(180deg, rgba(255, 255, 255, 0.06), transparent 22rem),
     var(--surface-color);
 }
 
 .article-card-compact {
   height: 100%;
-}
-
-.article-card-grid {
-  height: 100%;
-  padding: 1.25rem;
 }
 
 .article-card-header-row {
@@ -684,7 +679,6 @@
 }
 
 .home-featured-update {
-  min-height: 100%;
   align-content: start;
 }
 
@@ -719,7 +713,6 @@
 }
 
 .topic-tree-card {
-  position: relative;
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
   gap: 1rem;
@@ -749,7 +742,7 @@
 
 .topic-tree-kind span {
   margin-left: 0.6rem;
-  color: var(--text-faint);
+  color: var(--text-muted);
 }
 
 .topic-tree-title {

--- a/src/app/wiki/wiki.css
+++ b/src/app/wiki/wiki.css
@@ -674,6 +674,10 @@
   align-items: stretch;
 }
 
+.home-updates-layout > :only-child {
+  grid-column: 1 / -1;
+}
+
 .home-featured-update,
 .home-update-card {
   margin-bottom: 0;

--- a/src/app/wiki/wiki.css
+++ b/src/app/wiki/wiki.css
@@ -475,6 +475,16 @@
   margin-top: 1.8rem;
 }
 
+.wiki-home-hero {
+  padding-bottom: 1.35rem;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.wiki-home-section {
+  display: grid;
+  gap: 1.1rem;
+}
+
 .article-card,
 .topic-card,
 .admin-card,
@@ -542,8 +552,7 @@
   gap: 1rem;
 }
 
-.article-list .article-card,
-.recent-updates-shell .article-card {
+.article-list .article-card {
   margin-bottom: 0;
 }
 
@@ -658,26 +667,46 @@
   color: var(--accent-color);
 }
 
-.recent-updates-grid {
+.home-updates-layout {
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
+  grid-template-columns: minmax(0, 1.1fr) minmax(18rem, 0.9fr);
+  gap: 1rem;
+  align-items: stretch;
+}
+
+.home-featured-update,
+.home-update-card {
+  margin-bottom: 0;
+}
+
+.home-featured-update {
+  min-height: 100%;
+  align-content: start;
+}
+
+.home-featured-update h3 {
+  font-size: clamp(1.35rem, 2vw, 1.8rem);
+  line-height: 1.12;
+}
+
+.home-featured-update p {
+  font-size: 0.98rem;
+  line-height: 1.7;
+}
+
+.home-update-list {
+  display: grid;
   gap: 1rem;
 }
 
-@media (max-width: 768px) {
-  .recent-updates-grid {
-    grid-template-columns: 1fr;
-  }
-}
-
-.recent-updates-list {
+.home-update-card {
   display: grid;
-  gap: 1rem;
+  gap: 0.7rem;
 }
 
 .topic-tree {
   display: grid;
-  gap: 1rem;
+  gap: 1.1rem;
 }
 
 .topic-tree-node {
@@ -691,6 +720,14 @@
   grid-template-columns: minmax(0, 1fr) auto;
   gap: 1rem;
   align-items: start;
+  color: inherit;
+  text-decoration: none;
+}
+
+.topic-tree-node[data-depth="0"] > .topic-tree-card {
+  background:
+    linear-gradient(90deg, var(--surface-highlight), transparent 42%),
+    var(--surface-color);
 }
 
 .topic-tree-copy {
@@ -706,30 +743,24 @@
   text-transform: uppercase;
 }
 
+.topic-tree-kind span {
+  margin-left: 0.6rem;
+  color: var(--text-faint);
+}
+
 .topic-tree-title {
   margin: 0;
   font-size: clamp(1.05rem, 1.4vw, 1.32rem);
-}
-
-.topic-tree-title a {
-  position: relative;
-  z-index: 1;
-  display: block;
-  color: inherit;
-}
-
-/* Stretched link: title link covers entire card so clicking anywhere on the card navigates */
-.topic-tree-title a::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  z-index: -1;
 }
 
 .topic-tree-description {
   margin-top: 0.5rem;
   color: var(--text-muted);
   line-height: 1.65;
+}
+
+.topic-tree-meta {
+  margin-top: 0.8rem;
 }
 
 .topic-tree-metrics {
@@ -2038,7 +2069,7 @@ h2.activity-title {
   .search-grid,
   .admin-form-grid,
   .upload-grid,
-  .recent-updates-shell,
+  .home-updates-layout,
   .article-detail-grid,
   .topic-tree-card,
   .topic-subtopic-card,


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary

This pull request refines the wiki home page layout and information hierarchy to improve scannability and clarity around key metrics and content sections.

## Key Changes

### Header Metrics Reorganized
- The header pill metrics now highlight **total articles**, **mapped topics**, and **topic clusters** instead of the previous "recent updates surfaced" count
- Added a dedicated `wiki-home-hero` class with bottom border separator and adjusted page description copy
- Replaced inline admin button styles with a reusable `cluster` class

### Featured Latest Article with Secondary Updates
- Split the "Recently updated" section into a **featured latest article** (displayed prominently with more tags and larger typography) and a **compact secondary list** for additional updates
- Introduced a shared `RestrictedArticleIcon` component to reduce duplication of the access-restricted lock indicator
- Added locale-aware `homeDateFormatter` for consistent date display across both featured and secondary update cards
- Replaced the old `.recent-updates-grid` / `.recent-updates-list` layout with a new `.home-updates-layout` two-column design

### Topic Tree Improvements
- Added a `directArticleCount` field to `TopicRenderNode` to surface the number of articles directly attached to each topic (separate from total articles including descendants)
- Converted the entire topic card into a clickable link (`<Link>` wrapping the whole `.topic-tree-card`), removing the previous stretched-link pseudo-element technique
- Added a `depth` prop with a `Level {n}` indicator inside the kind label for nested topics
- Introduced visual differentiation for root topics via a `data-depth="0"` selector with a gradient background
- Each topic card now shows both direct article count and nested topic count in a meta row

### Supporting Styles
- Added `.wiki-home-section` spacing utility applied to recent updates and topics sections
- Refactored responsive grid rules so the new `.home-updates-layout` handles stacking on small screens
- Updated media query selector from `.recent-updates-shell` to `.home-updates-layout`

## Verification
- `npm run lint`
- `npm run typecheck`
- `npm run package-policy:check`
- `npm audit --audit-level=high`
- `npm run build` with PostgreSQL connection
- `npm run test` with PostgreSQL connection
- `git diff --check`

## Review Notes
- Two independent review passes were completed
- First pass addressed: nested topic level label, locale-neutral dates, removal of legacy recent-updates CSS
- Second pass found no blockers

---

## Summary

This PR refines the wiki home page to improve accessibility, labeling clarity, and visual consistency.

### Accessibility Improvements
- **Standardized date formatting**: Changed the home page date formatter from locale-default to `en-GB` for consistent display across users.
- **Enhanced screen reader support**: 
  - Added descriptive `aria-label` attributes to topic tree cards and article cards summarizing their key information (article counts, restriction status, topic placement).
  - Marked decorative/duplicate information (kicker labels, dates, level indicators) as `aria-hidden="true"` so screen readers don't repeat the data.
  - Replaced the `RestrictedArticleIcon`'s `title` attribute (tooltip) with `role="img"` and `aria-label="Restricted"` for proper assistive technology support.
- **Removed redundant accessible name**: Removed the standalone `aria-label` on the secondary articles container since each card now has its own descriptive label.

### Content & Copy Refinements
- Renamed the "topic clusters" metric to "branch topics" and added a helper function (`countBranchTopics`) that recursively counts all branch topics throughout the topic tree, not just root-level clusters.
- Replaced ad-hoc pluralization with a shared `pluralize` helper for consistency.
- Updated the topic tree meta to label the count as "total articles" for clarity.
- Removed the redundant nested topics count from the meta row (it was already shown in the metrics block).
- Removed fallback `?? []` on `restrictedTags` since the property is already typed as an array.

### Styling Adjustments
- Replaced the hardcoded `rgba(95, 115, 255, 0.18)` gradient with the existing `var(--accent-glow)` token for design system consistency.
- Removed an unused `.article-card-grid` rule.
- Added a rule so a single child in the updates layout spans the full grid width.
- Removed the `min-height: 100%` from the featured update card and `position: relative` from the topic tree card to let layout flow more naturally.
- Updated the topic tree level indicator color from `--text-faint` to `--text-muted` for better contrast.

---

## Description

Improved accessibility of the wiki home page by enhancing the screen reader labels for restricted articles. The labels now include the specific restriction tags, providing more informative context for assistive technology users when navigating restricted content.

### Changes
- Updated the `RestrictedArticleIcon` component to expose the restriction tags in its `aria-label` (e.g., "Restricted: internal, confidential").
- Enhanced the `articleCardLabel` function to include the restriction tags in the accessible name of article cards (e.g., "Restricted article (internal, confidential): Title in Topic"), so the tags are announced along with the article title and topic.
<!-- kody-pr-summary:end -->