### PR TITLE
test: cover article update rate and body limits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,3 +85,6 @@ jobs:
 
       - name: Run API tests
         run: npm run test:api
+
+      - name: Run security tests
+        run: npm run test:security

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test:cache": "node --env-file=.env.test --import tsx --test 'src/__tests__/cache/**/*.test.ts'",
     "test:rate-limit": "node --env-file=.env.test --import tsx --test src/__tests__/rate-limit.test.ts",
     "test:api": "node --import tsx --test 'src/__tests__/api/**/*.test.ts'",
-    "test:security": "node --import tsx --test src/__tests__/security/uploads.test.ts src/__tests__/security/proxy.test.ts",
+    "test:security": "node --env-file=.env.test --import tsx --test src/__tests__/security/uploads.test.ts src/__tests__/security/proxy.test.ts src/__tests__/security/articles-update.test.ts",
     "lint": "eslint",
     "typecheck": "tsc --noEmit",
     "db:migrate": "prisma migrate dev",

--- a/src/__tests__/api/bounded-json-routes.integration.test.ts
+++ b/src/__tests__/api/bounded-json-routes.integration.test.ts
@@ -124,12 +124,74 @@ test("legacy JSON routes enforce size and nesting limits (issue #192)", async ()
       where: { authorName: expectedAuthorName },
       select: { authorName: true, type: true },
     });
-    // Exactly one log is expected here: the empty-body lint success at the start.
-    assert.deepEqual(auditLogs, [{ authorName: expectedAuthorName, type: "lint" }]);
     const deletedLogs = await prisma.activityLog.deleteMany({
       where: { authorName: expectedAuthorName },
     });
+    await prisma.apiKey.delete({ where: { id: apiKey.id } });
+
+    // Exactly one log is expected here: the empty-body lint success at the start.
+    assert.deepEqual(auditLogs, [{ authorName: expectedAuthorName, type: "lint" }]);
     assert.equal(deletedLogs.count, 1);
+  }
+});
+
+test("article PATCH rejects oversized request bodies", async () => {
+  const { prisma } = await import("@/lib/prisma");
+  const { PATCH: updateArticle } = await import("@/app/api/articles/[id]/route");
+  const runId = crypto.randomUUID();
+  const rawKey = `noo_${crypto.randomBytes(32).toString("base64url")}`;
+  const keyHash = crypto.createHash("sha256").update(rawKey).digest("hex");
+
+  const apiKey = await prisma.apiKey.create({
+    data: {
+      name: `${TEST_PREFIX}${runId}`,
+      keyHash,
+      keyPrefix: rawKey.slice(0, 8),
+      permissions: "ADMIN",
+      allowedScopes: ["*"],
+    },
+  });
+
+  try {
+    const topic = await prisma.topic.create({
+      data: {
+        name: `${TEST_PREFIX}${runId}`,
+        slug: `${TEST_PREFIX}${runId}`,
+      },
+    });
+    const article = await prisma.article.create({
+      data: {
+        title: `${TEST_PREFIX}${runId}`,
+        slug: `${TEST_PREFIX}${runId}`,
+        content: "Original content",
+        topicId: topic.id,
+      },
+    });
+    const oversizedArticlePatchBody = JSON.stringify({
+      content: "x".repeat(
+        ARTICLE_LIMITS.maxContentSize + DEFAULT_JSON_BODY_MAX_BYTES + 1,
+      ),
+    });
+    const response = await updateArticle(
+      buildRequest(
+        rawKey,
+        `/api/articles/${article.id}`,
+        oversizedArticlePatchBody,
+        "PATCH",
+      ),
+      { params: Promise.resolve({ id: article.id }) },
+    );
+    assert.equal(response.status, 413);
+  } finally {
+    await prisma.activityLog.deleteMany({
+      where: { authorName: `${TEST_PREFIX}${runId}` },
+    });
+    await prisma.article.deleteMany({
+      where: { slug: `${TEST_PREFIX}${runId}` },
+    });
+    await prisma.topic.deleteMany({
+      where: { slug: `${TEST_PREFIX}${runId}` },
+    });
     await prisma.apiKey.delete({ where: { id: apiKey.id } });
   }
 });

