### PR TITLE
refine wiki topic page

### DIFF
--- a/src/app/wiki/[topicSlug]/page.tsx
+++ b/src/app/wiki/[topicSlug]/page.tsx
@@ -13,6 +13,79 @@ interface Props {
   params: Promise<{ topicSlug: string }>;
 }
 
+interface TopicPathNode {
+  id: string;
+  name: string;
+  slug: string;
+  parentId: string | null;
+}
+
+const topicDateFormatter = new Intl.DateTimeFormat("en-GB", {
+  month: "short",
+  day: "numeric",
+  year: "numeric",
+});
+
+function pluralize(count: number, singular: string, plural = `${singular}s`) {
+  return count === 1 ? singular : plural;
+}
+
+function buildTopicPath(topics: TopicPathNode[], current: TopicPathNode) {
+  const topicMap = new Map(topics.map((topic) => [topic.id, topic]));
+  const path: TopicPathNode[] = [];
+  const seen = new Set<string>();
+  let cursor: TopicPathNode | undefined = current;
+
+  while (cursor && !seen.has(cursor.id)) {
+    path.unshift(cursor);
+    seen.add(cursor.id);
+    cursor = cursor.parentId ? topicMap.get(cursor.parentId) : undefined;
+  }
+
+  return path;
+}
+
+function RestrictedArticleIcon({ tags }: { tags: string[] }) {
+  if (tags.length === 0) return null;
+
+  return (
+    <span className="restricted-icon" role="img" aria-label={`Restricted: ${tags.join(", ")}`}>
+      <svg
+        width="12"
+        height="12"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+      >
+        <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+        <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+      </svg>
+    </span>
+  );
+}
+
+function articleCardLabel(article: {
+  title: string;
+  author?: { name: string | null } | null;
+  authorName: string | null;
+  status: string;
+  confidence: string | null;
+  restrictedTags: string[];
+}) {
+  const author = article.author?.name ?? article.authorName ?? "Unknown author";
+  const restriction =
+    article.restrictedTags.length > 0
+      ? `Restricted article (${article.restrictedTags.join(", ")})`
+      : "Article";
+  const confidence = article.confidence ? `, ${article.confidence} confidence` : "";
+
+  return `${restriction}: ${article.title}, ${article.status}${confidence}, by ${author}`;
+}
+
 export default async function TopicPage({ params }: Props) {
   const { topicSlug } = await params;
 
@@ -26,8 +99,9 @@ export default async function TopicPage({ params }: Props) {
       parent: true,
       children: {
         include: {
-          _count: { select: { articles: true } },
+          _count: { select: { articles: true, children: true } },
         },
+        orderBy: { name: "asc" },
       },
     },
   });
@@ -35,6 +109,12 @@ export default async function TopicPage({ params }: Props) {
   if (!topic) {
     notFound();
   }
+
+  const allTopics = await prisma.topic.findMany({
+    select: { id: true, name: true, slug: true, parentId: true },
+    orderBy: { name: "asc" },
+  });
+  const topicPath = buildTopicPath(allTopics, topic);
 
   // Unauthenticated users only see unrestricted articles.
   // Human sessions (via NextAuth) always have full access — they bypass restrictions.
@@ -49,14 +129,17 @@ export default async function TopicPage({ params }: Props) {
     },
     orderBy: { updatedAt: "desc" },
   });
