### PR TITLE
Fix wiki home recent article layout

### DIFF
--- a/src/app/wiki/page.tsx
+++ b/src/app/wiki/page.tsx
@@ -138,8 +138,6 @@ export default async function WikiHomePage() {
   const totalArticles = Object.values(countMap).reduce((total, count) => total + count, 0);
   const topicTree = roots.map((topic) => buildTopicRenderNode(topic, countMap));
   const branchTopics = countBranchTopics(topicTree);
-  const latestArticle = recentArticles[0];
-  const secondaryArticles = recentArticles.slice(1);
 
   return (
     <div className="wiki-content wiki-home">
@@ -193,58 +191,25 @@ export default async function WikiHomePage() {
             </div>
           </div>
 
-          <div className="home-updates-layout">
-            {latestArticle ? (
+          <div className="home-update-list">
+            {recentArticles.map((article) => (
               <Link
-                href={`/wiki/${latestArticle.topic.slug}/${latestArticle.slug}`}
-                className="article-card article-card-featured home-featured-update"
-                aria-label={articleCardLabel({ ...latestArticle, topicName: latestArticle.topic.name })}
+                key={article.id}
+                href={`/wiki/${article.topic.slug}/${article.slug}`}
+                className="article-card article-card-compact home-update-card"
+                aria-label={articleCardLabel({ ...article, topicName: article.topic.name })}
               >
                 <div className="article-card-header-row">
-                  <span className="article-kicker" aria-hidden="true">{latestArticle.topic.name}</span>
-                  <span className="article-date" aria-hidden="true">{wikiDateFormatter.format(new Date(latestArticle.updatedAt))}</span>
+                  <span className="article-kicker" aria-hidden="true">{article.topic.name}</span>
+                  <span className="article-date" aria-hidden="true">{wikiDateFormatter.format(new Date(article.updatedAt))}</span>
                 </div>
                 <h3>
-                  <RestrictedArticleIcon tags={latestArticle.restrictedTags} />
-                  {latestArticle.title}
+                  <RestrictedArticleIcon tags={article.restrictedTags} />
+                  {article.title}
                 </h3>
-                <p>
-                  {latestArticle.excerpt ?? "Open the latest revision to read the current summary and linked references."}
-                </p>
-                {latestArticle.tags.length > 0 ? (
-                  <div className="article-tag-row article-tag-row-muted" aria-hidden="true">
-                    {latestArticle.tags.slice(0, 4).map((tag) => (
-                      <span key={tag.tag.id} className="tag-badge">
-                        {tag.tag.name}
-                      </span>
-                    ))}
-                  </div>
-                ) : null}
+                <p>{article.excerpt ?? "Open the latest revision to read the current summary and linked references."}</p>
               </Link>
-            ) : null}
-
-            {secondaryArticles.length > 0 ? (
-              <div className="home-update-list">
-                {secondaryArticles.map((article) => (
-                  <Link
-                    key={article.id}
-                    href={`/wiki/${article.topic.slug}/${article.slug}`}
-                    className="article-card article-card-compact home-update-card"
-                    aria-label={articleCardLabel({ ...article, topicName: article.topic.name })}
-                  >
-                    <div className="article-card-header-row">
-                      <span className="article-kicker" aria-hidden="true">{article.topic.name}</span>
-                      <span className="article-date" aria-hidden="true">{wikiDateFormatter.format(new Date(article.updatedAt))}</span>
-                    </div>
-                    <h3>
-                      <RestrictedArticleIcon tags={article.restrictedTags} />
-                      {article.title}
-                    </h3>
-                    <p>{article.excerpt ?? "Open the latest revision to read the current summary and linked references."}</p>
-                  </Link>
-                ))}
-              </div>
-            ) : null}
+            ))}
           </div>
         </section>
       )}

--- a/src/app/wiki/wiki.css
+++ b/src/app/wiki/wiki.css
@@ -559,19 +559,9 @@
 }
 
 .article-card-rich,
-.article-card-featured,
 .article-card-compact {
   display: grid;
   gap: 0.8rem;
-}
-
-.article-card-featured {
-  min-height: 100%;
-  padding: 1.5rem;
-  background:
-    radial-gradient(circle at top right, var(--accent-glow), transparent 34%),
-    linear-gradient(180deg, rgba(255, 255, 255, 0.06), transparent 22rem),
-    var(--surface-color);
 }
 
 .article-card-compact {
@@ -664,34 +654,8 @@
   color: var(--accent-color);
 }
 
-.home-updates-layout {
-  display: grid;
-  grid-template-columns: minmax(0, 1.1fr) minmax(18rem, 0.9fr);
-  gap: 1rem;
-  align-items: stretch;
-}
-
-.home-updates-layout > :only-child {
-  grid-column: 1 / -1;
-}
-
-.home-featured-update,
 .home-update-card {
   margin-bottom: 0;
-}
-
-.home-featured-update {
-  align-content: start;
-}
-
-.home-featured-update h3 {
-  font-size: clamp(1.35rem, 2vw, 1.8rem);
-  line-height: 1.12;
-}
-
-.home-featured-update p {
-  font-size: 0.98rem;
-  line-height: 1.7;
 }
 
 .home-update-list {
@@ -2134,7 +2098,6 @@ h2.activity-title {
   .search-grid,
   .admin-form-grid,
   .upload-grid,
-  .home-updates-layout,
   .article-detail-grid,
   .topic-tree-card,
   .topic-subtopic-card,


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary

This PR flattens the wiki home page "Recent updates" section into a single, uniform vertical list of compact article cards. Previously the section rendered the newest article as a larger featured card (with extra tag chips and distinctive gradient styling) alongside a stacked list of secondary articles in a two-column responsive grid. That distinction has been removed entirely.

## Changes

### `src/app/wiki/page.tsx`
- Removed the `latestArticle` / `secondaryArticles` split. The component now iterates over `recentArticles` directly, rendering every article with the same compact card markup (kicker, date, title with restricted icon, excerpt fallback).
- Collapsed the previous `home-updates-layout` wrapper and the inner `home-update-list` into a single `home-update-list` container so the structure matches the styling being kept.

### `src/app/wiki/wiki.css`
- Deleted the `.article-card-featured` rule (including its accent-glow radial gradient and padding/min-height styling).
- Deleted `.home-updates-layout` (two-column responsive grid), `.home-featured-update`, and its specific h3/p typography overrides.
- Removed the `.home-updates-layout` entry from the small-viewport `grid-template-columns: 1fr` override list, since the layout it referenced no longer exists.
- Compact `.home-update-card` styling and the `.home-update-list` grid rules are retained.

## Functional impact
- All recent articles now share identical visual weight and hierarchy on the wiki home page, with no featured/primary treatment for the newest entry.
- The excerpt fallback text is still shown for articles without one, but the tag-badge row that previously appeared only on the featured card is no longer rendered anywhere in the recent updates section.
- Responsive behavior simplifies: at narrow widths there is no longer a two-column layout to collapse, just a single stacked list.
<!-- kody-pr-summary:end -->