### PR TITLE
Extract shared bootstrap topic tree

### DIFF
--- a/docker/bootstrap-topics.json
+++ b/docker/bootstrap-topics.json
@@ -1,0 +1,95 @@
+[
+  {
+    "name": "Engineering",
+    "slug": "engineering",
+    "description": "Technical documentation, architecture, and engineering practices",
+    "children": [
+      {
+        "name": "Architecture",
+        "slug": "architecture",
+        "description": "System design and architectural decisions"
+      },
+      {
+        "name": "Backend",
+        "slug": "backend",
+        "description": "Server-side services and APIs"
+      },
+      {
+        "name": "Frontend",
+        "slug": "frontend",
+        "description": "UI/UX development and component libraries"
+      },
+      {
+        "name": "DevOps",
+        "slug": "devops",
+        "description": "Infrastructure, CI/CD, and deployment"
+      },
+      {
+        "name": "Security",
+        "slug": "security",
+        "description": "Security practices, audits, and hardening"
+      }
+    ]
+  },
+  {
+    "name": "Projects",
+    "slug": "projects",
+    "description": "Project-specific documentation",
+    "children": [
+      {
+        "name": "Noosphere",
+        "slug": "noosphere",
+        "description": "This wiki system"
+      },
+      {
+        "name": "PK-PRO",
+        "slug": "pk-pro",
+        "description": "Product knowledge database"
+      },
+      {
+        "name": "IHK Study Trainer",
+        "slug": "ihk-study-trainer",
+        "description": "Study and practice platform"
+      }
+    ]
+  },
+  {
+    "name": "Research",
+    "slug": "research",
+    "description": "Research notes, experiments, and findings",
+    "children": [
+      {
+        "name": "AI & LLMs",
+        "slug": "ai-llms",
+        "description": "LLM evaluations, prompts, and integrations"
+      },
+      {
+        "name": "Tools",
+        "slug": "tools",
+        "description": "Tool evaluations and comparisons"
+      }
+    ]
+  },
+  {
+    "name": "Workflows",
+    "slug": "workflows",
+    "description": "Operational runbooks and procedures",
+    "children": [
+      {
+        "name": "Deployment",
+        "slug": "deployment",
+        "description": "Deployment procedures"
+      },
+      {
+        "name": "Incident Response",
+        "slug": "incident-response",
+        "description": "How to handle incidents"
+      },
+      {
+        "name": "Onboarding",
+        "slug": "onboarding",
+        "description": "New member onboarding guides"
+      }
+    ]
+  }
+]

--- a/docker/bootstrap.mjs
+++ b/docker/bootstrap.mjs
@@ -1,53 +1,13 @@
 import crypto from "node:crypto";
+import { readFileSync } from "node:fs";
 import process from "node:process";
 import bcrypt from "bcryptjs";
 import pg from "pg";
 
 const { Pool } = pg;
