### PR TITLE
test: cover auth proxy rate limiting

### DIFF
--- a/src/__tests__/security/proxy.test.ts
+++ b/src/__tests__/security/proxy.test.ts
@@ -26,6 +26,29 @@ function request(path: string, init: RequestInit = {}) {
   });
 }
 
+async function expectRateLimitedAfter({
+  path,
+  method = "GET",
+  maxRequests,
+  ipPrefix,
+}: {
+  path: string;
+  method?: string;
+  maxRequests: number;
+  ipPrefix: string;
+}) {
+  const headers = { "x-real-ip": `${ipPrefix}-${crypto.randomUUID()}` };
+
+  for (let i = 0; i < maxRequests; i += 1) {
+    const response = await proxy(request(path, { method, headers }));
+    // 200 here means the proxy let the request continue to the downstream handler.
+    assert.equal(response.status, 200);
+  }
+
+  const blocked = await proxy(request(path, { method, headers }));
+  assert.equal(blocked.status, 429);
+}
+
 test("proxy adds security headers to wiki pages", async () => {
   const response = await proxy(request("/wiki/projects/example"));
 
@@ -36,16 +59,72 @@ test("proxy adds security headers to wiki pages", async () => {
 });
 
 test("proxy rate-limits article mutation routes", async () => {
-  const headers = { "x-real-ip": `patch-${crypto.randomUUID()}` };
-  let response = await proxy(request("/api/articles/article-1", { method: "PATCH", headers }));
+  await expectRateLimitedAfter({
+    path: "/api/articles/article-1",
+    method: "PATCH",
+    maxRequests: 30,
+    ipPrefix: "patch",
+  });
+});
 
-  for (let i = 1; i < 30; i += 1) {
-    response = await proxy(request("/api/articles/article-1", { method: "PATCH", headers }));
+test("proxy rate-limits NextAuth callback attempts", async () => {
+  await expectRateLimitedAfter({
+    path: "/api/auth/callback/credentials",
+    method: "POST",
+    maxRequests: 10,
+    ipPrefix: "auth",
+  });
+});
+
+test("proxy rate-limits a representative NextAuth non-callback route", async () => {
+  await expectRateLimitedAfter({
+    path: "/api/auth/signin",
+    maxRequests: 10,
+    ipPrefix: "auth-signin",
+  });
+});
+
+test("proxy rate-limits the wiki login page", async () => {
+  await expectRateLimitedAfter({
+    path: "/wiki/login",
+    maxRequests: 10,
+    ipPrefix: "login",
+  });
+});
+
+test("proxy auth rate limits are isolated per IP", async () => {
+  const path = "/wiki/login";
+  const saturatedIpHeaders = { "x-real-ip": `auth-ip-a-${crypto.randomUUID()}` };
+  const otherIpHeaders = { "x-real-ip": `auth-ip-b-${crypto.randomUUID()}` };
+
+  for (let i = 0; i < 10; i += 1) {
+    const response = await proxy(request(path, { headers: saturatedIpHeaders }));
+    assert.equal(response.status, 200);
   }
 
-  assert.notEqual(response.status, 429);
+  const blocked = await proxy(request(path, { headers: saturatedIpHeaders }));
+  assert.equal(blocked.status, 429);
 
-  const blocked = await proxy(request("/api/articles/article-1", { method: "PATCH", headers }));
+  const otherIpResponse = await proxy(request(path, { headers: otherIpHeaders }));
+  assert.equal(otherIpResponse.status, 200);
+});
+
+test("proxy shares the auth rate-limit budget across login and auth API routes", async () => {
+  const headers = { "x-real-ip": `auth-shared-${crypto.randomUUID()}` };
+
+  for (let i = 0; i < 5; i += 1) {
+    const response = await proxy(request("/wiki/login", { headers }));
+    assert.equal(response.status, 200);
+  }
+
+  for (let i = 0; i < 5; i += 1) {
+    const response = await proxy(
+      request("/api/auth/callback/credentials", { method: "POST", headers })
+    );
+    assert.equal(response.status, 200);
+  }
+
+  const blocked = await proxy(request("/wiki/login", { headers }));
   assert.equal(blocked.status, 429);
 });
 


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary
Add proxy-level test coverage for the existing authentication rate limiters on the NextAuth credentials callback and the wiki login page, verifying that the 10 requests/minute/IP threshold permits the 10th request and rejects the 11th with HTTP 429.

## Changes
- **`src/__tests__/security/proxy.test.ts`**: Added two new test cases alongside the existing article mutation rate-limit test.
  - **"proxy rate-limits NextAuth callback attempts"** — Sends repeated `POST` requests to `/api/auth/callback/credentials` using a unique `x-real-ip` header. After 10 requests the response is confirmed not to be 429, and the 11th request is asserted to return 429.
  - **"proxy rate-limits the wiki login page"** — Sends repeated `GET` requests to `/wiki/login` using a unique `x-real-ip` header, with the same threshold check (10 permitted, 11th blocked with 429).

## Technical Notes
- Each test uses a unique `x-real-ip` value derived from `crypto.randomUUID()` to avoid cross-test interference in the limiter's client-key state.
- The test for the credentials callback uses `POST` to match the actual auth submission flow, while the wiki login test uses `GET` since that is how the login page is served.
- These tests exercise the `auth` rate limiter already applied by the proxy to `/api/auth*` and `/wiki/login`; no production code changes are required.
- The threshold semantics (10 allowed, 11th blocked) are explicitly validated by separating the final blocking request from the loop that performs the first 10 requests.

## Impact
- Locks in the current rate-limiting contract for sensitive authentication surfaces, ensuring regressions that disable or misconfigure the proxy's `auth` limiter (on either the credentials callback or the login page) will be caught by `npm run test:security`.
- No runtime behavior change; production rate-limit configuration is unchanged.

---

Add tests covering rate limiting for authentication-related proxy routes.

- Extract the rate-limit assertion logic from the existing article mutation test into a reusable `expectRateLimitedAfter` helper that drives requests under a unique client IP until a 429 is returned.
- Refactor the article PATCH test to use the new helper, verifying the 30-request threshold.
- Add a test confirming `/api/auth/callback/credentials` returns 429 after 10 POSTs from the same IP.
- Add a test confirming `/wiki/login` returns 429 after 10 GETs from the same IP.

---

Adds test coverage for auth proxy rate limiting

---

## Summary

This PR expands the existing proxy security test suite to provide comprehensive coverage of the rate-limiting behavior on authentication-related routes. Previously, only the article mutation route (`/api/articles/article-1`) had dedicated rate-limit coverage; the new tests formalize and verify the auth proxy's behavior across multiple entry points.

## Key Changes

**Introduced a reusable test helper** (`expectRateLimitedAfter`) that:
- Sends `maxRequests` requests with a unique `x-real-ip` header and asserts each returns `200` (forwarded to the downstream handler)
- Sends one additional request and asserts it returns `429` (rate-limited by the proxy)

This helper replaces the previous hand-rolled loop in the article-mutation test and is now reused across multiple scenarios.

**New test cases added:**

1. **NextAuth callback rate limiting** — Verifies that `POST /api/auth/callback/credentials` returns `429` after 10 requests from the same IP.
2. **NextAuth non-callback route rate limiting** — Verifies the same threshold (10 requests) applies to a representative non-callback route such as `/api/auth/signin`.
3. **Wiki login page rate limiting** — Verifies that `GET /wiki/login` returns `429` after 10 requests from the same IP.
4. **Per-IP isolation** — Confirms that saturating one IP's budget does not block requests from a different IP against the wiki login route.
5. **Shared auth budget across entry points** — Verifies that the wiki login page and NextAuth callback route draw from the same rate-limit bucket for a given IP: 5 login requests + 5 callback POSTs exhaust the 10-request budget, causing the 11th login request to return `429`.

**Refactored existing test:** The article-mutation rate-limit test now uses the shared helper instead of inlining its loop, making the expected threshold (30 requests) explicit in the test signature.

## Impact

These tests serve as executable documentation of the auth proxy's rate-limiting contract — confirming that login pages and NextAuth endpoints share a unified per-IP budget, that the threshold is enforced, and that limits are properly isolated across distinct client IPs. They guard against regressions in the rate-limiting middleware configuration.
<!-- kody-pr-summary:end -->