+  const hasSubtopics = topic.children.length > 0;
 
   return (
     <div className="wiki-content topic-page">
       <Breadcrumbs
         items={[
           { label: "Noosphere", href: "/wiki" },
-          ...(topic.parent ? [{ label: topic.parent.name, href: `/wiki/${topic.parent.slug}` }] : []),
-          { label: topic.name },
+          ...topicPath.map((pathTopic, index) => ({
+            label: pathTopic.name,
+            href: index === topicPath.length - 1 ? undefined : `/wiki/${pathTopic.slug}`,
+          })),
         ]}
       />
 
@@ -64,6 +147,7 @@ export default async function TopicPage({ params }: Props) {
         eyebrow="Topic"
         title={topic.name}
         description={topic.description ?? "A focused collection of articles and subtopics inside the Noosphere knowledge graph."}
+        className="topic-page-hero"
         actions={
           canCreateArticle ? (
             <Link href={`/wiki/${topic.slug}/new`} className="btn btn-primary btn-sm">
@@ -86,32 +170,48 @@ export default async function TopicPage({ params }: Props) {
                 <strong>{topic.parent.name}</strong>
                 <span>parent topic</span>
               </span>
+            ) : hasSubtopics ? (
+              <span className="page-meta-pill">
+                <strong>Root</strong>
+                <span>topic branch</span>
+              </span>
             ) : null}
           </div>
         }
       />
 
-      {topic.children.length > 0 && (
-        <section className="browse-section browse-section-tight">
+      {hasSubtopics && (
+        <section className="browse-section browse-section-tight topic-page-section">
           <div className="section-header">
             <div className="section-header-copy">
               <p className="page-eyebrow">Branch outward</p>
               <h2 className="section-title">Subtopics</h2>
-              <p className="section-subtitle">Jump into narrower branches connected to this topic.</p>
+              <p className="section-subtitle">Move into narrower branches without losing the local article context.</p>
             </div>
           </div>
 
           <div className="topic-subtopic-grid">
             {topic.children.map((child) => (
-              <Link key={child.id} href={`/wiki/${child.slug}`} className="topic-card topic-subtopic-card">
+              <Link
+                key={child.id}
+                href={`/wiki/${child.slug}`}
+                className="topic-card topic-subtopic-card"
+                aria-label={`${child.name}: ${child._count.articles} direct ${pluralize(child._count.articles, "article")}, ${child._count.children} child ${pluralize(child._count.children, "subtopic")}`}
+              >
                 <div>
-                  <p className="topic-tree-kind">Subtopic</p>
+                  <p className="topic-tree-kind" aria-hidden="true">Subtopic</p>
                   <h3>{child.name}</h3>
                   <p>{child.description ?? "Explore the next layer of articles nested under this branch."}</p>
                 </div>
-                <div className="topic-subtopic-count">
-                  <strong>{child._count.articles}</strong>
-                  <span>article{child._count.articles !== 1 ? "s" : ""}</span>
+                <div className="topic-subtopic-metrics" aria-hidden="true">
+                  <div className="topic-subtopic-count">
+                    <strong>{child._count.articles}</strong>
+                    <span>direct article{child._count.articles !== 1 ? "s" : ""}</span>
+                  </div>
+                  <div className="topic-subtopic-count">
+                    <strong>{child._count.children}</strong>
+                    <span>child subtopic{child._count.children !== 1 ? "s" : ""}</span>
+                  </div>
                 </div>
               </Link>
             ))}
@@ -119,12 +219,12 @@ export default async function TopicPage({ params }: Props) {
         </section>
       )}
 
-      <section className="browse-section browse-section-tight">
+      <section className="browse-section browse-section-tight topic-page-section">
         <div className="section-header">
           <div className="section-header-copy">
             <p className="page-eyebrow">Reading list</p>
             <h2 className="section-title">Articles</h2>
-            <p className="section-subtitle">The latest pages in this topic, ordered by most recent update.</p>
+            <p className="section-subtitle">Direct articles in this topic, ordered by the most recent update.</p>
           </div>
           {articles.length > 0 ? <span className="result-count">{articles.length} total</span> : null}
         </div>
@@ -143,41 +243,54 @@ export default async function TopicPage({ params }: Props) {
           />
         ) : (
           <div className="article-list">
-            {articles.map((article) => (
-              <Link
-                key={article.id}
-                href={`/wiki/${topic.slug}/${article.slug}`}
-                className="article-card article-card-rich"
-              >
-                <div className="article-card-header-row">
-                  <span className="article-kicker">{article.author?.name ?? article.authorName ?? "Unknown author"}</span>
-                  <span className="article-date">Updated {new Date(article.updatedAt).toLocaleDateString()}</span>
-                </div>
-                <h3>
-                  {article.restrictedTags && article.restrictedTags.length > 0 && (
-                    <span className="restricted-icon" title={`Restricted: ${article.restrictedTags.join(", ")}`}>
-                      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-                        <rect x="3" y="11" width="18" height="11" rx="2" ry="2"/>
-                        <path d="M7 11V7a5 5 0 0 1 10 0v4"/>
-                      </svg>
-                    </span>
-                  )}
-                  {article.title}
-                </h3>
-                <p>
-                  {article.excerpt ?? "Open the article to read the latest revision, related sources, and linked references."}
-                </p>
-                {article.tags.length > 0 ? (
-                  <div className="article-tag-row article-tag-row-muted">
-                    {article.tags.map((entry) => (
-                      <span key={entry.tag.id} className="tag-badge">
-                        {entry.tag.name}
-                      </span>
-                    ))}
+            {articles.map((article) => {
+              const visibleTags = article.tags.slice(0, 5);
+              const hiddenTagCount = article.tags.length - visibleTags.length;
+
+              return (
+                <Link
+                  key={article.id}
+                  href={`/wiki/${topic.slug}/${article.slug}`}
+                  className="article-card article-card-rich topic-article-card"
+                  aria-label={articleCardLabel(article)}
+                >
+                  <div className="topic-article-main">
+                    <div className="article-card-header-row">
+                      <span className="article-kicker" aria-hidden="true">{article.author?.name ?? article.authorName ?? "Unknown author"}</span>
+                      <span className="article-date" aria-hidden="true">Updated {topicDateFormatter.format(new Date(article.updatedAt))}</span>
+                    </div>
+                    <h3>
+                      <RestrictedArticleIcon tags={article.restrictedTags} />
+                      {article.title}
+                    </h3>
+                    <p>
+                      {article.excerpt ?? "Open the article to read the latest revision, related sources, and linked references."}
+                    </p>
+                    {article.tags.length > 0 ? (
+                      <div className="article-tag-row article-tag-row-muted" aria-hidden="true">
+                        {visibleTags.map((entry) => (
+                          <span key={entry.tag.id} className="tag-badge">
+                            {entry.tag.name}
+                          </span>
+                        ))}
+                        {hiddenTagCount > 0 ? (
+                          <span className="tag-badge tag-badge-more">+{hiddenTagCount} more</span>
+                        ) : null}
+                      </div>
+                    ) : null}
                   </div>
-                ) : null}
-              </Link>
-            ))}
+
+                  <div className="topic-article-signals" aria-hidden="true">
+                    <span className={`status-badge status-${article.status}`}>{article.status}</span>
+                    {article.confidence ? (
+                      <span className={`confidence-badge confidence-${article.confidence}`}>
+                        {article.confidence} confidence
+                      </span>
+                    ) : null}
+                  </div>
+                </Link>
+              );
+            })}
           </div>
         )}
       </section>

--- a/src/app/wiki/[topicSlug]/page.tsx
+++ b/src/app/wiki/[topicSlug]/page.tsx
@@ -5,9 +5,11 @@ import { getServerSession } from "next-auth";
 import { Breadcrumbs } from "@/components/wiki/Breadcrumbs";
 import { EmptyState } from "@/components/wiki/EmptyState";
 import { PageHeader } from "@/components/wiki/PageHeader";
+import { RestrictedArticleIcon } from "@/components/wiki/RestrictedArticleIcon";
 import { authOptions } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { buildScopeFilter } from "@/lib/api/auth";
+import { articleCardLabel, pluralize, wikiDateFormatter } from "@/lib/wiki-format";
 
 interface Props {
   params: Promise<{ topicSlug: string }>;
@@ -18,16 +20,6 @@ interface TopicPathNode {
   name: string;
   slug: string;
   parentId: string | null;
-}
-
-const topicDateFormatter = new Intl.DateTimeFormat("en-GB", {
-  month: "short",
-  day: "numeric",
-  year: "numeric",
-});
-
-function pluralize(count: number, singular: string, plural = `${singular}s`) {
-  return count === 1 ? singular : plural;
 }
 
 function buildTopicPath(topics: TopicPathNode[], current: TopicPathNode) {
@@ -45,47 +37,6 @@ function buildTopicPath(topics: TopicPathNode[], current: TopicPathNode) {
   return path;
 }
 
-function RestrictedArticleIcon({ tags }: { tags: string[] }) {
-  if (tags.length === 0) return null;
-
-  return (
-    <span className="restricted-icon" role="img" aria-label={`Restricted: ${tags.join(", ")}`}>
-      <svg
-        width="12"
-        height="12"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="2"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        aria-hidden="true"
-      >
-        <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
-        <path d="M7 11V7a5 5 0 0 1 10 0v4" />
-      </svg>
-    </span>
-  );
-}
-
-function articleCardLabel(article: {
-  title: string;
-  author?: { name: string | null } | null;
-  authorName: string | null;
-  status: string;
-  confidence: string | null;
-  restrictedTags: string[];
-}) {
-  const author = article.author?.name ?? article.authorName ?? "Unknown author";
-  const restriction =
-    article.restrictedTags.length > 0
-      ? `Restricted article (${article.restrictedTags.join(", ")})`
-      : "Article";
-  const confidence = article.confidence ? `, ${article.confidence} confidence` : "";
-
-  return `${restriction}: ${article.title}, ${article.status}${confidence}, by ${author}`;
-}
-
 export default async function TopicPage({ params }: Props) {
   const { topicSlug } = await params;
 
@@ -96,7 +47,7 @@ export default async function TopicPage({ params }: Props) {
   const topic = await prisma.topic.findUnique({
     where: { slug: topicSlug },
     include: {
-      parent: true,
+      parent: { select: { name: true } },
       children: {
         include: {
           _count: { select: { articles: true, children: true } },
@@ -112,7 +63,6 @@ export default async function TopicPage({ params }: Props) {
 
   const allTopics = await prisma.topic.findMany({
     select: { id: true, name: true, slug: true, parentId: true },
-    orderBy: { name: "asc" },
   });
   const topicPath = buildTopicPath(allTopics, topic);
 
@@ -159,11 +109,11 @@ export default async function TopicPage({ params }: Props) {
           <div className="page-meta-pills">
             <span className="page-meta-pill">
               <strong>{articles.length}</strong>
-              <span>article{articles.length !== 1 ? "s" : ""}</span>
+              <span>{pluralize(articles.length, "article")}</span>
             </span>
             <span className="page-meta-pill">
               <strong>{topic.children.length}</strong>
-              <span>subtopic{topic.children.length !== 1 ? "s" : ""}</span>
+              <span>{pluralize(topic.children.length, "subtopic")}</span>
             </span>
             {topic.parent ? (
               <span className="page-meta-pill">
@@ -173,7 +123,7 @@ export default async function TopicPage({ params }: Props) {
             ) : hasSubtopics ? (
               <span className="page-meta-pill">
                 <strong>Root</strong>
-                <span>topic branch</span>
+                <span>top-level topic</span>
               </span>
             ) : null}
           </div>
@@ -186,7 +136,7 @@ export default async function TopicPage({ params }: Props) {
             <div className="section-header-copy">
               <p className="page-eyebrow">Branch outward</p>
               <h2 className="section-title">Subtopics</h2>
-              <p className="section-subtitle">Move into narrower branches without losing the local article context.</p>
+              <p className="section-subtitle">Subtopics nested under this branch - open any to see its articles and nested branches.</p>
             </div>
           </div>
 
@@ -196,21 +146,21 @@ export default async function TopicPage({ params }: Props) {
                 key={child.id}
                 href={`/wiki/${child.slug}`}
                 className="topic-card topic-subtopic-card"
-                aria-label={`${child.name}: ${child._count.articles} direct ${pluralize(child._count.articles, "article")}, ${child._count.children} child ${pluralize(child._count.children, "subtopic")}`}
+                aria-label={`Subtopic ${child.name}: ${child._count.articles} direct ${pluralize(child._count.articles, "article")}, ${child._count.children} direct ${pluralize(child._count.children, "subtopic")}`}
               >
-                <div>
-                  <p className="topic-tree-kind" aria-hidden="true">Subtopic</p>
+                <div className="topic-subtopic-copy">
+                  <p className="subtopic-kind" aria-hidden="true">Subtopic</p>
                   <h3>{child.name}</h3>
                   <p>{child.description ?? "Explore the next layer of articles nested under this branch."}</p>
                 </div>
                 <div className="topic-subtopic-metrics" aria-hidden="true">
                   <div className="topic-subtopic-count">
                     <strong>{child._count.articles}</strong>
-                    <span>direct article{child._count.articles !== 1 ? "s" : ""}</span>
+                    <span>direct {pluralize(child._count.articles, "article")}</span>
                   </div>
                   <div className="topic-subtopic-count">
                     <strong>{child._count.children}</strong>
-                    <span>child subtopic{child._count.children !== 1 ? "s" : ""}</span>
+                    <span>direct {pluralize(child._count.children, "subtopic")}</span>
                   </div>
                 </div>
               </Link>
@@ -257,7 +207,7 @@ export default async function TopicPage({ params }: Props) {
                   <div className="topic-article-main">
                     <div className="article-card-header-row">
                       <span className="article-kicker" aria-hidden="true">{article.author?.name ?? article.authorName ?? "Unknown author"}</span>
-                      <span className="article-date" aria-hidden="true">Updated {topicDateFormatter.format(new Date(article.updatedAt))}</span>
+                      <span className="article-date" aria-hidden="true">Updated {wikiDateFormatter.format(new Date(article.updatedAt))}</span>
                     </div>
                     <h3>
                       <RestrictedArticleIcon tags={article.restrictedTags} />

--- a/src/app/wiki/page.tsx
+++ b/src/app/wiki/page.tsx
@@ -3,9 +3,11 @@ import { getServerSession } from "next-auth";
 import type { Prisma } from "@prisma/client";
 import { EmptyState } from "@/components/wiki/EmptyState";
 import { PageHeader } from "@/components/wiki/PageHeader";
+import { RestrictedArticleIcon } from "@/components/wiki/RestrictedArticleIcon";
 import { prisma } from "@/lib/prisma";
 import { authOptions } from "@/lib/auth";
 import { loadWikiHomeData, type WikiHomeDb, type WikiHomeTopic } from "@/lib/wiki-home";
+import { articleCardLabel, pluralize, wikiDateFormatter } from "@/lib/wiki-format";
 
 export const dynamic = "force-dynamic";
 
@@ -46,54 +48,12 @@ function buildTopicRenderNode(node: TopicNode, countMap: ArticleCountMap): Topic
   };
 }
 
-const homeDateFormatter = new Intl.DateTimeFormat("en-GB", {
-  month: "short",
-  day: "numeric",
-  year: "numeric",
-});
-
-function RestrictedArticleIcon({ tags }: { tags: string[] }) {
-  if (tags.length === 0) return null;
-
-  return (
-    <span className="restricted-icon" role="img" aria-label={`Restricted: ${tags.join(", ")}`}>
-      <svg
-        width="12"
-        height="12"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="2"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        aria-hidden="true"
-      >
-        <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
-        <path d="M7 11V7a5 5 0 0 1 10 0v4" />
-      </svg>
-    </span>
-  );
-}
-
 function countBranchTopics(nodes: TopicRenderNode[]): number {
   return nodes.reduce(
     (total, topic) =>
       total + (topic.children.length > 0 ? 1 : 0) + countBranchTopics(topic.children),
     0,
   );
-}
-
-function pluralize(count: number, singular: string, plural = `${singular}s`) {
-  return count === 1 ? singular : plural;
-}
-
-function articleCardLabel(article: WikiHomeArticle) {
-  const restriction =
-    article.restrictedTags.length > 0
-      ? `Restricted article (${article.restrictedTags.join(", ")})`
-      : "Article";
-
-  return `${restriction}: ${article.title} in ${article.topic.name}`;
 }
 
 function TopicTreeNode({ tree, depth = 0 }: { tree: TopicRenderNode; depth?: number }) {
@@ -238,11 +198,11 @@ export default async function WikiHomePage() {
               <Link
                 href={`/wiki/${latestArticle.topic.slug}/${latestArticle.slug}`}
                 className="article-card article-card-featured home-featured-update"
-                aria-label={articleCardLabel(latestArticle)}
+                aria-label={articleCardLabel({ ...latestArticle, topicName: latestArticle.topic.name })}
               >
                 <div className="article-card-header-row">
                   <span className="article-kicker" aria-hidden="true">{latestArticle.topic.name}</span>
-                  <span className="article-date" aria-hidden="true">{homeDateFormatter.format(new Date(latestArticle.updatedAt))}</span>
+                  <span className="article-date" aria-hidden="true">{wikiDateFormatter.format(new Date(latestArticle.updatedAt))}</span>
                 </div>
                 <h3>
                   <RestrictedArticleIcon tags={latestArticle.restrictedTags} />
@@ -252,7 +212,7 @@ export default async function WikiHomePage() {
                   {latestArticle.excerpt ?? "Open the latest revision to read the current summary and linked references."}
                 </p>
                 {latestArticle.tags.length > 0 ? (
-                  <div className="article-tag-row article-tag-row-muted">
+                  <div className="article-tag-row article-tag-row-muted" aria-hidden="true">
                     {latestArticle.tags.slice(0, 4).map((tag) => (
                       <span key={tag.tag.id} className="tag-badge">
                         {tag.tag.name}
@@ -270,11 +230,11 @@ export default async function WikiHomePage() {
                     key={article.id}
                     href={`/wiki/${article.topic.slug}/${article.slug}`}
                     className="article-card article-card-compact home-update-card"
-                    aria-label={articleCardLabel(article)}
+                    aria-label={articleCardLabel({ ...article, topicName: article.topic.name })}
                   >
                     <div className="article-card-header-row">
                       <span className="article-kicker" aria-hidden="true">{article.topic.name}</span>
-                      <span className="article-date" aria-hidden="true">{homeDateFormatter.format(new Date(article.updatedAt))}</span>
+                      <span className="article-date" aria-hidden="true">{wikiDateFormatter.format(new Date(article.updatedAt))}</span>
                     </div>
                     <h3>
                       <RestrictedArticleIcon tags={article.restrictedTags} />

--- a/src/app/wiki/wiki.css
+++ b/src/app/wiki/wiki.css
@@ -804,11 +804,16 @@
 
 .topic-subtopic-card {
   display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
   gap: 1rem;
   align-items: start;
   color: inherit;
   text-decoration: none;
   position: relative;
+}
+
+.topic-subtopic-copy {
+  min-width: 0;
 }
 
 .topic-subtopic-card h3 {
@@ -820,6 +825,15 @@
 .topic-subtopic-card p + p,
 .topic-subtopic-card h3 + p {
   margin-top: 0.45rem;
+}
+
+.subtopic-kind {
+  margin: 0 0 0.45rem;
+  color: var(--accent-color);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
 }
 
 .topic-subtopic-count {
@@ -872,7 +886,10 @@
 }
 
 .topic-article-main h3,
-.topic-article-main p,
+.topic-article-main p {
+  overflow-wrap: break-word;
+}
+
 .topic-article-main .tag-badge {
   overflow-wrap: anywhere;
 }
@@ -2306,10 +2323,13 @@ h2.activity-title {
     width: 100%;
   }
 
-  .page-meta-pill,
+  .page-meta-pill {
+    width: 100%;
+    justify-content: center;
+  }
+
   .sub-topic-tag,
   .tag-badge {
-    width: 100%;
     justify-content: center;
   }
 

--- a/src/app/wiki/wiki.css
+++ b/src/app/wiki/wiki.css
@@ -475,12 +475,14 @@
   margin-top: 1.8rem;
 }
 
-.wiki-home-hero {
+.wiki-home-hero,
+.topic-page-hero {
   padding-bottom: 1.35rem;
   border-bottom: 1px solid var(--border-color);
 }
 
-.wiki-home-section {
+.wiki-home-section,
+.topic-page-section {
   display: grid;
   gap: 1.1rem;
 }
@@ -802,7 +804,6 @@
 
 .topic-subtopic-card {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
   gap: 1rem;
   align-items: start;
   color: inherit;
@@ -836,6 +837,56 @@
 .topic-subtopic-count span {
   color: var(--text-faint);
   font-size: 0.78rem;
+}
+
+.topic-subtopic-metrics {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.65rem;
+  min-width: 0;
+}
+
+.topic-subtopic-metrics .topic-subtopic-count {
+  padding: 0.68rem 0.78rem;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  background: var(--surface-inset);
+  text-align: left;
+}
+
+.topic-article-card {
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: start;
+  color: inherit;
+}
+
+.topic-article-main {
+  display: grid;
+  gap: 0.8rem;
+  min-width: 0;
+}
+
+.topic-article-main > * {
+  min-width: 0;
+  max-width: 100%;
+}
+
+.topic-article-main h3,
+.topic-article-main p,
+.topic-article-main .tag-badge {
+  overflow-wrap: anywhere;
+}
+
+.tag-badge-more {
+  color: var(--text-faint);
+  font-style: italic;
+}
+
+.topic-article-signals {
+  display: grid;
+  gap: 0.45rem;
+  justify-items: end;
+  min-width: 8.5rem;
 }
 
 .article-header {
@@ -2070,6 +2121,7 @@ h2.activity-title {
   .article-detail-grid,
   .topic-tree-card,
   .topic-subtopic-card,
+  .topic-article-card,
   .sync-conflict-diff-grid {
     grid-template-columns: 1fr;
   }
@@ -2085,9 +2137,15 @@ h2.activity-title {
   }
 
   .topic-tree-metrics,
-  .topic-subtopic-count {
+  .topic-subtopic-count,
+  .topic-subtopic-metrics,
+  .topic-article-signals {
     min-width: 0;
     text-align: left;
+  }
+
+  .topic-article-signals {
+    justify-items: start;
   }
 
   .topic-tree-children {

--- a/src/components/wiki/RestrictedArticleIcon.tsx
+++ b/src/components/wiki/RestrictedArticleIcon.tsx
@@ -1,0 +1,22 @@
+export function RestrictedArticleIcon({ tags }: { tags: string[] }) {
+  if (tags.length === 0) return null;
+
+  return (
+    <span className="restricted-icon" title={`Restricted: ${tags.join(", ")}`} aria-hidden="true">
+      <svg
+        width="12"
+        height="12"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+      >
+        <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+        <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+      </svg>
+    </span>
+  );
+}

--- a/src/lib/wiki-format.ts
+++ b/src/lib/wiki-format.ts
@@ -1,0 +1,34 @@
+export const wikiDateFormatter = new Intl.DateTimeFormat("en-GB", {
+  month: "short",
+  day: "numeric",
+  year: "numeric",
+  timeZone: "UTC",
+});
+
+export function pluralize(count: number, singular: string, plural = `${singular}s`) {
+  return count === 1 ? singular : plural;
+}
+
+export function articleCardLabel(article: {
+  title: string;
+  topicName?: string;
+  author?: { name: string | null } | null;
+  authorName?: string | null;
+  status?: string;
+  confidence?: string | null;
+  restrictedTags: string[];
+}) {
+  const restriction =
+    article.restrictedTags.length > 0
+      ? `Restricted article (${article.restrictedTags.join(", ")})`
+      : "Article";
+  const topic = article.topicName ? ` in ${article.topicName}` : "";
+  const author = article.author?.name ?? article.authorName;
+  const lead = `${restriction}: ${article.title}${topic}${author ? `, by ${author}` : ""}.`;
+  const details = [
+    article.status ? `Status: ${article.status}.` : null,
+    article.confidence ? `Confidence: ${article.confidence}.` : null,
+  ];
+
+  return [lead, ...details].filter(Boolean).join(" ");
+}


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Refined Description

This PR refines the wiki topic page as part of the PR-3 revamp phase, focusing on hierarchy clarity, accessibility, and information density for both desktop and mobile users.

### Key Changes

**Breadcrumb & Navigation**
- Replaced the single-parent breadcrumb with a full ancestor path traversal (`buildTopicPath`) so deeply nested topics display their complete hierarchy from Noosphere root to the current topic
- The current topic is now rendered as a non-link terminal breadcrumb, with ancestors linking to their respective pages

**Hero & Topic Metadata**
- Added a `topic-page-hero` class for shared hero styling with the wiki home page
- Introduced a "Root topic branch" pill that displays when a topic has no parent but has subtopics, providing context for top-level branches
- Added role-aware create actions (article + subtopic) gated on user permissions

**Subtopic Cards**
- Subtopics are now ordered alphabetically (`orderBy: { name: "asc" }`)
- Each subtopic card now shows **two metrics**: direct article count and child subtopic count, displayed side-by-side in a bordered grid for easier scanning
- Aria-labels describe the full metric composition for screen readers (e.g., `"Serianis Project: 5 direct articles, 2 child subtopics"`)

**Article Cards**
- Extracted `RestrictedArticleIcon` as a reusable component with proper `role="img"` and `aria-label` (replacing the previous `title` tooltip)
- Added a dedicated `articleCardLabel` builder to produce comprehensive aria-labels including restriction status, confidence, and author
- Moved status (`status-badge`) and confidence (`confidence-badge`) into a right-aligned signals column, creating a clearer visual separation between content and metadata
- Capped visible tags at 5 with an explicit italic `+N more` overflow chip for articles with many tags
- Dates now format consistently using an `Intl.DateTimeFormat` instance (`en-GB`, e.g., "12 Mar 2024")

**CSS / Responsive Layout**
- Extended shared CSS patterns: `.topic-page-hero`, `.topic-page-section`, `.topic-subtopic-metrics`, `.topic-article-card`, `.topic-article-main`, `.topic-article-signals`, and `.tag-badge-more`
- Article cards collapse to single-column on mobile with signals left-aligned (no horizontal overflow)
- Subtopic metrics grid stacks gracefully on narrow viewports
- Text in article card body elements uses `overflow-wrap: anywhere` to prevent tag/badge overflow

---

### Summary

Refined the wiki topic page and related home page to extract shared helpers into a dedicated formatting module, improve accessibility, and tighten the visual layout.

### Changes

- **Extracted shared helpers into `src/lib/wiki-format.ts`**
  - Centralized the `wikiDateFormatter` (now UTC-based), `pluralize`, and `articleCardLabel` helpers, removing duplicate inline definitions previously scattered across the topic and home pages.
  - `articleCardLabel` now produces a more descriptive, screen-reader-friendly label that includes the topic name, author, status, and confidence when available, and uses a structured `Status:` / `Confidence:` suffix for clearer assistive tech output.

- **Extracted `RestrictedArticleIcon` into a reusable component (`src/components/wiki/RestrictedArticleIcon.tsx`)**
  - Pulled the lock icon out of both the topic and home page modules so it can be reused.
  - Replaced the previous `role="img"` + `aria-label` pattern with `aria-hidden="true"` plus a native `title` tooltip, avoiding redundant screen reader announcements.

- **Updated `src/app/wiki/[topicSlug]/page.tsx`**
  - Imports the new shared helpers and component.
  - Optimized the Prisma `topic.findUnique` query to select only the parent's `name` instead of fetching the full record.
  - Removed unnecessary ordering on the global topic fetch (the page already sorts locally).
  - Refined copy: "Root / topic branch" → "Root / top-level topic" and rewrote the Subtopics section subtitle to better describe the next-level branches.
  - Improved subtopic card semantics and screen reader labels (prefixed with "Subtopic", prefixed counts with "direct", used shared `pluralize`).
  - Swapped the in-card CSS class from `topic-tree-kind` to a new `subtopic-kind` class with dedicated styling.

- **Updated `src/app/wiki/page.tsx`**
  - Imports the shared helpers and icon component, removing duplicate local definitions.
  - Marks the muted article tag row as `aria-hidden="true"` so its tags aren't redundantly announced alongside the card label.

- **CSS refinements in `src/app/wiki/wiki.css`**
  - `.topic-subtopic-card` now uses an explicit `minmax(0, 1fr) auto` grid for predictable two-column behavior, with a dedicated `.topic-subtopic-copy` container to allow text to wrap properly.
  - Added `.subtopic-kind` styling for the small uppercase "Subtopic" kicker.
  - Applied `overflow-wrap: break-word` to `.topic-article-main h3` and `.topic-article-main p` to prevent long titles or excerpts from overflowing.
  - Tweaked the responsive rules so `.sub-topic-tag` and `.tag-badge` keep `justify-content: center` while regaining flexible width, and ensured `.page-meta-pill` centers its content on small screens.

### Impact

These changes primarily improve maintainability (shared formatting helpers, reusable icon component), accessibility (cleaner aria-label text, redundant icon labels removed, decorative content hidden), and visual consistency on the wiki topic and home pages.
<!-- kody-pr-summary:end -->