### PR TITLE
fix: B4 SSR markdown sanitize tests + F46 light-mode contrast fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test:cache": "node --env-file=.env.test --import tsx --test 'src/__tests__/cache/**/*.test.ts'",
     "test:rate-limit": "node --env-file=.env.test --import tsx --test src/__tests__/rate-limit.test.ts",
     "test:api": "node --import tsx --test 'src/__tests__/api/**/*.test.ts'",
-    "test:security": "node --env-file=.env.test --import tsx --test src/__tests__/security/uploads.test.ts src/__tests__/security/proxy.test.ts src/__tests__/security/articles-update.test.ts",
+    "test:security": "node --env-file=.env.test --import tsx --test src/__tests__/security/uploads.test.ts src/__tests__/security/proxy.test.ts src/__tests__/security/articles-update.test.ts src/__tests__/security/markdown-sanitize.test.ts",
     "lint": "eslint",
     "typecheck": "tsc --noEmit",
     "db:migrate": "prisma migrate dev",

--- a/src/__tests__/security/markdown-sanitize.test.ts
+++ b/src/__tests__/security/markdown-sanitize.test.ts
@@ -3,42 +3,18 @@ import test from "node:test";
 
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
-import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
+import { WikiMarkdown } from "@/components/wiki/WikiMarkdown";
 
 /**
  * B4: Verify that server-side markdown rendering sanitizes dangerous HTML.
  *
- * The wiki article SSR path (src/app/wiki/[topicSlug]/[articleSlug]/page.tsx)
- * uses ReactMarkdown + remarkGfm + rehype-sanitize with an extended schema
- * that preserves className on code/pre for syntax highlighting.
- *
- * This test asserts that <script>, <iframe>, inline event handlers, and
- * javascript: URLs in markdown content are rendered as inert text,
- * not executable HTML.
+ * These tests render the shared WikiMarkdown component used by the SSR article
+ * page and the editor preview, so they fail if production markdown wiring
+ * drifts away from rehype-sanitize or the shared syntax-highlighting mapping.
  */
 
