### PR TITLE
Fix topic empty states and path typing

### DIFF
--- a/src/__tests__/wiki/topic-page.test.ts
+++ b/src/__tests__/wiki/topic-page.test.ts
@@ -1,20 +1,44 @@
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
 import test from "node:test";
+import { buildTopicPath, getTopicArticlesEmptyState, type TopicPathNode } from "@/lib/wiki-topic-page";
 
-const topicPageSource = readFileSync(resolve("src/app/wiki/[topicSlug]/page.tsx"), "utf8");
+const topics: TopicPathNode[] = [
+  { id: "root", name: "Root", slug: "root", parentId: null },
+  { id: "branch", name: "Branch", slug: "branch", parentId: "root" },
+  { id: "leaf", name: "Leaf", slug: "leaf", parentId: "branch" },
+];
 
-test("topic page path builder uses Prisma payload typing", () => {
-  assert.match(topicPageSource, /satisfies Prisma\.TopicSelect/);
-  assert.match(topicPageSource, /type TopicPathNode = Prisma\.TopicGetPayload/);
-  assert.doesNotMatch(topicPageSource, /interface TopicPathNode/);
-  assert.match(topicPageSource, /select: topicPathSelect/);
+test("topic page path builder returns ancestor breadcrumbs in order", () => {
+  assert.deepEqual(
+    buildTopicPath(topics, topics[2]).map((topic) => topic.slug),
+    ["root", "branch", "leaf"],
+  );
 });
 
-test("topic page distinguishes leaf and branch empty article states", () => {
-  assert.match(topicPageSource, /No direct articles yet/);
-  assert.match(topicPageSource, /This branch is organized through subtopics/);
-  assert.match(topicPageSource, /No articles or subtopics yet/);
-  assert.match(topicPageSource, /This leaf topic is ready for its first article/);
+test("topic page path builder stops on cyclic parents", () => {
+  const cyclicTopics: TopicPathNode[] = [
+    { id: "a", name: "A", slug: "a", parentId: "b" },
+    { id: "b", name: "B", slug: "b", parentId: "a" },
+  ];
+
+  assert.deepEqual(
+    buildTopicPath(cyclicTopics, cyclicTopics[0]).map((topic) => topic.slug),
+    ["b", "a"],
+  );
+});
+
+test("topic page uses branch empty article copy when direct subtopics exist", () => {
+  assert.deepEqual(getTopicArticlesEmptyState(true), {
+    title: "No direct articles yet",
+    description: "This branch is organized through subtopics. Open one below, or add a direct article here.",
+    actionLabel: "Add direct article",
+  });
+});
+
+test("topic page uses leaf empty article copy when no subtopics exist", () => {
+  assert.deepEqual(getTopicArticlesEmptyState(false), {
+    title: "No articles or subtopics yet",
+    description: "This leaf topic is ready for its first article when there is something to preserve here.",
+    actionLabel: "Create the first article",
+  });
 });

--- a/src/__tests__/wiki/topic-page.test.ts
+++ b/src/__tests__/wiki/topic-page.test.ts
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const topicPageSource = readFileSync(resolve("src/app/wiki/[topicSlug]/page.tsx"), "utf8");
+
+test("topic page path builder uses Prisma payload typing", () => {
+  assert.match(topicPageSource, /satisfies Prisma\.TopicSelect/);
+  assert.match(topicPageSource, /type TopicPathNode = Prisma\.TopicGetPayload/);
+  assert.doesNotMatch(topicPageSource, /interface TopicPathNode/);
+  assert.match(topicPageSource, /select: topicPathSelect/);
+});
+
+test("topic page distinguishes leaf and branch empty article states", () => {
+  assert.match(topicPageSource, /No direct articles yet/);
+  assert.match(topicPageSource, /This branch is organized through subtopics/);
+  assert.match(topicPageSource, /No articles or subtopics yet/);
+  assert.match(topicPageSource, /This leaf topic is ready for its first article/);
+});

--- a/src/app/wiki/[topicSlug]/page.tsx
+++ b/src/app/wiki/[topicSlug]/page.tsx
@@ -2,6 +2,7 @@ export const dynamic = "force-dynamic";
 import { notFound } from "next/navigation";
 import Link from "next/link";
 import { getServerSession } from "next-auth";
+import type { Prisma } from "@prisma/client";
 import { Breadcrumbs } from "@/components/wiki/Breadcrumbs";
 import { EmptyState } from "@/components/wiki/EmptyState";
 import { PageHeader } from "@/components/wiki/PageHeader";
@@ -15,12 +16,14 @@ interface Props {
   params: Promise<{ topicSlug: string }>;
 }
 
-interface TopicPathNode {
-  id: string;
-  name: string;
-  slug: string;
-  parentId: string | null;
-}
+const topicPathSelect = {
+  id: true,
+  name: true,
+  slug: true,
+  parentId: true,
+} satisfies Prisma.TopicSelect;
+
+type TopicPathNode = Prisma.TopicGetPayload<{ select: typeof topicPathSelect }>;
 
 function buildTopicPath(topics: TopicPathNode[], current: TopicPathNode) {
   const topicMap = new Map(topics.map((topic) => [topic.id, topic]));
@@ -62,7 +65,7 @@ export default async function TopicPage({ params }: Props) {
   }
 
   const allTopics = await prisma.topic.findMany({
-    select: { id: true, name: true, slug: true, parentId: true },
+    select: topicPathSelect,
   });
   const topicPath = buildTopicPath(allTopics, topic);
 
@@ -80,6 +83,17 @@ export default async function TopicPage({ params }: Props) {
     orderBy: { updatedAt: "desc" },
   });
   const hasSubtopics = topic.children.length > 0;
+  const emptyArticlesState = hasSubtopics
+    ? {
+        title: "No direct articles yet",
+        description: "This branch is organized through subtopics. Open one below, or add a direct article here.",
+        actionLabel: "Add direct article",
+      }
+    : {
+        title: "No articles or subtopics yet",
+        description: "This leaf topic is ready for its first article when there is something to preserve here.",
+        actionLabel: "Create the first article",
+      };
 
   return (
     <div className="wiki-content topic-page">
@@ -181,12 +195,12 @@ export default async function TopicPage({ params }: Props) {
 
         {articles.length === 0 ? (
           <EmptyState
-            title="No articles yet"
-            description="Articles in this topic will appear here once they are created."
+            title={emptyArticlesState.title}
+            description={emptyArticlesState.description}
             action={
               canCreateArticle ? (
                 <Link href={`/wiki/${topic.slug}/new`} className="btn btn-primary btn-sm">
-                  Create the first article
+                  {emptyArticlesState.actionLabel}
                 </Link>
               ) : null
             }

--- a/src/app/wiki/[topicSlug]/page.tsx
+++ b/src/app/wiki/[topicSlug]/page.tsx
@@ -2,7 +2,6 @@ export const dynamic = "force-dynamic";
 import { notFound } from "next/navigation";
 import Link from "next/link";
 import { getServerSession } from "next-auth";
-import type { Prisma } from "@prisma/client";
 import { Breadcrumbs } from "@/components/wiki/Breadcrumbs";
 import { EmptyState } from "@/components/wiki/EmptyState";
 import { PageHeader } from "@/components/wiki/PageHeader";
@@ -11,33 +10,10 @@ import { authOptions } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { buildScopeFilter } from "@/lib/api/auth";
 import { articleCardLabel, pluralize, wikiDateFormatter } from "@/lib/wiki-format";
+import { buildTopicPath, getTopicArticlesEmptyState, topicPathSelect } from "@/lib/wiki-topic-page";
 
 interface Props {
   params: Promise<{ topicSlug: string }>;
-}
-
-const topicPathSelect = {
-  id: true,
-  name: true,
-  slug: true,
-  parentId: true,
-} satisfies Prisma.TopicSelect;
-
-type TopicPathNode = Prisma.TopicGetPayload<{ select: typeof topicPathSelect }>;
-
-function buildTopicPath(topics: TopicPathNode[], current: TopicPathNode) {
-  const topicMap = new Map(topics.map((topic) => [topic.id, topic]));
-  const path: TopicPathNode[] = [];
-  const seen = new Set<string>();
-  let cursor: TopicPathNode | undefined = current;
-
-  while (cursor && !seen.has(cursor.id)) {
-    path.unshift(cursor);
-    seen.add(cursor.id);
-    cursor = cursor.parentId ? topicMap.get(cursor.parentId) : undefined;
-  }
-
-  return path;
 }
 
 export default async function TopicPage({ params }: Props) {
@@ -83,17 +59,7 @@ export default async function TopicPage({ params }: Props) {
     orderBy: { updatedAt: "desc" },
   });
   const hasSubtopics = topic.children.length > 0;
-  const emptyArticlesState = hasSubtopics
-    ? {
-        title: "No direct articles yet",
-        description: "This branch is organized through subtopics. Open one below, or add a direct article here.",
-        actionLabel: "Add direct article",
-      }
-    : {
-        title: "No articles or subtopics yet",
-        description: "This leaf topic is ready for its first article when there is something to preserve here.",
-        actionLabel: "Create the first article",
-      };
+  const emptyArticlesState = getTopicArticlesEmptyState(hasSubtopics);
 
   return (
     <div className="wiki-content topic-page">

--- a/src/lib/wiki-topic-page.ts
+++ b/src/lib/wiki-topic-page.ts
@@ -1,0 +1,39 @@
+import type { Prisma } from "@prisma/client";
+
+export const topicPathSelect = {
+  id: true,
+  name: true,
+  slug: true,
+  parentId: true,
+} satisfies Prisma.TopicSelect;
+
+export type TopicPathNode = Prisma.TopicGetPayload<{ select: typeof topicPathSelect }>;
+
+export function buildTopicPath(topics: TopicPathNode[], current: TopicPathNode) {
+  const topicMap = new Map(topics.map((topic) => [topic.id, topic]));
+  const path: TopicPathNode[] = [];
+  const seen = new Set<string>();
+  let cursor: TopicPathNode | undefined = current;
+
+  while (cursor && !seen.has(cursor.id)) {
+    path.unshift(cursor);
+    seen.add(cursor.id);
+    cursor = cursor.parentId ? topicMap.get(cursor.parentId) : undefined;
+  }
+
+  return path;
+}
+
+export function getTopicArticlesEmptyState(hasSubtopics: boolean) {
+  return hasSubtopics
+    ? {
+        title: "No direct articles yet",
+        description: "This branch is organized through subtopics. Open one below, or add a direct article here.",
+        actionLabel: "Add direct article",
+      }
+    : {
+        title: "No articles or subtopics yet",
+        description: "This leaf topic is ready for its first article when there is something to preserve here.",
+        actionLabel: "Create the first article",
+      };
+}


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary

This PR refines the wiki topic page so that empty states clearly distinguish between **branch topics** (which contain subtopics but no direct articles) and **leaf topics** (which contain neither articles nor subtopics). It also replaces the manually declared `TopicPathNode` interface with a Prisma-derived payload type to keep the path-builder typing in lockstep with the actual select clause.

## Changes

### Wiki topic page (`src/app/wiki/[topicSlug]/page.tsx`)

- **Empty-state copy now branches on topic shape:**
  - Branch topics (`hasSubtopics === true`) show:
    - Title: *"No direct articles yet"*
    - Description: *"This branch is organized through subtopics. Open one below, or add a direct article here."*
    - Action label: *"Add direct article"*
  - Leaf topics (`hasSubtopics === false`) show:
    - Title: *"No articles or subtopics yet"*
    - Description: *"This leaf topic is ready for its first article when there is something to preserve here."*
    - Action label: *"Create the first article"*
  - The selection is done once into an `emptyArticlesState` object and then passed through to the existing `<EmptyState />` component.
- **Prisma-typed path builder:**
  - Removed the hand-written `interface TopicPathNode { id, name, slug, parentId }`.
  - Added `const topicPathSelect = { id: true, name: true, slug: true, parentId: true } satisfies Prisma.TopicSelect;`.
  - Derived the type as `type TopicPathNode = Prisma.TopicGetPayload<{ select: typeof topicPathSelect }>;` so any change to the select shape is automatically reflected in the type.

### Tests (`src/__tests__/wiki/topic-page.test.ts`)

- New source-text based tests guard the wiki page so that future edits don't silently regress either concern:
  - Asserts the topic page:
    - uses `satisfies Prisma.TopicSelect`,
    - declares `type TopicPathNode = Prisma.TopicGetPayload<...>`,
    - does **not** declare `interface TopicPathNode`,
    - passes `select: topicPathSelect` to the Prisma call.
  - Asserts the topic page contains the new branch and leaf empty-state strings:
    - `"No direct articles yet"` / `"This branch is organized through subtopics"`
    - `"No articles or subtopics yet"` / `"This leaf topic is ready for its first article"`

## Impact

- **UX:** Users landing on an empty topic now get a clearer cue about whether they are at a branch (with subtopics to navigate into) or a leaf (the terminus of the topic tree), and the primary action label reflects that distinction.
- **Type safety:** The path-builder typing is no longer a parallel hand-maintained interface — it is generated from the exact `select` object passed to Prisma, eliminating a class of drift bugs if the select shape changes.
- **Testability:** The two narrow guards give quick, local protection for the copy and the typing change without requiring a full render test; broader behavior verification remains covered by the existing wiki test suite.

Closes #224 (empty-state distinction) and #225 (Prisma-aligned path typing).

---

Refactored the wiki topic page to extract the topic path logic and empty-state copy into a dedicated module, and replaced string-based source assertions with proper unit tests.

Key changes:

- **New `src/lib/wiki-topic-page.ts` module**: Centralizes the `topicPathSelect` Prisma payload, the `TopicPathNode` type (derived via `Prisma.TopicGetPayload`), the `buildTopicPath` function (which walks parent IDs and guards against cycles), and the `getTopicArticlesEmptyState` helper that returns branch vs. leaf empty-state copy.
- **`src/app/wiki/[topicSlug]/page.tsx` cleanup**: Removed the inline `topicPathSelect`, `TopicPathNode` type, `buildTopicPath` function, and the inline empty-state ternary. The page now imports these from the new module and calls `getTopicArticlesEmptyState(hasSubtopics)`.
- **Test rewrite (`src/__tests__/wiki/topic-page.test.ts`)**: Replaced fragile `readFileSync` + `assert.match` string assertions on the source file with behavioral tests:
  - Verifies `buildTopicPath` returns ancestors in order (root → branch → leaf).
  - Verifies `buildTopicPath` stops on cyclic parent relationships.
  - Verifies `getTopicArticlesEmptyState(true)` returns the "branch / no direct articles yet" copy.
  - Verifies `getTopicArticlesEmptyState(false)` returns the "leaf / no articles or subtopics yet" copy.

This keeps the wiki topic page rendering behavior identical while making the path-building logic and empty-state copy independently testable.
<!-- kody-pr-summary:end -->