### PR TITLE
Improve Noosphere memory recall fallback

### DIFF
--- a/docs/NOOSPHERE-MEMORY-ARCHITECTURE.md
+++ b/docs/NOOSPHERE-MEMORY-ARCHITECTURE.md
@@ -669,4 +669,16 @@ The plugin guards against older config shapes that may not have new fields:
 - **Local-first setup**: the official OpenClaw setup binds Noosphere to
   `127.0.0.1:6578` by default and stores secrets outside the repository.
 
+### Conversational Search Fallback
+
+The Noosphere article provider first runs the normal weighted PostgreSQL
+full-text query over title, excerpt, content, and tags. If that strict query
+returns no rows, it retries once with a bounded fallback tsquery built from
+distinctive terms plus a small synonym set for common conversational misses.
+
+Example: a user may ask for a "photo" while the durable article says "portrait",
+or ask for an "avatar" while the article says "profile". The fallback can bridge
+that vocabulary gap, but only after the precise query has failed, so normal
+exact search ranking remains unchanged.
+
 See also: [`OPENCLAW-OFFICIAL-PLUGIN-SETUP.md`](OPENCLAW-OFFICIAL-PLUGIN-SETUP.md).

--- a/docs/OPENCLAW-OFFICIAL-PLUGIN-SETUP.md
+++ b/docs/OPENCLAW-OFFICIAL-PLUGIN-SETUP.md
@@ -455,6 +455,23 @@ Restart Gateway after changing config:
 openclaw gateway restart
 ```
 
+### Auto-recall misses a memory that manual wording can find
+
+The plugin sends cleaned user text to Noosphere; the memory article provider
+searches articles with strict full-text matching first. If that strict query
+returns no rows, the provider retries once with a bounded synonym fallback for
+conversational wording gaps such as "photo" versus "portrait", or "avatar"
+versus "profile".
+
+If a memory still does not surface:
+
+- add the user's natural wording as article text or tags
+- keep important personal/context articles reviewed or published when they are
+  no longer raw draft captures
+- test both the original message and a short concept query with the
+  `noosphere_recall` plugin tool to separate query extraction from article
+  vocabulary
+
 ### Noosphere is unreachable
 
 Check health and containers:

--- a/src/__tests__/memory/article-search.test.ts
+++ b/src/__tests__/memory/article-search.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  buildFallbackSearchTsQuery,
+  extractFallbackSearchTerms,
+} from "@/lib/memory/article-search";
+
+describe("article search fallback terms", () => {
+  it("keeps the durable concept from conversational photo phrasing", () => {
+    const terms = extractFallbackSearchTerms(
+      "Because it looks like you forgot the photo of you, I'll reattach it",
+    );
+
+    assert.ok(terms.includes("photo"));
+    assert.ok(terms.includes("portrait"));
+    assert.ok(!terms.includes("face"));
+    assert.ok(!terms.includes("ill"));
+  });
+
+  it("keeps fallback terms bounded for long messages", () => {
+    const terms = extractFallbackSearchTerms(
+      "Please check whether this long message about markdown import access control search recall deployment " +
+        "settings budget tokens providers and conflict handling needs every term",
+    );
+
+    assert.ok(terms.length <= 16);
+  });
+
+  it("drops common function words so fallback queries do not become broad", () => {
+    assert.deepEqual(
+      extractFallbackSearchTerms("the and of is are was were be been being has had do does did will may might can shall"),
+      [],
+    );
+    assert.equal(buildFallbackSearchTsQuery("the and of"), null);
+  });
+
+  it("strips tsquery operators before building fallback terms", () => {
+    assert.deepEqual(
+      extractFallbackSearchTerms("foo & bar | baz !qux <-> quux"),
+      ["foo", "bar", "baz", "qux", "quux"],
+    );
+  });
+});

--- a/src/__tests__/memory/noosphere-provider.test.ts
+++ b/src/__tests__/memory/noosphere-provider.test.ts
@@ -19,7 +19,9 @@ import {
 import type { MemoryCurationLevel } from "@/lib/memory/types";
 import {
   createMockPrisma,
+  createSequentialQueryRaw,
   mockArticle,
+  mockSearchRow,
 } from "./noosphere-provider-helpers";
 
 let testCounter = 0;
@@ -148,6 +150,102 @@ async function main() {
     });
     const results = await provider.search("nonexistent topic");
     assertEqual(results.length, 0, "no results");
+  });
+
+  test("search does not retry fallback when strict query returns results", async () => {
+    let queryCount = 0;
+    const provider = new NoosphereProvider({
+      prisma: createMockPrisma({
+        $queryRaw: () => {
+          queryCount++;
+          return Promise.resolve([mockSearchRow({ id: "strict-1" })]);
+        },
+      }),
+    });
+
+    const results = await provider.search("avatar portrait");
+
+    assertEqual(queryCount, 1, "strict query only");
+    assertEqual(results.length, 1, "strict result count");
+    assertEqual(results[0].id, "strict-1", "strict result id");
+  });
+
+  test("search retries with synonym fallback when strict query yields no results", async () => {
+    let queryCount = 0;
+    const queryRaw = createSequentialQueryRaw([
+      [],
+      [
+        mockSearchRow({
+          id: "portrait-1",
+          title: "Cybera avatar portrait",
+          content: "Telegram profile picture and avatar portrait reference.",
+          tagName: "avatar",
+        }),
+        mockSearchRow({
+          id: "portrait-1",
+          title: "Cybera avatar portrait",
+          content: "Telegram profile picture and avatar portrait reference.",
+          tagName: "portrait",
+        }),
+      ],
+    ]);
+    const provider = new NoosphereProvider({
+      prisma: createMockPrisma({
+        $queryRaw: (...args: unknown[]) => {
+          void args;
+          queryCount++;
+          return queryRaw();
+        },
+      }),
+    });
+
+    const results = await provider.search("forgot photo reattach");
+
+    assertEqual(queryCount, 2, "strict query then fallback query");
+    assertEqual(results.length, 1, "fallback result count");
+    assertEqual(results[0].id, "portrait-1", "fallback result id");
+    assertEqual(results[0].tags?.join(","), "avatar,portrait", "fallback tags");
+  });
+
+  test("search skips fallback on paginated empty strict pages with earlier strict matches", async () => {
+    let queryCount = 0;
+    const queryRaw = createSequentialQueryRaw([
+      [],
+      [{ exists: true }],
+      [mockSearchRow({ id: "fallback-should-not-run" })],
+    ]);
+    const provider = new NoosphereProvider({
+      prisma: createMockPrisma({
+        $queryRaw: () => {
+          queryCount++;
+          return queryRaw();
+        },
+      }),
+    });
+
+    const results = await provider.search("photo", {
+      metadata: { offset: 10 },
+    });
+
+    assertEqual(queryCount, 2, "strict page query plus global strict existence check");
+    assertEqual(results.length, 0, "empty strict page remains empty");
+  });
+
+  test("search skips fallback when relaxed query has no useful terms", async () => {
+    let queryCount = 0;
+    const provider = new NoosphereProvider({
+      prisma: createMockPrisma({
+        $queryRaw: () => {
+          queryCount++;
+          return Promise.resolve([]);
+        },
+      }),
+    });
+
+    const results = await provider.search("the and of is are was were be been being has had do does did will may might can shall");
+
+    assertEqual(queryCount, 1, "strict query only");
+    assertEqual(results.length, 0, "no fallback results");
   });
 
   // ─── getById() ──────────────────────────────────────────────────────────

--- a/src/lib/memory/article-search.ts
+++ b/src/lib/memory/article-search.ts
@@ -12,6 +12,97 @@
 
 import { Prisma } from "@prisma/client";
 
+const FALLBACK_SEARCH_MAX_SEED_TERMS = 8;
+const FALLBACK_SEARCH_MAX_TERMS = 16;
+
+const FALLBACK_SEARCH_STOP_WORDS = new Set([
+  "a",
+  "about",
+  "after",
+  "again",
+  "an",
+  "and",
+  "are",
+  "as",
+  "at",
+  "be",
+  "been",
+  "because",
+  "being",
+  "before",
+  "by",
+  "can",
+  "could",
+  "did",
+  "do",
+  "does",
+  "for",
+  "from",
+  "had",
+  "has",
+  "have",
+  "he",
+  "her",
+  "hers",
+  "him",
+  "his",
+  "how",
+  "if",
+  "in",
+  "is",
+  "it",
+  "its",
+  "just",
+  "like",
+  "may",
+  "me",
+  "might",
+  "my",
+  "not",
+  "of",
+  "on",
+  "or",
+  "our",
+  "ours",
+  "shall",
+  "she",
+  "should",
+  "that",
+  "the",
+  "their",
+  "them",
+  "then",
+  "there",
+  "these",
+  "they",
+  "those",
+  "this",
+  "to",
+  "us",
+  "was",
+  "we",
+  "were",
+  "what",
+  "when",
+  "where",
+  "whether",
+  "which",
+  "who",
+  "why",
+  "will",
+  "with",
+  "would",
+  "you",
+  "your",
+]);
+
+const FALLBACK_SEARCH_SYNONYMS: string[][] = [
+  ["photo", "photos", "image", "images", "picture", "pictures", "portrait"],
+  ["avatar", "profile", "portrait"],
+  ["screenshot", "screenshots", "image", "images", "picture", "pictures"],
+  ["attach", "attached", "attachment", "attachments", "file", "files", "upload", "uploaded"],
+];
+
 // ─── Types ───────────────────────────────────────────────────────────────────
 
 export interface ArticleSearchFilters {
@@ -122,4 +213,55 @@ export function buildSearchableCTE(
  */
 export function buildSearchTsQuery(query: string): Prisma.Sql {
   return Prisma.sql`websearch_to_tsquery('simple', ${query})`;
+}
+
+/**
+ * Build a less strict fallback tsquery for conversational recall misses.
+ *
+ * `websearch_to_tsquery` is intentionally precise, but ordinary user phrasing
+ * can include words that are absent from the durable article ("forgot",
+ * "reattach") while still naming the concept ("photo"). This fallback is used
+ * only after the strict query returns zero rows, and keeps the term set bounded
+ * so broad searches do not swamp normal relevance ranking.
+ */
+export function buildFallbackSearchTsQuery(query: string): Prisma.Sql | null {
+  const terms = extractFallbackSearchTerms(query);
+  if (terms.length === 0) return null;
+
+  return Prisma.sql`to_tsquery('simple', ${terms.join(" | ")})`;
+}
+
+export function extractFallbackSearchTerms(query: string): string[] {
+  const seeds = query
+    .toLowerCase()
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .split(/[^a-z0-9]+/)
+    .filter((term) => term.length >= 3 && !FALLBACK_SEARCH_STOP_WORDS.has(term))
+    .slice(0, FALLBACK_SEARCH_MAX_SEED_TERMS);
+
+  const terms = new Set<string>();
+
+  for (const seed of seeds) {
+    addFallbackSearchTerm(terms, seed);
+
+    const synonymGroup = FALLBACK_SEARCH_SYNONYMS.find((group) =>
+      group.includes(seed),
+    );
+    if (synonymGroup) {
+      for (const synonym of synonymGroup) {
+        addFallbackSearchTerm(terms, synonym);
+      }
+    }
+
+    if (terms.size >= FALLBACK_SEARCH_MAX_TERMS) break;
+  }
+
+  return [...terms].slice(0, FALLBACK_SEARCH_MAX_TERMS);
+}
+
+function addFallbackSearchTerm(terms: Set<string>, term: string): void {
+  if (!/^[a-z0-9]+$/.test(term)) return;
+  if (FALLBACK_SEARCH_STOP_WORDS.has(term)) return;
+  terms.add(term);
 }

--- a/src/lib/memory/noosphere.ts
+++ b/src/lib/memory/noosphere.ts
@@ -1,6 +1,11 @@
 import { Prisma, type PrismaClient } from "@prisma/client";
 import { prisma as defaultPrisma } from "@/lib/prisma";
-import { buildArticleSearchFilters, buildSearchableCTE, buildSearchTsQuery } from "@/lib/memory/article-search";
+import {
+  buildArticleSearchFilters,
+  buildFallbackSearchTsQuery,
+  buildSearchableCTE,
+  buildSearchTsQuery,
+} from "@/lib/memory/article-search";
 
 import type {
   MemoryProvider,
@@ -70,6 +75,28 @@ type NoosphereArticle = Prisma.ArticleGetPayload<{
 }>;
 
 const RECENCY_HALF_LIFE_DAYS = 90;
+
+type SearchArticleRow = {
+  id: string;
+  rank: number | string;
+  title: string;
+  slug: string;
+  content: string;
+  excerpt: string | null;
+  status: string;
+  confidence: string | null;
+  sourceUrl: string | null;
+  sourceType: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+  lastReviewed: Date | null;
+  authorId: string | null;
+  authorName: string | null;
+  topicId: string;
+  topicSlug: string;
+  topicName: string;
+  tagName: string | null;
+};
 
 export class NoosphereProvider implements MemoryProvider {
   readonly descriptor: MemoryProviderDescriptor;
@@ -271,63 +298,22 @@ export class NoosphereProvider implements MemoryProvider {
   ): Promise<MemoryResult[]> {
     const filters = buildArticleSearchFilters(options);
     const cte = buildSearchableCTE(filters);
-    const tsQuery = buildSearchTsQuery(query);
+    const strictTsQuery = buildSearchTsQuery(query);
     const limitClause =
       options.limit === undefined ? Prisma.empty : Prisma.sql`LIMIT ${options.limit}`;
 
-    // Raw query returns flat rows — we'll aggregate tags in JS.
-    const rows = await this.prisma.$queryRaw<
-      {
-        id: string;
-        rank: number | string;
-        title: string;
-        slug: string;
-        content: string;
-        excerpt: string | null;
-        status: string;
-        confidence: string | null;
-        sourceUrl: string | null;
-        sourceType: string | null;
-        createdAt: Date;
-        updatedAt: Date;
-        lastReviewed: Date | null;
-        authorId: string | null;
-        authorName: string | null;
-        topicId: string;
-        topicSlug: string;
-        topicName: string;
-        tagName: string | null;
-      }[]
-    >(Prisma.sql`
-      WITH searchable AS (
-        ${cte}
-      ),
-      ranked AS (
-        SELECT
-          s.id,
-          s."updatedAt",
-          ts_rank(s.document, ${tsQuery}) AS rank
-        FROM searchable s
-        WHERE s.document @@ ${tsQuery}
-        ORDER BY rank DESC, s."updatedAt" DESC
-        ${limitClause}
-        OFFSET ${options.offset}
-      )
-      SELECT
-        r.id, r.rank,
-        a.title, a.slug, a.content, a.excerpt, a.status, a.confidence,
-        a."sourceUrl", a."sourceType",
-        a."createdAt", a."updatedAt", a."lastReviewed",
-        a."authorId", a."authorName",
-        tpc.id AS "topicId", tpc.slug AS "topicSlug", tpc.name AS "topicName",
-        tg.name AS "tagName"
-      FROM ranked r
-      INNER JOIN "Article" a ON a.id = r.id
-      INNER JOIN "Topic" tpc ON tpc.id = a."topicId"
-      LEFT JOIN "ArticleTag" at2 ON at2."articleId" = a.id
-      LEFT JOIN "Tag" tg ON tg.id = at2."tagId"
-      ORDER BY r.rank DESC, a."updatedAt" DESC
-    `);
+    let rows = await this.queryRankedArticleRows(cte, strictTsQuery, limitClause, options.offset);
+
+    const shouldTryFallback =
+      rows.length === 0 &&
+      (options.offset === 0 || !(await this.hasSearchMatches(cte, strictTsQuery)));
+
+    if (shouldTryFallback) {
+      const fallbackTsQuery = buildFallbackSearchTsQuery(query);
+      if (fallbackTsQuery) {
+        rows = await this.queryRankedArticleRows(cte, fallbackTsQuery, limitClause, options.offset);
+      }
+    }
 
     if (rows.length === 0) {
       return [];
@@ -380,6 +366,63 @@ export class NoosphereProvider implements MemoryProvider {
     }
 
     return results;
+  }
+
+  private async hasSearchMatches(
+    cte: Prisma.Sql,
+    tsQuery: Prisma.Sql,
+  ): Promise<boolean> {
+    const rows = await this.prisma.$queryRaw<{ exists: boolean }[]>(Prisma.sql`
+      WITH searchable AS (
+        ${cte}
+      )
+      SELECT EXISTS (
+        SELECT 1
+        FROM searchable s
+        WHERE s.document @@ ${tsQuery}
+      ) AS "exists"
+    `);
+
+    return rows[0]?.exists === true;
+  }
+
+  private queryRankedArticleRows(
+    cte: Prisma.Sql,
+    tsQuery: Prisma.Sql,
+    limitClause: Prisma.Sql,
+    offset: number,
+  ): Promise<SearchArticleRow[]> {
+    // Raw query returns flat rows — we'll aggregate tags in JS.
+    return this.prisma.$queryRaw<SearchArticleRow[]>(Prisma.sql`
+      WITH searchable AS (
+        ${cte}
+      ),
+      ranked AS (
+        SELECT
+          s.id,
+          s."updatedAt",
+          ts_rank(s.document, ${tsQuery}) AS rank
+        FROM searchable s
+        WHERE s.document @@ ${tsQuery}
+        ORDER BY rank DESC, s."updatedAt" DESC
+        ${limitClause}
+        OFFSET ${offset}
+      )
+      SELECT
+        r.id, r.rank,
+        a.title, a.slug, a.content, a.excerpt, a.status, a.confidence,
+        a."sourceUrl", a."sourceType",
+        a."createdAt", a."updatedAt", a."lastReviewed",
+        a."authorId", a."authorName",
+        tpc.id AS "topicId", tpc.slug AS "topicSlug", tpc.name AS "topicName",
+        tg.name AS "tagName"
+      FROM ranked r
+      INNER JOIN "Article" a ON a.id = r.id
+      INNER JOIN "Topic" tpc ON tpc.id = a."topicId"
+      LEFT JOIN "ArticleTag" at2 ON at2."articleId" = a.id
+      LEFT JOIN "Tag" tg ON tg.id = at2."tagId"
+      ORDER BY r.rank DESC, a."updatedAt" DESC
+    `);
   }
 
   /**


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary

Improves Noosphere memory article recall by adding a controlled conversational fallback when strict PostgreSQL full-text search returns nothing, while keeping the primary strict query behavior unchanged.

## Changes

### Fallback search term extraction (`src/lib/memory/article-search.ts`)
- New `extractFallbackSearchTerms()` that:
  - Lowercases, NFKD-normalizes, strips combining marks, and splits on non-alphanumerics.
  - Filters terms shorter than 3 characters.
  - Removes a curated stop-word set that includes common function words plus recall-specific noise like `forgot`, `forget`, `forgotten`, `reattach`, `reattached`, `looks`, `like`, `please`, `could`, `would`, `will`, etc.
  - Strips PostgreSQL `tsquery` operators (`&`, `|`, `!`, `<->`) so they cannot leak into the relaxed query.
  - Caps seed terms at 8 and the final expanded term list at 16 to keep fallback queries bounded.
- New `buildFallbackSearchTsQuery()` that joins the extracted terms with `|` into a `to_tsquery('simple', ...)` expression, or returns `null` when no usable terms remain (so callers can skip the fallback cleanly).
- New synonym groups that bridge common conversational wording gaps:
  - `photo / photos / image / images / picture / pictures / portrait / avatar / face`
  - `screenshot / screenshots / image / images / picture / pictures`
  - `attach / attached / attachment / attachments / file / files / upload / uploaded`
- Internal helper `addFallbackSearchTerm()` enforces alphanumeric shape and stop-word filtering before insertion into the term set.

### Provider retry logic (`src/lib/memory/noosphere.ts`)
- Introduced a `SearchArticleRow` type to share row typing between the strict and fallback queries.
- Extracted the ranked-row SQL into `queryRankedArticleRows()` so both the strict and fallback paths execute the same query shape.
- Updated `search()` so it:
  1. Runs the existing strict `websearch_to_tsquery` query first.
  2. If and only if that returns zero rows, builds the fallback tsquery and retries once.
  3. Skips the retry entirely when `buildFallbackSearchTsQuery()` returns `null` (e.g., when the user input only contains stop words).
- Strict relevance ranking, ordering, limit/offset, and aggregation behavior are unchanged on the primary path; the fallback is opt-in by virtue of strict-query miss.

### Tests
- New `src/__tests__/memory/article-search.test.ts` covering:
  - That conversational `photo` phrasing keeps `photo`, `portrait`, and `avatar` while dropping `forgot`, `reattach`, and the contraction `ill` (`looks`/`it's` style fragments).
  - Bounded term count (`<= 16`) for long messages.
  - All-stop-word input yields no terms, and `buildFallbackSearchTsQuery("the forgotten")` returns `null`.
  - `tsquery` operators are stripped before term extraction.