-const sanitizeSchema = {
-  ...defaultSchema,
-  attributes: {
-    ...defaultSchema.attributes,
-    code: [...(defaultSchema.attributes?.code ?? []), "className"],
-    pre: [...(defaultSchema.attributes?.pre ?? []), "className"],
-  },
-};
-
 function renderMarkdown(content: string): string {
-  return renderToStaticMarkup(
-    React.createElement(
-      ReactMarkdown,
-      {
-        remarkPlugins: [remarkGfm],
-        rehypePlugins: [[rehypeSanitize, sanitizeSchema]],
-      },
-      content,
-    ),
-  );
+  return renderToStaticMarkup(React.createElement(WikiMarkdown, { content }));
 }
 
 test("B4: <script> tags are rendered as inert text, not executable HTML", () => {
@@ -47,6 +23,7 @@ test("B4: <script> tags are rendered as inert text, not executable HTML", () => 
 
   // rehype-sanitize strips the entire <script> element (tag + content)
   assert.doesNotMatch(html, /<script\b/);
+  assert.doesNotMatch(html, /alert\("xss"\)/);
   // Surrounding text is preserved
   assert.ok(html.includes("Some text"), "surrounding text should be preserved");
   assert.ok(html.includes("More text"), "surrounding text should be preserved");
@@ -59,18 +36,27 @@ test("B4: <iframe> tags are rendered as inert text", () => {
   assert.doesNotMatch(html, /<iframe\b/);
 });
 
-test("B4: inline event handlers (onclick) are stripped from links", () => {
+test("B4: raw HTML links with inline event handlers are not rendered as HTML", () => {
   const malicious = '<a href="https://ok.example.com" onclick="alert(1)">link</a>';
   const html = renderMarkdown(malicious);
 
-  assert.ok(!html.includes("onclick"), "onclick must be stripped");
+  assert.doesNotMatch(html, /onclick/i);
+  assert.doesNotMatch(html, /<a\b/);
+});
+
+test("B4: safe markdown links preserve href attributes", () => {
+  const safeLink = "[safe link](https://ok.example.com)";
+  const html = renderMarkdown(safeLink);
+
+  assert.match(html, /href="https:\/\/ok\.example\.com"/);
+  assert.ok(html.includes("safe link"), "safe link text should be preserved");
 });
 
 test("B4: javascript: URLs are stripped from markdown links", () => {
-  const malicious = "[click me](javascript:void(0))";
+  const malicious = "[click me](JaVaScRiPt:void(0))";
   const html = renderMarkdown(malicious);
 
-  assert.ok(!html.includes("javascript:"), "javascript: protocol must be stripped");
+  assert.doesNotMatch(html, /javascript:/i, "javascript: protocol must be stripped");
 });
 
 test("B4: legitimate markdown formatting is preserved", () => {
@@ -80,12 +66,16 @@ test("B4: legitimate markdown formatting is preserved", () => {
   assert.ok(html.includes("<h1>"), "h1 should be preserved");
   assert.ok(html.includes("<strong>"), "bold should be preserved");
   assert.ok(html.includes("<em>"), "italic should be preserved");
-  assert.ok(html.includes("<code>"), "inline code should be preserved");
+  assert.match(html, /<code\b[^>]*>code<\/code>/, "inline code should be preserved");
+  assert.doesNotMatch(html, /node="\[object Object\]"/, "ReactMarkdown internals should not leak to HTML");
+  assert.ok(html.includes("<ul>"), "unordered lists should be preserved");
+  assert.ok(html.includes("<li>"), "list items should be preserved");
 });
 
 test("B4: code block className is preserved for syntax highlighting", () => {
   const codeBlock = "```js\nconst x = 1;\n```";
   const html = renderMarkdown(codeBlock);
 
-  assert.match(html, /language-js/, "language-js className should be preserved");
+  assert.match(html, /\blanguage-js\b/, "language-js className should be preserved");
+  assert.doesNotMatch(html, /\blanguage-json\b/, "language-js assertion should not match language-json");
 });

--- a/src/__tests__/security/markdown-sanitize.test.ts
+++ b/src/__tests__/security/markdown-sanitize.test.ts
@@ -3,7 +3,12 @@ import test from "node:test";
 
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import { WikiMarkdown } from "@/components/wiki/WikiMarkdown";
+import {
+  ARTICLE_REHYPE_PLUGINS,
+  ARTICLE_REMARK_PLUGINS,
+  ARTICLE_SANITIZE_SCHEMA,
+  WikiMarkdown,
+} from "@/components/wiki/WikiMarkdown";
 
 /**
  * B4: Verify that server-side markdown rendering sanitizes dangerous HTML.
@@ -16,6 +21,19 @@ import { WikiMarkdown } from "@/components/wiki/WikiMarkdown";
 function renderMarkdown(content: string): string {
   return renderToStaticMarkup(React.createElement(WikiMarkdown, { content }));
 }
+
+test("B4: shared markdown config preserves syntax-highlight classes", () => {
+  const [rehypeSanitizeEntry] = ARTICLE_REHYPE_PLUGINS as [unknown[]];
+
+  assert.ok(ARTICLE_REMARK_PLUGINS.length > 0, "remark plugins should be configured");
+  assert.strictEqual(
+    rehypeSanitizeEntry[1],
+    ARTICLE_SANITIZE_SCHEMA,
+    "rehype-sanitize should use the exported article sanitize schema",
+  );
+  assert.ok(ARTICLE_SANITIZE_SCHEMA.attributes?.code?.includes("className"));
+  assert.ok(ARTICLE_SANITIZE_SCHEMA.attributes?.pre?.includes("className"));
+});
 
 test("B4: <script> tags are rendered as inert text, not executable HTML", () => {
   const malicious = 'Some text\n\n<script>alert("xss")</script>\n\nMore text';
@@ -74,8 +92,11 @@ test("B4: legitimate markdown formatting is preserved", () => {
 
 test("B4: code block className is preserved for syntax highlighting", () => {
   const codeBlock = "```js\nconst x = 1;\n```";
+  const jsonBlock = "```json\n{\"x\":1}\n```";
   const html = renderMarkdown(codeBlock);
+  const jsonHtml = renderMarkdown(jsonBlock);
 
   assert.match(html, /\blanguage-js\b/, "language-js className should be preserved");
-  assert.doesNotMatch(html, /\blanguage-json\b/, "language-js assertion should not match language-json");
+  assert.match(jsonHtml, /\blanguage-json\b/, "language-json className should be preserved");
+  assert.doesNotMatch(jsonHtml, /\blanguage-js\b/, "language-json should not satisfy language-js checks");
 });

--- a/src/__tests__/security/markdown-sanitize.test.ts
+++ b/src/__tests__/security/markdown-sanitize.test.ts
@@ -54,7 +54,11 @@ test("B4: <iframe> tags are rendered as inert text", () => {
   assert.doesNotMatch(html, /<iframe\b/);
 });
 
-test("B4: raw HTML links with inline event handlers are not rendered as HTML", () => {
+test("B4: raw HTML with inline event handlers is stripped (no tag or handler appears in output)", () => {
+  // ReactMarkdown + rehype-sanitize (without rehype-raw) treats raw HTML in the source
+  // as text that gets sanitized. An <a> with onclick never becomes a rendered element
+  // with the attribute because sanitize removes unknown/dangerous constructs.
+  // We assert both the dangerous attribute and the tag are absent.
   const malicious = '<a href="https://ok.example.com" onclick="alert(1)">link</a>';
   const html = renderMarkdown(malicious);
 

--- a/src/__tests__/security/markdown-sanitize.test.ts
+++ b/src/__tests__/security/markdown-sanitize.test.ts
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
+
+/**
+ * B4: Verify that server-side markdown rendering sanitizes dangerous HTML.
+ *
+ * The wiki article SSR path (src/app/wiki/[topicSlug]/[articleSlug]/page.tsx)
+ * uses ReactMarkdown + remarkGfm + rehype-sanitize with an extended schema
+ * that preserves className on code/pre for syntax highlighting.
+ *
+ * This test asserts that <script>, <iframe>, inline event handlers, and
+ * javascript: URLs in markdown content are rendered as inert text,
+ * not executable HTML.
+ */
+
+const sanitizeSchema = {
+  ...defaultSchema,
+  attributes: {
+    ...defaultSchema.attributes,
+    code: [...(defaultSchema.attributes?.code ?? []), "className"],
+    pre: [...(defaultSchema.attributes?.pre ?? []), "className"],
+  },
+};
+
+function renderMarkdown(content: string): string {
+  return renderToStaticMarkup(
+    React.createElement(
+      ReactMarkdown,
+      {
+        remarkPlugins: [remarkGfm],
+        rehypePlugins: [[rehypeSanitize, sanitizeSchema]],
+      },
+      content,
+    ),
+  );
+}
+
+test("B4: <script> tags are rendered as inert text, not executable HTML", () => {
+  const malicious = 'Some text\n\n<script>alert("xss")</script>\n\nMore text';
+  const html = renderMarkdown(malicious);
+
+  // rehype-sanitize strips the entire <script> element (tag + content)
+  assert.doesNotMatch(html, /<script\b/);
+  // Surrounding text is preserved
+  assert.ok(html.includes("Some text"), "surrounding text should be preserved");
+  assert.ok(html.includes("More text"), "surrounding text should be preserved");
+});
+
+test("B4: <iframe> tags are rendered as inert text", () => {
+  const malicious = '<iframe src="https://evil.example.com"></iframe>\n\nText';
+  const html = renderMarkdown(malicious);
+
+  assert.doesNotMatch(html, /<iframe\b/);
+});
+
+test("B4: inline event handlers (onclick) are stripped from links", () => {
+  const malicious = '<a href="https://ok.example.com" onclick="alert(1)">link</a>';
+  const html = renderMarkdown(malicious);
+
+  assert.ok(!html.includes("onclick"), "onclick must be stripped");
+});
+
+test("B4: javascript: URLs are stripped from markdown links", () => {
+  const malicious = "[click me](javascript:void(0))";
+  const html = renderMarkdown(malicious);
+
+  assert.ok(!html.includes("javascript:"), "javascript: protocol must be stripped");
+});
+
+test("B4: legitimate markdown formatting is preserved", () => {
+  const legit = "# Heading\n\n**bold** and *italic* and `code`\n\n- item";
+  const html = renderMarkdown(legit);
+
+  assert.ok(html.includes("<h1>"), "h1 should be preserved");
+  assert.ok(html.includes("<strong>"), "bold should be preserved");
+  assert.ok(html.includes("<em>"), "italic should be preserved");
+  assert.ok(html.includes("<code>"), "inline code should be preserved");
+});
+
+test("B4: code block className is preserved for syntax highlighting", () => {
+  const codeBlock = "```js\nconst x = 1;\n```";
+  const html = renderMarkdown(codeBlock);
+
+  assert.match(html, /language-js/, "language-js className should be preserved");
+});

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -13,7 +13,7 @@
   --color-surface-elevated: rgba(255, 252, 247, 0.9);
   --color-text: #121723;
   --color-text-muted: #5e6375;
-  --color-text-faint: #81879b;
+  --color-text-faint: #5a637c;
   --color-border: rgba(18, 23, 35, 0.12);
   --color-border-strong: rgba(18, 23, 35, 0.18);
   --color-accent: #2b746b;

--- a/src/app/wiki/[topicSlug]/[articleSlug]/page.tsx
+++ b/src/app/wiki/[topicSlug]/[articleSlug]/page.tsx
@@ -8,22 +8,7 @@ import { authOptions } from "@/lib/auth";
 import { filterVisibleRelatedArticleRows } from "@/lib/articles/relations";
 import { DeleteArticleForm } from "@/components/wiki/DeleteArticleForm";
 import { PageHeader } from "@/components/wiki/PageHeader";
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
-import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
-import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
-import { oneDark } from "react-syntax-highlighter/dist/esm/styles/prism";
-
-// Extend default rehype-sanitize schema to preserve className on code/pre
-// elements so syntax highlighting (language-xyz classes) is not stripped.
-const sanitizeSchema = {
-  ...defaultSchema,
-  attributes: {
-    ...defaultSchema.attributes,
-    code: [...(defaultSchema.attributes?.code ?? []), "className"],
-    pre: [...(defaultSchema.attributes?.pre ?? []), "className"],
-  },
-};
+import { WikiMarkdown } from "@/components/wiki/WikiMarkdown";
 import { deleteArticle } from "./edit/actions";
 
 interface Props {
@@ -214,34 +199,7 @@ export default async function ArticlePage({ params }: Props) {
       </header>
 
       <article className="markdown-body article-prose">
-        <ReactMarkdown
-          remarkPlugins={[remarkGfm]}
-          rehypePlugins={[[rehypeSanitize, sanitizeSchema]]}
-          components={{
-            code({ className, children, ...props }) {
-              const inline = !className;
-              const match = /language-(\w+)/.exec(className || "");
-              if (!inline && match) {
-                return (
-                  <SyntaxHighlighter
-                    style={oneDark}
-                    language={match[1]}
-                    PreTag="div"
-                  >
-                    {String(children).replace(/\n$/, "")}
-                  </SyntaxHighlighter>
-                );
-              }
-              return (
-                <code className={className} {...props}>
-                  {children}
-                </code>
-              );
-            },
-          }}
-        >
-          {article.content}
-        </ReactMarkdown>
+        <WikiMarkdown content={article.content} />
       </article>
 
       <section className="revision-summary-card">

--- a/src/components/wiki/MarkdownPreviewTabs.tsx
+++ b/src/components/wiki/MarkdownPreviewTabs.tsx
@@ -1,28 +1,12 @@
 "use client";
 
 import { type KeyboardEvent, useEffect, useMemo, useRef, useState } from "react";
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
-import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
-import type { PluggableList } from "unified";
 import { MarkdownToolbar } from "@/components/wiki/MarkdownToolbar";
+import { WikiMarkdown } from "@/components/wiki/WikiMarkdown";
 import {
   MARKDOWN_TEXTAREA_UPDATE_EVENT,
   type MarkdownTextareaUpdateDetail,
 } from "@/components/wiki/markdownTextareaUpdate";
-
-// Extend default schema to preserve className on code/pre for syntax highlighting
-const sanitizeSchema = {
-  ...defaultSchema,
-  attributes: {
-    ...defaultSchema.attributes,
-    code: [...(defaultSchema.attributes?.code ?? []), "className"],
-    pre: [...(defaultSchema.attributes?.pre ?? []), "className"],
-  },
-};
-
-const REMARK_PLUGINS: PluggableList = [remarkGfm];
-const REHYPE_PLUGINS: PluggableList = [[rehypeSanitize, sanitizeSchema]];
 
 interface MarkdownPreviewTabsProps {
   targetTextareaId: string;
@@ -206,7 +190,7 @@ export function MarkdownPreviewTabs({
 
         <div id={previewPaneId} className="markdown-editor-preview preview-pane markdown-body">
           {activeMode === "write" ? null : trimmedContent ? (
-            <ReactMarkdown remarkPlugins={REMARK_PLUGINS} rehypePlugins={REHYPE_PLUGINS}>{trimmedContent}</ReactMarkdown>
+            <WikiMarkdown content={trimmedContent} />
           ) : activeMode === "split" ? (
             <p className="text-muted">Preview will appear here as you type.</p>
           ) : (

--- a/src/components/wiki/WikiMarkdown.tsx
+++ b/src/components/wiki/WikiMarkdown.tsx
@@ -1,0 +1,61 @@
+import ReactMarkdown, { type Components } from "react-markdown";
+import remarkGfm from "remark-gfm";
+import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
+import type { PluggableList } from "unified";
+import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
+import { oneDark } from "react-syntax-highlighter/dist/esm/styles/prism";
+
+export const ARTICLE_SANITIZE_SCHEMA = {
+  ...defaultSchema,
+  attributes: {
+    ...defaultSchema.attributes,
+    code: [...(defaultSchema.attributes?.code ?? []), "className"],
+    pre: [...(defaultSchema.attributes?.pre ?? []), "className"],
+  },
+};
+
+export const ARTICLE_REMARK_PLUGINS: PluggableList = [remarkGfm];
+export const ARTICLE_REHYPE_PLUGINS: PluggableList = [[rehypeSanitize, ARTICLE_SANITIZE_SCHEMA]];
+
+const LANGUAGE_CLASS_PATTERN = /\blanguage-([\w-]+)\b/;
+
+const ARTICLE_MARKDOWN_COMPONENTS: Components = {
+  code({ className, children, node, ...props }) {
+    void node;
+
+    const match = LANGUAGE_CLASS_PATTERN.exec(className || "");
+    if (className && match) {
+      return (
+        <SyntaxHighlighter
+          style={oneDark}
+          language={match[1]}
+          PreTag="div"
+        >
+          {String(children).replace(/\n$/, "")}
+        </SyntaxHighlighter>
+      );
+    }
+
+    return (
+      <code className={className} {...props}>
+        {children}
+      </code>
+    );
+  },
+};
+
+interface WikiMarkdownProps {
+  content: string;
+}
+
+export function WikiMarkdown({ content }: WikiMarkdownProps) {
+  return (
+    <ReactMarkdown
+      remarkPlugins={ARTICLE_REMARK_PLUGINS}
+      rehypePlugins={ARTICLE_REHYPE_PLUGINS}
+      components={ARTICLE_MARKDOWN_COMPONENTS}
+    >
+      {content}
+    </ReactMarkdown>
+  );
+}

--- a/src/components/wiki/WikiMarkdown.tsx
+++ b/src/components/wiki/WikiMarkdown.tsx
@@ -20,8 +20,9 @@ export const ARTICLE_REHYPE_PLUGINS: PluggableList = [[rehypeSanitize, ARTICLE_S
 const LANGUAGE_CLASS_PATTERN = /\blanguage-([\w-]+)\b/;
 
 const ARTICLE_MARKDOWN_COMPONENTS: Components = {
-  code({ className, children, node, ...props }) {
-    void node;
+  code({ className, children, ...props }) {
+    const codeProps = { ...props };
+    delete (codeProps as { node?: unknown }).node;
 
     const match = LANGUAGE_CLASS_PATTERN.exec(className || "");
     if (className && match) {
@@ -37,7 +38,7 @@ const ARTICLE_MARKDOWN_COMPONENTS: Components = {
     }
 
     return (
-      <code className={className} {...props}>
+      <code className={className} {...codeProps}>
         {children}
       </code>
     );


### PR DESCRIPTION
## Summary

Addresses B4 and F46 with focused changes:

- Adds a shared `WikiMarkdown` renderer that owns the wiki article markdown pipeline: `ReactMarkdown`, `remark-gfm`, `rehype-sanitize`, the article sanitize schema, and the syntax-highlighting `code` mapping.
- Uses the shared renderer in both the SSR article page and the editor preview, so production rendering no longer has duplicated sanitize/plugin wiring.
- Adds B4 security tests that render the same shared component through `renderToStaticMarkup` and verify dangerous HTML/protocols are removed while safe markdown output is preserved.
- Raises light-mode `--color-text-faint` from `#81879b` to `#5a637c`, improving contrast against `#f6f2ea` from 3.20:1 to 5.36:1. Dark mode remains unchanged.

## B4 Coverage

The security suite covers:

- `<script>` tag and inner payload removal
- `<iframe>` removal
- raw HTML link/event-handler non-rendering under the production pipeline
- safe markdown link `href` preservation
- mixed-case `javascript:` URL stripping
- heading, bold, italic, inline code, unordered list, and list item preservation
- syntax-highlighting class preservation with word-boundary assertions
- guard against ReactMarkdown internal `node` props leaking into HTML

## Verification

- `npx eslint src/components/wiki/WikiMarkdown.tsx 'src/app/wiki/[topicSlug]/[articleSlug]/page.tsx' src/components/wiki/MarkdownPreviewTabs.tsx src/__tests__/security/markdown-sanitize.test.ts`
- `npx tsc --noEmit`
- `npm run test:security`
- `DATABASE_URL=<local noosphere db> npm run build`


<!-- kody-pr-summary:start -->
**Pull Request Summary**

This PR consolidates duplicate markdown rendering logic into a single shared component and hardens SSR sanitization tests, plus fixes a light-mode contrast issue.

**Key Changes**

1. **Extracted shared `WikiMarkdown` component** (`src/components/wiki/WikiMarkdown.tsx`, new): Centralizes the ReactMarkdown + remark-gfm + rehype-sanitize configuration, custom sanitize schema (preserves `className` on `code`/`pre` for syntax highlighting), and the syntax-highlighting `code` component override that was previously duplicated.

2. **Replaced inline markdown setup in two call sites**:
   - SSR article page (`src/app/wiki/[topicSlug]/[articleSlug]/page.tsx`) now uses `<WikiMarkdown content={article.content} />`.
   - Editor preview tabs (`src/components/wiki/MarkdownPreviewTabs.tsx`) now uses `<WikiMarkdown content={trimmedContent} />`.
   
   This ensures both the SSR article rendering and the live editor preview share an identical markdown pipeline, so a future change to sanitization or syntax highlighting can't drift between them.

3. **Hardened B4 SSR sanitization tests** (`src/__tests__/security/markdown-sanitize.test.ts`): The tests now exercise the real `WikiMarkdown` component instead of a duplicate local `ReactMarkdown` instance. Assertions were tightened:
   - `<script>` test now also asserts the script body (`alert("xss")`) is removed, not just the tag.
   - Inline event handler test now also asserts raw `<a>` HTML is not emitted, plus added a positive test that safe markdown links preserve `href`.
   - `javascript:` URL test now uses mixed-case input to catch case-insensitive bypasses and uses a case-insensitive regex.
   - Formatting test now uses a precise regex for `<code>` (avoiding false positives from `<codeblock>`), explicitly checks list elements, and guards against ReactMarkdown internals leaking into output.
   - Code block test now uses word boundaries so the `language-js` assertion can't accidentally match `language-json`.

**Functional Impact**

- The wiki's SSR article page and the editor preview now render markdown through a single, audited pipeline, reducing the risk of sanitization regressions in one path but not the other.
- Sanitization tests now fail when production wiring diverges from the shared component (e.g., if `rehype-sanitize` is removed, the schema is weakened, or ReactMarkdown internals leak into the DOM).
- Mixed-case `javascript:` URLs and raw HTML `<a>` tags with event handlers are now explicitly covered by tests, closing two potential XSS regression vectors.

Note: The PR title also mentions an "F46 light-mode contrast fix," but no corresponding code changes for that item are present in the provided diff.

---

**Title:** fix: B4 SSR markdown sanitize tests + F46 light-mode contrast fix

**Description:**

Expanded server-side markdown sanitize test coverage and fixed SSR rendering of code blocks.

**Changes:**

- **Test exports**: Updated `markdown-sanitize.test.ts` to import `ARTICLE_REHYPE_PLUGINS`, `ARTICLE_REMARK_PLUGINS`, and `ARTICLE_SANITIZE_SCHEMA` directly from `WikiMarkdown.tsx`, enabling direct verification of the shared configuration.

- **New configuration test**: Added a test asserting that the shared markdown pipeline preserves syntax-highlighting className attributes for both `code` and `pre` elements in the sanitize schema.

- **Improved code-block test**: Split the syntax-highlighting test into separate assertions for JavaScript (`language-js`) and JSON (`language-json`) fenced code blocks, ensuring each language class is correctly preserved end-to-end.

- **`WikiMarkdown.tsx` SSR fix**: Refactored the custom `code` component to strip the `node` prop via object spread/delete instead of destructuring it out (avoids passing the non-serializable MDAST `node` through server rendering, which would otherwise emit an extra `node="[object Object]"` attribute into the static markup).

---

## Pull Request Description

This PR updates the B4 SSR markdown sanitize test to strengthen its assertions around how raw HTML containing inline event handlers is handled.

### Changes

**Modified Test: B4 raw HTML with inline event handlers**

The test was retitled and its assertions strengthened to verify that raw HTML containing inline event handlers (e.g., `<a href="..." onclick="alert(1)">link</a>`) is fully stripped from the rendered output. Previously, the test focused only on ensuring that the rendered HTML did not contain the dangerous `onclick` attribute. The updated test now asserts both:

1. The dangerous inline event handler attribute does not appear in the output
2. The raw `<a>` tag itself is also absent, since ReactMarkdown combined with `rehype-sanitize` (without `rehype-raw`) treats raw HTML in the source as text that gets sanitized away

A comment was also added to the test explaining the rendering pipeline behavior so the test's intent is clear to future maintainers.
<!-- kody-pr-summary:end -->