-
-const TOPICS = [
-  {
-    name: "Engineering",
-    slug: "engineering",
-    description: "Technical documentation, architecture, and engineering practices",
-    children: [
-      { name: "Architecture", slug: "architecture", description: "System design and architectural decisions" },
-      { name: "Backend", slug: "backend", description: "Server-side services and APIs" },
-      { name: "Frontend", slug: "frontend", description: "UI/UX development and component libraries" },
-      { name: "DevOps", slug: "devops", description: "Infrastructure, CI/CD, and deployment" },
-      { name: "Security", slug: "security", description: "Security practices, audits, and hardening" },
-    ],
-  },
-  {
-    name: "Projects",
-    slug: "projects",
-    description: "Project-specific documentation",
-    children: [
-      { name: "Noosphere", slug: "noosphere", description: "This wiki system" },
-      { name: "PK-PRO", slug: "pk-pro", description: "Product knowledge database" },
-      { name: "IHK Study Trainer", slug: "ihk-study-trainer", description: "Study and practice platform" },
-    ],
-  },
-  {
-    name: "Research",
-    slug: "research",
-    description: "Research notes, experiments, and findings",
-    children: [
-      { name: "AI & LLMs", slug: "ai-llms", description: "LLM evaluations, prompts, and integrations" },
-      { name: "Tools", slug: "tools", description: "Tool evaluations and comparisons" },
-    ],
-  },
-  {
-    name: "Workflows",
-    slug: "workflows",
-    description: "Operational runbooks and procedures",
-    children: [
-      { name: "Deployment", slug: "deployment", description: "Deployment procedures" },
-      { name: "Incident Response", slug: "incident-response", description: "How to handle incidents" },
-      { name: "Onboarding", slug: "onboarding", description: "New member onboarding guides" },
-    ],
-  },
-];
+const TOPICS = JSON.parse(
+  readFileSync(new URL("./bootstrap-topics.json", import.meta.url), "utf8"),
+);
 
 function requireEnv(name) {
   const value = process.env[name];

--- a/scripts/seed-topics.ts
+++ b/scripts/seed-topics.ts
@@ -3,49 +3,23 @@
  * Usage: npx tsx scripts/seed-topics.ts
  */
 
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { closePrisma, prisma } from "./_prisma";
 
-const TOPICS = [
-  {
-    name: "Engineering",
-    slug: "engineering",
-    description: "Technical documentation, architecture, and engineering practices",
-    children: [
-      { name: "Architecture", slug: "architecture", description: "System design and architectural decisions" },
-      { name: "Backend", slug: "backend", description: "Server-side services and APIs" },
-      { name: "Frontend", slug: "frontend", description: "UI/UX development and component libraries" },
-      { name: "DevOps", slug: "devops", description: "Infrastructure, CI/CD, and deployment" },
-      { name: "Security", slug: "security", description: "Security practices, audits, and hardening" },
-    ],
-  },
-  {
-    name: "Projects",
-    slug: "projects",
-    description: "Project-specific documentation",
-    children: [
-      { name: "Noosphere", slug: "noosphere", description: "This wiki system" },
-    ],
-  },
-  {
-    name: "Research",
-    slug: "research",
-    description: "Research notes, experiments, and findings",
-    children: [
-      { name: "AI & LLMs", slug: "ai-llms", description: "LLM evaluations, prompts, and integrations" },
-      { name: "Tools", slug: "tools", description: "Tool evaluations and comparisons" },
-    ],
-  },
-  {
-    name: "Workflows",
-    slug: "workflows",
-    description: "Operational runbooks and procedures",
-    children: [
-      { name: "Deployment", slug: "deployment", description: "Deployment procedures" },
-      { name: "Incident Response", slug: "incident-response", description: "How to handle incidents" },
-      { name: "Onboarding", slug: "onboarding", description: "New member onboarding guides" },
-    ],
-  },
-];
+interface BootstrapTopic {
+  name: string;
+  slug: string;
+  description?: string | null;
+  children?: BootstrapTopic[];
+}
+
+const TOPICS = JSON.parse(
+  readFileSync(
+    fileURLToPath(new URL("../docker/bootstrap-topics.json", import.meta.url)),
+    "utf8",
+  ),
+) as BootstrapTopic[];
 
 async function seedTopics() {
   console.log("Seeding topics...\n");

--- a/src/__tests__/api/bootstrap-topics.test.ts
+++ b/src/__tests__/api/bootstrap-topics.test.ts
@@ -1,7 +1,8 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
-import { join } from "node:path";
+import { dirname, resolve } from "node:path";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 
 interface BootstrapTopic {
   name: string;
@@ -10,14 +11,16 @@ interface BootstrapTopic {
   children?: BootstrapTopic[];
 }
 
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+
 function readBootstrapTopics() {
   return JSON.parse(
-    readFileSync(join(process.cwd(), "docker", "bootstrap-topics.json"), "utf8"),
+    readFileSync(resolve(repoRoot, "docker", "bootstrap-topics.json"), "utf8"),
   ) as BootstrapTopic[];
 }
 
 function readRepoFile(path: string) {
-  return readFileSync(join(process.cwd(), path), "utf8");
+  return readFileSync(resolve(repoRoot, path), "utf8");
 }
 
 test("bootstrap topic tree is valid and shared by seed/bootstrap scripts", () => {

--- a/src/__tests__/api/bootstrap-topics.test.ts
+++ b/src/__tests__/api/bootstrap-topics.test.ts
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import test from "node:test";
+
+interface BootstrapTopic {
+  name: string;
+  slug: string;
+  description?: string | null;
+  children?: BootstrapTopic[];
+}
+
+function readBootstrapTopics() {
+  return JSON.parse(
+    readFileSync(join(process.cwd(), "docker", "bootstrap-topics.json"), "utf8"),
+  ) as BootstrapTopic[];
+}
+
+function readRepoFile(path: string) {
+  return readFileSync(join(process.cwd(), path), "utf8");
+}
+
+test("bootstrap topic tree is valid and shared by seed/bootstrap scripts", () => {
+  const topics = readBootstrapTopics();
+  const slugs = new Set<string>();
+
+  function visit(topic: BootstrapTopic) {
+    assert.equal(typeof topic.name, "string");
+    assert.equal(typeof topic.slug, "string");
+    assert.match(topic.slug, /^[a-z0-9-]+$/);
+    assert.equal(slugs.has(topic.slug), false, `duplicate topic slug: ${topic.slug}`);
+    slugs.add(topic.slug);
+    for (const child of topic.children ?? []) visit(child);
+  }
+
+  assert.ok(topics.length > 0, "bootstrap topics should not be empty");
+  for (const topic of topics) visit(topic);
+  assert.ok(slugs.has("noosphere"));
+  assert.ok(slugs.has("pk-pro"));
+  assert.ok(slugs.has("ihk-study-trainer"));
+});
+
+test("bootstrap and seed scripts load the shared topic tree file", () => {
+  const bootstrapSource = readRepoFile("docker/bootstrap.mjs");
+  const seedSource = readRepoFile("scripts/seed-topics.ts");
+
+  assert.match(bootstrapSource, /bootstrap-topics\.json/);
+  assert.match(seedSource, /bootstrap-topics\.json/);
+  assert.doesNotMatch(bootstrapSource, /const\s+TOPICS\s*=\s*\[/);
+  assert.doesNotMatch(seedSource, /const\s+TOPICS\s*=\s*\[/);
+});


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request extracts the default bootstrap topic tree into a shared JSON file (`docker/bootstrap-topics.json`) and refactors both the Docker bootstrap script and the standalone seeding script to consume it, eliminating duplicated topic definitions and preventing inline drift between the two entrypoints.

### Functional changes

- **New shared source of truth**: Both `docker/bootstrap.mjs` and `scripts/seed-topics.ts` now load topics from `docker/bootstrap-topics.json` via `readFileSync` instead of declaring inline arrays. The Docker script uses `new URL("./bootstrap-topics.json", import.meta.url)` for ESM-relative resolution; the TypeScript script uses `fileURLToPath` to bridge its `import.meta.url` to a path suitable for `readFileSync`.
- **Tree parity recovery**: Comparing the previous inline versions, `scripts/seed-topics.ts` was missing two children under the `Projects` parent (`PK-PRO` and `IHK Study Trainer`). By pointing both scripts at the JSON file, the seed script now provisions the same `noosphere`, `pk-pro`, and `ihk-study-trainer` sub-topics that Docker bootstrap already created — closing a silent inconsistency between local seeding and container initialization.
- **Typed consumption in TypeScript**: `scripts/seed-topics.ts` introduces a `BootstrapTopic` interface (`name`, `slug`, optional `description`, optional `children`) and casts the parsed JSON to `BootstrapTopic[]`, preserving type safety without requiring a TypeScript JSON import resolver.

### New guard test (`src/__tests__/api/bootstrap-topics.test.ts`)

- **Structural validation**: Walks the shared tree and asserts each node has string `name`/`slug`, that slugs match `^[a-z0-9-]+, and that slugs are unique across the entire hierarchy (parents + descendants).
- **Seed-content assertions**: Confirms the tree is non-empty and explicitly requires the `noosphere`, `pk-pro`, and `ihk-study-trainer` slugs to exist — locking in the three project sub-topics that had drifted between entrypoints.
- **Drift guard**: Reads `docker/bootstrap.mjs` and `scripts/seed-topics.ts` as text and asserts each (a) references `bootstrap-topics.json` and (b) no longer contains `const TOPICS = [`. This prevents either entrypoint from regressing to an inline literal and silently re-diverging from the shared tree.

### Scope of change

The patch touches only the two bootstrap/seed entrypoints and adds the new test file; no runtime behavior of topic creation, ordering, or persistence is altered — same topics, same slugs, same descriptions, now sourced from a single file with regression coverage.

---

This PR refactors the bootstrap topic tree test file to use a more reliable path resolution method.

The changes update `src/__tests__/api/bootstrap-topics.test.ts` to replace the dependency on `process.cwd()` with a computed `repoRoot` path based on the test file's own location (using `import.meta.url` and `fileURLToPath`). Both helper functions (`readBootstrapTopics` and `readRepoFile`) now resolve file paths relative to this `repoRoot` instead of the current working directory.

This makes the test more robust by no longer assuming the test runner's working directory is the repository root, allowing it to pass regardless of where the test command is invoked from.
<!-- kody-pr-summary:end -->