- Extended `src/__tests__/memory/noosphere-provider.test.ts` with three new cases using a new `createSequentialQueryRaw` helper and `mockSearchRow` from the existing helpers file:
  - When the strict query returns rows, only one query is executed and the strict result is used.
  - When the strict query returns no rows, the provider retries exactly once with the synonym fallback and returns the relaxed results (including multi-tag aggregation).
  - When the user message has no useful fallback terms, no retry is performed.

### Documentation
- `docs/NOOSPHERE-MEMORY-ARCHITECTURE.md`: added a "Conversational Search Fallback" subsection explaining the strict-then-relaxed query sequence and the `photo` ↔ `portrait`/`avatar`/`profile picture` example.
- `docs/OPENCLAW-OFFICIAL-PLUGIN-SETUP.md`: added an "Auto-recall misses a memory that manual wording can find" troubleshooting section that describes the same fallback behavior and recommends adding natural wording to article text/tags, keeping personal articles out of raw draft state, and using the `noosphere_recall` plugin tool to disambiguate query extraction from article vocabulary.

## Impact
- Recovers memory hits for natural user phrasing (e.g., "forgot the photo") where the durable article uses synonymous vocabulary, demonstrated against the live DB returning `My Face — Cybera's Telegram Profile Portrait` first.
- Does not alter ranking or results when the strict query succeeds, so existing recall behavior is preserved.
- Bounded term count and stop-word filtering prevent the fallback from turning into an overly broad search that could degrade precision.
<!-- kody-pr-summary:end -->