### PR TITLE
feat: rate limiter follow-up enhancements (timeout, Retry-After, oversized header short-circuit, EVALSHA)

### DIFF
--- a/src/__tests__/_helpers/fake-redis.ts
+++ b/src/__tests__/_helpers/fake-redis.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { REDIS_RATE_LIMIT_SCRIPT } from "@/lib/rate-limit-redis";
 
 type PipelineCommand =
   | { method: "zremrangebyscore"; args: [string, string, string] }
@@ -16,7 +17,6 @@ export class FakeRedisClient {
   connectCalls = 0;
   readonly evalKeys: string[] = [];
   evalshaCalls = 0;
-  evalFallbackCalls = 0;
 
   private readonly values = new Map<string, string>();
   private readonly expires = new Map<string, number>();
@@ -94,11 +94,8 @@ export class FakeRedisClient {
     return 1;
   }
 
-  /** SHA1 of the rate-limit script body.  Must match rate-limit-redis.ts. */
   private static readonly SCRIPT_SHA =
-    createHash("sha1")
-      .update('\nredis.call("ZREMRANGEBYSCORE", KEYS[1], "-inf", ARGV[1])\nlocal count = redis.call("ZCARD", KEYS[1])\n\nif count >= tonumber(ARGV[3]) then\n  return 0\nend\n\nredis.call("ZADD", KEYS[1], ARGV[2], ARGV[4])\nredis.call("EXPIRE", KEYS[1], ARGV[5])\nreturn 1\n')
-      .digest("hex");
+    createHash("sha1").update(REDIS_RATE_LIMIT_SCRIPT).digest("hex");
 
   async evalsha(
     sha1: string,

--- a/src/__tests__/_helpers/fake-redis.ts
+++ b/src/__tests__/_helpers/fake-redis.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 type PipelineCommand =
   | { method: "zremrangebyscore"; args: [string, string, string] }
   | { method: "zcard"; args: [string] }
@@ -13,6 +15,8 @@ export class FakeRedisClient {
   status = "wait";
   connectCalls = 0;
   readonly evalKeys: string[] = [];
+  evalshaCalls = 0;
+  evalFallbackCalls = 0;
 
   private readonly values = new Map<string, string>();
   private readonly expires = new Map<string, number>();
@@ -90,6 +94,27 @@ export class FakeRedisClient {
     return 1;
   }
 
+  /** SHA1 of the rate-limit script body.  Must match rate-limit-redis.ts. */
+  private static readonly SCRIPT_SHA =
+    createHash("sha1")
+      .update('\nredis.call("ZREMRANGEBYSCORE", KEYS[1], "-inf", ARGV[1])\nlocal count = redis.call("ZCARD", KEYS[1])\n\nif count >= tonumber(ARGV[3]) then\n  return 0\nend\n\nredis.call("ZADD", KEYS[1], ARGV[2], ARGV[4])\nredis.call("EXPIRE", KEYS[1], ARGV[5])\nreturn 1\n')
+      .digest("hex");
+
+  async evalsha(
+    sha1: string,
+    numberOfKeys: number,
+    ...args: Array<string | number>
+  ): Promise<number> {
+    this.assertReady();
+    this.evalshaCalls++;
+    if (sha1 !== FakeRedisClient.SCRIPT_SHA) {
+      throw new Error("NOSCRIPT No matching script. Please use EVAL.");
+    }
+    // Delegate to the existing eval logic (skip the script body arg).
+    this.evalKeys.push(args[0] as string);
+    return this.runRateLimitScript(numberOfKeys, args);
+  }
+
   async eval(
     _script: string,
     numberOfKeys: number,
@@ -100,11 +125,26 @@ export class FakeRedisClient {
       throw new Error("FakeRedisClient only supports one-key rate-limit scripts");
     }
 
+    // Validate basic types (runRateLimitScript does full validation).
+    if (typeof args[0] !== "string" || typeof args[4] !== "string") {
+      throw new Error("Invalid rate-limit script arguments");
+    }
+    this.evalKeys.push(args[0] as string);
+    return this.runRateLimitScript(numberOfKeys, args);
+  }
+
+  private runRateLimitScript(
+    numberOfKeys: number,
+    args: Array<string | number>
+  ): number {
+    if (numberOfKeys !== 1) {
+      throw new Error("FakeRedisClient only supports one-key rate-limit scripts");
+    }
+
     const [key, windowStart, now, maxRequests, member, ttlSeconds] = args;
     if (typeof key !== "string" || typeof member !== "string") {
       throw new Error("Invalid rate-limit script arguments");
     }
-    this.evalKeys.push(key);
 
     this.zremrangebyscore(key, "-inf", String(windowStart));
     const count = this.zcard(key);

--- a/src/__tests__/_helpers/fake-redis.ts
+++ b/src/__tests__/_helpers/fake-redis.ts
@@ -10,23 +10,40 @@ type PipelineCommand =
 interface FakeRedisClientOptions {
   connectDelayMs?: number;
   rejectConnect?: boolean;
+  evalshaDelayMs?: number;
+  evalshaError?: Error;
+  evalDelayMs?: number;
+  evalResultAfterDelay?: number;
+  disconnectKeepsStatus?: boolean;
 }
 
 export class FakeRedisClient {
   status = "wait";
   connectCalls = 0;
+  disconnectCalls = 0;
   readonly evalKeys: string[] = [];
   evalshaCalls = 0;
+  evalCalls = 0;
 
   private readonly values = new Map<string, string>();
   private readonly expires = new Map<string, number>();
   private readonly sortedSets = new Map<string, Array<{ score: number; member: string }>>();
   private readonly connectDelayMs: number;
   private readonly rejectConnect: boolean;
+  private readonly evalshaDelayMs: number;
+  private readonly evalshaError: Error | undefined;
+  private readonly evalDelayMs: number;
+  private readonly evalResultAfterDelay: number | undefined;
+  private readonly disconnectKeepsStatus: boolean;
 
   constructor(options: FakeRedisClientOptions = {}) {
     this.connectDelayMs = options.connectDelayMs ?? 0;
     this.rejectConnect = options.rejectConnect ?? false;
+    this.evalshaDelayMs = options.evalshaDelayMs ?? 0;
+    this.evalshaError = options.evalshaError;
+    this.evalDelayMs = options.evalDelayMs ?? 0;
+    this.evalResultAfterDelay = options.evalResultAfterDelay;
+    this.disconnectKeepsStatus = options.disconnectKeepsStatus ?? false;
   }
 
   async connect() {
@@ -41,7 +58,10 @@ export class FakeRedisClient {
   }
 
   disconnect() {
-    this.status = "end";
+    this.disconnectCalls += 1;
+    if (!this.disconnectKeepsStatus) {
+      this.status = "end";
+    }
   }
 
   async get(key: string): Promise<string | null> {
@@ -104,6 +124,11 @@ export class FakeRedisClient {
   ): Promise<number> {
     this.assertReady();
     this.evalshaCalls++;
+    await delay(this.evalshaDelayMs);
+    if (this.evalshaError) {
+      throw this.evalshaError;
+    }
+    this.assertReady();
     if (sha1 !== FakeRedisClient.SCRIPT_SHA) {
       throw new Error("NOSCRIPT No matching script. Please use EVAL.");
     }
@@ -117,6 +142,13 @@ export class FakeRedisClient {
     numberOfKeys: number,
     ...args: Array<string | number>
   ): Promise<number> {
+    this.assertReady();
+    this.evalCalls += 1;
+    await delay(this.evalDelayMs);
+    if (this.evalResultAfterDelay !== undefined) {
+      this.evalKeys.push(args[0] as string);
+      return this.evalResultAfterDelay;
+    }
     this.assertReady();
     if (numberOfKeys !== 1) {
       throw new Error("FakeRedisClient only supports one-key rate-limit scripts");
@@ -200,5 +232,11 @@ export class FakeRedisClient {
     if (this.status !== "ready") {
       throw new Error("Redis command executed before client was ready");
     }
+  }
+}
+
+async function delay(ms: number): Promise<void> {
+  if (ms > 0) {
+    await new Promise((resolve) => setTimeout(resolve, ms));
   }
 }

--- a/src/__tests__/_helpers/fake-redis.ts
+++ b/src/__tests__/_helpers/fake-redis.ts
@@ -51,6 +51,9 @@ export class FakeRedisClient {
 
   async connect() {
     this.connectCalls += 1;
+    // ioredis leaves "wait" synchronously when connect() starts. Preserve
+    // that transition so concurrent-connection tests exercise real behavior.
+    this.status = "connecting";
     if (this.connectDelayMs > 0) {
       await new Promise((resolve) => setTimeout(resolve, this.connectDelayMs));
     }

--- a/src/__tests__/_helpers/fake-redis.ts
+++ b/src/__tests__/_helpers/fake-redis.ts
@@ -13,8 +13,9 @@ interface FakeRedisClientOptions {
   evalshaDelayMs?: number;
   evalshaError?: Error;
   evalDelayMs?: number;
-  evalResultAfterDelay?: number;
+  evalReturnValue?: number;
   disconnectKeepsStatus?: boolean;
+  disconnectError?: Error;
 }
 
 export class FakeRedisClient {
@@ -33,8 +34,9 @@ export class FakeRedisClient {
   private readonly evalshaDelayMs: number;
   private readonly evalshaError: Error | undefined;
   private readonly evalDelayMs: number;
-  private readonly evalResultAfterDelay: number | undefined;
+  private readonly evalReturnValue: number | undefined;
   private readonly disconnectKeepsStatus: boolean;
+  private readonly disconnectError: Error | undefined;
 
   constructor(options: FakeRedisClientOptions = {}) {
     this.connectDelayMs = options.connectDelayMs ?? 0;
@@ -42,8 +44,9 @@ export class FakeRedisClient {
     this.evalshaDelayMs = options.evalshaDelayMs ?? 0;
     this.evalshaError = options.evalshaError;
     this.evalDelayMs = options.evalDelayMs ?? 0;
-    this.evalResultAfterDelay = options.evalResultAfterDelay;
+    this.evalReturnValue = options.evalReturnValue;
     this.disconnectKeepsStatus = options.disconnectKeepsStatus ?? false;
+    this.disconnectError = options.disconnectError;
   }
 
   async connect() {
@@ -59,6 +62,9 @@ export class FakeRedisClient {
 
   disconnect() {
     this.disconnectCalls += 1;
+    if (this.disconnectError) {
+      throw this.disconnectError;
+    }
     if (!this.disconnectKeepsStatus) {
       this.status = "end";
     }
@@ -145,9 +151,9 @@ export class FakeRedisClient {
     this.assertReady();
     this.evalCalls += 1;
     await delay(this.evalDelayMs);
-    if (this.evalResultAfterDelay !== undefined) {
+    if (this.evalReturnValue !== undefined) {
       this.evalKeys.push(args[0] as string);
-      return this.evalResultAfterDelay;
+      return this.evalReturnValue;
     }
     this.assertReady();
     if (numberOfKeys !== 1) {

--- a/src/__tests__/rate-limit-fallback.test.ts
+++ b/src/__tests__/rate-limit-fallback.test.ts
@@ -207,12 +207,16 @@ describe("Rate Limiter Fallback (Redis failures)", () => {
   });
 
   it("warns again when Redis recovers and a later degradation begins", async () => {
-    const originalEval = fakeRedis.eval.bind(fakeRedis);
+    const originalEvalsha = fakeRedis.evalsha.bind(fakeRedis);
     let shouldFail = true;
-    fakeRedis.eval = async (...args: Parameters<FakeRedisClient["eval"]>) => {
+    fakeRedis.evalsha = (async (
+      sha1: string,
+      numberOfKeys: number,
+      ...args: Array<string | number>
+    ) => {
       if (shouldFail) throw new Error("Redis unavailable");
-      return originalEval(...args);
-    };
+      return originalEvalsha(sha1, numberOfKeys, ...args);
+    }) as typeof fakeRedis.evalsha;
 
     const request = makeRequest("10.0.0.63");
     const options = { windowMs: 60_000, maxRequests: 10, keyPrefix: "warning-transition" };

--- a/src/__tests__/rate-limit-fallback.test.ts
+++ b/src/__tests__/rate-limit-fallback.test.ts
@@ -153,13 +153,18 @@ describe("Rate Limiter Fallback (Redis failures)", () => {
   });
 
   it("falls back to in-process limiter when the atomic check returns invalid data", async () => {
-    fakeRedis.eval = async () => null as never;
+    let evalshaCalled = false;
+    fakeRedis.evalsha = async () => {
+      evalshaCalled = true;
+      return null as never;
+    };
 
     const request = makeRequest("10.0.0.60");
     const options = { windowMs: 60_000, maxRequests: 1, keyPrefix: "pipe-null" };
 
     // First request: invalid Redis response → warmed fallback allows.
     assert.deepStrictEqual(await rateLimit(request, options), { allowed: true });
+    assert.equal(evalshaCalled, true);
 
     // Second request: fallback blocks (bucket full).
     const result2 = await rateLimit(request, options);
@@ -167,7 +172,9 @@ describe("Rate Limiter Fallback (Redis failures)", () => {
   });
 
   it("falls back to in-process limiter when the atomic check throws", async () => {
-    fakeRedis.eval = async () => {
+    let evalshaCalled = false;
+    fakeRedis.evalsha = async () => {
+      evalshaCalled = true;
       throw new Error("Redis connection lost");
     };
 
@@ -181,6 +188,7 @@ describe("Rate Limiter Fallback (Redis failures)", () => {
     try {
       // First request: Redis throws → warmed fallback allows.
       assert.deepStrictEqual(await rateLimit(request, options), { allowed: true });
+      assert.equal(evalshaCalled, true);
 
       // Second request: fallback blocks (bucket full).
       const result2 = await rateLimit(request, options);

--- a/src/__tests__/rate-limit-redis-integration.test.ts
+++ b/src/__tests__/rate-limit-redis-integration.test.ts
@@ -2,6 +2,11 @@ import { after, before, describe, it } from "node:test";
 import assert from "assert";
 import Redis from "ioredis";
 import { checkRedisRateLimit } from "@/lib/rate-limit-redis";
+import {
+  getReadyRedisClient,
+  _redisTestHooks,
+} from "@/lib/cache/redis";
+import { FakeRedisClient } from "./_helpers/fake-redis";
 
 const redisUrl = process.env.REDIS_URL;
 
@@ -69,5 +74,57 @@ describe("Redis rate limiter integration", { skip: !redisUrl }, () => {
       }),
       true
     );
+  });
+
+  it("rebuilds the timed-out singleton after the reconnect cooldown", async () => {
+    const originalDateNow = Date.now;
+    let currentTime = originalDateNow();
+    const wedgedClient = new FakeRedisClient({
+      evalshaDelayMs: 40,
+      disconnectKeepsStatus: true,
+    });
+    await wedgedClient.connect();
+    _redisTestHooks.setClientForTesting(wedgedClient as never);
+    Date.now = () => currentTime;
+
+    try {
+      await assert.rejects(
+        checkRedisRateLimit(wedgedClient as never, {
+          key: `test:ratelimit:recovery-timeout:${crypto.randomUUID()}`,
+          windowMs: 60_000,
+          maxRequests: 5,
+          now: currentTime,
+          timeoutMs: 25,
+        }),
+        /Redis eval timed out/
+      );
+
+      assert.equal(await getReadyRedisClient(), null);
+      currentTime += 5_001;
+      // getReadyRedisClient checks the mocked clock synchronously before its
+      // first await. Restore the real clock immediately afterward so ioredis
+      // internals do not inherit the test clock while connecting.
+      const recoveryPromise = getReadyRedisClient();
+      Date.now = originalDateNow;
+      const recoveredClient = await recoveryPromise;
+      assert.ok(recoveredClient);
+      assert.notStrictEqual(recoveredClient, wedgedClient);
+
+      const key = `test:ratelimit:recovered:${crypto.randomUUID()}`;
+      keys.add(key);
+      assert.equal(
+        await checkRedisRateLimit(recoveredClient, {
+          key,
+          windowMs: 60_000,
+          maxRequests: 5,
+          now: Date.now(),
+          member: "after-recovery",
+        }),
+        true
+      );
+    } finally {
+      Date.now = originalDateNow;
+      _redisTestHooks.reset();
+    }
   });
 });

--- a/src/__tests__/rate-limit.test.ts
+++ b/src/__tests__/rate-limit.test.ts
@@ -110,6 +110,48 @@ describe("Redis Rate Limiter", () => {
     assert.ok(fakeRedis.evalKeys[0].length < 128);
   });
 
+  it("short-circuits oversized identifiers without hashing", async () => {
+    const oversized = "x".repeat(512);
+    const request = makeRequest(oversized);
+
+    assert.deepStrictEqual(
+      await rateLimit(request, {
+        windowMs: 60_000,
+        maxRequests: 5,
+        keyPrefix: "oversized-identifier",
+      }),
+      { allowed: true }
+    );
+
+    // The key should use the "invalid:oversized" short-circuit, not a hash.
+    assert.equal(fakeRedis.evalKeys.length, 1);
+    assert.ok(fakeRedis.evalKeys[0].includes("invalid:oversized"));
+    assert.ok(fakeRedis.evalKeys[0].length < 80);
+  });
+
+  it("includes a Retry-After header on 429 responses", async () => {
+    const request = makeRequest("10.0.0.20");
+    const options = { windowMs: 30_000, maxRequests: 1, keyPrefix: "retry-after" };
+
+    await rateLimit(request, options); // First request OK
+    const result = await rateLimit(request, options); // Second blocked
+
+    assert.equal(result.allowed, false);
+    if (!result.allowed) {
+      assert.equal(result.response.status, 429);
+      assert.equal(result.response.headers.get("Retry-After"), "30");
+    }
+  });
+
+  it("uses EVALSHA and falls back to EVAL on NOSCRIPT", async () => {
+    // The FakeRedisClient.evalsha throws NOSCRIPT for unknown SHAs.
+    // Verify that a normal call uses evalsha first.
+    const request = makeRequest("10.0.0.21");
+    await rateLimit(request, { windowMs: 60_000, maxRequests: 5, keyPrefix: "evalsha-test" });
+
+    assert.ok(fakeRedis.evalshaCalls > 0, "EVALSHA should be called first");
+  });
+
   it("falls back to in-process limiter when Redis client is unavailable", async () => {
     // Simulate Redis not configured by passing null-like state
     const request = makeRequest("10.0.0.6");

--- a/src/__tests__/rate-limit.test.ts
+++ b/src/__tests__/rate-limit.test.ts
@@ -6,7 +6,7 @@ import {
   fallbackLimiter,
   _fallbackLimiterTestHooks,
 } from "@/lib/rate-limit-fallback";
-import { _redisTestHooks } from "@/lib/cache/redis";
+import { getReadyRedisClient, _redisTestHooks } from "@/lib/cache/redis";
 import { NextRequest } from "next/server";
 import { FakeRedisClient } from "./_helpers/fake-redis";
 
@@ -205,9 +205,46 @@ describe("Redis Rate Limiter", () => {
 
     assert.equal(results[0].status, "rejected");
     assert.equal(results[1].status, "rejected");
-    // Exercise the singleton recovery cleanup while status still reads ready.
-    _redisTestHooks.reset();
     assert.equal(fakeRedis.disconnectCalls, 1);
+    // The singleton is removed synchronously and the cooldown suppresses an
+    // immediate reconnect even though the fake still reports status="ready".
+    assert.equal(await getReadyRedisClient(), null);
+  });
+
+  it("preserves concurrent timeout errors when disconnect cleanup throws", async () => {
+    fakeRedis = new FakeRedisClient({
+      evalshaDelayMs: 40,
+      disconnectError: new Error("disconnect failed"),
+    });
+    await fakeRedis.connect();
+    _redisTestHooks.setClientForTesting(fakeRedis as never);
+    const originalConsoleError = console.error;
+    console.error = () => {};
+
+    try {
+      const options = {
+        key: "ratelimit:disconnect-error:10.0.0.26",
+        windowMs: 60_000,
+        maxRequests: 5,
+        now: Date.now(),
+        timeoutMs: 25,
+      };
+      const results = await Promise.allSettled([
+        checkRedisRateLimit(fakeRedis as never, options),
+        checkRedisRateLimit(fakeRedis as never, options),
+      ]);
+
+      for (const result of results) {
+        assert.equal(result.status, "rejected");
+        if (result.status === "rejected") {
+          assert.match(String(result.reason), /Redis eval timed out/);
+        }
+      }
+      assert.equal(fakeRedis.disconnectCalls, 1);
+      assert.equal(await getReadyRedisClient(), null);
+    } finally {
+      console.error = originalConsoleError;
+    }
   });
 
   it("does not issue EVAL when NOSCRIPT arrives after the timeout", async () => {
@@ -231,11 +268,11 @@ describe("Redis Rate Limiter", () => {
     assert.equal(fakeRedis.evalKeys.length, 0);
   });
 
-  it("discards a successful EVAL response that settles after the timeout", async () => {
+  it("discards a late EVAL response that settles after the timeout", async () => {
     fakeRedis = new FakeRedisClient({
       evalshaError: new Error("NOSCRIPT No matching script. Please use EVAL."),
       evalDelayMs: 40,
-      evalResultAfterDelay: 0,
+      evalReturnValue: 0,
     });
     await fakeRedis.connect();
 

--- a/src/__tests__/rate-limit.test.ts
+++ b/src/__tests__/rate-limit.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, beforeEach, afterEach } from "node:test";
 import assert from "assert";
 import { rateLimit, _rateLimitTestHooks } from "@/lib/rate-limit";
+import { checkRedisRateLimit } from "@/lib/rate-limit-redis";
 import {
   fallbackLimiter,
   _fallbackLimiterTestHooks,
@@ -177,6 +178,79 @@ describe("Redis Rate Limiter", () => {
     } finally {
       fakeRedis.evalsha = originalEvalsha;
     }
+  });
+
+  it("disconnects a wedged Redis client once when concurrent checks time out", async () => {
+    fakeRedis = new FakeRedisClient({
+      evalshaDelayMs: 40,
+      // Real ioredis stays "ready" until the socket emits close, so status
+      // cannot be used as the synchronous disconnect-once guard.
+      disconnectKeepsStatus: true,
+    });
+    await fakeRedis.connect();
+    _redisTestHooks.setClientForTesting(fakeRedis as never);
+
+    const options = {
+      key: "ratelimit:evalsha-timeout:10.0.0.23",
+      windowMs: 60_000,
+      maxRequests: 5,
+      now: Date.now(),
+      timeoutMs: 25,
+    };
+    const results = await Promise.allSettled([
+      checkRedisRateLimit(fakeRedis as never, options),
+      checkRedisRateLimit(fakeRedis as never, options),
+    ]);
+    await new Promise((resolve) => setTimeout(resolve, 25));
+
+    assert.equal(results[0].status, "rejected");
+    assert.equal(results[1].status, "rejected");
+    // Exercise the singleton recovery cleanup while status still reads ready.
+    _redisTestHooks.reset();
+    assert.equal(fakeRedis.disconnectCalls, 1);
+  });
+
+  it("does not issue EVAL when NOSCRIPT arrives after the timeout", async () => {
+    fakeRedis = new FakeRedisClient({
+      evalshaDelayMs: 40,
+      evalshaError: new Error("NOSCRIPT No matching script. Please use EVAL."),
+    });
+    await fakeRedis.connect();
+
+    await assert.rejects(checkRedisRateLimit(fakeRedis as never, {
+      key: "ratelimit:late-noscript:10.0.0.24",
+      windowMs: 60_000,
+      maxRequests: 5,
+      now: Date.now(),
+      timeoutMs: 25,
+    }), /Redis eval timed out/);
+    await new Promise((resolve) => setTimeout(resolve, 25));
+
+    assert.equal(fakeRedis.disconnectCalls, 1);
+    assert.equal(fakeRedis.evalCalls, 0);
+    assert.equal(fakeRedis.evalKeys.length, 0);
+  });
+
+  it("discards a successful EVAL response that settles after the timeout", async () => {
+    fakeRedis = new FakeRedisClient({
+      evalshaError: new Error("NOSCRIPT No matching script. Please use EVAL."),
+      evalDelayMs: 40,
+      evalResultAfterDelay: 0,
+    });
+    await fakeRedis.connect();
+
+    await assert.rejects(checkRedisRateLimit(fakeRedis as never, {
+      key: "ratelimit:late-eval:10.0.0.25",
+      windowMs: 60_000,
+      maxRequests: 5,
+      now: Date.now(),
+      timeoutMs: 25,
+    }), /Redis eval timed out/);
+    await new Promise((resolve) => setTimeout(resolve, 25));
+
+    assert.equal(fakeRedis.evalCalls, 1);
+    assert.equal(fakeRedis.disconnectCalls, 1);
+    assert.equal(fakeRedis.evalKeys.length, 1);
   });
 
   it("falls back to in-process limiter when Redis client is unavailable", async () => {

--- a/src/__tests__/rate-limit.test.ts
+++ b/src/__tests__/rate-limit.test.ts
@@ -144,12 +144,27 @@ describe("Redis Rate Limiter", () => {
   });
 
   it("uses EVALSHA and falls back to EVAL on NOSCRIPT", async () => {
-    // The FakeRedisClient.evalsha throws NOSCRIPT for unknown SHAs.
-    // Verify that a normal call uses evalsha first.
+    // Phase 1: normal call — EVALSHA succeeds with the correct SHA.
     const request = makeRequest("10.0.0.21");
     await rateLimit(request, { windowMs: 60_000, maxRequests: 5, keyPrefix: "evalsha-test" });
-
     assert.ok(fakeRedis.evalshaCalls > 0, "EVALSHA should be called first");
+
+    // Phase 2: force NOSCRIPT by overriding evalsha to always throw.
+    // The EVAL fallback should kick in and the request should still succeed.
+    const originalEvalsha = fakeRedis.evalsha.bind(fakeRedis);
+    fakeRedis.evalsha = async () => {
+      throw new Error("NOSCRIPT No matching script. Please use EVAL.");
+    };
+    try {
+      const result = await rateLimit(makeRequest("10.0.0.22"), {
+        windowMs: 60_000,
+        maxRequests: 5,
+        keyPrefix: "evalsha-noscript",
+      });
+      assert.deepStrictEqual(result, { allowed: true });
+    } finally {
+      fakeRedis.evalsha = originalEvalsha;
+    }
   });
 
   it("falls back to in-process limiter when Redis client is unavailable", async () => {

--- a/src/__tests__/rate-limit.test.ts
+++ b/src/__tests__/rate-limit.test.ts
@@ -152,6 +152,7 @@ describe("Redis Rate Limiter", () => {
     // Phase 2: force NOSCRIPT by overriding evalsha to always throw.
     // The EVAL fallback should kick in and the request should still succeed.
     const originalEvalsha = fakeRedis.evalsha.bind(fakeRedis);
+    const evalKeysBefore = fakeRedis.evalKeys.length;
     fakeRedis.evalsha = async () => {
       throw new Error("NOSCRIPT No matching script. Please use EVAL.");
     };
@@ -162,6 +163,17 @@ describe("Redis Rate Limiter", () => {
         keyPrefix: "evalsha-noscript",
       });
       assert.deepStrictEqual(result, { allowed: true });
+      // EVAL fallback must have actually run — a new evalKey entry for this IP
+      // proves the Lua script executed (not just degradedResult allowing it).
+      assert.equal(
+        fakeRedis.evalKeys.length,
+        evalKeysBefore + 1,
+        "EVAL fallback should have added a new eval key"
+      );
+      assert.ok(
+        fakeRedis.evalKeys[fakeRedis.evalKeys.length - 1].includes("evalsha-noscript"),
+        "EVAL fallback key should match the request's keyPrefix"
+      );
     } finally {
       fakeRedis.evalsha = originalEvalsha;
     }
@@ -314,6 +326,7 @@ describe("Redis Rate Limiter", () => {
       _fallbackLimiterTestHooks.reset();
       // Swap in a fresh FakeRedis so Phase 1's ZSET entries are gone.
       fakeRedis = new FakeRedisClient();
+      await fakeRedis.connect();
       _redisTestHooks.setClientForTesting(fakeRedis as never);
       const recovered = await rateLimit(request, options);
       assert.deepStrictEqual(recovered, { allowed: true });

--- a/src/__tests__/rate-limit.test.ts
+++ b/src/__tests__/rate-limit.test.ts
@@ -6,7 +6,12 @@ import {
   fallbackLimiter,
   _fallbackLimiterTestHooks,
 } from "@/lib/rate-limit-fallback";
-import { getReadyRedisClient, _redisTestHooks } from "@/lib/cache/redis";
+import {
+  disconnectRedisClientOnce,
+  getRedisClient,
+  getReadyRedisClient,
+  _redisTestHooks,
+} from "@/lib/cache/redis";
 import { NextRequest } from "next/server";
 import { FakeRedisClient } from "./_helpers/fake-redis";
 
@@ -93,7 +98,7 @@ describe("Redis Rate Limiter", () => {
     assert.deepStrictEqual(result, { allowed: true });
   });
 
-  it("hashes invalid proxy identifiers before storing rate-limit keys", async () => {
+  it("bounds attacker-controlled proxy identifiers in rate-limit keys", async () => {
     const maliciousIdentifier = "x".repeat(12_000);
     const request = makeRequest(maliciousIdentifier);
 
@@ -240,11 +245,32 @@ describe("Redis Rate Limiter", () => {
           assert.match(String(result.reason), /Redis eval timed out/);
         }
       }
-      assert.equal(fakeRedis.disconnectCalls, 1);
+      // Both concurrent timeout paths may retry because every cleanup attempt
+      // throws; neither failure may permanently poison the once-guard.
+      assert.equal(fakeRedis.disconnectCalls, 2);
       assert.equal(await getReadyRedisClient(), null);
     } finally {
       console.error = originalConsoleError;
     }
+  });
+
+  it("allows disconnect cleanup to retry after a synchronous failure", () => {
+    let disconnectCalls = 0;
+    const client = {
+      disconnect(): void {
+        disconnectCalls += 1;
+        if (disconnectCalls === 1) {
+          throw new Error("disconnect failed once");
+        }
+      },
+    };
+
+    assert.throws(
+      () => disconnectRedisClientOnce(client as never),
+      /disconnect failed once/
+    );
+    assert.doesNotThrow(() => disconnectRedisClientOnce(client as never));
+    assert.equal(disconnectCalls, 2);
   });
 
   it("does not issue EVAL when NOSCRIPT arrives after the timeout", async () => {
@@ -564,6 +590,35 @@ describe("Rate Limiter Edge Cases", () => {
     }
   });
 
+  it("does not let a stale failed connect evict a replacement singleton", async () => {
+    const staleClient = new FakeRedisClient({
+      connectDelayMs: 20,
+      rejectConnect: true,
+    });
+    const replacementClient = new FakeRedisClient({ connectDelayMs: 40 });
+    _redisTestHooks.setClientForTesting(staleClient as never);
+    const originalConsoleError = console.error;
+    console.error = () => {};
+
+    try {
+      const staleAttempt = getReadyRedisClient();
+      _redisTestHooks.setClientForTesting(replacementClient as never);
+      const replacementAttempts = [
+        getReadyRedisClient(),
+        getReadyRedisClient(),
+      ];
+
+      assert.equal(await staleAttempt, null);
+      assert.strictEqual(getRedisClient(), replacementClient);
+      const recovered = await Promise.all(replacementAttempts);
+      assert.deepStrictEqual(recovered, [replacementClient, replacementClient]);
+      assert.equal(replacementClient.connectCalls, 1);
+      assert.strictEqual(getRedisClient(), replacementClient);
+    } finally {
+      console.error = originalConsoleError;
+    }
+  });
+
   it("falls back to in-process limiter and suppresses immediate retries when the lazy Redis connect fails", async () => {
     const failingRedis = new FakeRedisClient({ rejectConnect: true });
     _redisTestHooks.setClientForTesting(failingRedis as never);
@@ -591,6 +646,28 @@ describe("Rate Limiter Edge Cases", () => {
       // The second call should short-circuit on the reconnect cooldown instead
       // of attempting, and logging, another failed Redis connection.
       assert.equal(errorLogs.length, 1);
+    } finally {
+      console.error = originalConsoleError;
+    }
+  });
+
+  it("fails safely and clears the singleton when connect and disconnect both throw", async () => {
+    const failingRedis = new FakeRedisClient({
+      rejectConnect: true,
+      disconnectError: new Error("disconnect failed"),
+    });
+    _redisTestHooks.setClientForTesting(failingRedis as never);
+    const originalConsoleError = console.error;
+    console.error = () => {};
+
+    try {
+      assert.equal(await getReadyRedisClient(), null);
+      assert.equal(failingRedis.connectCalls, 1);
+      assert.equal(failingRedis.disconnectCalls, 1);
+      // The reconnect cooldown and cleared singleton prevent the same failed
+      // client from being handed out again.
+      assert.equal(await getReadyRedisClient(), null);
+      assert.equal(failingRedis.connectCalls, 1);
     } finally {
       console.error = originalConsoleError;
     }

--- a/src/lib/cache/redis.ts
+++ b/src/lib/cache/redis.ts
@@ -7,10 +7,31 @@ let redisConnectPromise: Promise<void> | null = null;
 
 const REDIS_RECONNECT_COOLDOWN_MS = 5000;
 const TERMINAL_REDIS_STATUSES = new Set(["close", "end"]);
+const disconnectingRedisClients = new WeakSet<object>();
+
+/**
+ * Start disconnecting a client at most once. ioredis does not transition
+ * `status` synchronously, so status checks alone cannot deduplicate concurrent
+ * timeout and recovery paths that share the singleton.
+ */
+export function disconnectRedisClientOnce(
+  client: Pick<Redis, "disconnect">
+): void {
+  const identity = client as object;
+  if (disconnectingRedisClients.has(identity)) return;
+
+  disconnectingRedisClients.add(identity);
+  try {
+    client.disconnect();
+  } catch (error) {
+    disconnectingRedisClients.delete(identity);
+    throw error;
+  }
+}
 
 function resetRedisClient(client: Redis | null = redisClient): void {
-  if (client) {
-    client.disconnect();
+  if (client && !TERMINAL_REDIS_STATUSES.has(client.status)) {
+    disconnectRedisClientOnce(client);
   }
   redisClient = null;
   redisConnectPromise = null;

--- a/src/lib/cache/redis.ts
+++ b/src/lib/cache/redis.ts
@@ -21,11 +21,29 @@ export function disconnectRedisClientOnce(
   if (disconnectingRedisClients.has(identity)) return;
 
   disconnectingRedisClients.add(identity);
+  client.disconnect();
+}
+
+/**
+ * Disconnect a timed-out client and synchronously remove it from the shared
+ * singleton. ioredis updates `status` only after the socket close event, so
+ * waiting for a terminal status could hand the same wedged client to another
+ * request. The cooldown also prevents a reconnect storm during an outage.
+ */
+export function invalidateRedisClient(
+  client: Pick<Redis, "disconnect">
+): void {
+  if (redisClient === client) {
+    redisClient = null;
+    redisConnectPromise = null;
+    nextConnectAttemptAt = Date.now() + REDIS_RECONNECT_COOLDOWN_MS;
+  }
   try {
-    client.disconnect();
+    disconnectRedisClientOnce(client);
   } catch (error) {
-    disconnectingRedisClients.delete(identity);
-    throw error;
+    // The singleton was already invalidated above. Preserve the original
+    // command-timeout error rather than replacing it with cleanup failure.
+    console.error("Redis disconnect error:", error);
   }
 }
 

--- a/src/lib/cache/redis.ts
+++ b/src/lib/cache/redis.ts
@@ -21,7 +21,14 @@ export function disconnectRedisClientOnce(
   if (disconnectingRedisClients.has(identity)) return;
 
   disconnectingRedisClients.add(identity);
-  client.disconnect();
+  try {
+    client.disconnect();
+  } catch (error) {
+    // A failed cleanup must not permanently poison the identity guard. A
+    // later recovery path may be able to disconnect the same client.
+    disconnectingRedisClients.delete(identity);
+    throw error;
+  }
 }
 
 /**
@@ -47,12 +54,25 @@ export function invalidateRedisClient(
   }
 }
 
-function resetRedisClient(client: Redis | null = redisClient): void {
-  if (client && !TERMINAL_REDIS_STATUSES.has(client.status)) {
-    disconnectRedisClientOnce(client);
+function resetRedisClient(
+  client: Redis | null = redisClient,
+  connectPromise: Promise<void> | null = redisConnectPromise
+): void {
+  // Clear shared state before best-effort socket cleanup. If disconnect throws,
+  // callers must still fail safely instead of retaining a broken singleton.
+  if (redisClient === client) {
+    redisClient = null;
   }
-  redisClient = null;
-  redisConnectPromise = null;
+  if (redisConnectPromise === connectPromise) {
+    redisConnectPromise = null;
+  }
+  if (!client) return;
+
+  try {
+    disconnectRedisClientOnce(client);
+  } catch (error) {
+    console.error("Redis disconnect error:", error);
+  }
 }
 
 /**
@@ -119,21 +139,33 @@ export async function getReadyRedisClient(): Promise<Redis | null> {
     return client;
   }
 
-  if (client.status !== "wait") {
-    return null;
-  }
-
+  let connectPromise = redisConnectPromise;
   try {
-    redisConnectPromise ??= client.connect().finally(() => {
-      redisConnectPromise = null;
-    });
-    await redisConnectPromise;
+    if (!connectPromise) {
+      if (client.status !== "wait") {
+        return null;
+      }
+      connectPromise = client.connect();
+      redisConnectPromise = connectPromise;
+    }
+    await connectPromise;
+    if (redisClient !== client) {
+      resetRedisClient(client, connectPromise);
+      return null;
+    }
     return (client.status as string) === "ready" ? client : null;
   } catch (error) {
     console.error("Redis connection error:", error);
-    nextConnectAttemptAt = Date.now() + REDIS_RECONNECT_COOLDOWN_MS;
-    resetRedisClient(client);
+    if (redisClient === client) {
+      nextConnectAttemptAt = Date.now() + REDIS_RECONNECT_COOLDOWN_MS;
+    }
+    resetRedisClient(client, connectPromise);
     return null;
+  } finally {
+    // A stale connect attempt must not erase a replacement client's promise.
+    if (redisConnectPromise === connectPromise) {
+      redisConnectPromise = null;
+    }
   }
 }
 

--- a/src/lib/rate-limit-redis.ts
+++ b/src/lib/rate-limit-redis.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import type Redis from "ioredis";
 
 interface RedisRateLimitOptions {
@@ -15,6 +16,11 @@ interface RedisRateLimitOptions {
  *  the instant the oldest in-window entry becomes queryable-out-of-window. */
 const TTL_GRACE_SECONDS = 1;
 
+/** Maximum time to wait for a Redis eval response before falling back.
+ *  Covers wedged-socket scenarios where the client is "ready" but the
+ *  connection is stuck mid-command. */
+const EVAL_TIMEOUT_MS = 1500;
+
 // Redis executes Lua scripts atomically, so concurrent app instances cannot
 // both observe the same pre-limit count and over-admit requests.
 const REDIS_RATE_LIMIT_SCRIPT = `
@@ -30,28 +36,84 @@ redis.call("EXPIRE", KEYS[1], ARGV[5])
 return 1
 `;
 
+const SCRIPT_SHA = createHash("sha1").update(REDIS_RATE_LIMIT_SCRIPT).digest("hex");
+
 /**
  * Atomically prune, count, and conditionally record a request in Redis.
+ *
+ * Uses EVALSHA with automatic EVAL fallback (via ioredis defineCommand pattern)
+ * to avoid re-sending the script body on every call.  The entire eval is wrapped
+ * in a timeout to handle wedged-socket scenarios where the client reports
+ * "ready" but the connection is stuck mid-command.
+ *
  * Returns null for an unexpected Redis response so the caller can use its
  * already-warmed in-process fallback rather than trusting malformed state.
+ * Throws on timeout or Redis error so the caller's catch block routes to
+ * the degraded path.
  */
 export async function checkRedisRateLimit(
-  redis: Pick<Redis, "eval">,
+  redis: Pick<Redis, "eval" | "evalsha">,
   options: RedisRateLimitOptions
 ): Promise<boolean | null> {
-  const result = await redis.eval(
-    REDIS_RATE_LIMIT_SCRIPT,
-    1,
+  const args: Array<string | number> = [
     options.key,
     options.now - options.windowMs,
     options.now,
     options.maxRequests,
     options.member ?? `${options.now}:${crypto.randomUUID()}`,
-    Math.ceil(options.windowMs / 1000) + TTL_GRACE_SECONDS
-  );
+    Math.ceil(options.windowMs / 1000) + TTL_GRACE_SECONDS,
+  ];
+
+  const evalPromise = evalWithFallback(redis, args);
+
+  const result = await timeoutRace(evalPromise, EVAL_TIMEOUT_MS, options.key);
 
   if (result === 1 || result === "1") return true;
   if (result === 0 || result === "0") return false;
   console.warn("[rate-limit-redis] Unexpected script result", { key: options.key, result });
   return null;
+}
+
+/**
+ * Try EVALSHA first; on NOSCRIPT error (script evicted from Redis cache),
+ * fall back to EVAL.  This mirrors ioredis's built-in behaviour but gives
+ * us explicit control over the fallback path.
+ */
+async function evalWithFallback(
+  redis: Pick<Redis, "eval" | "evalsha">,
+  args: Array<string | number>
+): Promise<number | string> {
+  try {
+    return (await redis.evalsha(SCRIPT_SHA, 1, ...args)) as number | string;
+  } catch (err: unknown) {
+    // NOSCRIPT means Redis doesn't have the script cached.  Fall back to EVAL.
+    if (err instanceof Error && /NOSCRIPT/i.test(err.message)) {
+      return (await redis.eval(REDIS_RATE_LIMIT_SCRIPT, 1, ...args)) as number | string;
+    }
+    throw err;
+  }
+}
+
+/**
+ * Race the eval promise against a timeout.  If the timeout fires, throw an
+ * error so the caller's catch block routes to the degraded fallback path.
+ */
+async function timeoutRace(
+  promise: Promise<number | string>,
+  timeoutMs: number,
+  key: string
+): Promise<number | string> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timer = setTimeout(
+      () => reject(new Error(`Redis eval timed out after ${timeoutMs}ms (key: ${key})`)),
+      timeoutMs
+    );
+  });
+
+  try {
+    return await Promise.race([promise, timeoutPromise]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
 }

--- a/src/lib/rate-limit-redis.ts
+++ b/src/lib/rate-limit-redis.ts
@@ -23,7 +23,7 @@ const EVAL_TIMEOUT_MS = 1500;
 
 // Redis executes Lua scripts atomically, so concurrent app instances cannot
 // both observe the same pre-limit count and over-admit requests.
-const REDIS_RATE_LIMIT_SCRIPT = `
+export const REDIS_RATE_LIMIT_SCRIPT = `
 redis.call("ZREMRANGEBYSCORE", KEYS[1], "-inf", ARGV[1])
 local count = redis.call("ZCARD", KEYS[1])
 
@@ -37,7 +37,6 @@ return 1
 `;
 
 const SCRIPT_SHA = createHash("sha1").update(REDIS_RATE_LIMIT_SCRIPT).digest("hex");
-
 /**
  * Atomically prune, count, and conditionally record a request in Redis.
  *
@@ -95,8 +94,11 @@ async function evalWithFallback(
 }
 
 /**
- * Race the eval promise against a timeout.  If the timeout fires, throw an
- * error so the caller's catch block routes to the degraded fallback path.
+ * Race the eval promise against a timeout.  If the timeout fires, the
+ * in-flight Redis promise may still reject later (broken pipe, cluster
+ * failover, etc.).  We attach a no-op catch to prevent that late rejection
+ * from surfacing as an unhandled promise rejection — but only AFTER the
+ * race is settled, so the first rejection still propagates correctly.
  */
 async function timeoutRace(
   promise: Promise<number | string>,
@@ -115,5 +117,8 @@ async function timeoutRace(
     return await Promise.race([promise, timeoutPromise]);
   } finally {
     if (timer) clearTimeout(timer);
+    // The race is over.  Silently consume any late rejection from the loser
+    // so it doesn't surface as an unhandled promise rejection.
+    promise.catch(() => {});
   }
 }

--- a/src/lib/rate-limit-redis.ts
+++ b/src/lib/rate-limit-redis.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import type Redis from "ioredis";
-import { disconnectRedisClientOnce } from "@/lib/cache/redis";
+import { invalidateRedisClient } from "@/lib/cache/redis";
 
 interface RedisRateLimitOptions {
   key: string;
@@ -81,7 +81,7 @@ export async function checkRedisRateLimit(
     ctx.aborted = true;
     // Force the client to reconnect on next call.  Without this, a wedged
     // but status="ready" socket silently queues every subsequent command (H1).
-    disconnectRedisClientOnce(redis);
+    invalidateRedisClient(redis);
   });
 
   if (result === 1 || result === "1") return true;
@@ -121,8 +121,11 @@ async function evalWithFallback(
         ...args
       )) as number | string;
       // A command already written to Redis cannot be recalled. If the timeout
-      // fired while EVAL was in flight, discard its late result and keep the
-      // request on the degraded, fail-closed path.
+      // fired while EVAL was in flight, discard its late result and let the
+      // warmed per-process limiter decide the request. The script may consume
+      // one Redis slot even if that local decision differs, but removing it
+      // would be unsafe: the local path may have allowed this request, and
+      // other instances rely on the shared counter.
       if (ctx.aborted) throw err;
       return result;
     }

--- a/src/lib/rate-limit-redis.ts
+++ b/src/lib/rate-limit-redis.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 import type Redis from "ioredis";
+import { disconnectRedisClientOnce } from "@/lib/cache/redis";
 
 interface RedisRateLimitOptions {
   key: string;
@@ -7,6 +8,7 @@ interface RedisRateLimitOptions {
   maxRequests: number;
   now: number;
   member?: string;
+  timeoutMs?: number;
 }
 
 /** Grace period (seconds) added to the TTL so the EXPIRE window always
@@ -74,11 +76,12 @@ export async function checkRedisRateLimit(
 
   const evalPromise = evalWithFallback(redis, args, ctx);
 
-  const result = await timeoutRace(evalPromise, EVAL_TIMEOUT_MS, options.key, () => {
+  const timeoutMs = options.timeoutMs ?? EVAL_TIMEOUT_MS;
+  const result = await timeoutRace(evalPromise, timeoutMs, options.key, () => {
     ctx.aborted = true;
     // Force the client to reconnect on next call.  Without this, a wedged
     // but status="ready" socket silently queues every subsequent command (H1).
-    redis.disconnect();
+    disconnectRedisClientOnce(redis);
   });
 
   if (result === 1 || result === "1") return true;
@@ -108,7 +111,20 @@ async function evalWithFallback(
     if (ctx.aborted) throw err;
     // NOSCRIPT means Redis doesn't have the script cached.  Fall back to EVAL.
     if (err instanceof Error && /NOSCRIPT/i.test(err.message)) {
-      return (await redis.eval(REDIS_RATE_LIMIT_SCRIPT, 1, ...args)) as number | string;
+      // Keep this check next to the mutating fallback call. It makes the
+      // invariant explicit and prevents a later refactor from inserting an
+      // async boundary between the catch-level guard and EVAL.
+      if (ctx.aborted) throw err;
+      const result = (await redis.eval(
+        REDIS_RATE_LIMIT_SCRIPT,
+        1,
+        ...args
+      )) as number | string;
+      // A command already written to Redis cannot be recalled. If the timeout
+      // fired while EVAL was in flight, discard its late result and keep the
+      // request on the degraded, fail-closed path.
+      if (ctx.aborted) throw err;
+      return result;
     }
     throw err;
   }

--- a/src/lib/rate-limit-redis.ts
+++ b/src/lib/rate-limit-redis.ts
@@ -147,10 +147,17 @@ async function timeoutRace(
   onTimeout?: () => void
 ): Promise<number | string> {
   let timer: ReturnType<typeof setTimeout> | undefined;
-  let timedOut = false;
   const timeoutPromise = new Promise<never>((_, reject) => {
     timer = setTimeout(() => {
-      timedOut = true;
+      // Abort and invalidate before settling the race. Promise reactions run
+      // after this timer callback returns, so no queued NOSCRIPT handler or
+      // subsequent caller can observe the abandoned client as usable.
+      try {
+        onTimeout?.();
+      } catch (error) {
+        // Cleanup must not replace the command-timeout error seen by callers.
+        console.error("Redis timeout cleanup error:", error);
+      }
       reject(new Error(`Redis eval timed out after ${timeoutMs}ms (key: ${key})`));
     }, timeoutMs);
   });
@@ -159,8 +166,6 @@ async function timeoutRace(
     return await Promise.race([promise, timeoutPromise]);
   } finally {
     if (timer) clearTimeout(timer);
-    // Only fire the timeout callback when the timeout actually won the race.
-    if (timedOut) onTimeout?.();
     // The race is over.  Silently consume any late rejection from the loser
     // so it doesn't surface as an unhandled promise rejection.
     promise.catch(() => {});

--- a/src/lib/rate-limit-redis.ts
+++ b/src/lib/rate-limit-redis.ts
@@ -40,10 +40,14 @@ const SCRIPT_SHA = createHash("sha1").update(REDIS_RATE_LIMIT_SCRIPT).digest("he
 /**
  * Atomically prune, count, and conditionally record a request in Redis.
  *
- * Uses EVALSHA with automatic EVAL fallback (via ioredis defineCommand pattern)
- * to avoid re-sending the script body on every call.  The entire eval is wrapped
- * in a timeout to handle wedged-socket scenarios where the client reports
- * "ready" but the connection is stuck mid-command.
+ * Uses EVALSHA with automatic EVAL fallback (manual evalsha/eval on NOSCRIPT,
+ * matching ioredis's built-in behaviour) to avoid re-sending the script body
+ * on every call.  The entire eval is wrapped in a timeout to handle
+ * wedged-socket scenarios where the client reports "ready" but the connection
+ * is stuck mid-command.
+ *
+ * On timeout, the Redis client is disconnected so the next `getReadyRedisClient()`
+ * rebuilds a fresh connection rather than queueing commands onto a dead socket.
  *
  * Returns null for an unexpected Redis response so the caller can use its
  * already-warmed in-process fallback rather than trusting malformed state.
@@ -51,7 +55,7 @@ const SCRIPT_SHA = createHash("sha1").update(REDIS_RATE_LIMIT_SCRIPT).digest("he
  * the degraded path.
  */
 export async function checkRedisRateLimit(
-  redis: Pick<Redis, "eval" | "evalsha">,
+  redis: Pick<Redis, "eval" | "evalsha" | "disconnect">,
   options: RedisRateLimitOptions
 ): Promise<boolean | null> {
   const args: Array<string | number> = [
@@ -63,9 +67,19 @@ export async function checkRedisRateLimit(
     Math.ceil(options.windowMs / 1000) + TTL_GRACE_SECONDS,
   ];
 
-  const evalPromise = evalWithFallback(redis, args);
+  // Abort context prevents the EVAL fallback from firing after the outer
+  // timeout race has already settled (H2: avoids counter drift from late
+  // NOSCRIPT → EVAL writes against a connection the caller abandoned).
+  const ctx = { aborted: false };
 
-  const result = await timeoutRace(evalPromise, EVAL_TIMEOUT_MS, options.key);
+  const evalPromise = evalWithFallback(redis, args, ctx);
+
+  const result = await timeoutRace(evalPromise, EVAL_TIMEOUT_MS, options.key, () => {
+    ctx.aborted = true;
+    // Force the client to reconnect on next call.  Without this, a wedged
+    // but status="ready" socket silently queues every subsequent command (H1).
+    redis.disconnect();
+  });
 
   if (result === 1 || result === "1") return true;
   if (result === 0 || result === "0") return false;
@@ -77,14 +91,21 @@ export async function checkRedisRateLimit(
  * Try EVALSHA first; on NOSCRIPT error (script evicted from Redis cache),
  * fall back to EVAL.  This mirrors ioredis's built-in behaviour but gives
  * us explicit control over the fallback path.
+ *
+ * The abort context prevents issuing a follow-up EVAL after the outer timeout
+ * race has already settled (H2).
  */
 async function evalWithFallback(
   redis: Pick<Redis, "eval" | "evalsha">,
-  args: Array<string | number>
+  args: Array<string | number>,
+  ctx: { aborted: boolean }
 ): Promise<number | string> {
   try {
     return (await redis.evalsha(SCRIPT_SHA, 1, ...args)) as number | string;
   } catch (err: unknown) {
+    // If the outer race already timed out, do NOT issue a follow-up EVAL —
+    // the caller has moved on and a late write would cause counter drift.
+    if (ctx.aborted) throw err;
     // NOSCRIPT means Redis doesn't have the script cached.  Fall back to EVAL.
     if (err instanceof Error && /NOSCRIPT/i.test(err.message)) {
       return (await redis.eval(REDIS_RATE_LIMIT_SCRIPT, 1, ...args)) as number | string;
@@ -103,20 +124,24 @@ async function evalWithFallback(
 async function timeoutRace(
   promise: Promise<number | string>,
   timeoutMs: number,
-  key: string
+  key: string,
+  onTimeout?: () => void
 ): Promise<number | string> {
   let timer: ReturnType<typeof setTimeout> | undefined;
+  let timedOut = false;
   const timeoutPromise = new Promise<never>((_, reject) => {
-    timer = setTimeout(
-      () => reject(new Error(`Redis eval timed out after ${timeoutMs}ms (key: ${key})`)),
-      timeoutMs
-    );
+    timer = setTimeout(() => {
+      timedOut = true;
+      reject(new Error(`Redis eval timed out after ${timeoutMs}ms (key: ${key})`));
+    }, timeoutMs);
   });
 
   try {
     return await Promise.race([promise, timeoutPromise]);
   } finally {
     if (timer) clearTimeout(timer);
+    // Only fire the timeout callback when the timeout actually won the race.
+    if (timedOut) onTimeout?.();
     // The race is over.  Silently consume any late rejection from the loser
     // so it doesn't surface as an unhandled promise rejection.
     promise.catch(() => {});

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -76,7 +76,7 @@ function rateLimitExceeded(
   windowMs: number
 ): { allowed: false; response: NextResponse } {
   const response = apiError("Too many requests", 429);
-  // Tell clients when to retry..ceil ensures we never under-report
+  // Tell clients when to retry. ceil ensures we never under-report
   // the wait time due to sub-second rounding.
   response.headers.set("Retry-After", String(Math.ceil(windowMs / 1000)));
   return { allowed: false, response };

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -18,10 +18,13 @@ interface RateLimitOptions {
 const MAX_IDENTIFIER_LENGTH = 256;
 
 function getClientIdentifier(request: NextRequest): string {
+  const xff = request.headers.get("x-forwarded-for");
+  // Cap before parsing so a multi-kilobyte x-forwarded-for doesn't waste CPU
+  // on split/trim.  1 024 bytes is generous for any legitimate proxy chain.
   const rawIdentifier = (
     request.headers.get("x-real-ip") ??
     request.headers.get("cf-connecting-ip") ??
-    request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
+    (xff ? xff.slice(0, 1024).split(",")[0]?.trim() : null) ??
     "unknown"
   ).trim();
 

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -15,6 +15,8 @@ interface RateLimitOptions {
   keyPrefix?: string;
 }
 
+const MAX_IDENTIFIER_LENGTH = 256;
+
 function getClientIdentifier(request: NextRequest): string {
   const rawIdentifier = (
     request.headers.get("x-real-ip") ??
@@ -26,8 +28,12 @@ function getClientIdentifier(request: NextRequest): string {
   if (!rawIdentifier) return "unknown";
   if (isIP(rawIdentifier)) return rawIdentifier.toLowerCase();
 
-  // Proxy headers are untrusted. Hash invalid values so a request cannot pin
-  // many kilobytes of attacker-controlled text in every fallback Map key.
+  // Proxy headers are untrusted. Short-circuit oversized values before
+  // hashing to avoid wasting CPU on attacker-controlled kilobyte-scale headers.
+  if (rawIdentifier.length > MAX_IDENTIFIER_LENGTH) return "invalid:oversized";
+
+  // Hash remaining invalid values so a request cannot pin many kilobytes of
+  // attacker-controlled text in every fallback Map key.
   return `invalid:${createHash("sha256")
     .update(rawIdentifier)
     .digest("base64url")}`;
@@ -63,20 +69,24 @@ function markRedisResponded(): void {
   firstErrorLogged = false;
 }
 
-function rateLimitExceeded(): { allowed: false; response: NextResponse } {
-  return {
-    allowed: false,
-    response: apiError("Too many requests", 429),
-  };
+function rateLimitExceeded(
+  windowMs: number
+): { allowed: false; response: NextResponse } {
+  const response = apiError("Too many requests", 429);
+  // Tell clients when to retry..ceil ensures we never under-report
+  // the wait time due to sub-second rounding.
+  response.headers.set("Retry-After", String(Math.ceil(windowMs / 1000)));
+  return { allowed: false, response };
 }
 
 function degradedResult(
-  fallbackDecision: FallbackDecision
+  fallbackDecision: FallbackDecision,
+  windowMs: number
 ): { allowed: true } | { allowed: false; response: NextResponse } {
   // A saturated map cannot safely track a previously unseen key. Healthy
   // Redis can still decide it, but during degradation we must fail closed.
   return fallbackDecision === "capacity-saturated"
-    ? rateLimitExceeded()
+    ? rateLimitExceeded(windowMs)
     : { allowed: true };
 }
 
@@ -97,14 +107,14 @@ export async function rateLimit(
     now
   );
   if (fallbackDecision === "limit-exceeded") {
-    return rateLimitExceeded();
+    return rateLimitExceeded(options.windowMs);
   }
 
   const redis = await getReadyRedisClient();
 
   if (!redis) {
     warnFallbackEngaged("client not ready");
-    return degradedResult(fallbackDecision);
+    return degradedResult(fallbackDecision, options.windowMs);
   }
 
   try {
@@ -117,7 +127,7 @@ export async function rateLimit(
 
     if (redisAllowed === null) {
       warnFallbackEngaged("atomic check returned invalid result");
-      return degradedResult(fallbackDecision);
+      return degradedResult(fallbackDecision, options.windowMs);
     }
 
     markRedisResponded();
@@ -126,13 +136,13 @@ export async function rateLimit(
       if (fallbackDecision === "allowed") {
         fallbackLimiter.rollback(key, now);
       }
-      return rateLimitExceeded();
+      return rateLimitExceeded(options.windowMs);
     }
 
     return { allowed: true };
   } catch (error) {
     warnFallbackEngaged("atomic check threw", error);
-    return degradedResult(fallbackDecision);
+    return degradedResult(fallbackDecision, options.windowMs);
   }
 }
 


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
### Summary

This PR layers four follow-up hardening enhancements onto the existing Redis-backed rate limiter: safe header handling before hashing, accurate Retry-After signaling, bounded eval latency, and optimized script delivery. Together they close specific issues identified during review of the preceding rate-limit work (PR #276).

### Detailed Changes

#### 1. Oversized proxy-header identifier short-circuit (`src/lib/rate-limit.ts`)
- Adds a `MAX_IDENTIFIER_LENGTH = 256` constant and bails early with `"invalid:oversized"` when an untrusted proxy header exceeds it.
- Previously, oversized values flowed straight into SHA-256 hashing, wasting CPU on attacker-controlled kilobyte-scale inputs and still allowing those values to influence the fallback map key shape.
- The hash path is preserved for legitimate-length but malformed identifiers.

#### 2. `Retry-After` header on 429 responses (`src/lib/rate-limit.ts`)
- `rateLimitExceeded` now accepts `windowMs` and sets `Retry-After: ceil(windowMs / 1000)` on the 429 response, per RFC 7231 §7.1.3.
- `degradedResult` and every 429-returning branch in `rateLimit` propagate `options.windowMs` so the header reflects the actual configured window rather than a hardcoded value.
- Ceiling division guarantees the wait hint is never smaller than the true window.

#### 3. Eval timeout via `Promise.race` (`src/lib/rate-limit-redis.ts`)
- Adds `EVAL_TIMEOUT_MS = 1500` covering the case where ioredis reports `ready: true` yet a command stalls mid-flight (e.g., wedged socket, network partition).
- New `timeoutRace` helper races the eval against a `setTimeout` rejection; the timer is always cleared in `finally`, avoiding leaks.
- On timeout, an explicit error is thrown so the existing catch block in `rateLimit` routes through `degradedResult`, preserving the fail-closed degradation semantics.
- The `checkRedisRateLimit` signature widens to require both `eval` and `evalsha` on the client.

#### 4. `EVALSHA` with automatic `EVAL` fallback (`src/lib/rate-limit-redis.ts`)
- Precomputes `SCRIPT_SHA` once via `createHash("sha1").update(REDIS_RATE_LIMIT_SCRIPT).digest("hex")`.
- New `evalWithFallback` helper tries `evalsha` first; on a `NOSCRIPT` error (script evicted from Redis cache) it transparently retries with full `eval`, mirroring and slightly extending ioredis's built-in pattern with explicit error matching.
- Eliminates re-sending the ~400-byte script body on every call and keeps behavior deterministic when the cache misses.
- Test-helper `FakeRedisClient` computes the matching SHA, accepts `evalsha` calls, delegates to shared `runRateLimitScript` logic, and still emits `NOSCRIPT` for unknown SHAs so the fallback path is exercisable.

#### 5. Test coverage updates
- **`fake-redis.ts`**: Adds `evalshaCalls` / `evalFallbackCalls` counters, a static `SCRIPT_SHA` matching production, an `evalsha` implementation with NOSCRIPT simulation, and extracts shared `runRateLimitScript` so both `eval` and `evalsha` exercise identical logic.
- **`rate-limit.test.ts`**: Three new tests
  - Oversized (512-byte) identifier short-circuits to `invalid:oversized` and the key length stays compact.
  - 429 responses carry the correct `Retry-After: 30` value for a 30-second window.
  - `evalsha` is called on the hot path (counter assertion).
- **`rate-limit-fallback.test.ts`**: The Redis-recovery monkey-patch is updated from `eval` → `evalsha`, with restored fallback delegation to the original `evalsha`.

### Functional Impact

- **Security**: Resource-bound protection against oversized proxy-header abuse and a bounded blast radius for stuck Redis connections.
- **Compliance**: 429s now self-document their retry interval, improving client behavior under throttling.
- **Performance**: Per-request Redis payload is reduced to just the SHA and key arguments on the hot path; cache-miss recovery remains correct.
- **Reliability**: Wedged-socket scenarios no longer block request handling indefinitely; they fall through to the existing degraded path with the same observability (a `Redis eval timed out after 1500ms` warning).

---

## Summary

This pull request enhances the Redis rate limiter with several follow-up improvements referenced in issue #242.

## Changes

### Script Export for Testing Consistency
- Exported `REDIS_RATE_LIMIT_SCRIPT` as a public constant so test helpers can compute the SHA1 hash from the same source string. This eliminates the previous duplication where the test fixture hard-coded the script body, which created a risk of the two staying out of sync.

### Script Hash Deduplication
- Replaced the duplicated hash literal in the test helper (`fake-redis.ts`) with one derived from the exported constant, ensuring any future edits to the Lua script body are automatically reflected in tests.

### Cleanup of Unused Tracking Field
- Removed the now-unused `evalFallbackCalls` counter from the fake Redis client.

### Robust Timeout Handling
- Improved `timeoutRace()` to silently swallow late rejections from the losing Redis promise once the race has settled. Previously, if the timeout fired first, the underlying `evalsha`/`eval` promise could still reject afterward (e.g. broken pipe, cluster failover) and surface as an unhandled promise rejection. The catch handler is attached only after the race resolves, so the first rejection still propagates correctly to the caller when it wins.

## Impact
- **Testing**: Eliminates a class of silent test bugs caused by script hash drift between production and test code.
- **Reliability**: Prevents late Redis failures from producing noisy unhandled promise rejection warnings while still surfacing real errors to the degraded fallback path when they are timely.

---

## Summary

This PR enhances the Redis rate limiter with several follow-up improvements.

## Changes

### Test coverage: EVALSHA with NOSCRIPT fallback

The existing test for EVALSHA was expanded to cover the full fallback path. Previously it only verified that EVALSHA was called first; now it also forces a NOSCRIPT error by overriding `evalsha` to always throw, then confirms that the EVAL fallback path is exercised and the rate limit decision still succeeds (returns `{ allowed: true }`). This locks in the NOSCRIPT recovery behavior so future refactors don't silently regress it.

---

## Summary

This PR introduces follow-up enhancements to the Redis rate limiter, addressing three reliability hazards (H1/H2) discovered in the previous review.

### Changes

**`src/lib/rate-limit-redis.ts` — Timeout race hardening (H1)**
- `checkRedisRateLimit` now accepts a `disconnect()`-capable Redis client. When the EVAL/EVALSHA call hits its timeout, the client is forcibly disconnected before the function rejects. This prevents the wedged-socket problem where a Redis instance reports `status="ready"` but silently deadlocks subsequent commands by queueing them onto a non-responsive socket. The next call will get a freshly rebuilt connection.
- `evalWithFallback` now takes an `aborted` context shared with the timeout race. If the outer race has already settled via timeout, no follow-up `EVAL` will fire on a NOSCRIPT response (H2: prevents counter drift from late writes against a connection the caller has already abandoned).
- `timeoutRace` accepts an `onTimeout` callback invoked exactly once when the timeout wins the race. Earlier it could fire on any loser rejection; now it only fires when timeout actually triggered.

**`src/lib/rate-limit.ts` — Oversized-header short-circuit**
- `x-forwarded-for` is sliced to 1 024 bytes **before** splitting/trimming. A multi-kilobyte header no longer wastes CPU on string parsing. The cap is generous for any plausible proxy chain. Other headers (`x-real-ip`, `cf-connecting-ip`) already have natural upper bounds from HTTP layer limits and remain uncapped.

### Tests

**`src/__tests__/rate-limit.test.ts`**
- The EVAL fallback (NOSCRIPT) test now asserts that `evalKeys.length` increased by exactly one and that the new key contains `keyPrefix`. Previously, the test only verified `allowed: true`, which would have passed even if the fallback silently no-op'd (H3 — silent degradation masquerading as success).
- The recovery test now calls `await fakeRedis.connect()` on the freshly swapped-in `FakeRedisClient` so its `ready` state is observable in the same way as the initial setup.

### Issue Reference

Closes the follow-up items from #242.

---

## Summary

This PR enhances the Redis rate limiter with several follow-up improvements focused on timeout handling, reliability, and graceful degradation.

### Key Changes

1. **Configurable timeout** — `checkRedisRateLimit` now accepts an optional `timeoutMs` parameter, defaulting to the existing internal `EVAL_TIMEOUT_MS`. This allows callers (and tests) to tune the timeout per use case.

2. **Disconnect-once guarantee** — Replaced the direct `redis.disconnect()` call with a new `disconnectRedisClientOnce(redis)` helper. Previously, concurrent timed-out checks could each call `disconnect()` independently, potentially causing redundant or racy disconnects. The helper ensures the client is disconnected only once even under concurrency, while remaining safe against repeated invocations from the singleton recovery path.

3. **Late NOSCRIPT and late EVAL handling** — When the timeout fires during a Redis call:
   - If a NOSCRIPT error surfaces **after** the timeout, the rate limiter no longer falls back to `EVAL` (which would issue an additional round-trip on an already-degraded client). The late error is rethrown so the request stays on the fail-closed path.
   - If an `EVAL` call returns **after** the timeout, its result is discarded. Since the command has already been executed in Redis, the side effect cannot be rolled back, so the late response is thrown away and the limiter remains fail-closed.

4. **Test infrastructure improvements** — Extended `FakeRedisClient` to simulate:
   - Configurable delays on `EVALSHA` and `EVAL` calls
   - Optional `NOSCRIPT` error injection from `EVALSHA`
   - Optional short-circuit for `EVAL` results after a delay
   - A `disconnectKeepsStatus` option that mirrors ioredis's real behavior of staying `"ready"` until the socket emits close, enabling accurate testing of the disconnect-once guard.

5. **New test coverage** — Added three tests verifying:
   - A wedged (slow) Redis client is disconnected exactly once when concurrent checks time out, even though the client status remains `"ready"`.
   - No `EVAL` is issued when a NOSCRIPT error arrives after the timeout.
   - A late but successful `EVAL` response is discarded, and the disconnect-once guard still triggers exactly once.

---

This pull request builds on the existing Redis rate limiter with several follow-up enhancements focused on robustness around timeouts, oversized header handling, and Lua script caching (EVALSHA).

Key changes:

- **Timeout-induced disconnect safety**: Replaces the prior `disconnectRedisClientOnce` call with `invalidateRedisClient`, and adds a regression test confirming that when cleanup throws during a timeout, the original "Redis eval timed out" errors are still preserved for concurrent callers and the singleton is removed (so a reconnect is suppressed during cooldown). This prevents a wedged but status="ready" socket from silently queuing commands.

- **Late EVAL response handling**: Clarifies the comment around discarding late EVAL responses — the request falls back to the warmed per-process limiter rather than the degraded fail-closed path, accepting the small risk of one Redis slot being consumed even if the local decision differs, since other instances depend on the shared counter.

- **Fake Redis test helper improvements**: Renames `evalResultAfterDelay` to `evalReturnValue` for clarity, and adds support for simulating a `disconnect()` that throws an error, enabling the new timeout/disconnect-error regression test.

- **Test refactor**: Imports `getReadyRedisClient` to assert the singleton was actually invalidated, and renames a test to better describe its behavior ("discards a late EVAL response that settles after the timeout").

Note: The pull request title also references "Retry-After" and "oversized header short-circuit" enhancements, but the provided diff only shows changes related to timeout/EVAL behavior and test helper improvements. Those additional features may be in other files not included in this patch set.

---

**feat: rate limiter follow-up enhancements (timeout, Retry-After, oversized header short-circuit, EVALSHA)**

This PR hardens the Redis-backed rate limiter around four follow-up scenarios surfaced after the initial rate-limiter work.

**Timeout cleanup ordering** — `timeoutRace` now runs the cleanup callback synchronously inside the timer before rejecting the race. This prevents any queued NOSCRIPT handlers or subsequent callers from observing the abandoned client as still usable, and wraps cleanup errors so they cannot mask the original timeout error reported to callers.

**Retry-After header** — Sets the `Retry-After` response header on 429 responses (window seconds, ceiled) so well-behaved clients back off correctly. (Also corrects a minor comment typo.)

**Oversized proxy identifier handling** — Replaces the previous hashing path with an explicit length bound so attacker-controlled `x-forwarded-for` values cannot produce arbitrarily large rate-limit keys. Covered by a regression test using a 12,000-character identifier.

**EVALSHA-first execution** — The atomic check now uses `EVALSHA` (with `EVAL` fallback for NOSCRIPT), which is verified by updated tests asserting the SHA-based call path is exercised on both invalid-response and thrown-error fallback paths.

**Singleton recovery and reconnect guard fixes** —
- After a timeout, the wedged singleton is rebuilt after the reconnect cooldown; an integration test asserts that a new client is constructed and serves subsequent requests.
- Disconnect cleanup is allowed to retry after a synchronous failure (no permanent poison of the once-guard).
- A stale failed connect attempt can no longer evict a replacement singleton that was installed concurrently.
- When both connect and disconnect throw, the singleton is still cleared and the reconnect cooldown prevents the same failed client from being handed out again.

**Test infrastructure** — `FakeRedisClient.connect()` now sets `status = "connecting"` before awaiting the simulated delay so concurrent-connection tests mirror real `ioredis` behavior.
<!-- kody-pr-summary:end -->