### PR TITLE
Fix API key audit log attribution

### DIFF
--- a/src/__tests__/api/auth.test.ts
+++ b/src/__tests__/api/auth.test.ts
@@ -1,7 +1,15 @@
 import assert from "node:assert/strict";
-import test from "node:test";
-import { hasPermission, type AuthResult } from "@/lib/api/auth";
+import crypto from "node:crypto";
+import test, { after } from "node:test";
+import { NextRequest } from "next/server";
+import { checkRouteAuth, hasPermission, type AuthResult } from "@/lib/api/auth";
+import { hashApiKey } from "@/lib/api/keys";
+import { prisma } from "@/lib/prisma";
 import type { Permissions, Role } from "@prisma/client";
+
+after(async () => {
+  await prisma.$disconnect();
+});
 
 function authWithPermissions(permissions: Permissions): AuthResult {
   return { authorized: true, permissions, keyId: "key-1" };
@@ -71,3 +79,37 @@ test("hasPermission rejects unauthorized", () => {
 test("hasPermission rejects missing role/permissions", () => {
   assert.equal(hasPermission({ authorized: true }, ["READ"]), false);
 });
+
+test(
+  "checkRouteAuth includes API key names for audit authors",
+  { skip: !process.env.DATABASE_URL },
+  async () => {
+    const runId = crypto.randomUUID();
+    const rawKey = `noo_${crypto.randomBytes(32).toString("base64url")}`;
+    const keyName = `test-auth-name-${runId}`;
+    const apiKey = await prisma.apiKey.create({
+      data: {
+        name: keyName,
+        keyHash: hashApiKey(rawKey),
+        keyPrefix: rawKey.slice(0, 8),
+        permissions: "WRITE",
+        allowedScopes: ["*"],
+      },
+    });
+
+    try {
+      const request = new NextRequest("http://localhost/api/lint", {
+        headers: { Authorization: `Bearer ${rawKey}` },
+      });
+
+      const auth = await checkRouteAuth(request);
+
+      assert.equal(auth.authorized, true);
+      assert.equal(auth.keyId, apiKey.id);
+      assert.equal(auth.name, keyName);
+      assert.equal(auth.permissions, "WRITE");
+    } finally {
+      await prisma.apiKey.delete({ where: { id: apiKey.id } }).catch(() => undefined);
+    }
+  },
+);

--- a/src/__tests__/api/bounded-json-routes.integration.test.ts
+++ b/src/__tests__/api/bounded-json-routes.integration.test.ts
@@ -119,6 +119,17 @@ test("legacy JSON routes enforce size and nesting limits (issue #192)", async ()
     );
     assert.equal(oversizedArticleResponse.status, 413);
   } finally {
+    const expectedAuthorName = `${TEST_PREFIX}${runId}`;
+    const auditLogs = await prisma.activityLog.findMany({
+      where: { authorName: expectedAuthorName },
+      select: { authorName: true, type: true },
+    });
+    // Exactly one log is expected here: the empty-body lint success at the start.
+    assert.deepEqual(auditLogs, [{ authorName: expectedAuthorName, type: "lint" }]);
+    const deletedLogs = await prisma.activityLog.deleteMany({
+      where: { authorName: expectedAuthorName },
+    });
+    assert.equal(deletedLogs.count, 1);
     await prisma.apiKey.delete({ where: { id: apiKey.id } });
   }
 });

