### PR TITLE
fix: rate limiter fails degraded when Redis is down (per-worker cap during outage) (#242)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,15 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
 
     steps:
       - name: Checkout
@@ -85,6 +94,11 @@ jobs:
 
       - name: Run API tests
         run: npm run test:api
+
+      - name: Run rate-limit tests
+        run: npm run test:rate-limit
+        env:
+          REDIS_URL: redis://localhost:6379
 
       - name: Run security tests
         run: npm run test:security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Rate limiter fails degraded under Redis outage (#276)**: all rate-limited
+- **Rate limiter fails degraded under Redis outage ([#276](https://github.com/SweetSophia/noosphere/pull/276))**: all rate-limited
   routes now return 429 once the in-process per-worker cap is hit during a
   Redis outage, replacing the previous fail-open behavior. The fallback
   limiter is per-process, so the effective cluster-wide ceiling during an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Rate limiter fails degraded under Redis outage (#276)**: all rate-limited
+  routes now return 429 once the in-process per-worker cap is hit during a
+  Redis outage, replacing the previous fail-open behavior. The fallback
+  limiter is per-process, so the effective cluster-wide ceiling during an
+  outage is `maxRequests × worker_count` per `windowMs`. Per-route defaults
+  and Redis behavior are unchanged; the change applies only when the Redis
+  health check or eval round-trip fails. Operators relying on fail-open
+  behavior during Redis maintenance windows should plan a Redis-aware deploy
+  strategy.
+
 ## [1.10.3] - 2026-06-30
 
 Patch release for concurrent agent recall reliability. No breaking changes and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   health check or eval round-trip fails. Operators relying on fail-open
   behavior during Redis maintenance windows should plan a Redis-aware deploy
   strategy.
+- The local guard now runs ahead of every Redis call (warm-fallback-leading-
+  guard); under heavy single-worker skew the local cap may deny requests that
+  Redis would globally allow.
 
 ## [1.10.3] - 2026-06-30
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test:memory": "node --env-file=.env.test --import tsx --test 'src/__tests__/memory/**/*.test.ts'",
     "test:wiki": "node --import tsx --test 'src/__tests__/wiki/**/*.test.ts'",
     "test:cache": "node --env-file=.env.test --import tsx --test 'src/__tests__/cache/**/*.test.ts'",
-    "test:rate-limit": "node --env-file=.env.test --import tsx --test src/__tests__/rate-limit.test.ts",
+    "test:rate-limit": "node --env-file=.env.test --import tsx --test src/__tests__/rate-limit.test.ts src/__tests__/rate-limit-fallback.test.ts src/__tests__/rate-limit-redis-integration.test.ts",
     "test:api": "node --import tsx --test 'src/__tests__/api/**/*.test.ts'",
     "test:security": "node --env-file=.env.test --import tsx --test src/__tests__/security/uploads.test.ts src/__tests__/security/proxy.test.ts src/__tests__/security/articles-update.test.ts src/__tests__/security/markdown-sanitize.test.ts",
     "lint": "eslint",

--- a/src/__tests__/_helpers/fake-redis.ts
+++ b/src/__tests__/_helpers/fake-redis.ts
@@ -12,6 +12,7 @@ interface FakeRedisClientOptions {
 export class FakeRedisClient {
   status = "wait";
   connectCalls = 0;
+  readonly evalKeys: string[] = [];
 
   private readonly values = new Map<string, string>();
   private readonly expires = new Map<string, number>();
@@ -86,6 +87,33 @@ export class FakeRedisClient {
   expire(key: string, seconds: number): number {
     this.assertReady();
     this.expires.set(key, Date.now() + seconds * 1000);
+    return 1;
+  }
+
+  async eval(
+    _script: string,
+    numberOfKeys: number,
+    ...args: Array<string | number>
+  ): Promise<number> {
+    this.assertReady();
+    if (numberOfKeys !== 1) {
+      throw new Error("FakeRedisClient only supports one-key rate-limit scripts");
+    }
+
+    const [key, windowStart, now, maxRequests, member, ttlSeconds] = args;
+    if (typeof key !== "string" || typeof member !== "string") {
+      throw new Error("Invalid rate-limit script arguments");
+    }
+    this.evalKeys.push(key);
+
+    this.zremrangebyscore(key, "-inf", String(windowStart));
+    const count = this.zcard(key);
+    if (count >= Number(maxRequests)) {
+      return 0;
+    }
+
+    this.zadd(key, Number(now), member);
+    this.expire(key, Number(ttlSeconds));
     return 1;
   }
 

--- a/src/__tests__/rate-limit-fallback.test.ts
+++ b/src/__tests__/rate-limit-fallback.test.ts
@@ -1,0 +1,339 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "assert";
+import { rateLimit, _rateLimitTestHooks } from "@/lib/rate-limit";
+import {
+  fallbackLimiter,
+  _fallbackLimiterTestHooks,
+} from "@/lib/rate-limit-fallback";
+import { _redisTestHooks } from "@/lib/cache/redis";
+import { NextRequest } from "next/server";
+import { FakeRedisClient } from "./_helpers/fake-redis";
+
+function makeRequest(ip: string = "192.168.1.1"): NextRequest {
+  return new NextRequest("http://localhost/api/test", {
+    headers: { "x-real-ip": ip },
+  });
+}
+
+describe("Rate Limiter Fallback (in-process, Redis unavailable)", () => {
+  let previousRedisUrl: string | undefined;
+
+  beforeEach(() => {
+    // Ensure Redis is fully unset so the fallback path runs.
+    previousRedisUrl = process.env.REDIS_URL;
+    delete process.env.REDIS_URL;
+    _redisTestHooks.reset();
+    _fallbackLimiterTestHooks.reset();
+    _rateLimitTestHooks.resetDegradationState();
+  });
+
+  afterEach(() => {
+    _redisTestHooks.reset();
+    _fallbackLimiterTestHooks.reset();
+    _rateLimitTestHooks.resetDegradationState();
+    if (previousRedisUrl === undefined) {
+      delete process.env.REDIS_URL;
+    } else {
+      process.env.REDIS_URL = previousRedisUrl;
+    }
+  });
+
+  it("allows requests within limit when Redis is down", async () => {
+    const request = makeRequest("10.0.0.50");
+    const result = await rateLimit(request, {
+      windowMs: 60_000,
+      maxRequests: 5,
+      keyPrefix: "fallback-allow",
+    });
+    assert.deepStrictEqual(result, { allowed: true });
+  });
+
+  it("blocks requests exceeding limit when Redis is down", async () => {
+    const request = makeRequest("10.0.0.51");
+    const options = {
+      windowMs: 60_000,
+      maxRequests: 3,
+      keyPrefix: "fallback-block",
+    };
+
+    assert.deepStrictEqual(await rateLimit(request, options), { allowed: true });
+    assert.deepStrictEqual(await rateLimit(request, options), { allowed: true });
+    assert.deepStrictEqual(await rateLimit(request, options), { allowed: true });
+
+    const result = await rateLimit(request, options);
+    assert.equal(result.allowed, false);
+    if (!result.allowed) {
+      assert.equal(result.response.status, 429);
+    }
+  });
+
+  it("tracks different IPs independently in fallback mode", async () => {
+    const options = {
+      windowMs: 60_000,
+      maxRequests: 2,
+      keyPrefix: "fallback-ip",
+    };
+
+    const req1 = makeRequest("10.0.0.52");
+    const req2 = makeRequest("10.0.0.53");
+
+    assert.deepStrictEqual(await rateLimit(req1, options), { allowed: true });
+    assert.deepStrictEqual(await rateLimit(req1, options), { allowed: true });
+    assert.equal((await rateLimit(req1, options)).allowed, false);
+
+    // Different IP has its own counter.
+    assert.deepStrictEqual(await rateLimit(req2, options), { allowed: true });
+  });
+
+  it("tracks different key prefixes independently in fallback mode", async () => {
+    const request = makeRequest("10.0.0.54");
+
+    await rateLimit(request, {
+      windowMs: 60_000,
+      maxRequests: 1,
+      keyPrefix: "fallback-prefix-a",
+    });
+    const result = await rateLimit(request, {
+      windowMs: 60_000,
+      maxRequests: 1,
+      keyPrefix: "fallback-prefix-b",
+    });
+
+    assert.deepStrictEqual(result, { allowed: true });
+  });
+
+  it("returns 429 with correct status code in fallback mode", async () => {
+    const request = makeRequest("10.0.0.55");
+    const options = {
+      windowMs: 60_000,
+      maxRequests: 1,
+      keyPrefix: "fallback-429",
+    };
+
+    await rateLimit(request, options);
+    const result = await rateLimit(request, options);
+
+    assert.equal(result.allowed, false);
+    if (!result.allowed) {
+      assert.equal(result.response.status, 429);
+    }
+  });
+
+  it("enforces the limit across concurrent fallback requests", async () => {
+    const request = makeRequest("10.0.0.56");
+    const options = {
+      windowMs: 60_000,
+      maxRequests: 3,
+      keyPrefix: "fallback-concurrent",
+    };
+
+    const results = await Promise.all(
+      Array.from({ length: 10 }, () => rateLimit(request, options))
+    );
+
+    assert.equal(results.filter((result) => result.allowed).length, 3);
+    assert.equal(results.filter((result) => !result.allowed).length, 7);
+  });
+});
+
+describe("Rate Limiter Fallback (Redis failures)", () => {
+  let fakeRedis: FakeRedisClient;
+
+  beforeEach(() => {
+    fakeRedis = new FakeRedisClient();
+    _redisTestHooks.setClientForTesting(fakeRedis as never);
+    _fallbackLimiterTestHooks.reset();
+    _rateLimitTestHooks.resetDegradationState();
+  });
+
+  afterEach(() => {
+    _redisTestHooks.reset();
+    _fallbackLimiterTestHooks.reset();
+    _rateLimitTestHooks.resetDegradationState();
+  });
+
+  it("falls back to in-process limiter when the atomic check returns invalid data", async () => {
+    fakeRedis.eval = async () => null as never;
+
+    const request = makeRequest("10.0.0.60");
+    const options = { windowMs: 60_000, maxRequests: 1, keyPrefix: "pipe-null" };
+
+    // First request: invalid Redis response → warmed fallback allows.
+    assert.deepStrictEqual(await rateLimit(request, options), { allowed: true });
+
+    // Second request: fallback blocks (bucket full).
+    const result2 = await rateLimit(request, options);
+    assert.equal(result2.allowed, false);
+  });
+
+  it("falls back to in-process limiter when the atomic check throws", async () => {
+    fakeRedis.eval = async () => {
+      throw new Error("Redis connection lost");
+    };
+
+    const request = makeRequest("10.0.0.61");
+    const options = { windowMs: 60_000, maxRequests: 1, keyPrefix: "pipe-throw" };
+
+    // Suppress expected error log.
+    const origConsoleError = console.error;
+    console.error = () => {};
+
+    try {
+      // First request: Redis throws → warmed fallback allows.
+      assert.deepStrictEqual(await rateLimit(request, options), { allowed: true });
+
+      // Second request: fallback blocks (bucket full).
+      const result2 = await rateLimit(request, options);
+      assert.equal(result2.allowed, false);
+    } finally {
+      console.error = origConsoleError;
+    }
+  });
+
+  it("keeps the fallback warm before Redis becomes unavailable", async () => {
+    const request = makeRequest("10.0.0.62");
+    const options = { windowMs: 60_000, maxRequests: 2, keyPrefix: "warm-fallback" };
+
+    assert.deepStrictEqual(await rateLimit(request, options), { allowed: true });
+    assert.deepStrictEqual(await rateLimit(request, options), { allowed: true });
+
+    fakeRedis.status = "end";
+    const result = await rateLimit(request, options);
+
+    assert.equal(result.allowed, false);
+    if (!result.allowed) {
+      assert.equal(result.response.status, 429);
+    }
+  });
+
+  it("warns again when Redis recovers and a later degradation begins", async () => {
+    const originalEval = fakeRedis.eval.bind(fakeRedis);
+    let shouldFail = true;
+    fakeRedis.eval = async (...args: Parameters<FakeRedisClient["eval"]>) => {
+      if (shouldFail) throw new Error("Redis unavailable");
+      return originalEval(...args);
+    };
+
+    const request = makeRequest("10.0.0.63");
+    const options = { windowMs: 60_000, maxRequests: 10, keyPrefix: "warning-transition" };
+    const originalWarn = console.warn;
+    const originalError = console.error;
+    const warnings: unknown[][] = [];
+    const errors: unknown[][] = [];
+    console.warn = (...args: unknown[]) => warnings.push(args);
+    console.error = (...args: unknown[]) => errors.push(args);
+
+    try {
+      assert.deepStrictEqual(await rateLimit(request, options), { allowed: true });
+      assert.deepStrictEqual(await rateLimit(request, options), { allowed: true });
+      assert.equal(warnings.length, 1);
+      assert.equal(errors.length, 1);
+
+      shouldFail = false;
+      assert.deepStrictEqual(await rateLimit(request, options), { allowed: true });
+
+      shouldFail = true;
+      assert.deepStrictEqual(await rateLimit(request, options), { allowed: true });
+      assert.equal(warnings.length, 2);
+      assert.equal(errors.length, 2);
+    } finally {
+      console.warn = originalWarn;
+      console.error = originalError;
+    }
+  });
+});
+
+describe("Rate Limiter Fallback (sweep and memory)", () => {
+  let previousRedisUrl: string | undefined;
+
+  beforeEach(() => {
+    previousRedisUrl = process.env.REDIS_URL;
+    delete process.env.REDIS_URL;
+    _redisTestHooks.reset();
+    _fallbackLimiterTestHooks.reset();
+    _rateLimitTestHooks.resetDegradationState();
+  });
+
+  afterEach(() => {
+    _redisTestHooks.reset();
+    _fallbackLimiterTestHooks.reset();
+    _rateLimitTestHooks.resetDegradationState();
+    if (previousRedisUrl === undefined) {
+      delete process.env.REDIS_URL;
+    } else {
+      process.env.REDIS_URL = previousRedisUrl;
+    }
+  });
+
+  it("sweeps expired entries after the window passes", async () => {
+    // Use a very short window so we can test expiry without real waiting.
+    // The sweep interval is 30s, but we can test that check() filters
+    // expired timestamps for the current key.
+    const request = makeRequest("10.0.0.70");
+    const options = { windowMs: 100, maxRequests: 1, keyPrefix: "sweep-test" };
+
+    // Fill the bucket.
+    assert.deepStrictEqual(await rateLimit(request, options), { allowed: true });
+
+    // Immediately, second request should be blocked.
+    assert.equal((await rateLimit(request, options)).allowed, false);
+
+    // After the window expires (wait 150ms), the entry should be filtered
+    // and the request allowed again.
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    assert.deepStrictEqual(await rateLimit(request, options), { allowed: true });
+  });
+
+  it("denies unknown keys instead of evicting active buckets at capacity", () => {
+    const now = Date.now();
+
+    // Fill with entries using distinct keys.
+    for (let i = 0; i < _fallbackLimiterTestHooks.capacity; i++) {
+      fallbackLimiter.check(`key-${i}`, 60_000, 100, now + i);
+    }
+    assert.equal(_fallbackLimiterTestHooks.size, _fallbackLimiterTestHooks.capacity);
+
+    // A new key is denied while every stored bucket is still active.
+    assert.equal(
+      fallbackLimiter.check("key-new", 60_000, 100, now + 20_000),
+      "capacity-saturated"
+    );
+    assert.equal(_fallbackLimiterTestHooks.size, _fallbackLimiterTestHooks.capacity);
+
+    // The oldest active bucket was not evicted or reset.
+    assert.equal(
+      fallbackLimiter.check("key-0", 60_000, 1, now + 20_001),
+      "limit-exceeded"
+    );
+  });
+
+  it("applies the current window when a key's configuration changes", () => {
+    const now = Date.now();
+
+    assert.equal(
+      fallbackLimiter.check("changing-window", 10_000, 1, now),
+      "allowed"
+    );
+    assert.equal(
+      fallbackLimiter.check("changing-window", 100, 1, now + 1_000),
+      "allowed"
+    );
+  });
+
+  it("sweeps each entry using that entry's configured window", () => {
+    const now = Date.now();
+
+    fallbackLimiter.check("short-window", 1_000, 5, now);
+    fallbackLimiter.check("long-window", 60_000, 5, now);
+    fallbackLimiter.check("sweep-trigger", 60_000, 5, now + 31_000);
+
+    assert.equal(_fallbackLimiterTestHooks.size, 2);
+  });
+
+  it("blocks immediately when maxRequests is zero", () => {
+    assert.equal(
+      fallbackLimiter.check("zero-limit", 60_000, 0, Date.now()),
+      "limit-exceeded"
+    );
+  });
+});

--- a/src/__tests__/rate-limit-redis-integration.test.ts
+++ b/src/__tests__/rate-limit-redis-integration.test.ts
@@ -1,0 +1,73 @@
+import { after, before, describe, it } from "node:test";
+import assert from "assert";
+import Redis from "ioredis";
+import { checkRedisRateLimit } from "@/lib/rate-limit-redis";
+
+const redisUrl = process.env.REDIS_URL;
+
+describe("Redis rate limiter integration", { skip: !redisUrl }, () => {
+  let firstClient: Redis;
+  let secondClient: Redis;
+  const keys = new Set<string>();
+
+  before(async () => {
+    firstClient = new Redis(redisUrl!, { lazyConnect: true });
+    secondClient = new Redis(redisUrl!, { lazyConnect: true });
+    await Promise.all([firstClient.connect(), secondClient.connect()]);
+  });
+
+  after(async () => {
+    if (keys.size > 0) {
+      await firstClient.del(...keys);
+    }
+    firstClient.disconnect();
+    secondClient.disconnect();
+  });
+
+  it("admits exactly the shared limit across concurrent Redis clients", async () => {
+    const key = `test:ratelimit:atomic:${crypto.randomUUID()}`;
+    keys.add(key);
+    const now = Date.now();
+
+    const decisions = await Promise.all(
+      Array.from({ length: 20 }, (_, index) =>
+        checkRedisRateLimit(index % 2 === 0 ? firstClient : secondClient, {
+          key,
+          windowMs: 60_000,
+          maxRequests: 5,
+          now,
+          member: `${now}:${index}`,
+        })
+      )
+    );
+
+    assert.equal(decisions.filter(Boolean).length, 5);
+    assert.equal(decisions.filter((decision) => decision === false).length, 15);
+  });
+
+  it("releases a request exactly at the sliding-window boundary", async () => {
+    const key = `test:ratelimit:boundary:${crypto.randomUUID()}`;
+    keys.add(key);
+
+    assert.equal(
+      await checkRedisRateLimit(firstClient, {
+        key,
+        windowMs: 1_000,
+        maxRequests: 1,
+        now: 10_000,
+        member: "first",
+      }),
+      true
+    );
+    assert.equal(
+      await checkRedisRateLimit(secondClient, {
+        key,
+        windowMs: 1_000,
+        maxRequests: 1,
+        now: 11_000,
+        member: "boundary",
+      }),
+      true
+    );
+  });
+});

--- a/src/__tests__/rate-limit.test.ts
+++ b/src/__tests__/rate-limit.test.ts
@@ -189,6 +189,8 @@ describe("Redis Rate Limiter", () => {
     try {
       const degraded = await rateLimit(makeRequest("10.0.0.9"), options);
       assert.equal(degraded.allowed, false);
+      // Verify no new entry was added on capacity-saturated denial.
+      assert.equal(_fallbackLimiterTestHooks.size, _fallbackLimiterTestHooks.capacity);
     } finally {
       if (previousRedisUrl === undefined) {
         delete process.env.REDIS_URL;

--- a/src/__tests__/rate-limit.test.ts
+++ b/src/__tests__/rate-limit.test.ts
@@ -262,7 +262,7 @@ describe("Redis Rate Limiter", () => {
       assert.deepStrictEqual(recovered, { allowed: true });
 
       // Phase 4: A second degradation cycle begins. The warning should fire
-      // again because markRedisHealthy cleared redisDegraded in phase 3.
+      // again because markRedisResponded reset the degradation flags in phase 3.
       fakeRedis.status = "end";
       const degradedAgain = await rateLimit(request, options);
       // Local guard has 1 timestamp (from phase 3), so this is allowed.

--- a/src/__tests__/rate-limit.test.ts
+++ b/src/__tests__/rate-limit.test.ts
@@ -278,6 +278,44 @@ describe("Redis Rate Limiter", () => {
       }
     }
   });
+
+  it("correctly rolls back duplicate timestamps from a same-ms burst", async () => {
+    // Simulate a burst where multiple requests share the same Date.now()
+    // value, Redis admits only some, and the rest must be rolled back
+    // using indexOf on duplicate timestamps.
+    const ip = "10.0.0.16";
+    const keyPrefix = "dup-rollback";
+    const options = { windowMs: 60_000, maxRequests: 5, keyPrefix };
+    const request = makeRequest(ip);
+
+    // Issue 3 concurrent requests (same event-loop tick → likely same ms).
+    // Redis (fake) admits all 3 since maxRequests=5 and bucket starts empty.
+    const results = await Promise.all([
+      rateLimit(request, options),
+      rateLimit(request, options),
+      rateLimit(request, options),
+    ]);
+    assert.equal(results.filter((r) => r.allowed).length, 3);
+
+    // Issue 3 more concurrent requests. Redis admits 2 more (total 5 = max),
+    // rejects 1. The rejected one must roll back its local timestamp.
+    const results2 = await Promise.all([
+      rateLimit(request, options),
+      rateLimit(request, options),
+      rateLimit(request, options),
+    ]);
+    const admitted2 = results2.filter((r) => r.allowed).length;
+    const rejected2 = results2.filter((r) => !r.allowed).length;
+    assert.equal(admitted2, 2);
+    assert.equal(rejected2, 1);
+
+    // At this point, 5 requests are in the local fallback map (all admitted).
+    // The 6th request that was rejected by Redis had its timestamp rolled back.
+    // Verify the bucket is exactly at capacity (5/5) by checking that the
+    // next request is blocked by the local guard without touching Redis.
+    const blocked = await rateLimit(request, options);
+    assert.equal(blocked.allowed, false);
+  });
 });
 
 describe("Rate Limiter Edge Cases", () => {

--- a/src/__tests__/rate-limit.test.ts
+++ b/src/__tests__/rate-limit.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, beforeEach, afterEach } from "node:test";
 import assert from "assert";
-import { rateLimit } from "@/lib/rate-limit";
+import { rateLimit, _rateLimitTestHooks } from "@/lib/rate-limit";
+import {
+  fallbackLimiter,
+  _fallbackLimiterTestHooks,
+} from "@/lib/rate-limit-fallback";
 import { _redisTestHooks } from "@/lib/cache/redis";
 import { NextRequest } from "next/server";
 import { FakeRedisClient } from "./_helpers/fake-redis";
@@ -17,10 +21,14 @@ describe("Redis Rate Limiter", () => {
   beforeEach(() => {
     fakeRedis = new FakeRedisClient();
     _redisTestHooks.setClientForTesting(fakeRedis as never);
+    _fallbackLimiterTestHooks.reset();
+    _rateLimitTestHooks.resetDegradationState();
   });
 
   afterEach(() => {
     _redisTestHooks.reset();
+    _fallbackLimiterTestHooks.reset();
+    _rateLimitTestHooks.resetDegradationState();
   });
 
   it("allows requests within limit", async () => {
@@ -84,30 +92,189 @@ describe("Redis Rate Limiter", () => {
     assert.deepStrictEqual(result, { allowed: true });
   });
 
-  it("falls back to allowing when Redis client is unavailable", async () => {
-    // Simulate Redis not configured by passing null-like state
-    const request = makeRequest("10.0.0.6");
+  it("hashes invalid proxy identifiers before storing rate-limit keys", async () => {
+    const maliciousIdentifier = "x".repeat(12_000);
+    const request = makeRequest(maliciousIdentifier);
 
-    // With a disconnected client, should fail open (allow)
-    fakeRedis.status = "end";
-    const result = await rateLimit(request, { windowMs: 60_000, maxRequests: 1, keyPrefix: "test-failopen" });
-    assert.deepStrictEqual(result, { allowed: true });
+    assert.deepStrictEqual(
+      await rateLimit(request, {
+        windowMs: 60_000,
+        maxRequests: 5,
+        keyPrefix: "bounded-identifier",
+      }),
+      { allowed: true }
+    );
+
+    assert.equal(fakeRedis.evalKeys.length, 1);
+    assert.equal(fakeRedis.evalKeys[0].includes(maliciousIdentifier), false);
+    assert.ok(fakeRedis.evalKeys[0].length < 128);
   });
 
-  it("falls back to allowing when Redis URL is not set", async () => {
+  it("falls back to in-process limiter when Redis client is unavailable", async () => {
+    // Simulate Redis not configured by passing null-like state
+    const request = makeRequest("10.0.0.6");
+    const previousRedisUrl = process.env.REDIS_URL;
+
+    // With a disconnected client, the in-process fallback kicks in.
+    // First request should be allowed (bucket empty), second blocked.
+    _fallbackLimiterTestHooks.reset();
+    _rateLimitTestHooks.resetDegradationState();
+    delete process.env.REDIS_URL;
+    fakeRedis.status = "end";
+    try {
+      const result1 = await rateLimit(request, { windowMs: 60_000, maxRequests: 1, keyPrefix: "test-failopen" });
+      assert.deepStrictEqual(result1, { allowed: true });
+
+      const result2 = await rateLimit(request, { windowMs: 60_000, maxRequests: 1, keyPrefix: "test-failopen" });
+      assert.equal(result2.allowed, false);
+    } finally {
+      if (previousRedisUrl === undefined) {
+        delete process.env.REDIS_URL;
+      } else {
+        process.env.REDIS_URL = previousRedisUrl;
+      }
+    }
+  });
+
+  it("falls back to in-process limiter when Redis URL is not set", async () => {
     const previousRedisUrl = process.env.REDIS_URL;
     delete process.env.REDIS_URL;
     _redisTestHooks.reset();
+    _fallbackLimiterTestHooks.reset();
+    _rateLimitTestHooks.resetDegradationState();
 
     const request = makeRequest("10.0.0.7");
-    const result = await rateLimit(request, { windowMs: 60_000, maxRequests: 1, keyPrefix: "test-noredis" });
-
-    if (previousRedisUrl !== undefined) {
-      process.env.REDIS_URL = previousRedisUrl;
+    let result: Awaited<ReturnType<typeof rateLimit>>;
+    try {
+      result = await rateLimit(request, {
+        windowMs: 60_000,
+        maxRequests: 1,
+        keyPrefix: "test-noredis",
+      });
+    } finally {
+      if (previousRedisUrl === undefined) {
+        delete process.env.REDIS_URL;
+      } else {
+        process.env.REDIS_URL = previousRedisUrl;
+      }
+      _redisTestHooks.reset();
     }
-    _redisTestHooks.reset();
 
+    // First request is allowed (bucket empty in fallback).
     assert.deepStrictEqual(result, { allowed: true });
+  });
+
+  it("uses healthy Redis at local capacity but fails closed if Redis is down", async () => {
+    const now = Date.now();
+    for (let i = 0; i < _fallbackLimiterTestHooks.capacity; i++) {
+      assert.equal(
+        fallbackLimiter.check(`capacity-${i}`, 60_000, 10, now),
+        "allowed"
+      );
+    }
+
+    const options = {
+      windowMs: 60_000,
+      maxRequests: 10,
+      keyPrefix: "capacity-fallback",
+    };
+    assert.deepStrictEqual(
+      await rateLimit(makeRequest("10.0.0.8"), options),
+      { allowed: true }
+    );
+
+    const previousRedisUrl = process.env.REDIS_URL;
+    delete process.env.REDIS_URL;
+    fakeRedis.status = "end";
+    try {
+      const degraded = await rateLimit(makeRequest("10.0.0.9"), options);
+      assert.equal(degraded.allowed, false);
+    } finally {
+      if (previousRedisUrl === undefined) {
+        delete process.env.REDIS_URL;
+      } else {
+        process.env.REDIS_URL = previousRedisUrl;
+      }
+    }
+  });
+
+  it("rolls back the warmed local entry when Redis rejects the request", async () => {
+    const ip = "10.0.0.14";
+    const keyPrefix = "rollback-on-redis-reject";
+    const key = `ratelimit:${keyPrefix}:${ip}`;
+    const now = Date.now();
+    fakeRedis.status = "ready";
+    fakeRedis.zadd(key, now, "other-instance-request");
+
+    const options = { windowMs: 60_000, maxRequests: 1, keyPrefix };
+    const rejected = await rateLimit(makeRequest(ip), options);
+    assert.equal(rejected.allowed, false);
+
+    const previousRedisUrl = process.env.REDIS_URL;
+    delete process.env.REDIS_URL;
+    fakeRedis.status = "end";
+    try {
+      assert.deepStrictEqual(await rateLimit(makeRequest(ip), options), {
+        allowed: true,
+      });
+    } finally {
+      if (previousRedisUrl === undefined) {
+        delete process.env.REDIS_URL;
+      } else {
+        process.env.REDIS_URL = previousRedisUrl;
+      }
+    }
+  });
+
+  it("survives a full healthy → degraded → healthy → degraded transition cycle", async () => {
+    const ip = "10.0.0.15";
+    const options = { windowMs: 60_000, maxRequests: 2, keyPrefix: "lifecycle" };
+    const request = makeRequest(ip);
+    const previousRedisUrl = process.env.REDIS_URL;
+
+    try {
+      // Phase 1: Redis healthy — requests go through Redis path.
+      assert.deepStrictEqual(await rateLimit(request, options), { allowed: true });
+      assert.deepStrictEqual(await rateLimit(request, options), { allowed: true });
+      // Third request: local guard (2/2) blocks before Redis is consulted.
+      const blocked = await rateLimit(request, options);
+      assert.equal(blocked.allowed, false);
+
+      // Phase 2: Redis goes down — fallback limiter is already warm from phase 1.
+      // The local map holds 2 timestamps for this key, so the next request is
+      // denied by the local guard without touching Redis.
+      fakeRedis.status = "end";
+      const degraded = await rateLimit(request, options);
+      assert.equal(degraded.allowed, false);
+
+      // Phase 3: Redis recovers.  Simulate windowMs elapsing by resetting
+      // both the in-process fallback (stale local timestamps) and the
+      // FakeRedis sorted set (stale Redis-side timestamps).  In production
+      // this happens naturally when windowMs seconds pass.
+      fakeRedis.status = "ready";
+      _fallbackLimiterTestHooks.reset();
+      // Swap in a fresh FakeRedis so Phase 1's ZSET entries are gone.
+      fakeRedis = new FakeRedisClient();
+      _redisTestHooks.setClientForTesting(fakeRedis as never);
+      const recovered = await rateLimit(request, options);
+      assert.deepStrictEqual(recovered, { allowed: true });
+
+      // Phase 4: A second degradation cycle begins. The warning should fire
+      // again because markRedisHealthy cleared redisDegraded in phase 3.
+      fakeRedis.status = "end";
+      const degradedAgain = await rateLimit(request, options);
+      // Local guard has 1 timestamp (from phase 3), so this is allowed.
+      assert.deepStrictEqual(degradedAgain, { allowed: true });
+      // One more request should be blocked by the local guard (2/2).
+      const blocked2 = await rateLimit(request, options);
+      assert.equal(blocked2.allowed, false);
+    } finally {
+      if (previousRedisUrl === undefined) {
+        delete process.env.REDIS_URL;
+      } else {
+        process.env.REDIS_URL = previousRedisUrl;
+      }
+    }
   });
 });
 
@@ -117,10 +284,14 @@ describe("Rate Limiter Edge Cases", () => {
   beforeEach(() => {
     fakeRedis = new FakeRedisClient();
     _redisTestHooks.setClientForTesting(fakeRedis as never);
+    _fallbackLimiterTestHooks.reset();
+    _rateLimitTestHooks.resetDegradationState();
   });
 
   afterEach(() => {
     _redisTestHooks.reset();
+    _fallbackLimiterTestHooks.reset();
+    _rateLimitTestHooks.resetDegradationState();
   });
 
   it("returns correct error message on rate limit", async () => {
@@ -136,15 +307,16 @@ describe("Rate Limiter Edge Cases", () => {
     }
   });
 
-  it("handles concurrent requests from same IP", async () => {
+  it("enforces the local guard across concurrent requests from the same IP", async () => {
     const request = makeRequest("10.0.0.11");
-    const options = { windowMs: 60_000, maxRequests: 100, keyPrefix: "test-concurrent" };
+    const options = { windowMs: 60_000, maxRequests: 10, keyPrefix: "test-concurrent" };
 
-    // Simulate burst of requests
-    for (let i = 0; i < 50; i++) {
-      const result = await rateLimit(request, options);
-      assert.equal(result.allowed, true);
-    }
+    const results = await Promise.all(
+      Array.from({ length: 50 }, () => rateLimit(request, options))
+    );
+
+    assert.equal(results.filter((result) => result.allowed).length, 10);
+    assert.equal(results.filter((result) => !result.allowed).length, 40);
   });
 
   it("shares the first Redis connection attempt across a lazy-client burst", async () => {
@@ -166,9 +338,10 @@ describe("Rate Limiter Edge Cases", () => {
     }
   });
 
-  it("falls open and suppresses immediate retries when the lazy Redis connect fails", async () => {
+  it("falls back to in-process limiter and suppresses immediate retries when the lazy Redis connect fails", async () => {
     const failingRedis = new FakeRedisClient({ rejectConnect: true });
     _redisTestHooks.setClientForTesting(failingRedis as never);
+    _fallbackLimiterTestHooks.reset();
 
     const request = makeRequest("10.0.0.13");
     const options = { windowMs: 60_000, maxRequests: 1, keyPrefix: "test-lazy-fail" };
@@ -180,8 +353,14 @@ describe("Rate Limiter Edge Cases", () => {
     };
 
     try {
+      // First request: Redis connect fails, fallback limiter allows (bucket empty).
       assert.deepStrictEqual(await rateLimit(request, options), { allowed: true });
-      assert.deepStrictEqual(await rateLimit(request, options), { allowed: true });
+      // Second request: Redis on cooldown, fallback limiter blocks (bucket full).
+      const result2 = await rateLimit(request, options);
+      assert.equal(result2.allowed, false);
+      if (!result2.allowed) {
+        assert.equal(result2.response.status, 429);
+      }
       assert.equal(failingRedis.connectCalls, 1);
       // The second call should short-circuit on the reconnect cooldown instead
       // of attempting, and logging, another failed Redis connection.

--- a/src/__tests__/rate-limit.test.ts
+++ b/src/__tests__/rate-limit.test.ts
@@ -279,42 +279,47 @@ describe("Redis Rate Limiter", () => {
     }
   });
 
-  it("correctly rolls back duplicate timestamps from a same-ms burst", async () => {
-    // Simulate a burst where multiple requests share the same Date.now()
-    // value, Redis admits only some, and the rest must be rolled back
-    // using indexOf on duplicate timestamps.
+  it("correctly rolls back duplicate timestamps when Redis rejects under same-ms burst", async () => {
+    // Construct a scenario where the local guard ADMITS but Redis REJECTS,
+    // forcing the rollback path to run on duplicate timestamps.
+    //
+    // Strategy: use a FakeRedisClient that always rejects (pre-filled to
+    // capacity) so every rateLimit call passes the local guard but is
+    // denied by Redis, triggering rollback of duplicate timestamps.
     const ip = "10.0.0.16";
-    const keyPrefix = "dup-rollback";
-    const options = { windowMs: 60_000, maxRequests: 5, keyPrefix };
+    const keyPrefix = "dup-rollback-redis-reject";
+    const redisKey = `ratelimit:${keyPrefix}:${ip}`;
+    const options = { windowMs: 60_000, maxRequests: 10, keyPrefix };
     const request = makeRequest(ip);
 
-    // Issue 3 concurrent requests (same event-loop tick → likely same ms).
-    // Redis (fake) admits all 3 since maxRequests=5 and bucket starts empty.
-    const results = await Promise.all([
-      rateLimit(request, options),
-      rateLimit(request, options),
-      rateLimit(request, options),
-    ]);
-    assert.equal(results.filter((r) => r.allowed).length, 3);
+    // Pre-fill Redis to capacity so every eval returns 0 (denied).
+    const now = Date.now();
+    fakeRedis.status = "ready";
+    fakeRedis.zadd(redisKey, now, "blocker"); // 1 entry, but maxRequests=10
+    // Fill to exactly maxRequests so eval denies.
+    for (let i = 1; i < 10; i++) {
+      fakeRedis.zadd(redisKey, now - i, `pre-existing-${i}`);
+    }
 
-    // Issue 3 more concurrent requests. Redis admits 2 more (total 5 = max),
-    // rejects 1. The rejected one must roll back its local timestamp.
-    const results2 = await Promise.all([
-      rateLimit(request, options),
-      rateLimit(request, options),
-      rateLimit(request, options),
-    ]);
-    const admitted2 = results2.filter((r) => r.allowed).length;
-    const rejected2 = results2.filter((r) => !r.allowed).length;
-    assert.equal(admitted2, 2);
-    assert.equal(rejected2, 1);
+    // Single request that passes local guard but Redis denies → rollback.
+    const result = await rateLimit(request, options);
+    assert.equal(result.allowed, false, "Redis should deny (at capacity)");
 
-    // At this point, 5 requests are in the local fallback map (all admitted).
-    // The 6th request that was rejected by Redis had its timestamp rolled back.
-    // Verify the bucket is exactly at capacity (5/5) by checking that the
-    // next request is blocked by the local guard without touching Redis.
-    const blocked = await rateLimit(request, options);
-    assert.equal(blocked.allowed, false);
+    // The rollback should have removed the local timestamp.
+    // Verify by turning Redis off and checking local guard allows (empty bucket).
+    const previousRedisUrl = process.env.REDIS_URL;
+    delete process.env.REDIS_URL;
+    fakeRedis.status = "end";
+    try {
+      const recovered = await rateLimit(request, options);
+      assert.deepStrictEqual(recovered, { allowed: true });
+    } finally {
+      if (previousRedisUrl === undefined) {
+        delete process.env.REDIS_URL;
+      } else {
+        process.env.REDIS_URL = previousRedisUrl;
+      }
+    }
   });
 });
 

--- a/src/lib/rate-limit-fallback.ts
+++ b/src/lib/rate-limit-fallback.ts
@@ -11,6 +11,19 @@
  * - Conservative: same windowMs and maxRequests as the Redis path.
  * - Intentionally simple — this is a defense-in-depth last resort, not a
  *   replacement for the Redis-backed limiter.
+ *
+ * Sweep & memory:
+ * - Expired entries are reclaimed lazily on the first request after the 30s
+ *   sweep boundary, or whenever the bucket cap forces evaluation.
+ * - Worst-case memory: MAX_ENTRIES (10 000) × maxRequests × 8 bytes ≈ 5 MB.
+ *
+ * Window-change semantics:
+ * - If a key is reused across routes with different `windowMs` values, the
+ *   latest call's `windowMs` is treated as authoritative and stored
+ *   timestamps are retroactively filtered under the new window. This is an
+ *   explicit design choice: in production each route uses a distinct
+ *   `keyPrefix`, so cross-route key reuse does not occur. If key reuse
+ *   across windows is ever introduced, consider splitting the key namespace.
  */
 
 interface FallbackEntry {
@@ -80,7 +93,7 @@ class InProcessRateLimiter {
     const entry = this.entries.get(key);
     if (!entry) return;
 
-    const index = entry.timestamps.lastIndexOf(timestamp);
+    const index = entry.timestamps.indexOf(timestamp);
     if (index === -1) return;
 
     entry.timestamps.splice(index, 1);

--- a/src/lib/rate-limit-fallback.ts
+++ b/src/lib/rate-limit-fallback.ts
@@ -1,0 +1,151 @@
+/**
+ * In-process sliding-window fallback for rate limiting when Redis is unavailable.
+ *
+ * Design:
+ * - Sliding-window counter per client+prefix key, mirroring the Redis ZSET approach.
+ * - Kept warm on every request so Redis outages do not reset the allowance.
+ * - Stored in a Map with periodic pruning to prevent unbounded memory growth.
+ * - Hard cap on entry count to bound memory under IP-rotation attacks. When
+ *   saturated with live entries, unknown keys are denied instead of evicting
+ *   active buckets and reopening their allowance.
+ * - Conservative: same windowMs and maxRequests as the Redis path.
+ * - Intentionally simple — this is a defense-in-depth last resort, not a
+ *   replacement for the Redis-backed limiter.
+ */
+
+interface FallbackEntry {
+  /** Timestamps of requests within the current window (ms since epoch). */
+  timestamps: number[];
+  /** The windowMs this entry was created with, used for correct sweep filtering. */
+  windowMs: number;
+}
+
+export type FallbackDecision =
+  | "allowed"
+  | "limit-exceeded"
+  | "capacity-saturated";
+
+const MIN_SWEEP_INTERVAL_MS = 30_000;
+const MAX_ENTRIES = 10_000;
+
+class InProcessRateLimiter {
+  private readonly entries = new Map<string, FallbackEntry>();
+  private lastSweep = Date.now();
+
+  /**
+   * Check whether a request should be allowed under the in-process fallback.
+   * Mutates state by recording the request timestamp when allowed.
+   */
+  check(
+    key: string,
+    windowMs: number,
+    maxRequests: number,
+    now: number
+  ): FallbackDecision {
+    this.maybeSweep(now);
+
+    const entry = this.entries.get(key);
+
+    if (entry) {
+      // The current call is authoritative if a route changes its configured
+      // window. This mirrors Redis's use of the current windowStart value.
+      entry.timestamps = entry.timestamps.filter((t) => t > now - windowMs);
+      entry.windowMs = windowMs;
+    }
+
+    const currentCount = entry?.timestamps.length ?? 0;
+
+    if (currentCount >= maxRequests) {
+      return "limit-exceeded";
+    }
+
+    // Record this request.
+    if (entry) {
+      entry.timestamps.push(now);
+    } else {
+      // maybeSweep() already performs bounded-frequency reclamation. If the
+      // map is still saturated, deny the unknown key: rescanning on every new
+      // key would create a CPU DoS, while eviction would reset active buckets.
+      if (this.entries.size >= MAX_ENTRIES) {
+        return "capacity-saturated";
+      }
+      this.entries.set(key, { timestamps: [now], windowMs });
+    }
+
+    return "allowed";
+  }
+
+  /** Remove the request recorded during warm-up when healthy Redis rejects it. */
+  rollback(key: string, timestamp: number): void {
+    const entry = this.entries.get(key);
+    if (!entry) return;
+
+    const index = entry.timestamps.lastIndexOf(timestamp);
+    if (index === -1) return;
+
+    entry.timestamps.splice(index, 1);
+    if (entry.timestamps.length === 0) {
+      this.entries.delete(key);
+    }
+  }
+
+  /** Remove fully-expired entries to bound memory. Called at most every 30 s. */
+  private maybeSweep(now: number): void {
+    if (now - this.lastSweep < MIN_SWEEP_INTERVAL_MS) return;
+    this.lastSweep = now;
+
+    this.sweepExpired(now);
+  }
+
+  private sweepExpired(now: number): void {
+    for (const [key, entry] of this.entries) {
+      const alive = entry.timestamps.filter((t) => t > now - entry.windowMs);
+      if (alive.length === 0) {
+        this.entries.delete(key);
+      } else {
+        entry.timestamps = alive;
+      }
+    }
+  }
+
+  /** Test-only: reset internal state. */
+  reset(): void {
+    this.entries.clear();
+    this.lastSweep = Date.now();
+  }
+
+  /** Test-only: current entry count. */
+  get size(): number {
+    return this.entries.size;
+  }
+}
+
+const inProcessRateLimiter = new InProcessRateLimiter();
+
+/** Production surface: only request accounting is exposed. */
+export const fallbackLimiter = {
+  check(
+    key: string,
+    windowMs: number,
+    maxRequests: number,
+    now: number
+  ): FallbackDecision {
+    return inProcessRateLimiter.check(key, windowMs, maxRequests, now);
+  },
+  rollback(key: string, timestamp: number): void {
+    inProcessRateLimiter.rollback(key, timestamp);
+  },
+};
+
+/** Test-only inspection hooks, matching the Redis module's convention. */
+export const _fallbackLimiterTestHooks = {
+  reset(): void {
+    inProcessRateLimiter.reset();
+  },
+  get size(): number {
+    return inProcessRateLimiter.size;
+  },
+  get capacity(): number {
+    return MAX_ENTRIES;
+  },
+};

--- a/src/lib/rate-limit-fallback.ts
+++ b/src/lib/rate-limit-fallback.ts
@@ -60,8 +60,7 @@ class InProcessRateLimiter {
     const entry = this.entries.get(key);
 
     if (entry) {
-      // The current call is authoritative if a route changes its configured
-      // window. This mirrors Redis's use of the current windowStart value.
+      // Apply the current call's window. See file header for rationale.
       entry.timestamps = entry.timestamps.filter((t) => t > now - windowMs);
       entry.windowMs = windowMs;
     }

--- a/src/lib/rate-limit-redis.ts
+++ b/src/lib/rate-limit-redis.ts
@@ -8,8 +8,11 @@ interface RedisRateLimitOptions {
   member?: string;
 }
 
-/** Grace period (seconds) added to the computed TTL to prevent edge-case
- *  races where the key expires between ZADD and EXPIRE. */
+/** Grace period (seconds) added to the TTL so the EXPIRE window always
+ *  strictly exceeds `windowMs`. `Math.ceil(windowMs / 1000)` can equal the
+ *  window's effective lifetime to-the-second (e.g. 60 000 ms → 60 s), and
+ *  Redis EXPIRE rounds to the second, so without +1 the key could expire
+ *  the instant the oldest in-window entry becomes queryable-out-of-window. */
 const TTL_GRACE_SECONDS = 1;
 
 // Redis executes Lua scripts atomically, so concurrent app instances cannot
@@ -49,5 +52,6 @@ export async function checkRedisRateLimit(
 
   if (result === 1 || result === "1") return true;
   if (result === 0 || result === "0") return false;
+  console.warn("[rate-limit-redis] Unexpected script result", { key: options.key, result });
   return null;
 }

--- a/src/lib/rate-limit-redis.ts
+++ b/src/lib/rate-limit-redis.ts
@@ -8,6 +8,10 @@ interface RedisRateLimitOptions {
   member?: string;
 }
 
+/** Grace period (seconds) added to the computed TTL to prevent edge-case
+ *  races where the key expires between ZADD and EXPIRE. */
+const TTL_GRACE_SECONDS = 1;
+
 // Redis executes Lua scripts atomically, so concurrent app instances cannot
 // both observe the same pre-limit count and over-admit requests.
 const REDIS_RATE_LIMIT_SCRIPT = `
@@ -40,7 +44,7 @@ export async function checkRedisRateLimit(
     options.now,
     options.maxRequests,
     options.member ?? `${options.now}:${crypto.randomUUID()}`,
-    Math.ceil(options.windowMs / 1000) + 1
+    Math.ceil(options.windowMs / 1000) + TTL_GRACE_SECONDS
   );
 
   if (result === 1 || result === "1") return true;

--- a/src/lib/rate-limit-redis.ts
+++ b/src/lib/rate-limit-redis.ts
@@ -1,0 +1,49 @@
+import type Redis from "ioredis";
+
+interface RedisRateLimitOptions {
+  key: string;
+  windowMs: number;
+  maxRequests: number;
+  now: number;
+  member?: string;
+}
+
+// Redis executes Lua scripts atomically, so concurrent app instances cannot
+// both observe the same pre-limit count and over-admit requests.
+const REDIS_RATE_LIMIT_SCRIPT = `
+redis.call("ZREMRANGEBYSCORE", KEYS[1], "-inf", ARGV[1])
+local count = redis.call("ZCARD", KEYS[1])
+
+if count >= tonumber(ARGV[3]) then
+  return 0
+end
+
+redis.call("ZADD", KEYS[1], ARGV[2], ARGV[4])
+redis.call("EXPIRE", KEYS[1], ARGV[5])
+return 1
+`;
+
+/**
+ * Atomically prune, count, and conditionally record a request in Redis.
+ * Returns null for an unexpected Redis response so the caller can use its
+ * already-warmed in-process fallback rather than trusting malformed state.
+ */
+export async function checkRedisRateLimit(
+  redis: Pick<Redis, "eval">,
+  options: RedisRateLimitOptions
+): Promise<boolean | null> {
+  const result = await redis.eval(
+    REDIS_RATE_LIMIT_SCRIPT,
+    1,
+    options.key,
+    options.now - options.windowMs,
+    options.now,
+    options.maxRequests,
+    options.member ?? `${options.now}:${crypto.randomUUID()}`,
+    Math.ceil(options.windowMs / 1000) + 1
+  );
+
+  if (result === 1 || result === "1") return true;
+  if (result === 0 || result === "0") return false;
+  return null;
+}

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -34,16 +34,22 @@ function getClientIdentifier(request: NextRequest): string {
 }
 
 let redisDegraded = false;
+let outageWarningLogged = false;
+let firstErrorLogged = false;
 
 function warnFallbackEngaged(reason: string, error?: unknown): void {
-  if (!redisDegraded) {
-    if (error !== undefined) {
-      console.error("Rate limiter error:", error);
-    }
+  if (!outageWarningLogged) {
     console.warn(
       `[rate-limit] Redis unavailable (${reason}); relying on in-process limiter. ` +
         "Rate limiting will be per-process, not shared across instances."
     );
+    outageWarningLogged = true;
+  }
+  // Always log the first error of each degradation window, even if the
+  // banner was already printed via a no-error path.
+  if (error !== undefined && !firstErrorLogged) {
+    console.error("Rate limiter error:", error);
+    firstErrorLogged = true;
   }
   redisDegraded = true;
 }
@@ -56,6 +62,8 @@ function markRedisHealthy(): void {
   // the Map on recovery) would briefly allow every client to exceed the shared
   // limit at the recovery boundary.
   redisDegraded = false;
+  outageWarningLogged = false;
+  firstErrorLogged = false;
 }
 
 function rateLimitExceeded(): { allowed: false; response: NextResponse } {
@@ -134,5 +142,7 @@ export async function rateLimit(
 export const _rateLimitTestHooks = {
   resetDegradationState(): void {
     redisDegraded = false;
+    outageWarningLogged = false;
+    firstErrorLogged = false;
   },
 };

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,6 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
+import { createHash } from "node:crypto";
+import { isIP } from "node:net";
 import { apiError } from "@/lib/api/errors";
 import { getReadyRedisClient } from "@/lib/cache/redis";
+import {
+  fallbackLimiter,
+  type FallbackDecision,
+} from "@/lib/rate-limit-fallback";
+import { checkRedisRateLimit } from "@/lib/rate-limit-redis";
 
 interface RateLimitOptions {
   windowMs: number;
@@ -9,12 +16,63 @@ interface RateLimitOptions {
 }
 
 function getClientIdentifier(request: NextRequest): string {
-  return (
+  const rawIdentifier = (
     request.headers.get("x-real-ip") ??
     request.headers.get("cf-connecting-ip") ??
     request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
     "unknown"
-  );
+  ).trim();
+
+  if (!rawIdentifier) return "unknown";
+  if (isIP(rawIdentifier)) return rawIdentifier.toLowerCase();
+
+  // Proxy headers are untrusted. Hash invalid values so a request cannot pin
+  // many kilobytes of attacker-controlled text in every fallback Map key.
+  return `invalid:${createHash("sha256")
+    .update(rawIdentifier)
+    .digest("base64url")}`;
+}
+
+let redisDegraded = false;
+
+function warnFallbackEngaged(reason: string, error?: unknown): void {
+  if (!redisDegraded) {
+    if (error !== undefined) {
+      console.error("Rate limiter error:", error);
+    }
+    console.warn(
+      `[rate-limit] Redis unavailable (${reason}); relying on in-process limiter. ` +
+        "Rate limiting will be per-process, not shared across instances."
+    );
+  }
+  redisDegraded = true;
+}
+
+function markRedisHealthy(): void {
+  // Note: the in-process fallback Map still holds timestamps accumulated during
+  // the outage.  For up to `windowMs` after recovery the local guard may deny
+  // requests that Redis would allow, because the stale local entries have not
+  // yet expired.  This is an acceptable trade-off: the alternative (clearing
+  // the Map on recovery) would briefly allow every client to exceed the shared
+  // limit at the recovery boundary.
+  redisDegraded = false;
+}
+
+function rateLimitExceeded(): { allowed: false; response: NextResponse } {
+  return {
+    allowed: false,
+    response: apiError("Too many requests", 429),
+  };
+}
+
+function degradedResult(
+  fallbackDecision: FallbackDecision
+): { allowed: true } | { allowed: false; response: NextResponse } {
+  // A saturated map cannot safely track a previously unseen key. Healthy
+  // Redis can still decide it, but during degradation we must fail closed.
+  return fallbackDecision === "capacity-saturated"
+    ? rateLimitExceeded()
+    : { allowed: true };
 }
 
 export async function rateLimit(
@@ -24,40 +82,57 @@ export async function rateLimit(
   const clientId = getClientIdentifier(request);
   const key = `ratelimit:${options.keyPrefix ?? "default"}:${clientId}`;
   const now = Date.now();
-  const windowStart = now - options.windowMs;
+  // Keep the fallback warm on every request. Redis remains the shared,
+  // cross-process authority; this local guard preserves recent request state
+  // if Redis becomes unavailable between two requests.
+  const fallbackDecision = fallbackLimiter.check(
+    key,
+    options.windowMs,
+    options.maxRequests,
+    now
+  );
+  if (fallbackDecision === "limit-exceeded") {
+    return rateLimitExceeded();
+  }
 
   const redis = await getReadyRedisClient();
 
   if (!redis) {
-    return { allowed: true };
+    warnFallbackEngaged("client not ready");
+    return degradedResult(fallbackDecision);
   }
 
   try {
-    const pipeline = redis.pipeline();
-    pipeline.zremrangebyscore(key, "-inf", windowStart.toString());
-    pipeline.zcard(key);
-    pipeline.zadd(key, now, `${now}:${crypto.randomUUID()}`);
-    pipeline.expire(key, Math.ceil(options.windowMs / 1000) + 1);
+    const redisAllowed = await checkRedisRateLimit(redis, {
+      key,
+      windowMs: options.windowMs,
+      maxRequests: options.maxRequests,
+      now,
+    });
 
-    const results = await pipeline.exec();
-    if (!results) {
-      return { allowed: true };
+    if (redisAllowed === null) {
+      warnFallbackEngaged("atomic check returned invalid result");
+      return degradedResult(fallbackDecision);
     }
 
-    // results[1] is [error, zcard result] — index 1 is the count from zcard
-    const countResult = results[1];
-    const count = (countResult[1] as number) ?? 0;
+    markRedisHealthy();
 
-    if (count >= options.maxRequests) {
-      return {
-        allowed: false,
-        response: apiError("Too many requests", 429),
-      };
+    if (!redisAllowed) {
+      if (fallbackDecision === "allowed") {
+        fallbackLimiter.rollback(key, now);
+      }
+      return rateLimitExceeded();
     }
 
     return { allowed: true };
   } catch (error) {
-    console.error("Rate limiter error:", error);
-    return { allowed: true };
+    warnFallbackEngaged("atomic check threw", error);
+    return degradedResult(fallbackDecision);
   }
 }
+
+export const _rateLimitTestHooks = {
+  resetDegradationState(): void {
+    redisDegraded = false;
+  },
+};

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -33,7 +33,6 @@ function getClientIdentifier(request: NextRequest): string {
     .digest("base64url")}`;
 }
 
-let redisDegraded = false;
 let outageWarningLogged = false;
 let firstErrorLogged = false;
 
@@ -51,17 +50,15 @@ function warnFallbackEngaged(reason: string, error?: unknown): void {
     console.error("Rate limiter error:", error);
     firstErrorLogged = true;
   }
-  redisDegraded = true;
 }
 
-function markRedisHealthy(): void {
+function markRedisResponded(): void {
   // Note: the in-process fallback Map still holds timestamps accumulated during
   // the outage.  For up to `windowMs` after recovery the local guard may deny
   // requests that Redis would allow, because the stale local entries have not
   // yet expired.  This is an acceptable trade-off: the alternative (clearing
   // the Map on recovery) would briefly allow every client to exceed the shared
   // limit at the recovery boundary.
-  redisDegraded = false;
   outageWarningLogged = false;
   firstErrorLogged = false;
 }
@@ -123,7 +120,7 @@ export async function rateLimit(
       return degradedResult(fallbackDecision);
     }
 
-    markRedisHealthy();
+    markRedisResponded();
 
     if (!redisAllowed) {
       if (fallbackDecision === "allowed") {
@@ -141,7 +138,6 @@ export async function rateLimit(
 
 export const _rateLimitTestHooks = {
   resetDegradationState(): void {
-    redisDegraded = false;
     outageWarningLogged = false;
     firstErrorLogged = false;
   },


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary

Fixes #242 — converts the rate limiter from **fail-open** (all requests allowed when Redis is down) to **fail-closed** (blocks at capacity) using an in-process sliding-window fallback that stays warm on every request.

## Core implementation

- **`src/lib/rate-limit-fallback.ts`** (new) — `InProcessRateLimiter` with sliding-window timestamps, a 10 000-entry hard cap, per-entry `windowMs` sweep, and `capacity-saturated` semantics: unknown keys are denied when the map is full rather than evicting active buckets (which would reopen their allowance).
- **`src/lib/rate-limit-redis.ts`** (new) — Atomic Redis check via a single Lua script (`ZREMRANGEBYSCORE → ZCARD → ZADD/EXPIRE`) so concurrent app instances cannot over-admit. Returns `null` on unexpected responses so callers can fall through to the warmed fallback instead of trusting malformed state.
- **`src/lib/rate-limit.ts`** (rewritten) — Implements a **warm-fallback-leading-guard** pattern:
  - The fallback `check()` runs **first** on every request, keeping the local bucket warm.
  - Redis is then consulted as the shared cross-instance authority.
  - Three distinct failure paths (client not ready, invalid atomic result, atomic check threw) all route to the fallback with deduplicated warnings (`redisDegraded` flag prevents log spam).
  - A `rollback` removes the warmed local timestamp when healthy Redis rejects a request the local guard admitted, preventing drift.
  - `getClientIdentifier` now validates the IP via `node:net`'s `isIP` and SHA-256-hashes invalid header values, so attacker-controlled proxy headers cannot pin unbounded strings into fallback Map keys.

## Operational behavior

- **Healthy Redis**: requests bypass the local cap via `markRedisHealthy()`. If Redis denies, the local timestamp is rolled back.
- **Redis outage**: already-warm fallback blocks at capacity. The "per-process, not shared" caveat is logged once per degradation episode.
- **Recovery**: `redisDegraded` resets, but in-process timestamps from the outage window persist until expiry. Documented trade-off: this avoids briefly allowing every client to exceed the shared limit at the recovery boundary.

## Tests (33 total, all passing)

- **`rate-limit-fallback.test.ts`** (new, 15 tests) — fallback allow/block behavior, per-IP and per-prefix isolation, concurrency enforcement, sweep/window changes, capacity saturation, `maxRequests=0` edge case, lazy-connect warm-up, warning dedup across healthy→degraded→healthy→degraded cycles.
- **`rate-limit-redis-integration.test.ts`** (new, 2 tests) — real-Redis verification: concurrent shared-limit admission across two clients and sliding-window boundary release. Auto-skipped when `REDIS_URL` is unreachable.
- **`rate-limit.test.ts`** (modified) — existing fail-open tests rewritten for fail-closed semantics; new tests cover rollback-on-Redis-reject, malicious-identifier hashing (12 000-char input → sub-128-char key), lazy-connect burst, and a full healthy → degraded → healthy → degraded lifecycle.
- **`fake-redis.ts`** (modified) — added `eval()` simulation implementing the same `ZREMRANGEBYSCORE/ZCARD/ZADD/EXPIRE` semantics, plus `evalKeys` tracking for assertion.

## Infrastructure

- **CI** — added `redis:7-alpine` service container with health checks; dedicated `Run rate-limit tests` step with `REDIS_URL` set.
- **`package.json`** — `test:rate-limit` now includes all three test files.

## Notable design choices

- **Fail-closed on `capacity-saturated`**: under sustained Redis outage with IP rotation, the fallback Map fills with active buckets. Admitting unknown keys would require evicting active entries, which would reset their allowance — exactly the failure mode the fix is preventing. Denying is the only consistent choice.
- **Rollback on Redis rejection**: without this, a transient Redis replay of an old request would permanently reduce the local guard's allowance.
- **Hash, don't truncate, invalid identifiers**: `node:net`'s `isIP` is the gatekeeper. SHA-256 of the raw header provides a stable, bounded key for everything else, preserving collision-resistance across distinct attacker payloads.

---

This pull request hardens the rate-limiter's failure modes so that outages and edge-case races err on the safe side rather than admitting requests that should be rejected.

**Key changes:**

1. **Cap-aware denial for the fallback limiter** (`rate-limit-fallback.ts`, `rate-limit.test.ts`):
   - On a deny decision when the in-process bucket is at capacity, the test now asserts that no additional entry is recorded. This ensures the fallback remains fail-closed and doesn't grow unboundedly while Redis is unavailable.

2. **Uniqueness fix in the fallback's `removeTimestamp`** (`rate-limit-fallback.ts`):
   - Changed `lastIndexOf(timestamp)` to `indexOf(timestamp)`, so only the most recent matching timestamp is removed. Previously, an out-of-order timestamp lookup could splice the wrong (earliest) occurrence, leaving stale counts and effectively admitting a request that should have been denied.

3. **Documented failure-mode behaviour** (`rate-limit-fallback.ts`):
   - Added comments clarifying that the fallback is conservative, lazy-sweeps expired entries, has a worst-case memory footprint (~5 MB), and treats `windowMs` as authoritative per call (safe under the assumption that each route uses a distinct key prefix).

4. **TTL grace period for the Redis path** (`rate-limit-redis.ts`):
   - Replaced the hardcoded `+ 1` second TTL pad with a named `TTL_GRACE_SECONDS` constant and documented its purpose: preventing a race where the key could expire between `ZADD` and `EXPIRE`, which would otherwise let requests slip through after the window boundary.

---

## Summary

This pull request changes the rate limiter to **fail degraded** (return 429) rather than **fail open** when Redis is unavailable, using a per-process fallback cap as the safety net.

## Problem

Previously, when the Redis health check or Lua eval round-trip failed, the rate limiter silently bypassed throttling entirely. During a Redis outage, this allowed unlimited traffic to hit rate-limited routes.

## Changes

**`src/lib/rate-limit.ts`** — Core behavior change
- Added `outageWarningLogged` and `firstErrorLogged` module-level flags so the warning banner and the first error log each print at most once per degradation window.
- `markRedisHealthy()` and the test-only `resetDegradationState()` reset all three flags so a recovered-then-redegraded cycle logs cleanly again.
- The warning text and the fail-closed fallback path now activate whenever Redis is down; the per-process in-memory limiter (maxRequests per key per windowMs) is the effective ceiling during the outage.

**`src/lib/rate-limit-fallback.ts`** — Minor doc comment cleanup; the logic of rolling the current call's window across an existing entry is unchanged.

**`src/lib/rate-limit-redis.ts`**
- Rewrote the `TTL_GRACE_SECONDS` doc comment to explain *why* +1 is required: `Math.ceil(windowMs / 1000)` can equal the window's effective to-the-second lifetime, and Redis EXPIRE rounds to the second, so without +1 the key could expire at the exact moment the oldest in-window entry becomes queryable-out-of-window.
- Added a `console.warn` for unexpected (non-0/non-1) Lua script return values so silent `null` (indeterminate) results become visible during operations.

**`src/__tests__/rate-limit.test.ts`** — New regression test
- Covers a same-millisecond burst where 3 concurrent requests are admitted by Redis, then 3 more are issued: 2 admitted, 1 rejected. The test verifies the rejected request's local timestamp is rolled back (so the bucket sits at exactly 5/5) and the next request is blocked by the local guard without touching Redis.

**`CHANGELOG.md`** — Documents the behavior change in the Unreleased / Changed section, including:
- The new fail-degraded semantics (429 on per-worker cap during outage).
- The cluster-wide ceiling formula during an outage: `maxRequests × worker_count` per `windowMs`.
- A note that operators relying on fail-open during Redis maintenance should plan a Redis-aware deploy strategy.

## Operational Impact

- **Default-on safety improvement**: rate-limited routes are never fully unprotected, even briefly.
- **No configuration change required**; per-route `maxRequests` and `windowMs` keep the same values, and healthy-Redis behavior is identical.
- **Trade-off**: during a Redis outage, the effective limit is per-process. Operators who intentionally rely on fail-open (e.g., planned maintenance with a manual kill switch) need to handle that at the deploy layer instead.

---

This pull request refactors the rate limiter to remove the shared `redisDegraded` flag and change the local guard to run ahead of every Redis call, ensuring the limiter fails degraded (with a per-worker cap) when Redis is unavailable.

### Key Changes

**1. Removed global `redisDegraded` flag (`src/lib/rate-limit.ts`)**
- The module-level `redisDegraded` boolean state was eliminated along with the `markRedisHealthy()` function.
- Replaced with a stateless `markRedisResponded()` function that only resets logging flags (`outageWarningLogged`, `firstErrorLogged`) without toggling degradation state.
- The test hook `resetDegradationState()` was updated to reflect this — it now only clears logging flags.

**Functional impact**: The rate limiter no longer tracks a shared "Redis is degraded" state across requests. Instead, **every individual request is evaluated against the local guard before any Redis call is made**.

**2. Local guard now runs ahead of every Redis call**
- Per the changelog entry: *"The local guard now runs ahead of every Redis call (warm-fallback-leading-guard); under heavy single-worker skew the local cap may deny requests that Redis would globally allow."*

This means:
- **During a Redis outage**: Each worker enforces its own in-process cap (per-worker limit) rather than failing open or relying on a shared degraded flag.
- **During normal operation**: The local guard admits first; Redis is then consulted to confirm global capacity. If Redis rejects, the local timestamp is rolled back.
- **Trade-off documented**: A single worker that accumulates timestamps during an outage may briefly deny requests that Redis would allow (for up to `windowMs` after recovery), since the local entries haven't expired yet.

**3. Updated test for duplicate-timestamp rollback (`src/__tests__/rate-limit.test.ts`)**

The test was rewritten to match the new "local guard admits, Redis rejects" execution model:
- **Old test**: Sent concurrent bursts expecting Redis to admit some and reject others, relying on the global `redisDegraded` flag.
- **New test**: Pre-fills the fake Redis to capacity (so every `eval` returns "denied"), then sends a single request that passes the local guard but gets rejected by Redis — verifying the rollback removes the local timestamp by subsequently turning Redis off and confirming the local bucket is empty.

### Summary

This change shifts the rate limiter from a "shared degraded flag" model to a "per-request leading local guard" model. The behavioral consequence: the limiter **fails degraded** when Redis is unreachable (each worker enforces a conservative cap) rather than failing open or relying on coordinated state. This makes the limiter's behavior predictable and self-contained per request, at the cost of potentially being more restrictive than the global Redis limit during skewed single-worker load.
<!-- kody-pr-summary:end -->