--- a/src/__tests__/security/articles-update.test.ts
+++ b/src/__tests__/security/articles-update.test.ts
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+
+import { NextRequest } from "next/server";
+import { _redisTestHooks } from "@/lib/cache/redis";
+import { FakeRedisClient } from "../_helpers/fake-redis";
+
+test.beforeEach(() => {
+  _redisTestHooks.setClientForTesting(new FakeRedisClient() as never);
+});
+
+test.afterEach(() => {
+  _redisTestHooks.reset();
+});
+
+function requireDatabaseUrl(): void {
+  if (!process.env.DATABASE_URL) {
+    throw new Error("DATABASE_URL environment variable must be set for tests");
+  }
+}
+
+function patchRequest(ip: string): NextRequest {
+  return new NextRequest("http://localhost/api/articles/article-1", {
+    method: "PATCH",
+    headers: {
+      "Content-Type": "application/json",
+      "x-real-ip": ip,
+    },
+    body: JSON.stringify({ title: "Unauthorized update attempt" }),
+  });
+}
+
+test("PATCH /api/articles/[id] rate-limits before auth work", async () => {
+  // The route imports Prisma-backed auth helpers, but this assertion never
+  // reaches DB work: the limiter runs first and unauthenticated requests stop
+  // at 401 until the limiter returns 429.
+  requireDatabaseUrl();
+  const originalConsoleError = console.error;
+
+  try {
+    const { PATCH } = await import("@/app/api/articles/[id]/route");
+    const ip = `article-patch-${crypto.randomUUID()}`;
+    console.error = (...args: Parameters<typeof console.error>) => {
+      const [prefix] = args;
+      if (prefix === "[Auth] Session error:") {
+        return;
+      }
+      originalConsoleError(...args);
+    };
+
+    for (let i = 0; i < 30; i += 1) {
+      const response = await PATCH(patchRequest(ip), {
+        params: Promise.resolve({ id: "article-1" }),
+      });
+      assert.equal(response.status, 401);
+    }
+
+    const blocked = await PATCH(patchRequest(ip), {
+      params: Promise.resolve({ id: "article-1" }),
+    });
+    assert.equal(blocked.status, 429);
+  } finally {
+    console.error = originalConsoleError;
+  }
+});
+
+test("PATCH /api/articles/[id] uses the bounded JSON parser", async () => {
+  const source = await readFile(
+    path.join(process.cwd(), "src/app/api/articles/[id]/route.ts"),
+    "utf8",
+  );
+
+  assert.doesNotMatch(source, /request\.json\s*\(/);
+  assert.match(
+    source,
+    /readBoundedJsonObject<[^>]+>\s*\(\s*request,\s*ARTICLE_JSON_BODY_MAX_BYTES,\s*\)/,
+  );
+});

--- a/src/__tests__/security/articles-update.test.ts
+++ b/src/__tests__/security/articles-update.test.ts
@@ -1,6 +1,4 @@
 import assert from "node:assert/strict";
-import { readFile } from "node:fs/promises";
-import path from "node:path";
 import test from "node:test";
 
 import { NextRequest } from "next/server";
@@ -33,9 +31,9 @@ function patchRequest(ip: string): NextRequest {
 }
 
 test("PATCH /api/articles/[id] rate-limits before auth work", async () => {
-  // The route imports Prisma-backed auth helpers, but this assertion never
-  // reaches DB work: the limiter runs first and unauthenticated requests stop
-  // at 401 until the limiter returns 429.
+  // The first 30 requests pass the limiter and return 401 without DB work
+  // because they carry no API key/session. The 31st returning 429 proves the
+  // route-local limiter runs before auth.
   requireDatabaseUrl();
   const originalConsoleError = console.error;
 
@@ -64,17 +62,4 @@ test("PATCH /api/articles/[id] rate-limits before auth work", async () => {
   } finally {
     console.error = originalConsoleError;
   }
-});
-
-test("PATCH /api/articles/[id] uses the bounded JSON parser", async () => {
-  const source = await readFile(
-    path.join(process.cwd(), "src/app/api/articles/[id]/route.ts"),
-    "utf8",
-  );
-
-  assert.doesNotMatch(source, /request\.json\s*\(/);
-  assert.match(
-    source,
-    /readBoundedJsonObject<[^>]+>\s*\(\s*request,\s*ARTICLE_JSON_BODY_MAX_BYTES,\s*\)/,
-  );
 });


### PR DESCRIPTION
## Summary

This PR adds focused B7 coverage for the article update (`PATCH /api/articles/[id]`) endpoint's security boundaries.

## Changes

- Adds `src/__tests__/security/articles-update.test.ts` coverage proving the route-local article PATCH limiter runs before auth work: the first 30 unauthenticated requests return 401, and the 31st returns 429 from the limiter.
- Extends `src/__tests__/api/bounded-json-routes.integration.test.ts` with a DB-backed integration case proving oversized article PATCH bodies return HTTP 413 from the bounded JSON reader.
- Wires `npm run test:security` into CI so the route-level rate-limit coverage is enforced by the merge gate.
- Removes the redundant source-text parser assertion; the 413 integration test now carries the bounded-parser regression coverage behaviorally.

## Verification

- `npm run test:security` — 21/21 passing
- `npm run test:api` — 350/350 passing against an isolated temporary Postgres 16 database
- `npm run lint` — passes with one pre-existing unrelated warning in `src/app/wiki/admin/topics/actions.ts`
- `npm run typecheck` — passes
- Two sequential review passes on the follow-up diff — no blockers


<!-- kody-pr-summary:start -->
## Summary

This PR adjusts the security test suite for the PATCH article endpoint and wires security tests into CI:

### CI Workflow Changes (`.github/workflows/ci.yml`)
- Adds a new CI step that runs `npm run test:security`, ensuring the security-focused tests execute automatically on every build alongside the existing API tests.

### Security Test Updates (`src/__tests__/security/articles-update.test.ts`)
- **Removes the static-source JSON parser test**: Drops a test that read the route source file from disk and asserted it used `readBoundedJsonObject` instead of `request.json()`. The test no longer relies on filesystem access or source-string inspection.
- **Updates comments on the rate-limit test**: Clarifies the test's intent — the first 30 unauthenticated requests return 401 (because they lack credentials, without DB work), and the 31st request returning 429 demonstrates that the route-local limiter runs before authentication. The accompanying comment about "30 requests" is now made explicit instead of describing it indirectly.
- **Cleans up unused imports**: `readFile` from `node:fs/promises` and `path` from `node:path` are removed since the deleted test was their only consumer.

### Net Effect
The security test suite for article updates is now slimmer (one fewer test that performed file-system inspection) but better documented, and the remaining tests are now automatically executed in CI through the new `test:security` job step.
<!-- kody-pr-summary:end -->