--- a/src/__tests__/api/keys.test.ts
+++ b/src/__tests__/api/keys.test.ts
@@ -48,6 +48,7 @@ test("validateApiKey looks up by unique key hash and updates active keys", async
       findUniqueArgs = args;
       return {
         id: "key-active",
+        name: "Active test key",
         permissions: Permissions.READ,
         allowedScopes: ["scope-a"],
         revokedAt: null,
@@ -65,6 +66,7 @@ test("validateApiKey looks up by unique key hash and updates active keys", async
   assert.equal(result.valid, true);
   if (!result.valid) return;
   assert.equal(result.keyId, "key-active");
+  assert.equal(result.name, "Active test key");
   assert.equal(result.permissions, Permissions.READ);
   assert.deepEqual(result.allowedScopes, ["scope-a"]);
   assert.ok(updateManyArgs);
@@ -89,6 +91,7 @@ test("validateApiKey rejects revoked records after unique hash lookup", async ()
       findUniqueArgs = args;
       const record: ApiKeyValidationRecord = {
         id: "key-revoked",
+        name: "Revoked test key",
         permissions: Permissions.ADMIN,
         allowedScopes: ["*"],
         revokedAt: new Date(),
@@ -151,6 +154,7 @@ test("validateApiKey propagates last-used update errors", async () => {
     async findUnique() {
       return {
         id: "key-update-error",
+        name: "Update error test key",
         permissions: Permissions.READ,
         allowedScopes: [],
         revokedAt: null,
@@ -169,6 +173,7 @@ test("validateApiKey stays valid when last-used update is debounced", async () =
     async findUnique() {
       return {
         id: "key-debounced",
+        name: "Debounced test key",
         permissions: Permissions.READ,
         allowedScopes: [],
         revokedAt: null,
@@ -184,6 +189,7 @@ test("validateApiKey stays valid when last-used update is debounced", async () =
   assert.equal(result.valid, true);
   if (!result.valid) return;
   assert.equal(result.keyId, "key-debounced");
+  assert.equal(result.name, "Debounced test key");
 });
 
 test("validateApiKey rejects a real key after it is revoked", async () => {
@@ -204,6 +210,7 @@ test("validateApiKey rejects a real key after it is revoked", async () => {
     assert.equal(activeResult.valid, true);
     if (!activeResult.valid) return;
     assert.equal(activeResult.keyId, createdKey.id);
+    assert.equal(activeResult.name, createdKey.name);
 
     await prisma.apiKey.update({
       where: { id: createdKey.id },

--- a/src/__tests__/api/log.test.ts
+++ b/src/__tests__/api/log.test.ts
@@ -1,6 +1,20 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { formatDetailValue } from "@/lib/admin-log-format";
 import { parseDateFilter } from "@/lib/log-validation";
+
+test.describe("formatDetailValue", () => {
+  test("formats primitive, array, and object detail values for admin log tags", () => {
+    assert.equal(formatDetailValue(null), "null");
+    assert.equal(formatDetailValue("ready"), "ready");
+    assert.equal(formatDetailValue(3), "3");
+    assert.equal(formatDetailValue(true), "true");
+    assert.equal(formatDetailValue([]), "[]");
+    assert.equal(formatDetailValue(["a", 2, null]), "a, 2, null");
+    assert.equal(formatDetailValue([[1, 2], [3]]), "1, 2, 3");
+    assert.equal(formatDetailValue({ byType: { stale: 2 } }), '{"byType":{"stale":2}}');
+  });
+});
 
 test.describe("parseDateFilter", () => {
   // ── Both params null / no filter applied ────────────────────────────────

--- a/src/app/wiki/admin/log/page.tsx
+++ b/src/app/wiki/admin/log/page.tsx
@@ -6,6 +6,7 @@ import { Breadcrumbs } from "@/components/wiki/Breadcrumbs";
 import { PageHeader } from "@/components/wiki/PageHeader";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
+import { formatDetailValue } from "@/lib/admin-log-format";
 import { prisma } from "@/lib/prisma";
 
 export const metadata = {
@@ -186,7 +187,7 @@ export default async function ActivityLogPage({
                     <div className="activity-details">
                       {Object.entries(entry.details as Record<string, unknown>).map(([key, value]) => (
                         <span key={key} className="activity-detail-tag">
-                          {key}: {String(value)}
+                          {key}: {formatDetailValue(value)}
                         </span>
                       ))}
                     </div>

--- a/src/lib/admin-log-format.ts
+++ b/src/lib/admin-log-format.ts
@@ -1,0 +1,11 @@
+export function formatDetailValue(value: unknown): string {
+  if (value === null) return "null";
+  if (Array.isArray(value)) {
+    if (value.length === 0) return "[]";
+    return value.map((item) => formatDetailValue(item)).join(", ");
+  }
+  if (typeof value === "object") {
+    return JSON.stringify(value);
+  }
+  return String(value);
+}

--- a/src/lib/api/auth.ts
+++ b/src/lib/api/auth.ts
@@ -30,6 +30,7 @@ export async function checkRouteAuth(
       authorized: true,
       permissions: apiAuth.permissions,
       keyId: apiAuth.keyId,
+      name: apiAuth.name,
       allowedScopes: apiAuth.allowedScopes,
     };
   }

--- a/src/lib/api/keys.ts
+++ b/src/lib/api/keys.ts
@@ -10,6 +10,7 @@ const LAST_USED_DEBOUNCE_MS = 5 * 60 * 1000;
 
 export type ApiKeyValidationRecord = {
   id: string;
+  name: string;
   permissions: Permissions;
   allowedScopes: string[];
   revokedAt: Date | null;
@@ -55,7 +56,7 @@ export async function validateApiKey(
   rawKey: string,
   apiKeys: ApiKeyValidationClient = prisma.apiKey,
 ): Promise<
-  | { valid: true; permissions: Permissions; keyId: string; allowedScopes: string[] }
+  | { valid: true; permissions: Permissions; keyId: string; name: string; allowedScopes: string[] }
   | { valid: false }
 > {
   const hash = hashApiKey(rawKey);
@@ -85,6 +86,7 @@ export async function validateApiKey(
     valid: true,
     permissions: record.permissions,
     keyId: record.id,
+    name: record.name,
     allowedScopes: record.allowedScopes,
   };
 }
@@ -99,7 +101,7 @@ export async function validateApiKey(
 export async function requireApiKey(
   request: Request
 ): Promise<
-  | { authorized: true; permissions: Permissions; keyId: string; allowedScopes: string[] }
+  | { authorized: true; permissions: Permissions; keyId: string; name: string; allowedScopes: string[] }
   | { authorized: false }
 > {
   const authHeader = request.headers.get("Authorization");
@@ -118,6 +120,7 @@ export async function requireApiKey(
     authorized: true,
     permissions: result.permissions,
     keyId: result.keyId,
+    name: result.name,
     allowedScopes: result.allowedScopes,
   };
 }


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Pull Request Description

This PR fixes audit log attribution and rendering so API-key actions are correctly credited to the key's actual name instead of a generic value, and so the admin log UI renders structured detail values consistently.

### Key changes

**API key audit attribution**
- `validateApiKey` now reads and returns the `name` field from the database record, threading it through `requireApiKey` and `checkRouteAuth`.
- The route auth layer exposes the key name (`auth.name`) so downstream activity logging can record the real author instead of falling back to a generic identifier.

**Admin log detail formatting**
- New `formatDetailValue` helper normalizes detail tag rendering: primitives are coerced to strings, arrays (including empty arrays and nested arrays) are joined with `", "`, and objects are JSON-stringified.
- The admin log page now uses this helper when rendering detail tags, so empty arrays no longer disappear and structured values display predictably.

**Test coverage and cleanup**
- New `checkRouteAuth` integration test creates a real API key, runs the route auth against a `NextRequest`, and asserts the returned `keyId` and `name` match the created record. The test self-cleans the API key row (defensive `catch` to avoid failures during teardown) and disconnects Prisma after the suite.
- `validateApiKey` unit tests now verify the returned `name` for active, revoked, update-error, debounced, and end-to-end key scenarios.
- Bounded-JSON route integration test now scopes audit log cleanup to the expected author name (`TEST_PREFIX + runId`), asserts exactly one matching log (the initial empty-body lint success) exists before deletion, and deletes it alongside the API key—preventing residual `test-*` rows from accumulating in the database.

### Verification performed
- `npm run lint`, `npm run typecheck`, `npm run test:api`, `npm run build`, `npm run package-policy:check`, `npm audit --audit-level=high` all pass.
- Local database confirmed clean: 0 `test-*` `ApiKey` and 0 `test-*` `ActivityLog` rows leaked after the test run.
<!-- kody-pr-summary:end -->