### PR TITLE
fix: move wiki theme toggle into search field

### DIFF
--- a/src/app/wiki/layout.tsx
+++ b/src/app/wiki/layout.tsx
@@ -32,8 +32,8 @@ export default async function WikiLayout({
               </Link>
             </div>
 
-            <form action="/wiki/search" method="get" className="wiki-search-form">
-              <label className="wiki-search-shell">
+            <form action="/wiki/search" method="get" className="wiki-search-form" role="search">
+              <div className="wiki-search-shell">
                 <span className="wiki-search-icon" aria-hidden>
                   ⌕
                 </span>
@@ -49,15 +49,14 @@ export default async function WikiLayout({
                 <kbd className="wiki-search-shortcut" aria-hidden>
                   ⌘/Ctrl K
                 </kbd>
-              </label>
+                <ThemeToggle />
+              </div>
               <button type="submit" className="btn btn-secondary btn-sm">
                 Search
               </button>
             </form>
 
             <div className="wiki-header-actions">
-              <ThemeToggle />
-
               <nav className="wiki-nav" aria-label="Wiki navigation">
                 <Link href="/wiki" className="nav-link">
                   Browse

--- a/src/app/wiki/wiki.css
+++ b/src/app/wiki/wiki.css
@@ -33,9 +33,9 @@
 
 .wiki-header-row {
   display: grid;
-  grid-template-columns: minmax(16rem, auto) minmax(22rem, 1fr) auto;
+  grid-template-columns: minmax(16rem, auto) minmax(22rem, 1fr);
   align-items: center;
-  gap: 1rem;
+  gap: 0.85rem 1rem;
 }
 
 .wiki-header-brand,
@@ -44,10 +44,11 @@
 }
 
 .wiki-header-actions {
+  grid-column: 1 / -1;
   display: flex;
-  justify-content: flex-end;
+  justify-content: space-between;
   align-items: center;
-  gap: 1rem;
+  gap: 0.75rem 1rem;
   flex-wrap: wrap;
 }
 
@@ -229,6 +230,13 @@
     background var(--transition-base),
     border-color var(--transition-base),
     color var(--transition-base);
+}
+
+.wiki-search-shell .theme-toggle {
+  /* Keep the theme control visually inside the search field without widening the header. */
+  width: 2.25rem;
+  height: 2.25rem;
+  margin-right: -0.55rem;
 }
 
 .theme-toggle:hover {
@@ -2293,6 +2301,20 @@ h2.activity-title {
   .wiki-nav,
   .wiki-user-nav {
     width: 100%;
+  }
+
+  .wiki-nav {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.5rem;
+  }
+
+  .wiki-nav .nav-link {
+    width: auto;
+    min-width: 0;
+    padding-inline: 0.55rem;
+    font-size: 0.86rem;
+    white-space: nowrap;
   }
 
   .wiki-search-shell,


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary

This PR relocates the wiki theme toggle from the header actions row into the search field, and restructures the desktop header grid to prevent the nav/auth controls from competing with the brand/search row for horizontal space.

## Key Changes

### Search field now hosts the theme toggle
- The `ThemeToggle` component is moved from the `.wiki-header-actions` div into `.wiki-search-shell`, placing it visually inside the search input.
- `.wiki-search-shell .theme-toggle` is sized to 2.25rem × 2.25rem with a negative right margin so it sits flush inside the field without expanding the header.

### Search shell is a `div` instead of a `<label>`
- Because the shell now contains an interactive button (`ThemeToggle`), nesting another button inside a `<label>` would be invalid HTML.
- The input retains its `aria-label`, and the form gains `role="search"` to expose it as a search landmark for assistive tech.

### Desktop header becomes a two-row layout
- `.wiki-header-row` drops the third grid track (`auto`), so it now has only brand + search columns.
- `.wiki-header-actions` spans all columns (`grid-column: 1 / -1`) and uses `justify-content: space-between` so the nav links and auth controls sit on a second row beneath the brand/search row.
- Column and row gaps are tightened (`0.85rem 1rem` on the header, `0.75rem 1rem` on the actions row).

### Narrow mobile nav uses a two-column grid
- Below the existing mobile breakpoint, `.wiki-nav` switches to `grid-template-columns: repeat(2, minmax(0, 1fr))` with a 0.5rem gap.
- Each `.nav-link` gets `width: auto`, `min-width: 0`, tightened horizontal padding, smaller font, and `white-space: nowrap` so labels stay on one line.

## Functional Impact

- The theme toggle no longer consumes a dedicated header slot, eliminating the overlap risk between nav/auth controls and the search field on desktop.
- Mobile users get a compact two-column nav that prevents label wrapping at 320px width.
- Screen readers can now identify the search form via the `search` landmark role.
- HTML validity is preserved by replacing the wrapper `<label>` with a `<div>` since it now contains a button.
<!-- kody-pr-summary:end -->