### PR TITLE
test(fixture): RED-owner regression tests for execution-controller failure classes

### DIFF
--- a/docs/POSTGRES-PGVECTOR-EXECUTION-CONTROLLER.md
+++ b/docs/POSTGRES-PGVECTOR-EXECUTION-CONTROLLER.md
@@ -367,3 +367,65 @@ engine-plus-volume lock, runs the real verifier against a unique loopback health
 port, and commits complete evidence. Cleanup proves that no fixture unit,
 container, volume, network, or switch-labeled resource remains. Production
 containers, volumes, Compose, and health endpoint are never targets.
+
+## Six-owner Review 1 implementation (Aug 17)
+
+The six RED owners accepted by the corrected native review are implemented;
+controller and fixtures are green across the focused, real-systemd, and
+disposable-Docker suites.
+
+- **Execution entry rejects ambient test hooks**: `execute_prepared_state`
+  fails closed before any state mutation when a `NOOSPHERE_CONTROLLER_TEST_*`
+  variable is set outside explicitly enabled fixture mode. Inherited hooks can
+  no longer steer production evidence or transitions.
+- **Durable engine-volume state authority**: preparation keeps the runtime
+  claim in `lockRoot` and additionally mirrors the engine-plus-volume binding
+  to `<user state>/noosphere-pgvector-controller/authority/state-<key>.json`
+  (key: SHA-256 of engine and volume). A duplicate prepare for the same
+  identity is rejected while the recorded state path exists in a non-terminal
+  phase, even after the entire runtime directory is replaced. Records whose
+  state file is gone or `complete` are reclaimed under the same lock.
+  Execution revalidates the claim before any mutation, so a byte-identical
+  state copy at another path cannot execute. The durable root is captured from
+  the invoking user's home before the hermetic execution environment replaces
+  `HOME`.
+- **Pre-activation failures are fail-closed**: a latched signal after writer
+  authorization (real trap or fixture hook) and a verifier-artifact storage
+  failure at the allocation boundary both commit durable
+  `closure-stop-pending`, freshly stop and inspect-verify the writer, then
+  publish `incident/closure-interruption` or `incident/closure-artifact-storage`
+  before returning. The incident is never published before the verified stop.
+- **Source-recovery artifacts are controlled paths**: the derived
+  `source-recovery.stdout.log`, `stderr.log`, and `evidence.json` paths join
+  the controller's collision matrix; a derived path overlapping any bound
+  transition input is rejected at preparation.
+- **Unbound source-recovery evidence cannot be trusted**: retry binding is
+  keyed to the complete new evidence/log/provenance set; a retry that
+  republishes new evidence but fails to rebind is rejected rather than
+  silently accepted, so a crash between publication and binding cannot leak an
+  unbound path into a trusted state.
+- **Phase-owned state proofs**: `validate_controller_state` requires each
+  non-trivial phase to carry its own mechanism's proof with key-specific
+  diagnostics: `guardEvidence` for `authorization-running`,
+  `activation-running`, and `closure-running`; `authorizationEvidence` for
+  `closure-stop-pending`; `writerStopEvidence` for `closure-evidence-pending`
+  and every `closure-*` incident; `sourceRecoveryEvidence` for
+  `incident/pre-journal-source-verification`. Every inspect-verified
+  `stop_application_fail_closed` writes and binds
+  `writer-stop.evidence.json` before those phases are reachable, and the
+  writer-stop evidence path joins the controlled artifact namespace.
+- **Fixture corrections required by the corrected contracts**: the crafted
+  `closure-running` baseline in `test_closure_outcome_never_false_completes`
+  now carries `guardEvidence` and `writerStopEvidence` (as every real
+  closure-running state does), and
+  `test_authorization_evidence_is_durable_before_activation` asserts the
+  fail-closed incident contract for a pre-activation latched TERM instead of
+  the superseded resumable `activation-running` outcome.
+
+
+## 2026-08-18 — Re-review round 2 corrections
+
+- **Incident-class diagnostic (resume die)**: the `closure-stop-pending` resume die now compiles its jq program correctly (`.incidentClass // "unknown"`), so the operator always sees the real incident class instead of an empty jq error.
+- **Writer-stop evidence is retry-distinct**: `stop_application_fail_closed` allocates its evidence path through `select_process_artifact_base` (writer-stop role). The first stop owns the canonical `.writer-stop.evidence.json`; a later invocation that finds it allocates an InvocationID-suffixed path, so a crash between evidence publication and phase advance can never overwrite a prior truthful stop record — the same contract the source-recovery role already enforces.
+- **Invocation-suffixed paths join the collision matrix**: whenever an InvocationID is present (always at execute), `assert_controller_artifact_paths_separate` also checks the `.<InvocationID>` suffixed guard/authorization/verify/source-recovery/writer-stop paths against every bound input, matching what a retrying invocation actually writes.
+- **New regression fixtures**: `test_writer_stop_evidence_is_retry_distinct` (canonical-first, InvocationID-distinct retry, prior bytes survive, unsafe InvocationID rejected) and `test_invocation_suffixed_artifacts_cannot_collide_with_bound_inputs` (suffixed writer-stop path rejected as bound input with collision diagnostic; clean control passes).

--- a/docs/POSTGRES-PGVECTOR-EXECUTION-CONTROLLER.md
+++ b/docs/POSTGRES-PGVECTOR-EXECUTION-CONTROLLER.md
@@ -1,0 +1,369 @@
+# PostgreSQL pgvector execution controller
+
+The execution controller owns the process and evidence transaction around the
+pinned `switch-pgvector-compose.sh` guard. It does not replace or weaken the
+guard: database, authorization-volume, backup, recovery, and transition-journal
+mutations remain exclusively inside the pinned guard.
+
+## Safety boundary
+
+- Preparation validates an owner-only manifest and writes an owner-only durable
+  state file. It does not modify Compose or Docker state.
+- Execution is accepted only inside an explicitly named transient systemd
+  service whose InvocationID, MainPID, safety properties, and transient
+  provenance are queried from the user manager.
+- The controller starts Bash in privileged mode, installs a fixed bootstrap
+  PATH before its first utility call, and validates the manifest's fixed PATH
+  with that bootstrap toolchain before exporting the recorded value.
+- The controller executable itself, every child executable, environment file,
+  source snapshot, candidate Compose file,
+  Docker Compose version, and effective candidate Compose model is re-hashed
+  before publication.
+- Preparation and execution acquire the guard's exact
+  Docker-engine-plus-volume lock before every live Docker/Compose identity
+  query. The guard runs as a child and inherits that already-held descriptor;
+  the wrapper never `exec`s away its signal and recovery traps.
+- That same lock is the cooperative publication trust boundary for Compose,
+  the guard journal, and controller state. It remains held and is re-asserted
+  through the final completed-journal validation and `complete` state write.
+  Every legitimate actor that can replace those artifacts must participate in
+  the lock. A malicious non-cooperating same-UID writer requires a separate OS
+  identity/capability and is outside this shell-controller contract.
+- Every guard or verifier starts in a controller-owned process group. A trapped
+  signal is forwarded to that whole group; the controller reaps the direct
+  child and waits until the group is empty before writing process evidence or
+  releasing the lock.
+- `candidate-published` recovery ownership is fsynced before the atomic
+  candidate Compose rename. A stop on either side of the rename therefore has
+  one deterministic next-invocation action.
+- A successful deferred guard is only the pre-authorization boundary. The
+  completed guard journal and process evidence are durably bound first; the
+  same pinned guard then authorizes the writer, the controller activates the
+  app, and the unchanged full deployment verifier runs last. All three process
+  evidence records must be durable before `complete`.
+
+## Durable phases
+
+`prepared` → `candidate-published` → `guard-exited` →
+`authorization-running` → `activation-running` → `closure-running` →
+`complete`.
+
+A closure failure first enters resumable `closure-stop-pending`. The controller
+stops the app writer and verifies it is not running before committing terminal
+`incident`. A reboot or failed first stop therefore retries the required stop
+instead of stranding an unsafe writer behind a terminal state.
+
+If verifier evidence cannot be persisted after a failed closure check, the
+controller retains `closure-evidence-pending` with the writer verified stopped.
+A later invocation may retry evidence collection while the writer remains
+stopped, but it cannot run the activation step again. A signal latched after
+activation likewise commits fail-closed stop intent and verifies the writer is
+stopped before the controller returns.
+
+Any state for which automatic continuation is unsafe enters `incident`. A
+pre-journal interruption restores only the recorded source Compose snapshot and
+only after the source deployment verifier passes. Once a guard journal exists,
+the pinned guard owns recovery and revalidation.
+
+## Preparation
+
+Create the private controller, backup, and runtime-lock directories with mode
+`0700`. Build a mode-`0600` JSON manifest containing the paths, arguments,
+digests, Docker engine/endpoint, volume/container identities, and effective
+Compose signature required by `validate_execution_manifest`. Then run:
+
+```bash
+scripts/run-pgvector-transition-controller.sh \
+  --prepare \
+  --manifest /absolute/private/controller/manifest.json \
+  --state /absolute/private/controller/state.json
+```
+
+Preparation must finish with phase `prepared`. An existing prepared state is
+accepted only when it is byte-identical to the manifest, and its inode is not
+rewritten. A different manifest or any active/terminal phase is refused. If a
+recorded input changes, resolve or preserve the existing state and prepare a
+new manifest/state pair; never edit a prepared state file. The prepared state
+also binds the canonical SHA-256 fingerprint of the live PostgreSQL volume's
+`{Name,Driver,Mountpoint,CreatedAt,Scope,Labels,Options}` document. Execution
+re-inspects and compares that fingerprint while holding the same operation
+lock, rejecting a same-name replacement volume before any Compose action.
+
+## systemd execution contract
+
+Preflight the exact transient unit name as absent. The user manager must have
+linger enabled so reboot recovery can be initiated without an interactive
+login. The controller queries `Transient=yes`; a persistent installed service
+cannot satisfy this contract. Start the controller with these properties:
+
+```text
+Type=exec
+RemainAfterExit=no
+Restart=no
+KillMode=mixed
+TimeoutStartSec=infinity
+TimeoutStopSec=infinity
+RuntimeMaxSec=infinity
+UMask=0077
+WorkingDirectory=/absolute/repository/path
+```
+
+Set `CONTROLLER_UNIT` to that exact service name and pass only the prepared
+state path to execution:
+
+```bash
+scripts/run-pgvector-transition-controller.sh \
+  --execute \
+  --state /absolute/private/controller/state.json
+```
+
+Do not impose a systemd start, runtime, or stop timeout. TERM, INT, and HUP are
+latched once, forwarded to the active guard or verifier process group, and
+enforced at the next controller phase boundary. The controller does not return
+or release the inherited transition lock until that process group is empty.
+The interrupted process exits with the signal-derived status; deterministic
+recovery belongs to the next invocation.
+
+## Closure and recovery
+
+- Guard failure before a journal: verify the source runtime, atomically restore
+  the source snapshot, and commit `incident/pre-journal-source-restored`.
+- Guard journal present: invoke the pinned guard again under the inherited lock;
+  it decides recovery or completed-journal revalidation.
+- Deferred guard success: bind the completed journal and guard evidence, invoke
+  the same pinned guard with `--authorize-writer`, bind authorization evidence,
+  activate the app from the invocation-private candidate Compose model, then
+  run the unchanged full verifier.
+- Writer authorization or app activation failure: preserve the completed
+  candidate transition, keep or restore the app-stopped boundary, and commit a
+  closure incident. Never run the final verifier after failed activation.
+- Verifier failure after the guard journal completes: preserve candidate
+  database and Compose state, commit `closure-stop-pending`, stop and verify the
+  app writer, then commit the terminal incident. Never automatically roll back
+  a completed database transition.
+- Evidence-write/fsync failure: no `complete` transition is possible. Preserve
+  the state directory and resume from the existing durable phase.
+- Verifier failure: durably commit the stop requirement and verify that the app
+  writer stopped before terminal incident handling or fallible verifier-evidence
+  persistence.
+
+Production execution remains a separately approved item. A green controller PR
+and disposable fault matrix do not authorize downtime or the database switch.
+
+
+## Execution-time invariants added after Review 1 (Aug 10)
+
+- **Terminal-state precedence**: `incident` and `complete` phases refuse
+  before any guard-journal delegation; resume never silently re-runs the
+  guard from a terminal state.
+- **Systemd identity is queried, not asserted**: `require_systemd_execution_context`
+  binds `INVOCATION_ID`, `MainPID`, and `ActiveState` from `systemctl --user show`,
+  rejecting matches where the environment claims an identity the unit does not
+  corroborate. Focused fixtures override `query_systemd_unit_identity`.
+- **Preparation never orphans an active or terminal state**:
+  `prepare_execution_state` refuses to overwrite any existing state whose phase
+  is not `prepared`; an existing prepared state is accepted only when its bytes
+  already equal the manifest, without replacing the state inode.
+- **Live engine and lock-root rebinding**: `assert_live_engine_binding` queries
+  the recorded Docker executable for `info --format '{{.ID}}'` and compares it
+  to the recorded `engineId`; it also compares the recorded `lockRoot` to the
+  guard's `${XDG_RUNTIME_DIR:-/run/user/uid}` contract. Both checks run at
+  prepare and at execute while the engine-volume operation lock is already
+  held and before any Compose action.
+
+These guarantees do not weaken the pinned guard; they ensure the wrapper never
+enters a phase the guard has not authorised.
+
+## Execution-time invariants added after Review 1 (Aug 11)
+
+- **Hermetic child execution**: guard and verifier children start through
+  `env -i` with an explicit Docker endpoint/config, controller home,
+  Compose-env-file suppression, lock root, locale, and PATH. The PATH prepends
+  the recorded Docker executable's directory and must resolve `docker` back to
+  that exact recorded file.
+- **Bound verifier target**: the prepared manifest records a loopback-only
+  `appUrl`, and the verifier child receives that exact value as
+  `NOOSPHERE_APP_URL`. A disposable rehearsal therefore cannot accidentally
+  validate the production app endpoint.
+- **Signal latch enforcement**: the first TERM/INT/HUP is durably recorded and
+  stored in the controller latch. It is forwarded to whichever child is active,
+  and every later phase boundary refuses to continue with the corresponding
+  signal exit status. Repeated signals cannot re-enter persistence.
+- **Fail-closed verifier ordering**: a non-zero verifier result commits
+  `incident/closure-verification`, stops the app, and verifies
+  `State.Running=false` before any verifier-evidence storage.
+- **Durable closure evidence**: stdout and stderr are fsynced before hashing;
+  owner-only process-evidence files are atomically persisted; transition-guard,
+  writer-authorization, and closure-verifier evidence/log paths and hashes are
+  bound into controller state before the final atomic `complete` phase write.
+- **Semantic guard binding**: the source-transition controller accepts only
+  the recorded switch arguments and rejects
+  alternate modes, unknown options, duplicates, or mismatched targets.
+- **Compose/config identity**: the resolved Compose plugin executable and the
+  private one-file Docker config are path- and digest-bound at preparation and
+  rechecked before candidate publication.
+- **Durable recovery failures**: pre-journal recovery first records a recovery
+  intent; verification or restoration failure becomes a terminal, classified
+  incident instead of an automatically retryable transition phase.
+- **Chronological process evidence**: process timestamps must be canonical UTC
+  RFC3339 values and cannot end before they start.
+- **Publication recovery proof**: candidate publication re-hashes both the live
+  Compose file and the separate source-recovery snapshot while holding the
+  engine-volume lock, before committing publication intent.
+- **Canonical journal ownership**: `guardJournal` must resolve to the pinned
+  guard's deterministic `backupDir/volume.phase-a2b.json` path, and the
+  controller state path must resolve elsewhere.
+- **Trusted fixed PATH**: every configured PATH directory must resolve to a
+  root-owned directory without group/world write permission. This prevents the
+  deployment user from introducing a replacement critical utility after
+  preparation; the same check is repeated before publication.
+- **Host-derived evidence**: boot identity and journal cursors come from the
+  running host and user journal. Ambient test override variables cannot enter
+  durable production evidence.
+- **Truthful source-recovery evidence**: ordinary and signal-interrupted source
+  verifier runs preserve the exact child stdout/stderr bytes, including Bash's
+  deterministic `Terminated … sleep 0.1` diagnostic, and bind them with the
+  real host boot ID and independently sampled user-journal cursor.
+- **Integral process identity**: exit codes and controller/child PIDs must be
+  non-negative or positive JSON integers as appropriate; fractional numeric
+  values are rejected.
+
+## Publication-blocker corrections (Aug 12)
+
+- **Production-only hook sanitization**: direct controller execution resets the
+  internal fixture seam and removes every controller fault/signal hook before
+  execution. The fixture shim must explicitly opt in, so ambient user-manager
+  variables cannot synthesize a failure, signal, or evidence result.
+- **Artifact namespace separation**: controller state, guard/verifier logs, and
+  process-evidence files are canonically checked against every bound input,
+  executable, Compose file, journal, manifest, and Docker config at preparation
+  and execution. Derived outputs cannot truncate or overwrite transition inputs.
+- **Interruption evidence ordering**: after a child receives TERM/INT/HUP, the
+  controller records, fsyncs, and binds that child's exit/log evidence and its
+  durable phase before returning the signal-derived status. Verifier
+  interruption cannot falsely commit `complete`.
+- **Phase-specific terminal validity**: `complete` requires bound guard,
+  authorization, closure, and complete-journal evidence; `incident` requires a
+  non-empty incident class. A syntactically valid but evidentially incomplete
+  terminal state is rejected.
+- **Hermetic preparation**: preparation installs the recorded endpoint, PATH,
+  home, and Docker config and clears Compose/Docker overrides before any live
+  engine, plugin, version, or effective-model query. The certified preparation
+  context therefore matches the later execution context.
+- **Hermetic bootstrap**: the executable uses privileged `/bin/bash -p`, which
+  suppresses `BASH_ENV` and imported shell functions, and installs a fixed
+  system PATH before resolving itself or reading any manifest value.
+- **Pre-install PATH trust**: preparation and execution validate the recorded
+  fixed PATH with the bootstrap toolchain before assigning it to `PATH`; a
+  manifest-controlled directory cannot supply the utilities that judge its own
+  trust.
+- **Owned descendant lifecycle**: guard and verifier work runs in separate
+  process groups. Signal delivery and completion wait cover the entire group,
+  including descendants that inherit the transition lock descriptor.
+- **Resumable closure stop**: closure failures persist
+  `closure-stop-pending`; resume retries and verifies the app stop before the
+  state becomes terminal `incident`.
+- **Transient unit provenance**: execution requires the live systemd unit to
+  report `Transient=yes` in addition to the existing InvocationID, MainPID,
+  working-directory, restart, timeout, kill-mode, and umask checks.
+- **Docker-config namespace isolation**: state, logs, evidence, backups, and
+  locks cannot be equal to, descend from, or contain the one-file Docker config
+  directory.
+- **Terminal evidence revalidation**: accepting `complete` requires all three
+  zero-exit process-evidence files, their bound logs and hashes, and the
+  completed guard journal to remain present and unchanged.
+- **Recovery evidence preservation**: a resumed systemd invocation allocates
+  invocation-distinct process artifacts whenever prior evidence paths exist,
+  preserving the original transition child's provenance.
+
+## Final post-full-gate Review 1 corrections (Aug 13)
+
+- **Deferred writer restart is mandatory**: source-transition guard arguments
+  must include `--defer-app-restart`. The pinned guard therefore cannot restart
+  or authorize the candidate app writer before the controller has durably
+  bound the completed transition journal and pre-authorization guard evidence.
+- **Two-step writer closure is mandatory**: after that durable boundary, the
+  controller invokes the pinned guard's `--authorize-writer` mode, binds its
+  evidence, activates the app, and only then runs the unchanged full verifier.
+  Neither authorization nor activation can be skipped on resume.
+- **Invocation-private execution inputs**: each systemd invocation copies the
+  verified guard, verifier, Docker client, Compose plugin, Docker config,
+  environment file, source snapshot, and candidate Compose file into a private
+  bundle. The copies are re-hashed and their Compose/plugin identity is checked
+  before use, closing hash-then-pathname replacement races.
+- **Trusted system-executable ownership**: production Docker and Compose
+  executables may be root-owned or deployment-user-owned, but must be regular
+  non-symlink files without group/world write permission before they are copied
+  into the private bundle. Other transition inputs remain caller-owned.
+- **Serialized first preparation**: a deterministic, owner-only preparation
+  lock serializes the absent-state decision. Concurrent first preparations
+  cannot both publish a different initial controller state; only one exact
+  manifest wins.
+- **Stable fixed PATH names**: fixed-PATH components must be trusted canonical
+  directories or root-owned symlink aliases. A deployment-user-controlled
+  symlink cannot be retargeted after its resolved directory passed validation.
+- **Resumable verifier-evidence persistence**: once verifier failure requires
+  closure, the controller records `closure-stop-pending`, stops and verifies
+  the app writer, and only then records `closure-evidence-pending`. It next
+  binds verifier evidence and commits terminal `incident`. Evidence-storage
+  failure remains safely retryable with the writer already stopped; retry
+  never re-enters application activation.
+- **Post-activation signal closure**: TERM, INT, or HUP latched while activation
+  completes commits durable closure-stop intent and stops and verifies the
+  writer before returning the signal-derived exit status.
+- **Classified pre-journal restoration failures**: source-Compose safety checks
+  return control to the recovery owner. A missing, symlinked, or wrongly owned
+  live Compose file therefore commits a durable incident instead of exiting
+  from inside the restore helper.
+- **No-follow deterministic locks**: preparation and engine-volume lock files
+  are created through an atomic hard-link publication path, opened read/write
+  without truncation, and validated as owner-only regular non-symlink files
+  before `flock`. A pre-existing symlink cannot redirect or truncate a target.
+- **Trusted bootstrap utility resolution**: the privileged bootstrap PATH is
+  limited to system directories and excludes `/usr/local`. No bootstrap utility
+  is resolved through an unproven mutable directory before the recorded PATH
+  trust boundary is established.
+
+## Replacement Review 1 corrections (Aug 15)
+
+- **Pre-activation verifier artifacts**: every verifier log/evidence path and
+  initial owner-only file is selected and created before application
+  activation. A collision, unsafe path, or storage failure is therefore
+  rejected while the writer remains stopped.
+- **Stop-before-evidence ordering**: `closure-evidence-pending` is reachable
+  only after durable `closure-stop-pending` intent and an inspect-verified
+  stopped application. A failed stop or failed stop verification remains in
+  the retryable stop phase and cannot advance to evidence persistence.
+- **Prepared PostgreSQL volume identity**: preparation stores the canonical
+  Docker volume fingerprint, and execution revalidates all canonical fields
+  under the shared lock. Recreating a volume under the same name cannot reuse
+  prepared transition authority.
+- **Lock-first live identity checks**: engine ID, PostgreSQL volume inspection,
+  Compose plugin/version, and effective Compose-model queries in both prepare
+  and execute occur only after the exact engine-volume lock descriptor/path is
+  held. No live identity call can race a cooperating transition owner.
+
+Focused verification:
+
+```bash
+scripts/test-pgvector-transition-controller.sh
+scripts/test-pgvector-transition-controller-systemd.sh
+scripts/test-pgvector-transition-controller-docker.sh linux/amd64
+```
+
+The second command proves the controller's real transient-unit identity,
+MainPID, InvocationID, and collection boundary, then sends TERM to a second
+real unit and proves one child delivery, exit 143, and no false completion using
+disposable fake Docker/guard/verifier commands. It intentionally does not
+replace the stronger disposable Docker rehearsal through the pinned guard,
+which remains a separate pre-production verification stage.
+
+The third command supplies that stronger evidence. It creates uniquely named
+source containers and volumes, seeds the minimal Noosphere schema (including
+the round-trip-sensitive CHECK constraint), prepares the controller manifest,
+and launches the actual controller under a collected user unit. The controller
+publishes candidate Compose, invokes the pinned guard with the inherited
+engine-plus-volume lock, runs the real verifier against a unique loopback health
+port, and commits complete evidence. Cleanup proves that no fixture unit,
+container, volume, network, or switch-labeled resource remains. Production
+containers, volumes, Compose, and health endpoint are never targets.

--- a/docs/POSTGRES-PGVECTOR-EXECUTION-CONTROLLER.md
+++ b/docs/POSTGRES-PGVECTOR-EXECUTION-CONTROLLER.md
@@ -384,7 +384,10 @@ disposable-Docker suites.
   (key: SHA-256 of engine and volume). A duplicate prepare for the same
   identity is rejected while the recorded state path exists in a non-terminal
   phase, even after the entire runtime directory is replaced. Records whose
-  state file is gone or `complete` are reclaimed under the same lock.
+  state file is gone are reclaimed under the same lock; a `complete` state is
+  reclaimable only after its bound guard, authorization, closure, and journal
+  evidence validates. A retained runtime claim for that proven stale record
+  is atomically replaced while the operation lock is held.
   Execution revalidates the claim before any mutation, so a byte-identical
   state copy at another path cannot execute. The durable root is captured from
   the invoking user's home before the hermetic execution environment replaces
@@ -399,6 +402,10 @@ disposable-Docker suites.
   `source-recovery.stdout.log`, `stderr.log`, and `evidence.json` paths join
   the controller's collision matrix; a derived path overlapping any bound
   transition input is rejected at preparation.
+- **Bound transition inputs are pairwise distinct**: preparation rejects any
+  two semantically distinct inputs that canonicalize to the same path, so
+  candidate publication cannot overwrite the sole source snapshot or another
+  recovery dependency.
 - **Unbound source-recovery evidence cannot be trusted**: retry binding is
   keyed to the complete new evidence/log/provenance set; a retry that
   republishes new evidence but fails to rebind is rejected rather than

--- a/docs/superpowers/plans/2026-08-10-item3-execution-controller.md
+++ b/docs/superpowers/plans/2026-08-10-item3-execution-controller.md
@@ -232,3 +232,53 @@ identity query. Four independent RED owners, twelve affected legacy owners,
 and the complete 86-owner focused aggregate must be GREEN before the full
 policy/systemd/pinned-Docker/residue/production-source gate and replacement
 fresh Review 1. Review 2 remains sequentially blocked until Review 1 is clean.
+
+## 2026-08-17 — Six-owner implementation complete
+
+All six RED owners from the corrected Review 1 are GREEN, plus the three
+review-adjacent legacy corrections:
+
+1. Execute-entry fail-closed rejection of ambient `NOOSPHERE_CONTROLLER_TEST_*`
+   hooks (six-variable explicit diagnostic contract; unset retained as
+   defense-in-depth).
+2. Durable engine-volume state authority: runtime claim in `lockRoot` mirrored
+   to the XDG state root (`XDG_STATE_HOME` when set, else `$HOME/.local/state`)
+   under `noosphere-pgvector-controller/authority/`; duplicate prepare rejected
+   while the recorded state path exists in a non-terminal phase; execution
+   revalidates, so a copied state at a second path cannot execute. Stale
+   records (missing or `complete` state files) are reclaimed under the lock.
+3. Post-authorization pre-activation failures (latched signal, verifier
+   artifact-storage failure) commit `closure-stop-pending`, stop and
+   inspect-verify the writer with bound `writerStopEvidence`, then publish the
+   exact `closure-interruption` / `closure-artifact-storage` incident — never
+   before the verified stop.
+4. Source-recovery derived artifacts joined the controlled-path collision
+   matrix.
+5. Source-recovery retry allocates InvocationID-distinct artifact paths via
+   `select_process_artifact_base`, so prior unbound evidence/logs survive a
+   publication/bind crash byte-identically.
+6. Phase-owned state proofs inlined into `validate_controller_state`
+   (extraction-compatible) with per-key diagnostics; `writer-stop.evidence.json`
+   joined the controlled namespace.
+
+Fixture corrections required by the corrected contracts:
+`test_closure_outcome_never_false_completes` baseline now carries
+`guardEvidence` + `writerStopEvidence`; the crafted state's phase-authority
+tests assert incident classification instead of the superseded resumable
+`activation-running` outcome.
+
+Test-isolation hardening: durable authority records now honor
+`XDG_STATE_HOME`; the focused suite isolates its state root per run, the
+systemd fixture passes the same root into both transient units, and the Docker
+rehearsal relocates it into its disposable `tmp_dir` with a residue assertion.
+The invoking user's real state namespace is no longer touched by fixtures.
+
+Gate status (2026-08-17 22:4x): focused, systemd, and Docker suites re-running
+after the isolation change; controller + fixtures previously byte-stable GREEN
+across all three. Next: hygiene scan, sequential fresh Reviews 1 and 2,
+privacy scan, commit/push/PR #300 update, 20-minute CI/bot gate.
+
+
+## 2026-08-18 — Re-review round 2 stage (operator review comment 5321434858)
+
+Applied corrections per Sophie's round-2 re-review: (1) jq escaped-quote fix in the closure-stop-pending resume die; (2) writer-stop evidence retry-distinct allocation via `select_process_artifact_base`; (3) invocation-suffixed artifact paths added to the collision matrix. Two new regression fixtures cover the retry-distinct stop evidence and the suffixed-path collision rejection. Gate after corrections: policy GREEN, focused suite 102/102 GREEN, real transient-systemd GREEN, pinned-Docker GREEN, residue 0, production-source verify GREEN (50 topics / 512 articles / 15 keys). Findings 2-5 from the review recorded as follow-ups (dead `bootId` field wiring, `NOOSPHERE_CONTROLLER_TEST_CURSOR` deny-list symmetry, dead `--setenv` fixture lines, suffixed-path matrix completeness beyond writer-stop).

--- a/docs/superpowers/plans/2026-08-10-item3-execution-controller.md
+++ b/docs/superpowers/plans/2026-08-10-item3-execution-controller.md
@@ -1,0 +1,234 @@
+# Item #3 Execution Controller Verification Plan
+
+## Claim
+
+The one-time PostgreSQL source-to-candidate transition can be launched under
+systemd without creating an unowned state between candidate Compose publication
+and the pinned guard journal, and can be resumed after signals or reboot without
+guessing whether source restoration or candidate closure owns the next action.
+
+The controller must not weaken or replace `switch-pgvector-compose.sh`. The
+pinned guard remains the only database, authorization, and transition-journal
+mutator.
+
+## Scope
+
+- Add a separate execution controller and focused fixture suite.
+- Do not change the pinned guard, verifier, installer, image digests, or Compose
+  policy in this stage.
+- Keep production execution, downtime, and Phase C out of scope.
+
+## State model
+
+The controller owns one stable, owner-only state file per Docker engine and
+PostgreSQL volume. Its durable phases are:
+
+1. `prepared` — artifacts, environment model, command identities, source
+   snapshot, and guard arguments are verified and persisted; live Compose is
+   unchanged.
+2. `candidate-published` — recovery ownership is durably committed immediately
+   before candidate Compose is atomically published while the controller holds
+   the guard's engine-plus-volume lock. A stop between the state commit and the
+   rename safely restores the already-live source snapshot on resume.
+3. `guard-exited` — deferred guard exit status, process evidence, and the
+   completed transition journal are durably recorded.
+4. `authorization-running` — the pinned guard's writer-authorization mode is
+   running; successful process evidence is bound before activation.
+5. `activation-running` — authorization evidence is durable and candidate app
+   activation is pending or in progress.
+6. `closure-running` — the activated deployment's full verification is in
+   progress.
+7. `complete` — guard, authorization, and verifier evidence are durably
+   committed with the unchanged completed journal.
+8. `incident` — no automatic next action is safe; candidate/source state and
+   evidence are preserved for operator diagnosis.
+
+The stable state file is created before Compose publication. On a later
+invocation, `candidate-published` without a guard journal restores the exact
+source-staged Compose file only after source container and authorization checks
+pass. Any valid guard journal delegates recovery or completed-journal
+revalidation to the pinned guard.
+
+## Evidence path
+
+### Focused fixture suite
+
+1. **Pre-journal interruption**
+   - Inject failure immediately after candidate Compose publication.
+   - Verify controller state is durable and source Compose is restored.
+   - Repeat from a fresh process to model reboot recovery.
+
+2. **Shared lock ownership**
+   - Hold the exact engine-plus-volume lock in one fixture process.
+   - Verify a second controller fails before changing Compose.
+   - Verify the guard child receives and validates the inherited lock FD/path.
+   - Treat participation in this lock as the publication trust boundary for
+     controller state, Compose, and the guard journal. A malicious
+     non-cooperating same-UID writer requires a separate OS identity or
+     capability and is outside this shell-controller plan.
+
+3. **Hermetic execution inputs**
+   - Seed hostile Docker/Compose environment variables and an implicit `.env`.
+   - Verify the controller uses the recorded local Unix endpoint, explicit
+     env/config paths, minimal PATH, isolated Docker config, and recorded
+     Docker/Compose command identities.
+   - Mutate each recorded command/config input after preparation and verify
+     failure before Compose publication.
+
+4. **Signal and stop races**
+   - Inject TERM before child PID assignment, while the guard runs, after guard
+     exit, and during cleanup.
+   - Verify traps are idempotent, later signals cannot re-enter cleanup, and the
+     durable state selects exactly one next action.
+   - Verify the systemd launch contract has no start/runtime kill timeout and an
+     explicit infinite stop timeout; reboot recovery is a next-invocation rule,
+     not a claim that shutdown traps always finish.
+
+5. **Closure and evidence failures**
+   - Bind verifier stdout, stderr, exit status, InvocationID, boot ID, PID, and
+     start/end journal cursors to owner-only files.
+   - Verify identity/extension/count/infrastructure failures stop the app and
+     commit `incident` without rollback.
+   - Permit completed-journal guard revalidation only for isolated app-health
+     failure after all other checks are independently green.
+   - Fail evidence fsync/storage as a fixture and verify there is no false
+     `complete` state.
+
+### Integration evidence
+
+- Run the controller against disposable fake commands for every phase/fault.
+- Run the existing full guarded-switch matrix unchanged.
+- Run one disposable Docker transition/recovery rehearsal through the controller
+  on linux/amd64 before any production proposal.
+- Run syntax, policy, privacy, and staged-diff checks.
+
+The linux/amd64 controller rehearsal must bind a unique loopback app-health
+endpoint in the prepared manifest, run the real controller as the transient
+unit MainPID, invoke the pinned guard and real verifier against uniquely named
+Docker resources, and prove exact cleanup. A fake-dependency systemd fixture is
+process-ownership evidence only and cannot satisfy this item by itself.
+
+## Success criteria
+
+- Every injected interruption ends in one durable and diagnosable controller
+  phase.
+- No second controller or guard can run outside the shared lock.
+- Candidate Compose is never left published without either a valid guard journal
+  or controller-owned recovery state.
+- No verifier or evidence failure can be reported as success.
+- Existing guarded-switch tests remain green without changing the immutable
+  helper/installer chain.
+
+## Stronger fallback
+
+If shell fixtures cannot prove signal/reboot behavior directly enough, run the
+controller in a disposable user-manager namespace or VM and kill the wrapper and
+guard at each durable phase. Production remains excluded until that evidence is
+green and the change passes sequential review and the PR gate.
+
+### Stage 5b — Review 2 correction batch (4 BLOCKER + 3 HIGH)
+
+Review 2 (fresh Codex native subagent on the Stage-5-corrected worktree) found
+seven further substantive findings that bypass Stage 5. The integration gate is
+NOT green for production. The next bounded stage implements these seven
+corrections and re-verifies with a fresh third review before commit/push/PR.
+
+1. **BLOCKER** — Prepare/execute boundary leak. `sanitize_execution_environment`
+   does not unset `NOOSPHERE_CONTROLLER_TEST_*`. Inherited envvars can flip
+   evidence persistence, signal behavior, or terminal outcome after the pinned
+   guard has mutated the transition. (lines 308, 356–358, 453–455, 675–677, 1026–1028)
+2. **BLOCKER** — Path-separation covers only state↔journal. Derived log/evidence
+   paths are never checked against `liveCompose`, `sourceSnapshot`,
+   `candidateCompose`, `envFile`, guard, verifier, Docker config, or each
+   other. A collision such as `liveCompose == ${state%.json}.guard.stdout.log`
+   truncates the live Compose to zero bytes via tee before the guard runs.
+   (lines 869–871, 1019–1023, 1055–1059)
+3. **BLOCKER** — Guard/verifier TOCTOU. Scripts are hashed once at verify time
+   and then executed by pathname later. A same-user writer can swap bytes
+   between verify and exec without registering a digest failure. Bind exec to
+   a rehash right before invocation, or to a copy under a private path.
+   (lines 833–857, 1030–1031, 1063–1064)
+4. **BLOCKER** — Real signal discards child evidence. After a forwarded TERM
+   returns from `wait`, `abort_if_interrupted` exits at lines 1032 or 1065
+   before end timestamp/cursor capture, log fsync, or process-evidence binding.
+   A fresh interrupted run has only `lastInterruption`; its child outcome and
+   logs are not durably bound. (lines 1030–1042, 1063–1075)
+5. **HIGH** — Final guard-journal digest check is not atomic with
+   `phase=complete`. The journal is hashed, then the controller performs more
+   shell work before atomically writing `phase=complete`. Volume flock does
+   not lock the journal file; a non-cooperating same-user writer can change
+   the journal between the hash and the write. (lines 669–679)
+6. **HIGH** — Phase-dependent terminal invariants are not validated.
+   `validate_controller_state` accepts `phase=complete` without
+   `guardEvidence`, `closureEvidence`, or `guardJournalEvidence`, and accepts
+   `phase=incident` without an incident class. (lines 86–108, 172–181)
+7. **HIGH** — Preparation resolves Docker/Compose identity through ambient
+   configuration. `verify_execution_inputs` runs before
+   `sanitize_execution_environment`; inherited `DOCKER_HOST`,
+   `DOCKER_CONTEXT`, `DOCKER_CONFIG`, and `COMPOSE_*` can determine the
+   engine/plugin/model accepted into the prepared state. Hermetic
+   sanitization occurs only at execute, so preparation can certify a context
+   different from the recorded production execution context. (lines 824–858,
+   860–868, 983–997)
+
+Threat-model resolution (Aug 16): finding 5 is enforced at the cooperative
+engine-volume lock boundary. The controller retains and re-asserts that exact
+lock through the final completed-journal validation and `complete` state
+publication; fixtures prove a separately opened lock descriptor cannot acquire
+the lock at that boundary and can acquire it after controller exit. Protection
+from a malicious non-cooperating same-UID process would require the explicitly
+deferred identity/capability split rather than a shell-level digest recheck.
+
+Plan for Stage 5b: write seven RED fixtures first (each red for the specific
+mechanism), confirm RED, then implement the seven corrections in one bounded
+batch, re-verify with 32 focused fixtures + guarded-switch matrix + policy
+check + production source verification, then run a fresh third review before
+commit/push/PR.
+
+### Two-step writer closure — post-full-gate Review 1 corrections
+
+The fresh Review 1 of the durable transition → authorization → activation →
+verification lifecycle accepted three further blockers:
+
+1. A signal latched after app activation but before verifier launch could
+   return while the writer remained running and restartable.
+2. Resuming `closure-evidence-pending` selected normal closure and reactivated
+   the writer that the prior failed closure had already stopped.
+3. A missing or unsafe live Compose file exited from the restore helper instead
+   of returning to the recovery owner for durable incident classification.
+
+Verification is RED-first with one independent fixture per mechanism. The
+corrected artifact must stop and verify the writer before a post-activation
+signal returns, keep pending-evidence resumes activation-free, and classify
+unsafe pre-journal restoration as a durable incident. The focused suite,
+policy check, real transient-systemd fixture, pinned-guard Docker rehearsal,
+residue checks, and explicit production source-mode verification must all pass
+before a replacement fresh Review 1. Review 2 remains sequentially blocked
+until that Review 1 is clean.
+
+### Replacement Review 1 — four post-full-gate corrections
+
+The replacement Review 1 accepted four additional state/identity blockers:
+
+1. Verifier artifact allocation after application activation allowed a path or
+   storage failure to strand an active writer without durable verifier
+   evidence.
+2. `closure-evidence-pending` could be persisted before the writer stop was
+   inspect-verified, so failed stop verification could leave a misleading
+   evidence-retry phase.
+3. Prepared state named the PostgreSQL volume but did not bind its canonical
+   Docker metadata, allowing a same-name replacement between preparation and
+   execution.
+4. Preparation and execution performed live Docker/Compose identity queries
+   before acquiring the shared engine-volume lock, allowing cooperating
+   transition owners to race the certified identity.
+
+The corrected controller allocates verifier artifacts before activation,
+persists `closure-stop-pending` and verifies the stop before
+`closure-evidence-pending`, binds and rechecks the canonical
+`{Name,Driver,Mountpoint,CreatedAt,Scope,Labels,Options}` volume fingerprint,
+and acquires the shared operation lock before every live prepare/execute
+identity query. Four independent RED owners, twelve affected legacy owners,
+and the complete 86-owner focused aggregate must be GREEN before the full
+policy/systemd/pinned-Docker/residue/production-source gate and replacement
+fresh Review 1. Review 2 remains sequentially blocked until Review 1 is clean.

--- a/docs/superpowers/plans/2026-08-10-item3-execution-controller.md
+++ b/docs/superpowers/plans/2026-08-10-item3-execution-controller.md
@@ -245,8 +245,11 @@ review-adjacent legacy corrections:
    to the XDG state root (`XDG_STATE_HOME` when set, else `$HOME/.local/state`)
    under `noosphere-pgvector-controller/authority/`; duplicate prepare rejected
    while the recorded state path exists in a non-terminal phase; execution
-   revalidates, so a copied state at a second path cannot execute. Stale
-   records (missing or `complete` state files) are reclaimed under the lock.
+   revalidates, so a copied state at a second path cannot execute. Missing
+   state files are reclaimed under the lock; `complete` states relinquish
+   authority only after all bound completion evidence validates. A retained
+   runtime claim for either proven stale predecessor is atomically replaced
+   under that same lock.
 3. Post-authorization pre-activation failures (latched signal, verifier
    artifact-storage failure) commit `closure-stop-pending`, stop and
    inspect-verify the writer with bound `writerStopEvidence`, then publish the

--- a/scripts/run-pgvector-transition-controller.sh
+++ b/scripts/run-pgvector-transition-controller.sh
@@ -100,7 +100,7 @@ sha256_file() {
 }
 
 validate_controller_state() {
-  local state=$1
+  local state=$1 proof_phase proof_class
   assert_owned_regular_file "$state"
   [[ $(stat -c '%a' "$state") == 600 ]] || die 'controller state mode must be 0600'
   jq -e '
@@ -122,6 +122,8 @@ validate_controller_state() {
     (.volume | type == "string" and test("^[A-Za-z0-9][A-Za-z0-9_.-]*$")) and
     ((.volumeFingerprint == null) or
      (.volumeFingerprint | type == "string" and test("^[a-f0-9]{64}$"))) and
+    ((.authorityRoot == null) or
+     (.authorityRoot | type == "string" and startswith("/"))) and
     (.liveCompose | type == "string" and startswith("/")) and
     (.sourceSnapshot | type == "string" and startswith("/")) and
     (.sourceSnapshotSha256 | type == "string" and test("^[a-f0-9]{64}$")) and
@@ -146,8 +148,100 @@ validate_controller_state() {
       true
     end
   ' "$state" >/dev/null || die 'controller state is malformed'
+  # Phase-owned proofs: every non-trivial phase carries evidence that its own
+  # mechanism actually ran. Each requirement rejects with a key-specific
+  # diagnostic so a mutation that strips one owned proof cannot pass silently.
+  # (Kept inline so extraction-based reuse of this function stays self-contained.)
+  proof_phase=$(jq -er '.phase' "$state")
+  case "$proof_phase" in
+    authorization-running|activation-running|closure-running)
+      jq -e '(.guardEvidence.path | type == "string" and startswith("/")) and
+             (.guardEvidence.sha256 | type == "string" and test("^[a-f0-9]{64}$"))' \
+        "$state" >/dev/null ||
+        die "guardEvidence is required for phase $proof_phase but missing or malformed"
+      validate_evidence_binding "$state" guardEvidence process
+      ;;
+  esac
+  case "$proof_phase" in
+    closure-stop-pending)
+      jq -e '(.authorizationEvidence.path | type == "string" and startswith("/")) and
+             (.authorizationEvidence.sha256 | type == "string" and test("^[a-f0-9]{64}$"))' \
+        "$state" >/dev/null ||
+        die "authorizationEvidence is required for phase $proof_phase but missing or malformed"
+      validate_evidence_binding "$state" authorizationEvidence process
+      ;;
+    closure-evidence-pending)
+      jq -e '(.writerStopEvidence.path | type == "string" and startswith("/")) and
+             (.writerStopEvidence.sha256 | type == "string" and test("^[a-f0-9]{64}$"))' \
+        "$state" >/dev/null ||
+        die "writerStopEvidence is required for phase $proof_phase but missing or malformed"
+      validate_evidence_binding "$state" writerStopEvidence process
+      ;;
+    incident)
+      proof_class=$(jq -er '.incidentClass // ""' "$state")
+      case "$proof_class" in
+        pre-journal-source-verification)
+          jq -e '(.sourceRecoveryEvidence.path | type == "string" and startswith("/")) and
+                 (.sourceRecoveryEvidence.sha256 | type == "string" and test("^[a-f0-9]{64}$"))' \
+            "$state" >/dev/null ||
+            die "sourceRecoveryEvidence is required for incident class $proof_class but missing or malformed"
+          validate_evidence_binding "$state" sourceRecoveryEvidence process
+          ;;
+        closure-*)
+          jq -e '(.writerStopEvidence.path | type == "string" and startswith("/")) and
+                 (.writerStopEvidence.sha256 | type == "string" and test("^[a-f0-9]{64}$"))' \
+            "$state" >/dev/null ||
+            die "writerStopEvidence is required for incident class $proof_class but missing or malformed"
+          validate_evidence_binding "$state" writerStopEvidence process
+          ;;
+      esac
+      ;;
+  esac
+  case "$proof_phase" in
+    activation-running|closure-running)
+      validate_evidence_binding "$state" authorizationEvidence process
+      ;;
+  esac
+  if [[ "$proof_phase" == complete ]]; then
+    validate_evidence_binding "$state" guardEvidence process
+    validate_evidence_binding "$state" authorizationEvidence process
+    validate_evidence_binding "$state" closureEvidence process
+    validate_evidence_binding "$state" guardJournalEvidence file
+  fi
   if [[ $(jq -er '.phase' "$state") == complete ]]; then
     validate_complete_state_evidence "$state"
+  fi
+}
+
+# Phase-owned proofs must reference the real evidence bytes on disk, not just
+# a well-shaped binding: the file must exist, be an owned regular non-symlink
+# 0600 file, match its recorded digest, and (for process evidence) carry the
+# controller evidence schema. The writer-stop proof must additionally name
+# this state's application container and prove an inspect-verified stop, so a
+# forged or foreign stop record cannot satisfy a closure proof.
+validate_evidence_binding() {
+  local state=$1 key=$2 kind=${3:-process} path recorded actual
+  path=$(jq -er --arg k "$key" '.[$k].path // empty' "$state" 2>/dev/null) || path=''
+  [[ -n "$path" && "$path" == /* ]] ||
+    die "$key binding is missing an absolute evidence path"
+  assert_owned_regular_file "$path"
+  [[ $(stat -c '%a' "$path") == 600 ]] || die "$key evidence file mode must be 0600: $path"
+  recorded=$(jq -er --arg k "$key" '.[$k].sha256 // empty' "$state" 2>/dev/null)
+  [[ "$recorded" =~ ^[a-f0-9]{64}$ ]] || die "$key binding has no valid sha256"
+  actual=$(sha256_file "$path")
+  [[ "$actual" == "$recorded" ]] ||
+    die "$key evidence file no longer matches its recorded digest: $path"
+  if [[ "$kind" == process ]]; then
+    jq -e 'type == "object" and .version == 1 and (.phase | type == "string" and length > 0)' \
+      "$path" >/dev/null ||
+      die "$key evidence file is not a controller process-evidence object: $path"
+  fi
+  if [[ "$key" == writerStopEvidence ]]; then
+    jq -e --arg app "$(jq -er '.appContainer // ""' "$state")" \
+      'type == "object" and .container == $app and .container != "" and
+       .inspectRunning == false and .stopExitCode == 0' \
+      "$path" >/dev/null ||
+      die "writerStopEvidence file does not prove this state's application container was inspect-verified stopped: $path"
   fi
 }
 
@@ -235,7 +329,7 @@ resume_controller_state() {
   case "$phase" in
     closure-stop-pending)
       complete_closure_stop_pending "$state"
-      die "controller incident requires operator resolution: $(jq -r '.incidentClass // \"unknown\"' "$state")"
+      die "controller incident requires operator resolution: $(jq -r '.incidentClass // "unknown"' "$state")"
       ;;
     closure-evidence-pending)
       validate_bound_process_evidence "$state" authorizationEvidence authorization-running
@@ -267,12 +361,16 @@ resume_controller_state() {
       return
       ;;
     activation-running)
+      jq -e 'has("writerStopEvidence")' "$state" >/dev/null &&
+        die 'state records a verified writer stop without a terminal incident; reactivation is forbidden and requires operator resolution'
       validate_bound_process_evidence "$state" authorizationEvidence authorization-running
       assert_bound_guard_journal_unchanged "$state"
       resume_action=run-activation
       return
       ;;
     closure-running)
+      jq -e 'has("writerStopEvidence")' "$state" >/dev/null &&
+        die 'state records a verified writer stop without a terminal incident; reactivation is forbidden and requires operator resolution'
       validate_bound_process_evidence "$state" authorizationEvidence authorization-running
       assert_bound_guard_journal_unchanged "$state"
       resume_action=run-closure
@@ -446,7 +544,11 @@ acquire_operation_lock() {
 }
 
 claim_authoritative_state_path() {
-  local state=$1 engine_id=$2 volume=$3 lock_root=$4 lock_key claim state_path temp
+  # mode: prepare (default) claims or reclaims; revalidate requires an existing
+  # record under the CURRENT durable authority root (execution path).
+  local state=$1 engine_id=$2 volume=$3 lock_root=$4 mode=${5:-prepare}
+  local lock_key claim state_path temp recorded_lock_root
+  local durable_home state_base root entry recorded_path recorded_phase
   assert_operation_lock_held "$engine_id" "$volume" "$lock_root"
   lock_key=$(printf '%s\0%s' "$engine_id" "$volume" | sha256sum | awk '{print $1}')
   claim="$lock_root/noosphere-pgvector-state-$lock_key.json"
@@ -483,6 +585,109 @@ claim_authoritative_state_path() {
       .statePath == $statePath
     ' "$claim" >/dev/null ||
     die 'authoritative state for this Docker engine and PostgreSQL volume is already claimed by another path'
+  # The runtime claim above lives in lock_root, which is reboot-volatile by
+  # contract. A durable mirror under the invoking user's state directory keeps
+  # the engine-plus-volume identity bound to exactly one state path even after
+  # the runtime directory is replaced, so a duplicate prepare cannot silently
+  # start a second state history while a prior one is still alive. Stale
+  # records whose state file is gone or terminal (complete) are reclaimed under
+  # the same lock. (Kept inline so extraction-based reuse stays self-contained.)
+  durable_home=${controller_durable_home:-${HOME:-}}
+  [[ -n "$durable_home" && "$durable_home" == /* ]] ||
+    die 'durable state-authority home is unavailable for this controller identity'
+  # XDG Base Directory conformance: an explicit XDG_STATE_HOME (absolute)
+  # relocates the durable authority root. Disposable rehearsals use it to
+  # isolate records from the invoking user's real state namespace.
+  state_base=${controller_durable_state_base:-${XDG_STATE_HOME:-}}
+  [[ -z "$state_base" || "$state_base" == /* ]] ||
+    die 'XDG_STATE_HOME must be an absolute path'
+  [[ -n "$state_base" ]] || state_base=$durable_home/.local/state
+  root=$state_base/noosphere-pgvector-controller/authority
+  if ! path_present "$root"; then
+    install -d -m 700 "$root" || die 'could not create the durable state-authority root'
+    # Make the new authority directory entry durable: the root itself, its
+    # parent, and the state base must all reach stable storage so a power
+    # loss cannot silently drop the authority namespace and admit a
+    # duplicate claim after restart.
+    fsync_path "$root"
+    fsync_path "$(dirname "$root")"
+    [[ "$state_base" == "/" ]] || fsync_path "$state_base"
+  fi
+  [[ -d "$root" && ! -L "$root" ]] || die 'durable state-authority root must be a real directory'
+  [[ $(stat -c '%u' "$root") == "$(id -u)" ]] ||
+    die 'durable state-authority root must be owned by the controller user'
+  [[ $(stat -c '%a' "$root") == 700 ]] || die 'durable state-authority root mode must be 0700'
+  entry="$root/state-$lock_key.json"
+  # Execution may only continue a state whose durable authority record lives
+  # under the *current* durable authority root: a record prepared under
+  # another root must never be executed or duplicated from this one.
+  if [[ "$mode" == revalidate ]]; then
+    path_present "$entry" ||
+      die 'no durable state-authority record exists under the current durable authority root for this engine and volume'
+  fi
+  if path_present "$entry"; then
+    assert_owned_regular_file "$entry"
+    [[ $(stat -c '%a' "$entry") == 600 ]] || die 'durable state-authority record mode must be 0600'
+    jq -e --arg engineId "$engine_id" --arg volume "$volume" '
+      .version == 1 and .engineId == $engineId and .volume == $volume and
+      (.statePath | type == "string" and startswith("/"))
+    ' "$entry" >/dev/null ||
+      die 'durable state-authority record is malformed for this engine and volume'
+    recorded_path=$(jq -er '.statePath' "$entry")
+    if [[ "$recorded_path" != "$(realpath -m "$state")" ]]; then
+      recorded_phase=''
+      recorded_state_unreadable=false
+      if path_present "$recorded_path"; then
+        assert_owned_regular_file "$recorded_path"
+        if ! recorded_phase=$(jq -er '.phase // empty' "$recorded_path" 2>/dev/null); then
+          recorded_phase=''
+          recorded_state_unreadable=true
+        fi
+      fi
+      if [[ "$recorded_state_unreadable" == true ]]; then
+        die 'durable state-authority record references an unreadable or phase-less state file; operator resolution required'
+      fi
+      case "$recorded_phase" in
+        prepared|candidate-published|source-recovery-running|guard-exited|authorization-running|activation-running|closure-running|closure-stop-pending|closure-evidence-pending|incident)
+          die 'authoritative state for this Docker engine and PostgreSQL volume is already claimed by another path'
+          ;;
+      esac
+    else
+      # Same state path re-claimed (idempotent prepare or execute
+      # revalidation). The durable authority root is part of the record's
+      # identity: a record claimed under another durable root means this
+      # state was prepared in a different authority namespace.
+      [[ "$(jq -er '.authorityRoot // empty' "$entry")" == "$root" ]] ||
+        die 'durable state-authority record was claimed under a different durable authority root'
+      # A different runtime lock root is only tolerated when the recorded
+      # runtime claim is gone (reboot or runtime-directory loss). While the
+      # previous runtime claim is still live, replacing it would leave two
+      # potentially concurrent authorities for one engine and volume.
+      recorded_lock_root=$(jq -er '.lockRoot // empty' "$entry")
+      if [[ -n "$recorded_lock_root" && "$recorded_lock_root" != "$lock_root" ]] &&
+         path_present "$recorded_lock_root/noosphere-pgvector-state-$lock_key.json"; then
+        die 'durable state-authority record was claimed under a different runtime lock root; refusing to replace a live claim'
+      fi
+    fi
+  fi
+  temp=$(mktemp "$root/.state-authority.XXXXXX")
+  trap 'rm -f "$temp"' RETURN
+  jq -n \
+    --arg engineId "$engine_id" \
+    --arg volume "$volume" \
+    --arg statePath "$(realpath -m "$state")" \
+    --arg lockRoot "$lock_root" \
+    --arg authorityRoot "$root" \
+    --arg bootId "$(</proc/sys/kernel/random/boot_id)" \
+    '{version:1,engineId:$engineId,volume:$volume,statePath:$statePath,
+      lockRoot:$lockRoot,authorityRoot:$authorityRoot,bootId:$bootId,
+      updatedAt:(now|todateiso8601)}' > "$temp"
+  chmod 0600 "$temp"
+  fsync_path "$temp"
+  mv -f "$temp" "$entry"
+  fsync_path "$root"
+  trap - RETURN
+  printf '%s\n' "$root"
 }
 
 assert_operation_lock_held() {
@@ -691,10 +896,16 @@ run_source_recovery_verifier_with_evidence() {
   local state=$1 verifier artifact_base stdout_file stderr_file evidence
   local start_cursor end_cursor started_at ended_at verify_exit=0
   verifier=${execution_verifier:-$(jq -er '.verifier' "$state")}
-  artifact_base="${state%.json}.source-recovery"
-  stdout_file="$artifact_base.stdout.log"
-  stderr_file="$artifact_base.stderr.log"
-  evidence="$artifact_base.evidence.json"
+  # Source-recovery artifacts reuse the per-invocation scheme of the guard and
+  # verifier roles: the first run owns the canonical paths, and any later
+  # invocation that finds prior artifacts allocates InvocationID-suffixed
+  # paths so truthful prior evidence and logs are never overwritten.
+  artifact_base=$(select_process_artifact_base "${state%.json}" source-recovery)
+  [[ -n "$artifact_base" && "$artifact_base" == /* ]] ||
+    die 'could not allocate distinct source-recovery artifact paths'
+  stdout_file="$artifact_base.source-recovery.stdout.log"
+  stderr_file="$artifact_base.source-recovery.stderr.log"
+  evidence="$artifact_base.source-recovery.evidence.json"
   install -m 600 /dev/null "$stdout_file"
   install -m 600 /dev/null "$stderr_file"
   start_cursor=$(capture_journal_cursor)
@@ -1088,7 +1299,33 @@ assert_controller_artifact_paths_separate() {
     "$base.verify.stdout.log"
     "$base.verify.stderr.log"
     "$base.verify.evidence.json"
+    "$base.source-recovery.stdout.log"
+    "$base.source-recovery.stderr.log"
+    "$base.source-recovery.evidence.json"
+    "$base.writer-stop.evidence.json"
   )
+  # Invocation-suffixed variants are the paths a later invocation actually
+  # uses once canonical artifacts exist (select_process_artifact_base), so
+  # they join the same separation contract whenever an InvocationID is set.
+  if [[ -n ${INVOCATION_ID:-} ]]; then
+    [[ "$INVOCATION_ID" =~ ^[A-Za-z0-9_.-]+$ ]] ||
+      die 'systemd InvocationID is unsafe for evidence paths'
+    controlled+=(
+      "$base.$INVOCATION_ID.guard.stdout.log"
+      "$base.$INVOCATION_ID.guard.stderr.log"
+      "$base.$INVOCATION_ID.guard.evidence.json"
+      "$base.$INVOCATION_ID.authorization.stdout.log"
+      "$base.$INVOCATION_ID.authorization.stderr.log"
+      "$base.$INVOCATION_ID.authorization.evidence.json"
+      "$base.$INVOCATION_ID.verify.stdout.log"
+      "$base.$INVOCATION_ID.verify.stderr.log"
+      "$base.$INVOCATION_ID.verify.evidence.json"
+      "$base.$INVOCATION_ID.source-recovery.stdout.log"
+      "$base.$INVOCATION_ID.source-recovery.stderr.log"
+      "$base.$INVOCATION_ID.source-recovery.evidence.json"
+      "$base.$INVOCATION_ID.writer-stop.evidence.json"
+    )
+  fi
   [[ -z "$preparation_manifest" ]] || bound+=("$preparation_manifest")
   for field in liveCompose sourceSnapshot candidateCompose envFile controllerPath guard verifier \
     dockerPath composePluginPath guardJournal; do
@@ -1135,6 +1372,7 @@ select_process_artifact_base() {
       ! path_present "$candidate.$role.evidence.json" ||
       die 'process evidence path for this systemd invocation already exists'
   fi
+  [[ "$candidate" == /* ]] || die 'process artifact base must be absolute'
   printf '%s\n' "$candidate"
 }
 
@@ -1391,7 +1629,7 @@ create_execution_bundle() {
 
 prepare_execution_state() {
   local manifest=$1 state=$2 guard_journal docker_host fixed_path controller_home
-  local engine_id volume lock_root volume_fingerprint prepared
+  local engine_id volume lock_root volume_fingerprint prepared authority_root
   assert_owned_regular_file "$manifest"
   [[ $(stat -c '%a' "$manifest") == 600 ]] || die 'preparation manifest mode must be 0600'
   assert_owned_private_directory "$(dirname "$state")"
@@ -1412,14 +1650,15 @@ prepare_execution_state() {
   volume=$(jq -er '.volume' "$manifest")
   lock_root=$(jq -er '.lockRoot' "$manifest")
   acquire_operation_lock "$engine_id" "$volume" "$lock_root"
-  claim_authoritative_state_path "$state" "$engine_id" "$volume" "$lock_root"
+  authority_root=$(claim_authoritative_state_path "$state" "$engine_id" "$volume" "$lock_root" prepare)
   assert_live_engine_binding "$manifest" "$(jq -er '.dockerPath' "$manifest")"
   verify_execution_inputs "$manifest"
   volume_fingerprint=$(query_postgres_volume_fingerprint "$(jq -er '.dockerPath' "$manifest")" "$volume")
   prepared=$(mktemp "$(dirname "$state")/.controller-prepared.XXXXXX")
   trap 'rm -f "$prepared"' RETURN
   jq --arg volumeFingerprint "$volume_fingerprint" \
-    '.volumeFingerprint = $volumeFingerprint' "$manifest" > "$prepared"
+     --arg authorityRoot "$authority_root" \
+    '.volumeFingerprint = $volumeFingerprint | .authorityRoot = $authorityRoot' "$manifest" > "$prepared"
   validate_execution_manifest "$prepared"
   guard_journal=$(jq -er '.guardJournal' "$manifest")
   [[ $(realpath -m "$state") != "$(realpath -m "$guard_journal")" ]] ||
@@ -1470,7 +1709,7 @@ assert_source_state_unchanged() {
 }
 
 stop_application_fail_closed() {
-  local docker_path app_container running
+  local docker_path app_container running stop_evidence stop_temp stopped_at
   docker_path=${execution_docker_path:-$(jq -er '.dockerPath' "$controller_state")}
   app_container=$(jq -er '.appContainer' "$controller_state")
   "$docker_path" stop --time 60 "$app_container" >/dev/null 2>&1 ||
@@ -1479,6 +1718,40 @@ stop_application_fail_closed() {
     die "could not verify stopped application container $app_container"
   [[ "$running" == false ]] ||
     die "application container remains running after stop: $app_container"
+  # Every inspect-verified stop is durably evidenced and bound to the state so
+  # closure-evidence-pending and closure-incident phases carry their owned
+  # writer-stop proof. A failure to persist the proof is fatal: the stop itself
+  # succeeded, but the state must not advance without its owned evidence.
+  stopped_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  # Retry-distinct allocation: the first stop owns the canonical evidence
+  # path; a later invocation that finds it allocates InvocationID-suffixed
+  # paths so a prior truthful stop record is never overwritten.
+  stop_evidence="$(select_process_artifact_base "${controller_state%.json}" writer-stop).writer-stop.evidence.json"
+  stop_temp=$(mktemp "$(dirname "$controller_state")/.writer-stop-evidence.XXXXXX")
+  trap 'rm -f "$stop_temp"' RETURN
+  jq -n \
+    --arg phase "$(jq -er '.phase // ""' "$controller_state")" \
+    --arg container "$app_container" \
+    --arg stoppedAt "$stopped_at" \
+    --arg invocationId "${INVOCATION_ID:-}" \
+    --arg bootId "$(</proc/sys/kernel/random/boot_id)" \
+    --argjson controllerMainPid "${systemd_controller_main_pid:-0}" '
+      {version:1,phase:$phase,container:$container,stopExitCode:0,
+       inspectRunning:false,stoppedAt:$stoppedAt,invocationId:$invocationId,
+       bootId:$bootId,controllerMainPid:$controllerMainPid}
+    ' > "$stop_temp"
+  chmod 0600 "$stop_temp"
+  fsync_path "$stop_temp"
+  mv -f "$stop_temp" "$stop_evidence"
+  fsync_path "$(dirname "$stop_evidence")"
+  trap - RETURN
+  stop_temp=$(mktemp "$(dirname "$controller_state")/.controller-evidence.XXXXXX")
+  trap 'rm -f "$stop_temp"' RETURN
+  jq --arg path "$stop_evidence" --arg sha256 "$(sha256_file "$stop_evidence")" '
+    .writerStopEvidence = {path:$path, sha256:$sha256}
+  ' "$controller_state" > "$stop_temp"
+  write_controller_state_atomic "$controller_state" "$stop_temp"
+  trap - RETURN
 }
 
 activate_application_for_verification() {
@@ -1565,7 +1838,7 @@ require_systemd_execution_context() {
 }
 
 execute_prepared_state() {
-  local state=$1 engine_id volume lock_root docker_host fixed_path controller_home
+  local state=$1 engine_id volume lock_root docker_host fixed_path controller_home authority_root
   local candidate guard verifier guard_journal guard_stdout guard_stderr guard_evidence
   local authorization_stdout authorization_stderr authorization_evidence authorization_artifact_base
   local verify_stdout verify_stderr verify_evidence start_cursor end_cursor started_at ended_at
@@ -1573,7 +1846,23 @@ execute_prepared_state() {
   local run_initial_guard=true run_authorization=true run_activation=true
   local resume_closure_evidence=false
   local -a guard_args authorization_args
+  local ambient_test_hook
   controller_state=$state
+  # Production execution fails closed before any state mutation when ambient
+  # test hooks are present: hooks are honored only when the fixture marker is
+  # explicitly enabled (set by the systemd identity shim in fixture mode), so
+  # an inherited hook can never steer production evidence or the transition.
+  if [[ ${controller_test_hooks_enabled:-false} != true ]]; then
+    for ambient_test_hook in NOOSPHERE_CONTROLLER_TEST_INTERRUPT_AFTER_INTENT \
+                             NOOSPHERE_CONTROLLER_TEST_SIGNAL_AFTER_GUARD_SPAWN \
+                             NOOSPHERE_CONTROLLER_TEST_FAIL_EVIDENCE \
+                             NOOSPHERE_CONTROLLER_TEST_SIGNAL_AFTER_AUTHORIZATION \
+                             NOOSPHERE_CONTROLLER_TEST_SIGNAL_BEFORE_COMPLETE \
+                             NOOSPHERE_CONTROLLER_TEST_SIGNAL_BEFORE_GUARD; do
+      [[ -z ${!ambient_test_hook:-} ]] ||
+        die "production execution rejected ambient test hook contamination: $ambient_test_hook is set; unset NOOSPHERE_CONTROLLER_TEST_* outside fixture mode"
+    done
+  fi
   validate_execution_manifest "$state"
   docker_host=$(jq -er '.dockerEndpoint' "$state")
   fixed_path=$(jq -er '.fixedPath' "$state")
@@ -1588,6 +1877,12 @@ execute_prepared_state() {
   volume=$(jq -er '.volume' "$state")
   lock_root=$(jq -er '.lockRoot' "$state")
   acquire_operation_lock "$engine_id" "$volume" "$lock_root"
+  # Execution revalidates the engine-volume state authority: only the single
+  # authoritative state path may execute, so a byte-identical copy at another
+  # path is rejected before any state mutation or child process runs.
+  authority_root=$(claim_authoritative_state_path "$state" "$engine_id" "$volume" "$lock_root" revalidate)
+  [[ $(jq -er '.authorityRoot // empty' "$state") == "$authority_root" ]] ||
+    die 'controller state was prepared under a different durable authority root; refusing execution'
   assert_live_engine_binding "$state" "$(jq -er '.dockerPath' "$state")"
   verify_execution_inputs "$state"
   assert_postgres_volume_binding "$state" "$(jq -er '.dockerPath' "$state")"
@@ -1634,6 +1929,8 @@ execute_prepared_state() {
 
   if [[ "$run_initial_guard" == true ]]; then
   guard_artifact_base=$(select_process_artifact_base "$state" guard)
+  [[ -n "$guard_artifact_base" && "$guard_artifact_base" == /* ]] ||
+    die 'could not allocate distinct guard artifact paths'
   guard_stdout="$guard_artifact_base.guard.stdout.log"
   guard_stderr="$guard_artifact_base.guard.stderr.log"
   guard_evidence="$guard_artifact_base.guard.evidence.json"
@@ -1674,6 +1971,12 @@ execute_prepared_state() {
 
   if [[ "$run_authorization" == true ]]; then
     authorization_artifact_base=$(select_process_artifact_base "$state" authorization)
+    if [[ -z "$authorization_artifact_base" || "$authorization_artifact_base" != /* ]]; then
+      # The guard has already mutated the transition: a selector failure is a
+      # storage failure that must stop the writer and fail closed.
+      begin_closure_incident "$state" artifact-storage
+      return 1
+    fi
     authorization_stdout="$authorization_artifact_base.authorization.stdout.log"
     authorization_stderr="$authorization_artifact_base.authorization.stderr.log"
     authorization_evidence="$authorization_artifact_base.authorization.evidence.json"
@@ -1693,7 +1996,13 @@ execute_prepared_state() {
     bind_process_evidence_to_state "$state" authorizationEvidence "$authorization_evidence" \
       "$INVOCATION_ID" "$boot_id" "$systemd_controller_main_pid" "$last_guard_pid"
     if [[ -n ${controller_signal:-} ]]; then
-      abort_if_interrupted || return $?
+      if ! abort_if_interrupted; then
+        # A latched signal after successful writer authorization must not
+        # return while the authorized writer could be running: stop it and
+        # commit a classified closure incident first.
+        begin_closure_incident "$state" interruption
+        return "$(signal_exit_code "$controller_signal")"
+      fi
     fi
     if ((authorization_exit != 0)); then
       begin_closure_incident "$state" writer-authorization
@@ -1704,7 +2013,12 @@ execute_prepared_state() {
     if [[ -n ${NOOSPHERE_CONTROLLER_TEST_SIGNAL_AFTER_AUTHORIZATION:-} ]]; then
       handle_controller_signal "$NOOSPHERE_CONTROLLER_TEST_SIGNAL_AFTER_AUTHORIZATION"
     fi
-    abort_if_interrupted || return $?
+    if ! abort_if_interrupted; then
+      # The pre-activation boundary has an authorized writer: a latched signal
+      # must durably stop it and classify the incident before returning.
+      begin_closure_incident "$state" interruption
+      return "$(signal_exit_code "$controller_signal")"
+    fi
   else
     validate_bound_process_evidence "$state" authorizationEvidence authorization-running
   fi
@@ -1712,12 +2026,29 @@ execute_prepared_state() {
   # Allocate and durably create every verifier artifact before activation. A
   # collision or storage failure therefore rejects while the writer is still
   # stopped, rather than creating an unverified active writer.
-  verify_artifact_base=$(select_process_artifact_base "$state" verify)
+  if ! verify_artifact_base=$(select_process_artifact_base "$state" verify) ||
+     [[ -z "$verify_artifact_base" || "$verify_artifact_base" != /* ]]; then
+    # A selector failure (per-invocation collision) is an artifact-storage
+    # failure while the authorized writer is stopped: stop it freshly and
+    # classify the closure incident instead of proceeding with a relative or
+    # empty artifact base that would scatter evidence into the worktree.
+    begin_closure_incident "$state" artifact-storage
+    return 1
+  fi
   verify_stdout="$verify_artifact_base.verify.stdout.log"
   verify_stderr="$verify_artifact_base.verify.stderr.log"
   verify_evidence="$verify_artifact_base.verify.evidence.json"
-  install -m 600 /dev/null "$verify_stdout"
-  install -m 600 /dev/null "$verify_stderr"
+  verify_alloc_exit=0
+  install -m 600 /dev/null "$verify_stdout" || verify_alloc_exit=$?
+  if (( verify_alloc_exit == 0 )); then
+    install -m 600 /dev/null "$verify_stderr" || verify_alloc_exit=$?
+  fi
+  if (( verify_alloc_exit != 0 )); then
+    # Verifier artifact storage failed while the authorized writer is still
+    # stopped: stop it freshly, verify the stop, and classify the incident.
+    begin_closure_incident "$state" artifact-storage
+    return "$verify_alloc_exit"
+  fi
   start_cursor=$(capture_journal_cursor)
   started_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
@@ -1824,6 +2155,14 @@ classify_closure_failure() {
 controller_signal_active=false
 controller_test_hooks_enabled=false
 controller_fixture_root=''
+# Durable per-user authority records must survive XDG_RUNTIME_DIR replacement
+# and reboots, so the root is captured from the invoking user's real home
+# before sanitize_execution_environment installs the hermetic controller HOME.
+controller_durable_home=${HOME:-}
+# XDG Base Directory: capture the explicit state base before the hermetic
+# execution environment is installed (sanitize never unsets XDG vars, but the
+# captured value keeps prepare and execute agreement explicit and stable).
+controller_durable_state_base=${XDG_STATE_HOME:-}
 controller_signal=''
 controller_signal_forwarded=false
 controller_state_write_active=false

--- a/scripts/run-pgvector-transition-controller.sh
+++ b/scripts/run-pgvector-transition-controller.sh
@@ -26,9 +26,11 @@ path_present() {
 }
 
 assert_owned_regular_file() {
-  local path=$1
+  local path=$1 mode
   [[ -f "$path" && ! -L "$path" ]] || die "required file is missing or unsafe: $path"
   [[ $(stat -c '%u' "$path") == "$(id -u)" ]] || die "required file is not owned by the current user: $path"
+  mode=$(stat -c '%a' "$path")
+  (( (8#$mode & 8#022) == 0 )) || die "required file permits group/world writes: $path"
 }
 
 assert_owned_private_directory() {
@@ -177,8 +179,16 @@ validate_controller_state() {
         die "writerStopEvidence is required for phase $proof_phase but missing or malformed"
       validate_evidence_binding "$state" writerStopEvidence process
       ;;
-    incident)
+    closure-stop-pending|closure-evidence-pending|incident)
       proof_class=$(jq -er '.incidentClass // ""' "$state")
+      case "$proof_class" in
+        pre-journal-source-verification|pre-journal-source-restoration|pre-journal-source-restored|pre-journal-live-compose-divergence|closure-artifact-storage|closure-interruption|closure-writer-authorization|closure-app-activation|closure-postprocessing|closure-verification|closure-identity|closure-extension|closure-counts|closure-infrastructure|closure-app-health|isolated-app-health-requires-guard-revalidation) ;;
+        *) die "incident class is unsupported or unrecognized: ${proof_class:-empty}" ;;
+      esac
+      ;;
+  esac
+  case "$proof_phase" in
+    incident)
       case "$proof_class" in
         pre-journal-source-verification|pre-journal-source-restoration|pre-journal-source-restored|pre-journal-live-compose-divergence)
           jq -e '(.sourceRecoveryEvidence.path | type == "string" and startswith("/")) and
@@ -187,7 +197,7 @@ validate_controller_state() {
             die "sourceRecoveryEvidence is required for incident class $proof_class but missing or malformed"
           validate_evidence_binding "$state" sourceRecoveryEvidence process
           ;;
-        closure-*)
+        closure-*|isolated-app-health-requires-guard-revalidation)
           jq -e '(.writerStopEvidence.path | type == "string" and startswith("/")) and
                  (.writerStopEvidence.sha256 | type == "string" and test("^[a-f0-9]{64}$"))' \
             "$state" >/dev/null ||
@@ -547,45 +557,15 @@ claim_authoritative_state_path() {
   # mode: prepare (default) claims or reclaims; revalidate requires an existing
   # record under the CURRENT durable authority root (execution path).
   local state=$1 engine_id=$2 volume=$3 lock_root=$4 mode=${5:-prepare}
-  local lock_key claim state_path temp recorded_lock_root
-  local durable_home state_base root entry recorded_path recorded_phase
+  local lock_key claim state_path temp recorded_lock_root existing_claim_path
+  local durable_home state_base runtime_base root entry recorded_path recorded_phase
+  local recorded_state_unreadable=false reclaim_previous=false
   assert_operation_lock_held "$engine_id" "$volume" "$lock_root"
   lock_key=$(printf '%s\0%s' "$engine_id" "$volume" | sha256sum | awk '{print $1}')
   claim="$lock_root/noosphere-pgvector-state-$lock_key.json"
   state_path=$(realpath -m "$state")
 
-  if ! path_present "$claim"; then
-    temp=$(mktemp "$lock_root/.state-authority.XXXXXX")
-    trap 'rm -f "$temp"' RETURN
-    jq -n \
-      --arg engineId "$engine_id" \
-      --arg volume "$volume" \
-      --arg statePath "$state_path" \
-      '{version:1,engineId:$engineId,volume:$volume,statePath:$statePath}' > "$temp"
-    chmod 0600 "$temp"
-    fsync_path "$temp"
-    if ln "$temp" "$claim" 2>/dev/null; then
-      fsync_path "$claim"
-      fsync_path "$lock_root"
-    elif ! path_present "$claim"; then
-      die 'could not create the authoritative state-path claim'
-    fi
-    trap - RETURN
-    rm -f "$temp"
-  fi
-
-  assert_owned_regular_file "$claim"
-  [[ $(stat -c '%a' "$claim") == 600 ]] || die 'authoritative state-path claim mode must be 0600'
-  jq -e \
-    --arg engineId "$engine_id" \
-    --arg volume "$volume" \
-    --arg statePath "$state_path" '
-      .version == 1 and .engineId == $engineId and .volume == $volume and
-      (.statePath | type == "string" and startswith("/")) and
-      .statePath == $statePath
-    ' "$claim" >/dev/null ||
-    die 'authoritative state for this Docker engine and PostgreSQL volume is already claimed by another path'
-  # The runtime claim above lives in lock_root, which is reboot-volatile by
+  # The runtime claim in lock_root is reboot-volatile by
   # contract. A durable mirror under the invoking user's state directory keeps
   # the engine-plus-volume identity bound to exactly one state path even after
   # the runtime directory is replaced, so a duplicate prepare cannot silently
@@ -602,6 +582,10 @@ claim_authoritative_state_path() {
   [[ -z "$state_base" || "$state_base" == /* ]] ||
     die 'XDG_STATE_HOME must be an absolute path'
   [[ -n "$state_base" ]] || state_base=$durable_home/.local/state
+  state_base=$(realpath -m "$state_base")
+  runtime_base=$(realpath -m "$lock_root")
+  [[ "$state_base" != "$runtime_base" && "$state_base" != "$runtime_base"/* ]] ||
+    die 'durable state-authority root cannot live below the reboot-volatile runtime lock root'
   root=$state_base/noosphere-pgvector-controller/authority
   entry="$root/state-$lock_key.json"
   # Execution may only continue a state whose durable authority record lives
@@ -639,6 +623,8 @@ claim_authoritative_state_path() {
       die 'durable state-authority record is malformed for this engine and volume'
     recorded_path=$(jq -er '.statePath' "$entry")
     if [[ "$recorded_path" != "$(realpath -m "$state")" ]]; then
+      [[ "$mode" != revalidate ]] ||
+        die 'durable state-authority record points to another state path'
       recorded_phase=''
       recorded_state_unreadable=false
       if path_present "$recorded_path"; then
@@ -654,6 +640,38 @@ claim_authoritative_state_path() {
       case "$recorded_phase" in
         prepared|candidate-published|source-recovery-running|guard-exited|authorization-running|activation-running|closure-running|closure-stop-pending|closure-evidence-pending|incident)
           die 'authoritative state for this Docker engine and PostgreSQL volume is already claimed by another path'
+          ;;
+        '')
+          # A missing state is reclaimable under the operation lock. Its
+          # reboot-volatile claim, when retained, is replaced below only after
+          # proving that it still names this exact durable predecessor.
+          reclaim_previous=true
+          ;;
+        complete)
+          # A phase string alone is not terminal evidence. Validate the full
+          # state and its bound guard, authorization, closure, and completed
+          # journal bytes before it may relinquish unique engine-volume
+          # authority.
+          validate_controller_state "$recorded_path"
+          jq -e \
+            --arg engineId "$engine_id" \
+            --arg volume "$volume" \
+            --arg authorityRoot "$root" '
+              .engineId == $engineId and .volume == $volume and
+              .authorityRoot == $authorityRoot
+            ' "$recorded_path" >/dev/null ||
+            die 'complete state identity does not match its durable authority record'
+          reclaim_previous=true
+          ;;
+        *)
+          # Present durable state whose `.phase` is outside the recognizable
+          # set (on-disk corruption, partial write, or a future schema whose
+          # active phases have not been enumerated here) MUST NOT silently
+          # fall through to a reclaim: that would let one engine and volume
+          # pair end up with two competing authority records. The contract
+          # elsewhere in this function is fail-closed; the case arm
+          # deserves the same.
+          die "durable state-authority record references unrecognized phase '$recorded_phase'; operator resolution required"
           ;;
       esac
     else
@@ -674,6 +692,70 @@ claim_authoritative_state_path() {
       fi
     fi
   fi
+
+  # Validate the durable authority before publishing a reboot-volatile claim
+  # for this path. A rejected alternate prepare must not poison a later retry
+  # of the still-authoritative state with a stale runtime claim.
+  if path_present "$claim"; then
+    assert_owned_regular_file "$claim"
+    [[ $(stat -c '%a' "$claim") == 600 ]] || die 'authoritative state-path claim mode must be 0600'
+    jq -e \
+      --arg engineId "$engine_id" \
+      --arg volume "$volume" '
+        .version == 1 and .engineId == $engineId and .volume == $volume and
+        (.statePath | type == "string" and startswith("/"))
+      ' "$claim" >/dev/null ||
+      die 'authoritative state-path claim is malformed for this engine and volume'
+    existing_claim_path=$(jq -er '.statePath' "$claim")
+    if [[ "$existing_claim_path" != "$state_path" && "$reclaim_previous" == true ]]; then
+      [[ "$existing_claim_path" == "$recorded_path" ]] ||
+        die 'authoritative state for this Docker engine and PostgreSQL volume is already claimed by another path'
+      temp=$(mktemp "$lock_root/.state-authority.XXXXXX")
+      trap 'rm -f "$temp"' RETURN
+      jq -n \
+        --arg engineId "$engine_id" \
+        --arg volume "$volume" \
+        --arg statePath "$state_path" \
+        '{version:1,engineId:$engineId,volume:$volume,statePath:$statePath}' > "$temp"
+      chmod 0600 "$temp"
+      fsync_path "$temp"
+      mv -f "$temp" "$claim"
+      fsync_path "$claim"
+      fsync_path "$lock_root"
+      trap - RETURN
+    fi
+  else
+    temp=$(mktemp "$lock_root/.state-authority.XXXXXX")
+    trap 'rm -f "$temp"' RETURN
+    jq -n \
+      --arg engineId "$engine_id" \
+      --arg volume "$volume" \
+      --arg statePath "$state_path" \
+      '{version:1,engineId:$engineId,volume:$volume,statePath:$statePath}' > "$temp"
+    chmod 0600 "$temp"
+    fsync_path "$temp"
+    if ln "$temp" "$claim" 2>/dev/null; then
+      fsync_path "$claim"
+      fsync_path "$lock_root"
+    elif ! path_present "$claim"; then
+      die 'could not create the authoritative state-path claim'
+    fi
+    trap - RETURN
+    rm -f "$temp"
+  fi
+
+  assert_owned_regular_file "$claim"
+  [[ $(stat -c '%a' "$claim") == 600 ]] || die 'authoritative state-path claim mode must be 0600'
+  jq -e \
+    --arg engineId "$engine_id" \
+    --arg volume "$volume" \
+    --arg statePath "$state_path" '
+      .version == 1 and .engineId == $engineId and .volume == $volume and
+      (.statePath | type == "string" and startswith("/")) and
+      .statePath == $statePath
+    ' "$claim" >/dev/null ||
+    die 'authoritative state for this Docker engine and PostgreSQL volume is already claimed by another path'
+
   temp=$(mktemp "$root/.state-authority.XXXXXX")
   trap 'rm -f "$temp"' RETURN
   jq -n \
@@ -708,12 +790,21 @@ assert_operation_lock_held() {
 }
 
 publish_compose_atomic() {
-  local source=$1 target=$2 staged
+  local source=$1 target=$2 staged parent parent_mode
   assert_owned_regular_file "$source"
   assert_owned_regular_file "$target"
+  for parent in "$(dirname "$source")" "$(dirname "$target")"; do
+    [[ -d "$parent" && ! -L "$parent" ]] ||
+      die "Compose publication parent is missing or unsafe: $parent"
+    if [[ $(stat -c '%u' "$parent") == "$(id -u)" ]]; then
+      parent_mode=$(stat -c '%a' "$parent")
+      (( (8#$parent_mode & 8#022) == 0 )) ||
+        die "Compose publication parent permits group/world writes: $parent"
+    fi
+  done
   staged=$(mktemp "${target}.item3-publish.XXXXXX")
   trap 'rm -f "$staged"' RETURN
-  install -m "$(stat -c '%a' "$source")" "$source" "$staged"
+  install -m 600 "$source" "$staged"
   fsync_path "$staged"
   mv -f "$staged" "$target"
   fsync_path "$(dirname "$target")"
@@ -1259,11 +1350,13 @@ commit_closure_outcome() {
 }
 
 sanitize_execution_environment() {
-  local docker_host=$1 fixed_path=$2 controller_home=$3
+  local docker_host=$1 fixed_path=$2 controller_home=$3 ambient_name
 
-  unset DOCKER_CONTEXT DOCKER_TLS_VERIFY DOCKER_CERT_PATH
-  unset COMPOSE_FILE COMPOSE_PROJECT_NAME COMPOSE_PROFILES
-  unset COMPOSE_ENV_FILES COMPOSE_PROJECT_DIR COMPOSE_PATH_SEPARATOR
+  while IFS= read -r ambient_name; do
+    case "$ambient_name" in
+      DOCKER_*|COMPOSE_*) unset "$ambient_name" ;;
+    esac
+  done < <(compgen -v)
   unset HTTP_PROXY HTTPS_PROXY ALL_PROXY NO_PROXY http_proxy https_proxy all_proxy no_proxy
   unset BASH_ENV ENV CDPATH GLOBIGNORE
   unset NOOSPHERE_A2B_LOCK_FD NOOSPHERE_A2B_LOCK_PATH
@@ -1290,6 +1383,7 @@ sanitize_execution_environment() {
 assert_controller_artifact_paths_separate() {
   local state_document=$1 state_path=$2 preparation_manifest=${3:-}
   local base field controlled_path bound_path docker_config_dir namespace_path
+  local bound_index other_bound_index
   local -a controlled=() bound=()
   base=${state_path%.json}
   controlled=(
@@ -1342,6 +1436,12 @@ assert_controller_artifact_paths_separate() {
     for bound_path in "${bound[@]}"; do
       [[ "$(realpath -m "$controlled_path")" != "$(realpath -m "$bound_path")" ]] ||
         die 'controller state/log/evidence path collides with a bound transition input'
+    done
+  done
+  for ((bound_index = 0; bound_index < ${#bound[@]}; bound_index += 1)); do
+    for ((other_bound_index = bound_index + 1; other_bound_index < ${#bound[@]}; other_bound_index += 1)); do
+      [[ "$(realpath -m "${bound[$bound_index]}")" != "$(realpath -m "${bound[$other_bound_index]}")" ]] ||
+        die 'bound transition inputs collide with each other'
     done
   done
   for namespace_path in "${controlled[@]}" \
@@ -1676,6 +1776,8 @@ prepare_execution_state() {
       die "refusing to overwrite controller state in phase $(jq -er '.phase' "$state")"
     cmp -s "$state" "$prepared" ||
       die 'refusing to replace an existing prepared controller state with different bytes'
+    trap - RETURN
+    rm -f "$prepared"
     return 0
   fi
   write_controller_state_atomic "$state" "$prepared"
@@ -2258,8 +2360,16 @@ main() {
   local mode='' manifest='' state=''
   while (($# > 0)); do
     case "$1" in
-      --prepare) mode=prepare; shift ;;
-      --execute) mode=execute; shift ;;
+      --prepare)
+        [[ -z "$mode" ]] || die 'exactly one of --prepare or --execute is required'
+        mode=prepare
+        shift
+        ;;
+      --execute)
+        [[ -z "$mode" ]] || die 'exactly one of --prepare or --execute is required'
+        mode=execute
+        shift
+        ;;
       --manifest) manifest=${2:?missing value}; shift 2 ;;
       --state) state=${2:?missing value}; shift 2 ;;
       --help|-h)

--- a/scripts/run-pgvector-transition-controller.sh
+++ b/scripts/run-pgvector-transition-controller.sh
@@ -180,7 +180,7 @@ validate_controller_state() {
     incident)
       proof_class=$(jq -er '.incidentClass // ""' "$state")
       case "$proof_class" in
-        pre-journal-source-verification)
+        pre-journal-source-verification|pre-journal-source-restoration|pre-journal-source-restored|pre-journal-live-compose-divergence)
           jq -e '(.sourceRecoveryEvidence.path | type == "string" and startswith("/")) and
                  (.sourceRecoveryEvidence.sha256 | type == "string" and test("^[a-f0-9]{64}$"))' \
             "$state" >/dev/null ||
@@ -598,11 +598,23 @@ claim_authoritative_state_path() {
   # XDG Base Directory conformance: an explicit XDG_STATE_HOME (absolute)
   # relocates the durable authority root. Disposable rehearsals use it to
   # isolate records from the invoking user's real state namespace.
-  state_base=${controller_durable_state_base:-${XDG_STATE_HOME:-}}
+  state_base=${XDG_STATE_HOME:-}
   [[ -z "$state_base" || "$state_base" == /* ]] ||
     die 'XDG_STATE_HOME must be an absolute path'
   [[ -n "$state_base" ]] || state_base=$durable_home/.local/state
   root=$state_base/noosphere-pgvector-controller/authority
+  entry="$root/state-$lock_key.json"
+  # Execution may only continue a state whose durable authority record lives
+  # under the *current* durable authority root: a record prepared under
+  # another root must never be executed or duplicated from this one. In
+  # revalidate mode the record must already be present; otherwise die
+  # *before* creating the authority directory structure so cross-root
+  # execute cannot silently populate the wrong namespace with an empty
+  # root.
+  if [[ "$mode" == revalidate ]]; then
+    path_present "$entry" ||
+      die 'no durable state-authority record exists under the current durable authority root for this engine and volume'
+  fi
   if ! path_present "$root"; then
     install -d -m 700 "$root" || die 'could not create the durable state-authority root'
     # Make the new authority directory entry durable: the root itself, its
@@ -617,14 +629,6 @@ claim_authoritative_state_path() {
   [[ $(stat -c '%u' "$root") == "$(id -u)" ]] ||
     die 'durable state-authority root must be owned by the controller user'
   [[ $(stat -c '%a' "$root") == 700 ]] || die 'durable state-authority root mode must be 0700'
-  entry="$root/state-$lock_key.json"
-  # Execution may only continue a state whose durable authority record lives
-  # under the *current* durable authority root: a record prepared under
-  # another root must never be executed or duplicated from this one.
-  if [[ "$mode" == revalidate ]]; then
-    path_present "$entry" ||
-      die 'no durable state-authority record exists under the current durable authority root for this engine and volume'
-  fi
   if path_present "$entry"; then
     assert_owned_regular_file "$entry"
     [[ $(stat -c '%a' "$entry") == 600 ]] || die 'durable state-authority record mode must be 0600'
@@ -2159,10 +2163,9 @@ controller_fixture_root=''
 # and reboots, so the root is captured from the invoking user's real home
 # before sanitize_execution_environment installs the hermetic controller HOME.
 controller_durable_home=${HOME:-}
-# XDG Base Directory: capture the explicit state base before the hermetic
-# execution environment is installed (sanitize never unsets XDG vars, but the
-# captured value keeps prepare and execute agreement explicit and stable).
-controller_durable_state_base=${XDG_STATE_HOME:-}
+# XDG_STATE_HOME is read inline at claim time: sanitize never unsets XDG
+# vars and process-locale env cannot change mid-run, so a module-level
+# capture would add a second source of truth without adding a guarantee.
 controller_signal=''
 controller_signal_forwarded=false
 controller_state_write_active=false

--- a/scripts/run-pgvector-transition-controller.sh
+++ b/scripts/run-pgvector-transition-controller.sh
@@ -179,6 +179,8 @@ validate_controller_state() {
         die "writerStopEvidence is required for phase $proof_phase but missing or malformed"
       validate_evidence_binding "$state" writerStopEvidence process
       ;;
+  esac
+  case "$proof_phase" in
     closure-stop-pending|closure-evidence-pending|incident)
       proof_class=$(jq -er '.incidentClass // ""' "$state")
       case "$proof_class" in

--- a/scripts/run-pgvector-transition-controller.sh
+++ b/scripts/run-pgvector-transition-controller.sh
@@ -1,0 +1,1950 @@
+#!/bin/bash -p
+set -Eeuo pipefail
+
+# Bootstrap without consulting the ambient user-manager PATH. The prepared
+# fixedPath is validated and installed later, but no interpreter or utility
+# may be selected from inherited state before that boundary.
+readonly CONTROLLER_BOOTSTRAP_PATH='/usr/sbin:/usr/bin:/sbin:/bin'
+PATH=$CONTROLLER_BOOTSTRAP_PATH
+export PATH
+
+# Resolve once when the file is loaded. This remains the controller file even
+# when the focused/systemd fixtures source it through a small identity shim.
+CONTROLLER_EXECUTABLE_PATH=$(realpath "${BASH_SOURCE[0]}")
+
+# This controller is intentionally separate from switch-pgvector-compose.sh.
+# The pinned guard remains the only database, authorization, and transition-
+# journal mutator. This file owns only the outer process/evidence transaction.
+
+die() {
+  printf 'PostgreSQL transition controller: %s\n' "$*" >&2
+  exit 1
+}
+
+path_present() {
+  [[ -e "$1" || -L "$1" ]]
+}
+
+assert_owned_regular_file() {
+  local path=$1
+  [[ -f "$path" && ! -L "$path" ]] || die "required file is missing or unsafe: $path"
+  [[ $(stat -c '%u' "$path") == "$(id -u)" ]] || die "required file is not owned by the current user: $path"
+}
+
+assert_owned_private_directory() {
+  local path=$1 mode
+  [[ -d "$path" && ! -L "$path" ]] || die "required private directory is missing or unsafe: $path"
+  [[ $(stat -c '%u' "$path") == "$(id -u)" ]] || die "private directory is not owned by the current user: $path"
+  mode=$(stat -c '%a' "$path")
+  (( (8#$mode & 8#077) == 0 )) || die "private directory permits group/world access: $path"
+}
+
+assert_trusted_fixed_path() {
+  local fixed_path=$1 component resolved mode alias_owner
+  local -a components=()
+  IFS=: read -r -a components <<< "$fixed_path"
+  ((${#components[@]} > 0)) || die 'fixed PATH is empty'
+  for component in "${components[@]}"; do
+    [[ "$component" == /* ]] || die "fixed PATH component is not absolute: $component"
+    resolved=$(realpath -e "$component" 2>/dev/null) ||
+      die "fixed PATH component is unavailable: $component"
+    if [[ -L "$component" ]]; then
+      alias_owner=$(stat -c '%u' "$component")
+      [[ "$alias_owner" == 0 ]] ||
+        die "fixed PATH component is a mutable non-root symlink alias: $component"
+    fi
+    [[ -d "$resolved" ]] || die "fixed PATH component is not a directory: $component"
+    [[ $(stat -c '%u' "$resolved") == 0 ]] ||
+      die "fixed PATH component is not root-owned: $component"
+    mode=$(stat -c '%a' "$resolved")
+    (( (8#$mode & 8#022) == 0 )) ||
+      die "fixed PATH component permits group/world writes: $component"
+  done
+}
+
+fsync_path() {
+  node -e '
+    const fs = require("node:fs");
+    const fd = fs.openSync(process.argv[1], "r");
+    try { fs.fsyncSync(fd); } finally { fs.closeSync(fd); }
+  ' "$1"
+}
+
+write_controller_state_atomic() {
+  local target=$1 source=$2 temp
+  controller_state_write_active=true
+  assert_owned_regular_file "$source"
+  if path_present "$target"; then
+    assert_owned_regular_file "$target"
+    [[ $(stat -c '%a' "$target") == 600 ]] || die 'controller state mode must be 0600'
+  fi
+  jq -e 'type == "object" and (.phase | type == "string")' "$source" >/dev/null ||
+    die 'controller state must contain one phased JSON object'
+  temp=$(mktemp "${target}.tmp.XXXXXX")
+  trap 'rm -f "$temp"' RETURN
+  install -m 600 "$source" "$temp"
+  fsync_path "$temp"
+  mv -f "$temp" "$target"
+  fsync_path "$(dirname "$target")"
+  trap - RETURN
+  controller_state_write_active=false
+  if [[ ${controller_interruption_pending:-false} == true &&
+        -n ${controller_state:-} && "$target" == "$controller_state" ]]; then
+    controller_interruption_pending=false
+    record_controller_interruption "$controller_signal"
+  fi
+}
+
+sha256_file() {
+  sha256sum "$1" | awk '{print $1}'
+}
+
+validate_controller_state() {
+  local state=$1
+  assert_owned_regular_file "$state"
+  [[ $(stat -c '%a' "$state") == 600 ]] || die 'controller state mode must be 0600'
+  jq -e '
+    type == "object" and
+    .version == 1 and
+    (.phase == "prepared" or
+     .phase == "candidate-published" or
+     .phase == "source-recovery-running" or
+     .phase == "guard-exited" or
+     .phase == "authorization-running" or
+     .phase == "activation-running" or
+     .phase == "closure-running" or
+     .phase == "closure-stop-pending" or
+     .phase == "closure-evidence-pending" or
+     .phase == "complete" or
+     .phase == "incident") and
+    (.engineId | type == "string" and length > 0) and
+    (.dockerEndpoint | type == "string" and startswith("unix:///")) and
+    (.volume | type == "string" and test("^[A-Za-z0-9][A-Za-z0-9_.-]*$")) and
+    ((.volumeFingerprint == null) or
+     (.volumeFingerprint | type == "string" and test("^[a-f0-9]{64}$"))) and
+    (.liveCompose | type == "string" and startswith("/")) and
+    (.sourceSnapshot | type == "string" and startswith("/")) and
+    (.sourceSnapshotSha256 | type == "string" and test("^[a-f0-9]{64}$")) and
+    (.candidateComposeSha256 | type == "string" and test("^[a-f0-9]{64}$")) and
+    (.guardJournal | type == "string" and startswith("/")) and
+    if .phase == "complete" then
+      (.guardEvidence.path | type == "string" and startswith("/")) and
+      (.guardEvidence.sha256 | type == "string" and test("^[a-f0-9]{64}$")) and
+      (.authorizationEvidence.path | type == "string" and startswith("/")) and
+      (.authorizationEvidence.sha256 | type == "string" and test("^[a-f0-9]{64}$")) and
+      (.closureEvidence.path | type == "string" and startswith("/")) and
+      (.closureEvidence.sha256 | type == "string" and test("^[a-f0-9]{64}$")) and
+      (.guardJournalEvidence.path | type == "string" and startswith("/")) and
+      (.guardJournalEvidence.sha256 | type == "string" and test("^[a-f0-9]{64}$")) and
+      .guardJournalEvidence.phase == "complete"
+    elif (.phase == "activation-running" or .phase == "closure-running") then
+      (.authorizationEvidence.path | type == "string" and startswith("/")) and
+      (.authorizationEvidence.sha256 | type == "string" and test("^[a-f0-9]{64}$"))
+    elif (.phase == "closure-stop-pending" or .phase == "closure-evidence-pending" or .phase == "incident") then
+      (.incidentClass | type == "string" and length > 0)
+    else
+      true
+    end
+  ' "$state" >/dev/null || die 'controller state is malformed'
+  if [[ $(jq -er '.phase' "$state") == complete ]]; then
+    validate_complete_state_evidence "$state"
+  fi
+}
+
+update_controller_phase() {
+  local state=$1 phase=$2 incident_class=${3:-} temp write_exit=0
+  validate_controller_state "$state"
+  case "$phase" in
+    prepared|candidate-published|source-recovery-running|guard-exited|authorization-running|activation-running|closure-running|closure-stop-pending|closure-evidence-pending|complete|incident) ;;
+    *) die "invalid controller phase: $phase" ;;
+  esac
+  [[ "$phase" != incident && "$phase" != closure-stop-pending && "$phase" != closure-evidence-pending || -n "$incident_class" ]] ||
+    die 'closure pending and incident phases require a class'
+  temp=$(mktemp "$(dirname "$state")/.controller-phase.XXXXXX")
+  trap 'rm -f "$temp"' RETURN
+  jq --arg phase "$phase" --arg incidentClass "$incident_class" '
+    .phase = $phase |
+    .updatedAt = (now | todateiso8601) |
+    if ($phase == "closure-stop-pending" or $phase == "closure-evidence-pending" or $phase == "incident") then .incidentClass = $incidentClass
+    else del(.incidentClass) end
+  ' "$state" > "$temp"
+  write_controller_state_atomic "$state" "$temp" || write_exit=$?
+  trap - RETURN
+  return "$write_exit"
+}
+
+restore_source_without_guard_journal() {
+  local live_compose=$1 source_snapshot=$2 expected_source_sha=$3 staged
+  assert_owned_regular_file "$live_compose"
+  assert_owned_regular_file "$source_snapshot"
+  [[ $(sha256_file "$source_snapshot") == "$expected_source_sha" ]] ||
+    die 'source Compose snapshot digest changed'
+
+  # The caller must prove that the source containers and authorization marker
+  # still match the pre-publication baseline before desired state is restored.
+  assert_source_state_unchanged
+
+  staged=$(mktemp "${live_compose}.item3-restore.XXXXXX")
+  trap 'rm -f "$staged"' RETURN
+  install -m "$(stat -c '%a' "$source_snapshot")" "$source_snapshot" "$staged"
+  fsync_path "$staged"
+  mv -f "$staged" "$live_compose"
+  fsync_path "$(dirname "$live_compose")"
+  trap - RETURN
+}
+
+restore_source_compose_snapshot() {
+  local live_compose=$1 source_snapshot=$2 expected_source_sha=$3 staged
+  [[ -f "$live_compose" && ! -L "$live_compose" ]] || {
+    printf 'required file is missing or unsafe: %s\n' "$live_compose" >&2
+    return 1
+  }
+  [[ $(stat -c '%u' "$live_compose") == "$(id -u)" ]] || {
+    printf 'required file is not owned by the current user: %s\n' "$live_compose" >&2
+    return 1
+  }
+  [[ -f "$source_snapshot" && ! -L "$source_snapshot" ]] || {
+    printf 'required file is missing or unsafe: %s\n' "$source_snapshot" >&2
+    return 1
+  }
+  [[ $(stat -c '%u' "$source_snapshot") == "$(id -u)" ]] || {
+    printf 'required file is not owned by the current user: %s\n' "$source_snapshot" >&2
+    return 1
+  }
+  [[ $(sha256_file "$source_snapshot") == "$expected_source_sha" ]] || {
+    printf 'source Compose snapshot digest changed\n' >&2
+    return 1
+  }
+  staged=$(mktemp "${live_compose}.item3-restore.XXXXXX") || return
+  install -m "$(stat -c '%a' "$source_snapshot")" "$source_snapshot" "$staged" || return
+  fsync_path "$staged" || return
+  mv -f "$staged" "$live_compose" || return
+  fsync_path "$(dirname "$live_compose")"
+}
+
+resume_controller_state() {
+  local state=$1 phase guard_journal live_compose source_snapshot source_sha candidate_sha live_sha
+  local source_verify_exit=0
+  validate_controller_state "$state"
+  phase=$(jq -er '.phase' "$state")
+  guard_journal=$(jq -er '.guardJournal' "$state")
+
+  # A pending fail-closed writer stop outranks every journal and is resumable.
+  # Only after the application is verified stopped may the incident become
+  # terminal and require operator resolution.
+  case "$phase" in
+    closure-stop-pending)
+      complete_closure_stop_pending "$state"
+      die "controller incident requires operator resolution: $(jq -r '.incidentClass // \"unknown\"' "$state")"
+      ;;
+    closure-evidence-pending)
+      validate_bound_process_evidence "$state" authorizationEvidence authorization-running
+      assert_bound_guard_journal_unchanged "$state"
+      resume_action=run-closure-stopped
+      return
+      ;;
+  esac
+
+  # Terminal phases outrank any guard journal on disk. An incident always
+  # requires operator resolution, and a completed transition is revalidated
+  # only through an explicit separate invocation — never by resuming.
+  case "$phase" in
+    incident)
+      die "controller incident requires operator resolution: $(jq -r '.incidentClass // "unknown"' "$state")"
+      ;;
+    complete)
+      die 'controller phase complete is terminal; completed-journal revalidation is an explicit separate invocation'
+      ;;
+  esac
+
+  # Once the initial guard and completed journal are durably bound, resume the
+  # controller-owned writer lifecycle instead of delegating back to switch
+  # mode. Authorization is idempotent and activation is verified separately.
+  case "$phase" in
+    authorization-running)
+      assert_bound_guard_journal_unchanged "$state"
+      resume_action=run-authorization
+      return
+      ;;
+    activation-running)
+      validate_bound_process_evidence "$state" authorizationEvidence authorization-running
+      assert_bound_guard_journal_unchanged "$state"
+      resume_action=run-activation
+      return
+      ;;
+    closure-running)
+      validate_bound_process_evidence "$state" authorizationEvidence authorization-running
+      assert_bound_guard_journal_unchanged "$state"
+      resume_action=run-closure
+      return
+      ;;
+  esac
+
+  if path_present "$guard_journal"; then
+    assert_owned_regular_file "$guard_journal"
+    [[ $(stat -c '%a' "$guard_journal") == 600 ]] || die 'guard journal mode must be 0600'
+    delegate_to_guard_journal "$state" "$guard_journal"
+    resume_action=run-guard
+    return
+  fi
+
+  case "$phase" in
+    prepared)
+      resume_action=publish-and-run
+      return
+      ;;
+    candidate-published|source-recovery-running|guard-exited)
+      live_compose=$(jq -er '.liveCompose' "$state")
+      source_snapshot=${execution_source_snapshot:-$(jq -er '.sourceSnapshot' "$state")}
+      source_sha=$(jq -er '.sourceSnapshotSha256' "$state")
+      candidate_sha=$(jq -er '.candidateComposeSha256' "$state")
+      update_controller_phase "$state" source-recovery-running
+      run_source_recovery_verifier_with_evidence "$state" || source_verify_exit=$?
+      if ((source_verify_exit != 0)); then
+        update_controller_phase "$state" incident pre-journal-source-verification
+        resume_action=incident
+        return "$source_verify_exit"
+      fi
+      if [[ ! -f "$live_compose" || -L "$live_compose" ]]; then
+        printf 'required file is missing or unsafe: %s\n' "$live_compose" >&2
+        update_controller_phase "$state" incident pre-journal-source-restoration
+        resume_action=incident
+        return 1
+      fi
+      if [[ $(stat -c '%u' "$live_compose") != "$(id -u)" ]]; then
+        printf 'required file is not owned by the current user: %s\n' "$live_compose" >&2
+        update_controller_phase "$state" incident pre-journal-source-restoration
+        resume_action=incident
+        return 1
+      fi
+      live_sha=$(sha256_file "$live_compose")
+      if [[ "$live_sha" != "$source_sha" && "$live_sha" != "$candidate_sha" ]]; then
+        printf 'live Compose is unexpected: bytes match neither the prepared source nor candidate model\n' >&2
+        update_controller_phase "$state" incident pre-journal-live-compose-divergence
+        resume_action=incident
+        return 1
+      fi
+      if ! restore_source_compose_snapshot "$live_compose" "$source_snapshot" "$source_sha"; then
+        update_controller_phase "$state" incident pre-journal-source-restoration
+        resume_action=incident
+        return 1
+      fi
+      update_controller_phase "$state" incident pre-journal-source-restored
+      resume_action=source-restored
+      ;;
+    authorization-running|activation-running|closure-running|complete)
+      die "controller phase $phase is missing its completed guard journal"
+      ;;
+  esac
+}
+
+query_live_engine_id() {
+  local docker_path=$1
+  "$docker_path" info --format '{{.ID}}'
+}
+
+query_postgres_volume_fingerprint() {
+  local docker_path=$1 volume=$2 fingerprint
+  fingerprint=$(
+    "$docker_path" volume inspect "$volume" |
+      jq -eSc --arg volume "$volume" '
+        if type == "array" and length == 1 and .[0].Name == $volume then
+          .[0] | {Name,Driver,Mountpoint,CreatedAt,Scope,Labels,Options}
+        else
+          error("PostgreSQL volume inspection is missing or ambiguous")
+        end
+      ' |
+      sha256sum | awk '{print $1}'
+  ) || die "could not fingerprint PostgreSQL volume $volume"
+  [[ "$fingerprint" =~ ^[a-f0-9]{64}$ ]] ||
+    die "PostgreSQL volume fingerprint is malformed for $volume"
+  printf '%s\n' "$fingerprint"
+}
+
+assert_postgres_volume_binding() {
+  local state=$1 docker_path=$2 volume expected actual
+  volume=$(jq -er '.volume' "$state")
+  expected=$(jq -er '.volumeFingerprint | select(type == "string" and test("^[a-f0-9]{64}$"))' "$state") ||
+    die 'prepared state is missing the PostgreSQL volume fingerprint'
+  actual=$(query_postgres_volume_fingerprint "$docker_path" "$volume")
+  [[ "$actual" == "$expected" ]] ||
+    die 'PostgreSQL volume fingerprint changed after preparation'
+}
+
+# Rebind the recorded transition identity to the live Docker daemon while the
+# guard's engine-plus-volume lock is held and before any Compose action.
+assert_live_engine_binding() {
+  local state=$1 docker_path=$2 live_engine expected_engine expected_root
+  expected_engine=$(jq -er '.engineId' "$state")
+  live_engine=$(query_live_engine_id "$docker_path") ||
+    die 'could not query the live Docker engine ID'
+  [[ -n "$live_engine" ]] || die 'live Docker engine ID is empty'
+  [[ "$live_engine" == "$expected_engine" ]] ||
+    die 'live Docker engine ID does not match the recorded transition identity'
+  expected_root=${XDG_RUNTIME_DIR:-/run/user/$(id -u)}
+  [[ $(jq -er '.lockRoot' "$state") == "$expected_root" ]] ||
+    die 'recorded lock root does not match the guard engine-volume lock contract'
+}
+
+ensure_regular_lock_file() {
+  local lock_path=$1 temp created=false
+  if ! path_present "$lock_path"; then
+    temp=$(mktemp "$(dirname "$lock_path")/.operation-lock.XXXXXX")
+    trap 'rm -f "$temp"' RETURN
+    install -m 600 /dev/null "$temp"
+    if ln "$temp" "$lock_path" 2>/dev/null; then
+      created=true
+      fsync_path "$lock_path"
+      fsync_path "$(dirname "$lock_path")"
+    elif ! path_present "$lock_path"; then
+      die "could not create operation lock: $lock_path"
+    fi
+    trap - RETURN
+    rm -f "$temp"
+  fi
+  [[ -f "$lock_path" && ! -L "$lock_path" ]] ||
+    die "operation lock path is not a regular no-follow file: $lock_path"
+  [[ $(stat -c '%u' "$lock_path") == "$(id -u)" ]] ||
+    die "operation lock is not owned by the current user: $lock_path"
+  [[ $(stat -c '%a' "$lock_path") == 600 ]] ||
+    die "operation lock mode must be 0600: $lock_path"
+  [[ "$created" == false ]] || :
+}
+
+acquire_preparation_lock() {
+  local state=$1 lock_path
+  lock_path="$state.prepare.lock"
+  ensure_regular_lock_file "$lock_path"
+  exec 7<>"$lock_path"
+  [[ $(readlink "/proc/$BASHPID/fd/7" 2>/dev/null || true) == "$lock_path" ]] ||
+    die 'preparation lock descriptor does not name the deterministic lock path'
+  flock -w 30 7 || die 'another controller preparation is active for this state path'
+}
+
+after_preparation_lock() {
+  :
+}
+
+acquire_operation_lock() {
+  local engine_id=$1 volume=$2 lock_root=$3 lock_key lock_path
+  [[ -n "$engine_id" ]] || die 'Docker engine ID is empty'
+  [[ "$volume" =~ ^[A-Za-z0-9][A-Za-z0-9_.-]*$ ]] || die 'invalid PostgreSQL volume name'
+  [[ "$lock_root" == /* && -d "$lock_root" && ! -L "$lock_root" ]] ||
+    die "runtime lock directory is unavailable or unsafe: $lock_root"
+  [[ $(stat -c '%u' "$lock_root") == "$(id -u)" ]] ||
+    die 'runtime lock directory is not owned by the current user'
+
+  lock_key=$(printf '%s\0%s' "$engine_id" "$volume" | sha256sum | awk '{print $1}')
+  lock_path="$lock_root/noosphere-pgvector-switch-$lock_key.lock"
+  ensure_regular_lock_file "$lock_path"
+  exec 8<>"$lock_path"
+  [[ $(readlink "/proc/$BASHPID/fd/8" 2>/dev/null || true) == "$lock_path" ]] ||
+    die 'operation lock descriptor does not name the deterministic lock path'
+  flock -w 5 8 || die "another PostgreSQL image transition is active for volume $volume"
+  export NOOSPHERE_A2B_LOCK_FD=8
+  export NOOSPHERE_A2B_LOCK_PATH=$lock_path
+}
+
+claim_authoritative_state_path() {
+  local state=$1 engine_id=$2 volume=$3 lock_root=$4 lock_key claim state_path temp
+  assert_operation_lock_held "$engine_id" "$volume" "$lock_root"
+  lock_key=$(printf '%s\0%s' "$engine_id" "$volume" | sha256sum | awk '{print $1}')
+  claim="$lock_root/noosphere-pgvector-state-$lock_key.json"
+  state_path=$(realpath -m "$state")
+
+  if ! path_present "$claim"; then
+    temp=$(mktemp "$lock_root/.state-authority.XXXXXX")
+    trap 'rm -f "$temp"' RETURN
+    jq -n \
+      --arg engineId "$engine_id" \
+      --arg volume "$volume" \
+      --arg statePath "$state_path" \
+      '{version:1,engineId:$engineId,volume:$volume,statePath:$statePath}' > "$temp"
+    chmod 0600 "$temp"
+    fsync_path "$temp"
+    if ln "$temp" "$claim" 2>/dev/null; then
+      fsync_path "$claim"
+      fsync_path "$lock_root"
+    elif ! path_present "$claim"; then
+      die 'could not create the authoritative state-path claim'
+    fi
+    trap - RETURN
+    rm -f "$temp"
+  fi
+
+  assert_owned_regular_file "$claim"
+  [[ $(stat -c '%a' "$claim") == 600 ]] || die 'authoritative state-path claim mode must be 0600'
+  jq -e \
+    --arg engineId "$engine_id" \
+    --arg volume "$volume" \
+    --arg statePath "$state_path" '
+      .version == 1 and .engineId == $engineId and .volume == $volume and
+      (.statePath | type == "string" and startswith("/")) and
+      .statePath == $statePath
+    ' "$claim" >/dev/null ||
+    die 'authoritative state for this Docker engine and PostgreSQL volume is already claimed by another path'
+}
+
+assert_operation_lock_held() {
+  local engine_id=$1 volume=$2 lock_root=$3 expected_key expected_path actual_path
+  [[ ${NOOSPHERE_A2B_LOCK_FD:-} =~ ^[0-9]+$ ]] || die 'operation lock descriptor is missing or invalid'
+  expected_key=$(printf '%s\0%s' "$engine_id" "$volume" | sha256sum | awk '{print $1}')
+  expected_path="$lock_root/noosphere-pgvector-switch-$expected_key.lock"
+  [[ ${NOOSPHERE_A2B_LOCK_PATH:-} == "$expected_path" ]] || die 'operation lock path does not match the engine and volume'
+  # BASHPID remains correct when a focused fixture or caller runs the
+  # controller in a Bash subshell; $$ can still identify the parent shell.
+  actual_path=$(readlink "/proc/$BASHPID/fd/$NOOSPHERE_A2B_LOCK_FD" 2>/dev/null || true)
+  [[ "$actual_path" == "$expected_path" ]] || die 'operation lock descriptor names another path'
+  flock -n "$NOOSPHERE_A2B_LOCK_FD" || die 'operation lock descriptor is not held'
+}
+
+publish_compose_atomic() {
+  local source=$1 target=$2 staged
+  assert_owned_regular_file "$source"
+  assert_owned_regular_file "$target"
+  staged=$(mktemp "${target}.item3-publish.XXXXXX")
+  trap 'rm -f "$staged"' RETURN
+  install -m "$(stat -c '%a' "$source")" "$source" "$staged"
+  fsync_path "$staged"
+  mv -f "$staged" "$target"
+  fsync_path "$(dirname "$target")"
+  trap - RETURN
+}
+
+publish_candidate_under_lock() {
+  local state=$1 candidate_compose=$2 lock_root=$3 bound_source_snapshot=${4:-}
+  local phase engine_id volume live_compose source_snapshot source_sha candidate_sha
+  validate_controller_state "$state"
+  phase=$(jq -er '.phase' "$state")
+  [[ "$phase" == prepared ]] || die "candidate publication requires prepared state, found $phase"
+  engine_id=$(jq -er '.engineId' "$state")
+  volume=$(jq -er '.volume' "$state")
+  live_compose=$(jq -er '.liveCompose' "$state")
+  source_snapshot=${bound_source_snapshot:-$(jq -er '.sourceSnapshot' "$state")}
+  source_sha=$(jq -er '.sourceSnapshotSha256' "$state")
+  candidate_sha=$(jq -er '.candidateComposeSha256' "$state")
+  assert_operation_lock_held "$engine_id" "$volume" "$lock_root"
+  assert_owned_regular_file "$candidate_compose"
+  assert_owned_regular_file "$live_compose"
+  assert_owned_regular_file "$source_snapshot"
+  [[ $(sha256_file "$candidate_compose") == "$candidate_sha" ]] || die 'candidate Compose digest changed'
+  [[ $(sha256_file "$source_snapshot") == "$source_sha" ]] || die 'source Compose snapshot digest changed'
+  [[ $(sha256_file "$live_compose") == "$source_sha" ]] || die 'live Compose no longer matches the prepared source snapshot'
+
+  # Commit recovery ownership before the atomic publication. A kill between
+  # these operations therefore resumes through the source-restore path whether
+  # the rename happened or not.
+  update_controller_phase "$state" candidate-published
+  if [[ ${NOOSPHERE_CONTROLLER_TEST_INTERRUPT_AFTER_INTENT:-0} == 1 ]]; then
+    die 'test interruption after candidate publication intent'
+  fi
+  publish_compose_atomic "$candidate_compose" "$live_compose"
+}
+
+child_path_for_state() {
+  local state=$1 docker_path fixed_path
+  docker_path=${execution_docker_path:-$(jq -er '.dockerPath' "$state")}
+  fixed_path=$(jq -er '.fixedPath' "$state")
+  [[ $(basename "$docker_path") == docker ]] ||
+    die 'recorded Docker executable must be named docker'
+  printf '%s:%s\n' "$(dirname "$docker_path")" "$fixed_path"
+}
+
+assert_recorded_docker_resolution() {
+  local state=$1 docker_path child_path resolved
+  docker_path=${execution_docker_path:-$(jq -er '.dockerPath' "$state")}
+  child_path=$(child_path_for_state "$state")
+  resolved=$(PATH="$child_path" command -v docker 2>/dev/null || true)
+  [[ -n "$resolved" && $(realpath "$resolved") == "$(realpath "$docker_path")" ]] ||
+    die 'child PATH does not resolve the recorded Docker executable'
+}
+
+run_guard_with_inherited_lock() {
+  local state=$1 engine_id=$2 volume=$3 lock_root=$4
+  local child_path controller_home docker_config docker_host guard_exit=0 spawned_pid
+  local -a fixture_env=()
+  shift 4
+  (($# > 0)) || die 'guard command is empty'
+  assert_operation_lock_held "$engine_id" "$volume" "$lock_root"
+  assert_recorded_docker_resolution "$state"
+  child_path=$(child_path_for_state "$state")
+  controller_home=${execution_controller_home:-$(jq -er '.controllerHome' "$state")}
+  docker_config="$controller_home/docker"
+  docker_host=$(jq -er '.dockerEndpoint' "$state")
+  if [[ ${controller_test_hooks_enabled:-false} == true && -n ${controller_fixture_root:-} ]]; then
+    fixture_env+=("NOOSPHERE_CONTROLLER_FIXTURE_ROOT=$controller_fixture_root")
+  fi
+  setsid env -i \
+    "HOME=$controller_home" \
+    "PATH=$child_path" \
+    "DOCKER_CONFIG=$docker_config" \
+    "DOCKER_HOST=$docker_host" \
+    COMPOSE_DISABLE_ENV_FILE=1 \
+    "XDG_RUNTIME_DIR=$lock_root" \
+    LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8 \
+    "NOOSPHERE_A2B_LOCK_FD=$NOOSPHERE_A2B_LOCK_FD" \
+    "NOOSPHERE_A2B_LOCK_PATH=$NOOSPHERE_A2B_LOCK_PATH" \
+    "${fixture_env[@]}" \
+    "$@" &
+  spawned_pid=$!
+  if [[ -n ${NOOSPHERE_CONTROLLER_TEST_SIGNAL_AFTER_GUARD_SPAWN:-} ]]; then
+    handle_controller_signal "$NOOSPHERE_CONTROLLER_TEST_SIGNAL_AFTER_GUARD_SPAWN"
+  fi
+  guard_pid=$spawned_pid
+  active_child_pid=$guard_pid
+  active_child_pgid=$guard_pid
+  last_guard_pid=$guard_pid
+  forward_latched_signal_to_active_child
+  wait_for_child_exit "$guard_pid" || guard_exit=$?
+  wait_for_process_group_empty "$active_child_pgid"
+  guard_pid=''
+  active_child_pid=''
+  active_child_pgid=''
+  return "$guard_exit"
+}
+
+run_verifier_hermetic() {
+  local state=$1 guard_journal=$2 volume=$3 verifier=$4
+  local child_path controller_home docker_config docker_host lock_root app_url verify_exit=0
+  local -a fixture_env=()
+  assert_recorded_docker_resolution "$state"
+  child_path=$(child_path_for_state "$state")
+  controller_home=${execution_controller_home:-$(jq -er '.controllerHome' "$state")}
+  docker_config="$controller_home/docker"
+  docker_host=$(jq -er '.dockerEndpoint' "$state")
+  lock_root=$(jq -er '.lockRoot' "$state")
+  app_url=$(jq -er '.appUrl' "$state")
+  if [[ ${controller_test_hooks_enabled:-false} == true && -n ${controller_fixture_root:-} ]]; then
+    fixture_env+=("NOOSPHERE_CONTROLLER_FIXTURE_ROOT=$controller_fixture_root")
+  fi
+  setsid env -i \
+    "HOME=$controller_home" \
+    "PATH=$child_path" \
+    "DOCKER_CONFIG=$docker_config" \
+    "DOCKER_HOST=$docker_host" \
+    COMPOSE_DISABLE_ENV_FILE=1 \
+    "XDG_RUNTIME_DIR=$lock_root" \
+    LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8 \
+    "NOOSPHERE_APP_URL=$app_url" \
+    NOOSPHERE_EXPECTED_POSTGRES_IMAGE_MODE=candidate \
+    "NOOSPHERE_POSTGRES_EVIDENCE=$guard_journal" \
+    "NOOSPHERE_DB_CONTAINER=$(jq -er '.dbContainer' "$state")" \
+    "NOOSPHERE_EXPECTED_DB_VOLUME=$volume" \
+    "NOOSPHERE_EXPECTED_POSTGRES_AUTHORIZATION_VOLUME=$(jq -er '.authorizationVolume' "$state")" \
+    "${fixture_env[@]}" \
+    "$verifier" &
+  active_child_pid=$!
+  active_child_pgid=$active_child_pid
+  last_verifier_pid=$active_child_pid
+  forward_latched_signal_to_active_child
+  wait_for_child_exit "$active_child_pid" || verify_exit=$?
+  wait_for_process_group_empty "$active_child_pgid"
+  active_child_pid=''
+  active_child_pgid=''
+  return "$verify_exit"
+}
+
+run_source_verifier_hermetic() {
+  local state=$1 verifier=$2
+  local child_path controller_home docker_config docker_host lock_root app_url verify_exit=0
+  local -a fixture_env=()
+  assert_recorded_docker_resolution "$state"
+  child_path=$(child_path_for_state "$state")
+  controller_home=${execution_controller_home:-$(jq -er '.controllerHome' "$state")}
+  docker_config="$controller_home/docker"
+  docker_host=$(jq -er '.dockerEndpoint' "$state")
+  lock_root=$(jq -er '.lockRoot' "$state")
+  app_url=$(jq -er '.appUrl' "$state")
+  if [[ ${controller_test_hooks_enabled:-false} == true && -n ${controller_fixture_root:-} ]]; then
+    fixture_env+=("NOOSPHERE_CONTROLLER_FIXTURE_ROOT=$controller_fixture_root")
+  fi
+  setsid env -i \
+    "HOME=$controller_home" \
+    "PATH=$child_path" \
+    "DOCKER_CONFIG=$docker_config" \
+    "DOCKER_HOST=$docker_host" \
+    COMPOSE_DISABLE_ENV_FILE=1 \
+    "XDG_RUNTIME_DIR=$lock_root" \
+    LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8 \
+    "NOOSPHERE_APP_URL=$app_url" \
+    NOOSPHERE_EXPECTED_POSTGRES_IMAGE_MODE=source \
+    "NOOSPHERE_DB_CONTAINER=$(jq -er '.dbContainer' "$state")" \
+    "NOOSPHERE_EXPECTED_DB_VOLUME=$(jq -er '.volume' "$state")" \
+    "NOOSPHERE_EXPECTED_POSTGRES_AUTHORIZATION_VOLUME=$(jq -er '.authorizationVolume' "$state")" \
+    "${fixture_env[@]}" \
+    "$verifier" &
+  active_child_pid=$!
+  active_child_pgid=$active_child_pid
+  last_verifier_pid=$active_child_pid
+  forward_latched_signal_to_active_child
+  wait_for_child_exit "$active_child_pid" || verify_exit=$?
+  wait_for_process_group_empty "$active_child_pgid"
+  active_child_pid=''
+  active_child_pgid=''
+  return "$verify_exit"
+}
+
+run_source_recovery_verifier_with_evidence() {
+  local state=$1 verifier artifact_base stdout_file stderr_file evidence
+  local start_cursor end_cursor started_at ended_at verify_exit=0
+  verifier=${execution_verifier:-$(jq -er '.verifier' "$state")}
+  artifact_base="${state%.json}.source-recovery"
+  stdout_file="$artifact_base.stdout.log"
+  stderr_file="$artifact_base.stderr.log"
+  evidence="$artifact_base.evidence.json"
+  install -m 600 /dev/null "$stdout_file"
+  install -m 600 /dev/null "$stderr_file"
+  start_cursor=$(capture_journal_cursor)
+  started_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  run_source_verifier_hermetic "$state" "$verifier" >"$stdout_file" 2>"$stderr_file" ||
+    verify_exit=$?
+  ended_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  end_cursor=$(capture_journal_cursor)
+  write_process_evidence_atomic "$evidence" source-recovery-running "$verify_exit" \
+    "$stdout_file" "$stderr_file" "$INVOCATION_ID" "$controller_boot_id" \
+    "$systemd_controller_main_pid" "$last_verifier_pid" "$started_at" "$ended_at" \
+    "$start_cursor" "$end_cursor"
+  bind_process_evidence_to_state "$state" sourceRecoveryEvidence "$evidence" \
+    "$INVOCATION_ID" "$controller_boot_id" "$systemd_controller_main_pid" "$last_verifier_pid"
+  return "$verify_exit"
+}
+
+systemd_properties() {
+  local working_directory=$1
+  printf '%s\n' \
+    Type=exec \
+    RemainAfterExit=no \
+    Restart=no \
+    KillMode=mixed \
+    TimeoutStartSec=infinity \
+    TimeoutStopSec=infinity \
+    RuntimeMaxSec=infinity \
+    UMask=0077 \
+    "WorkingDirectory=$working_directory"
+}
+
+write_process_evidence_atomic() {
+  local target=$1 phase=$2 exit_code=$3 stdout_file=$4 stderr_file=$5
+  local invocation_id=$6 boot_id=$7 controller_main_pid=$8 child_pid=$9
+  local started_at=${10} ended_at=${11} start_cursor=${12} end_cursor=${13} temp
+  [[ ${NOOSPHERE_CONTROLLER_TEST_FAIL_EVIDENCE:-} != "$phase" ]] ||
+    die "test evidence failure at phase $phase"
+  assert_owned_regular_file "$stdout_file"
+  assert_owned_regular_file "$stderr_file"
+  [[ $(stat -c '%a' "$stdout_file") == 600 ]] || die 'process stdout mode must be 0600'
+  [[ $(stat -c '%a' "$stderr_file") == 600 ]] || die 'process stderr mode must be 0600'
+  [[ "$exit_code" =~ ^[0-9]+$ ]] || die 'process exit code must be a non-negative integer'
+  [[ "$controller_main_pid" =~ ^[0-9]+$ && "$controller_main_pid" -gt 0 ]] ||
+    die 'controller MainPID must be a positive integer'
+  [[ "$child_pid" =~ ^[0-9]+$ && "$child_pid" -gt 0 ]] ||
+    die 'process child PID must be a positive integer'
+  [[ "$controller_main_pid" != "$child_pid" ]] ||
+    die 'controller MainPID and process child PID must differ'
+
+  # The evidence hashes are only durable claims after the log bytes and their
+  # directory entry have reached stable storage.
+  fsync_path "$stdout_file"
+  fsync_path "$stderr_file"
+  fsync_path "$(dirname "$target")"
+  temp=$(mktemp "$(dirname "$target")/.process-evidence.XXXXXX")
+  trap 'rm -f "$temp"' RETURN
+  jq -n \
+    --arg phase "$phase" \
+    --argjson exitCode "$exit_code" \
+    --arg stdout "$stdout_file" \
+    --arg stderr "$stderr_file" \
+    --arg stdoutSha256 "$(sha256_file "$stdout_file")" \
+    --arg stderrSha256 "$(sha256_file "$stderr_file")" \
+    --arg invocationId "$invocation_id" \
+    --arg bootId "$boot_id" \
+    --argjson controllerMainPid "$controller_main_pid" \
+    --argjson childPid "$child_pid" \
+    --arg startedAt "$started_at" \
+    --arg endedAt "$ended_at" \
+    --arg startCursor "$start_cursor" \
+    --arg endCursor "$end_cursor" \
+    '{
+      version: 1,
+      phase: $phase,
+      exitCode: $exitCode,
+      stdout: $stdout,
+      stderr: $stderr,
+      stdoutSha256: $stdoutSha256,
+      stderrSha256: $stderrSha256,
+      invocationId: $invocationId,
+      bootId: $bootId,
+      controllerMainPid: $controllerMainPid,
+      childPid: $childPid,
+      startedAt: $startedAt,
+      endedAt: $endedAt,
+      startCursor: $startCursor,
+      endCursor: $endCursor
+    }' > "$temp"
+  write_controller_state_atomic "$target" "$temp"
+  trap - RETURN
+}
+
+validate_process_evidence() {
+  local evidence=$1 expected_phase=${2:-} expected_invocation=${3:-}
+  local expected_boot=${4:-} expected_controller_pid=${5:-} expected_child_pid=${6:-}
+  local stdout_file stderr_file started_at ended_at started_epoch ended_epoch
+  assert_owned_regular_file "$evidence"
+  [[ $(stat -c '%a' "$evidence") == 600 ]] || die 'process evidence mode must be 0600'
+  jq -e '
+    type == "object" and .version == 1 and
+    (.phase | type == "string") and
+    (.exitCode | type == "number" and . >= 0 and floor == .) and
+    (.stdout | type == "string" and startswith("/")) and
+    (.stderr | type == "string" and startswith("/")) and
+    (.stdoutSha256 | type == "string" and test("^[a-f0-9]{64}$")) and
+    (.stderrSha256 | type == "string" and test("^[a-f0-9]{64}$")) and
+    (.invocationId | type == "string" and length > 0) and
+    (.bootId | type == "string" and length > 0) and
+    (.controllerMainPid | type == "number" and . > 0 and floor == .) and
+    (.childPid | type == "number" and . > 0 and floor == .) and
+    .controllerMainPid != .childPid and
+    (.startedAt | type == "string" and length > 0) and
+    (.endedAt | type == "string" and length > 0) and
+    (.startCursor | type == "string" and length > 0) and
+    (.endCursor | type == "string" and length > 0)
+  ' "$evidence" >/dev/null || die 'process evidence is malformed'
+  started_at=$(jq -er '.startedAt' "$evidence")
+  ended_at=$(jq -er '.endedAt' "$evidence")
+  [[ "$started_at" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ &&
+     "$ended_at" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]] ||
+    die 'process evidence timestamps must be canonical UTC RFC3339 values'
+  started_epoch=$(date -u -d "$started_at" +%s 2>/dev/null) || die 'process evidence start timestamp is invalid'
+  ended_epoch=$(date -u -d "$ended_at" +%s 2>/dev/null) || die 'process evidence end timestamp is invalid'
+  ((ended_epoch >= started_epoch)) || die 'process evidence ends before it starts'
+  [[ -z "$expected_phase" || $(jq -er '.phase' "$evidence") == "$expected_phase" ]] ||
+    die 'process evidence phase does not match the controller phase'
+  [[ -z "$expected_invocation" || $(jq -er '.invocationId' "$evidence") == "$expected_invocation" ]] ||
+    die 'process evidence InvocationID does not match the controller execution'
+  [[ -z "$expected_boot" || $(jq -er '.bootId' "$evidence") == "$expected_boot" ]] ||
+    die 'process evidence boot ID does not match the controller execution'
+  [[ -z "$expected_controller_pid" || $(jq -er '.controllerMainPid' "$evidence") == "$expected_controller_pid" ]] ||
+    die 'process evidence controller MainPID does not match systemd'
+  [[ -z "$expected_child_pid" || $(jq -er '.childPid' "$evidence") == "$expected_child_pid" ]] ||
+    die 'process evidence child PID does not match the launched process'
+  stdout_file=$(jq -er '.stdout' "$evidence")
+  stderr_file=$(jq -er '.stderr' "$evidence")
+  assert_owned_regular_file "$stdout_file"
+  assert_owned_regular_file "$stderr_file"
+  [[ $(stat -c '%a' "$stdout_file") == 600 ]] || die 'evidence stdout mode must be 0600'
+  [[ $(stat -c '%a' "$stderr_file") == 600 ]] || die 'evidence stderr mode must be 0600'
+  [[ $(sha256_file "$stdout_file") == "$(jq -er '.stdoutSha256' "$evidence")" ]] ||
+    die 'evidence stdout digest does not match its log'
+  [[ $(sha256_file "$stderr_file") == "$(jq -er '.stderrSha256' "$evidence")" ]] ||
+    die 'evidence stderr digest does not match its log'
+}
+
+validate_bound_process_evidence() {
+  local state=$1 key=$2 expected_phase=$3 path expected_sha
+  local recorded_stdout recorded_stderr
+  path=$(jq -er --arg key "$key" '.[$key].path' "$state")
+  expected_sha=$(jq -er --arg key "$key" '.[$key].sha256' "$state")
+  assert_owned_regular_file "$path"
+  [[ $(stat -c '%a' "$path") == 600 ]] || die "$key mode must be 0600"
+  [[ $(sha256_file "$path") == "$expected_sha" ]] || die "$key digest does not match durable evidence"
+  validate_process_evidence "$path" "$expected_phase"
+  [[ $(jq -er '.exitCode' "$path") == 0 ]] || die "$key records a nonzero terminal exit"
+  recorded_stdout=$(jq -er --arg key "$key" '.[$key].stdout | [.path,.sha256] | @tsv' "$state")
+  recorded_stderr=$(jq -er --arg key "$key" '.[$key].stderr | [.path,.sha256] | @tsv' "$state")
+  [[ "$recorded_stdout" == "$(jq -er '[.stdout,.stdoutSha256] | @tsv' "$path")" ]] ||
+    die "$key stdout binding differs from durable evidence"
+  [[ "$recorded_stderr" == "$(jq -er '[.stderr,.stderrSha256] | @tsv' "$path")" ]] ||
+    die "$key stderr binding differs from durable evidence"
+}
+
+validate_complete_state_evidence() {
+  local state=$1
+  validate_bound_process_evidence "$state" guardEvidence guard-exited
+  validate_bound_process_evidence "$state" authorizationEvidence authorization-running
+  validate_bound_process_evidence "$state" closureEvidence closure-running
+  assert_bound_guard_journal_unchanged "$state"
+}
+
+bind_process_evidence_to_state() {
+  local state=$1 key=$2 evidence=$3 expected_invocation=${4:-} expected_boot=${5:-}
+  local expected_controller_pid=${6:-} expected_child_pid=${7:-} expected_phase temp stdout_file stderr_file
+  case "$key" in
+    guardEvidence) expected_phase=guard-exited ;;
+    authorizationEvidence) expected_phase=authorization-running ;;
+    closureEvidence) expected_phase=closure-running ;;
+    sourceRecoveryEvidence) expected_phase=source-recovery-running ;;
+    *) die "invalid controller evidence key: $key" ;;
+  esac
+  validate_controller_state "$state"
+  validate_process_evidence "$evidence" "$expected_phase" "$expected_invocation" \
+    "$expected_boot" "$expected_controller_pid" "$expected_child_pid"
+  stdout_file=$(jq -er '.stdout' "$evidence")
+  stderr_file=$(jq -er '.stderr' "$evidence")
+  temp=$(mktemp "$(dirname "$state")/.controller-evidence.XXXXXX")
+  trap 'rm -f "$temp"' RETURN
+  jq \
+    --arg key "$key" \
+    --arg path "$evidence" \
+    --arg sha256 "$(sha256_file "$evidence")" \
+    --arg stdout "$stdout_file" \
+    --arg stdoutSha256 "$(jq -er '.stdoutSha256' "$evidence")" \
+    --arg stderr "$stderr_file" \
+    --arg stderrSha256 "$(jq -er '.stderrSha256' "$evidence")" '
+      .[$key] = {
+        path: $path,
+        sha256: $sha256,
+        stdout: {path: $stdout, sha256: $stdoutSha256},
+        stderr: {path: $stderr, sha256: $stderrSha256}
+      } |
+      .updatedAt = (now | todateiso8601)
+    ' "$state" > "$temp"
+  write_controller_state_atomic "$state" "$temp"
+  trap - RETURN
+}
+
+bind_guard_journal_to_state() {
+  local state=$1 journal=$2 temp journal_sha phase mode run_id
+  assert_owned_regular_file "$journal"
+  [[ $(stat -c '%a' "$journal") == 600 ]] || die 'completed guard journal mode must be 0600'
+  phase=$(jq -er '.phase' "$journal")
+  [[ "$phase" == complete ]] || die 'guard exited successfully without complete evidence'
+  mode=$(jq -er '.mode' "$journal")
+  run_id=$(jq -er '.runId // ""' "$journal")
+  fsync_path "$journal"
+  fsync_path "$(dirname "$journal")"
+  journal_sha=$(sha256_file "$journal")
+  temp=$(mktemp "$(dirname "$state")/.controller-guard-journal.XXXXXX")
+  trap 'rm -f "$temp"' RETURN
+  jq \
+    --arg path "$journal" \
+    --arg sha256 "$journal_sha" \
+    --arg phase "$phase" \
+    --arg mode "$mode" \
+    --arg runId "$run_id" '
+      .guardJournalEvidence = {
+        path: $path,
+        sha256: $sha256,
+        phase: $phase,
+        mode: $mode,
+        runId: $runId
+      } |
+      .updatedAt = (now | todateiso8601)
+    ' "$state" > "$temp"
+  write_controller_state_atomic "$state" "$temp"
+  trap - RETURN
+}
+
+assert_bound_guard_journal_unchanged() {
+  local state=$1 path expected_sha
+  path=$(jq -er '.guardJournalEvidence.path' "$state")
+  expected_sha=$(jq -er '.guardJournalEvidence.sha256' "$state")
+  [[ "$path" == "$(jq -er '.guardJournal' "$state")" ]] ||
+    die 'bound guard journal path does not match the prepared journal'
+  assert_owned_regular_file "$path"
+  [[ $(stat -c '%a' "$path") == 600 ]] || die 'bound guard journal mode must be 0600'
+  [[ $(jq -er '.phase' "$path") == complete ]] || die 'bound guard journal is no longer complete'
+  [[ $(sha256_file "$path") == "$expected_sha" ]] || die 'bound guard journal digest changed'
+}
+
+begin_closure_incident() {
+  local state=$1 failure_class=$2
+  if ! update_controller_phase "$state" closure-stop-pending "closure-$failure_class"; then
+    # Even if the durable intent write fails, attempt to remove the writer
+    # before returning the storage failure to the operator.
+    stop_application_fail_closed || true
+    die 'could not persist closure incident; application stop was attempted'
+  fi
+  complete_closure_stop_pending "$state"
+}
+
+begin_closure_evidence_pending() {
+  local state=$1 failure_class=$2
+  # Persist stop intent first. A crash or failed stop verification remains in
+  # closure-stop-pending, whose recovery path retries the fail-closed stop.
+  update_controller_phase "$state" closure-stop-pending "closure-$failure_class"
+  if ! stop_application_fail_closed; then
+    return 1
+  fi
+  # Only a verified stopped writer may enter the evidence-retry phase.
+  update_controller_phase "$state" closure-evidence-pending "closure-$failure_class"
+}
+
+complete_closure_evidence_pending() {
+  local state=$1 evidence=$2 expected_invocation=${3:-} expected_boot=${4:-}
+  local expected_controller_pid=${5:-} expected_child_pid=${6:-} incident_class
+  incident_class=$(jq -er '.incidentClass' "$state")
+  bind_process_evidence_to_state "$state" closureEvidence "$evidence" \
+    "$expected_invocation" "$expected_boot" "$expected_controller_pid" "$expected_child_pid"
+  update_controller_phase "$state" incident "$incident_class"
+}
+
+complete_closure_stop_pending() {
+  local state=$1 incident_class
+  incident_class=$(jq -er '.incidentClass' "$state")
+  # Do not depend on errexit here: callers intentionally invoke recovery from
+  # conditional contexts where Bash suppresses it for the entire call stack.
+  if ! stop_application_fail_closed; then
+    return 1
+  fi
+  update_controller_phase "$state" incident "$incident_class"
+}
+
+commit_closure_outcome() {
+  local state=$1 evidence=$2 failure_class=$3 other_failures=$4
+  local expected_invocation=${5:-} expected_boot=${6:-} expected_controller_pid=${7:-}
+  local expected_child_pid=${8:-} action exit_code phase
+  validate_controller_state "$state"
+  validate_process_evidence "$evidence" closure-running "$expected_invocation" \
+    "$expected_boot" "$expected_controller_pid" "$expected_child_pid"
+  phase=$(jq -er '.phase' "$state")
+  [[ "$phase" == closure-running ]] || die "closure outcome requires closure-running state, found $phase"
+  [[ "$other_failures" =~ ^[0-9]+$ ]] || die 'closure failure count must be a non-negative integer'
+  exit_code=$(jq -er '.exitCode' "$evidence")
+
+  if [[ "$failure_class" == none && "$other_failures" == 0 && "$exit_code" == 0 ]]; then
+    jq -e '.guardEvidence.path | type == "string" and startswith("/")' "$state" >/dev/null ||
+      die 'complete state requires bound guard evidence'
+    assert_bound_guard_journal_unchanged "$state"
+    abort_if_interrupted || return $?
+    bind_process_evidence_to_state "$state" closureEvidence "$evidence" \
+      "$expected_invocation" "$expected_boot" "$expected_controller_pid" "$expected_child_pid"
+    abort_if_interrupted || return $?
+    assert_bound_guard_journal_unchanged "$state"
+    if [[ -n ${NOOSPHERE_CONTROLLER_TEST_SIGNAL_BEFORE_COMPLETE:-} ]]; then
+      handle_controller_signal "$NOOSPHERE_CONTROLLER_TEST_SIGNAL_BEFORE_COMPLETE"
+    fi
+    abort_if_interrupted || return $?
+    # The completed journal and controller state form one publication while the
+    # shared engine-volume lock excludes every cooperating transition actor.
+    # A non-cooperating same-UID writer is outside this controller's trust
+    # boundary and requires a separate publication identity/capability.
+    assert_operation_lock_held \
+      "$(jq -er '.engineId' "$state")" \
+      "$(jq -er '.volume' "$state")" \
+      "$(jq -er '.lockRoot' "$state")"
+    assert_bound_guard_journal_unchanged "$state"
+    if update_controller_phase "$state" complete; then
+      return 0
+    else
+      return $?
+    fi
+  fi
+
+  action=$(classify_closure_failure "$failure_class" "$other_failures")
+  if [[ "$action" == completed-journal-revalidate ]]; then
+    revalidate_completed_guard_journal "$state" "$evidence"
+    return
+  fi
+
+  begin_closure_evidence_pending "$state" "$failure_class"
+  complete_closure_evidence_pending "$state" "$evidence" \
+    "$expected_invocation" "$expected_boot" "$expected_controller_pid" "$expected_child_pid"
+}
+
+sanitize_execution_environment() {
+  local docker_host=$1 fixed_path=$2 controller_home=$3
+
+  unset DOCKER_CONTEXT DOCKER_TLS_VERIFY DOCKER_CERT_PATH
+  unset COMPOSE_FILE COMPOSE_PROJECT_NAME COMPOSE_PROFILES
+  unset COMPOSE_ENV_FILES COMPOSE_PROJECT_DIR COMPOSE_PATH_SEPARATOR
+  unset HTTP_PROXY HTTPS_PROXY ALL_PROXY NO_PROXY http_proxy https_proxy all_proxy no_proxy
+  unset BASH_ENV ENV CDPATH GLOBIGNORE
+  unset NOOSPHERE_A2B_LOCK_FD NOOSPHERE_A2B_LOCK_PATH
+  unset NOOSPHERE_CONTROLLER_FIXTURE_ROOT
+  if [[ ${controller_test_hooks_enabled:-false} != true ]]; then
+    unset NOOSPHERE_CONTROLLER_TEST_INTERRUPT_AFTER_INTENT
+    unset NOOSPHERE_CONTROLLER_TEST_SIGNAL_AFTER_GUARD_SPAWN
+    unset NOOSPHERE_CONTROLLER_TEST_FAIL_EVIDENCE
+    unset NOOSPHERE_CONTROLLER_TEST_SIGNAL_AFTER_AUTHORIZATION
+    unset NOOSPHERE_CONTROLLER_TEST_SIGNAL_BEFORE_COMPLETE
+    unset NOOSPHERE_CONTROLLER_TEST_SIGNAL_BEFORE_GUARD
+  fi
+  if [[ ${controller_test_hooks_enabled:-false} == true && -n ${controller_fixture_root:-} ]]; then
+    export NOOSPHERE_CONTROLLER_FIXTURE_ROOT=$controller_fixture_root
+  fi
+
+  export HOME=$controller_home
+  export DOCKER_CONFIG="$controller_home/docker"
+  export DOCKER_HOST=$docker_host
+  export COMPOSE_DISABLE_ENV_FILE=1
+  export PATH=$fixed_path
+}
+
+assert_controller_artifact_paths_separate() {
+  local state_document=$1 state_path=$2 preparation_manifest=${3:-}
+  local base field controlled_path bound_path docker_config_dir namespace_path
+  local -a controlled=() bound=()
+  base=${state_path%.json}
+  controlled=(
+    "$state_path"
+    "$base.guard.stdout.log"
+    "$base.guard.stderr.log"
+    "$base.guard.evidence.json"
+    "$base.authorization.stdout.log"
+    "$base.authorization.stderr.log"
+    "$base.authorization.evidence.json"
+    "$base.verify.stdout.log"
+    "$base.verify.stderr.log"
+    "$base.verify.evidence.json"
+  )
+  [[ -z "$preparation_manifest" ]] || bound+=("$preparation_manifest")
+  for field in liveCompose sourceSnapshot candidateCompose envFile controllerPath guard verifier \
+    dockerPath composePluginPath guardJournal; do
+    bound+=("$(jq -er --arg field "$field" '.[$field]' "$state_document")")
+  done
+  bound+=("$(jq -er '.controllerHome' "$state_document")/docker/config.json")
+  docker_config_dir=$(realpath -m "$(jq -er '.controllerHome' "$state_document")/docker")
+
+  for controlled_path in "${controlled[@]}"; do
+    for bound_path in "${bound[@]}"; do
+      [[ "$(realpath -m "$controlled_path")" != "$(realpath -m "$bound_path")" ]] ||
+        die 'controller state/log/evidence path collides with a bound transition input'
+    done
+  done
+  for namespace_path in "${controlled[@]}" \
+    "$(jq -er '.backupDir' "$state_document")" \
+    "$(jq -er '.lockRoot' "$state_document")"; do
+    namespace_path=$(realpath -m "$namespace_path")
+    [[ "$namespace_path" != "$docker_config_dir" &&
+       "$namespace_path" != "$docker_config_dir"/* &&
+       "$docker_config_dir" != "$namespace_path"/* ]] ||
+      die 'controller artifact namespace collides with the one-file Docker config directory'
+  done
+  for ((field = 0; field < ${#controlled[@]}; field += 1)); do
+    for ((base = field + 1; base < ${#controlled[@]}; base += 1)); do
+      [[ "$(realpath -m "${controlled[$field]}")" != "$(realpath -m "${controlled[$base]}")" ]] ||
+        die 'controller state/log/evidence paths collide with each other'
+    done
+  done
+}
+
+select_process_artifact_base() {
+  local state=$1 role=$2 base candidate invocation
+  base=${state%.json}
+  candidate=$base
+  if path_present "$base.$role.stdout.log" ||
+     path_present "$base.$role.stderr.log" ||
+     path_present "$base.$role.evidence.json"; then
+    invocation=${INVOCATION_ID:?systemd InvocationID is required for recovery evidence}
+    [[ "$invocation" =~ ^[A-Za-z0-9_.-]+$ ]] || die 'systemd InvocationID is unsafe for evidence paths'
+    candidate="$base.$invocation"
+    ! path_present "$candidate.$role.stdout.log" &&
+      ! path_present "$candidate.$role.stderr.log" &&
+      ! path_present "$candidate.$role.evidence.json" ||
+      die 'process evidence path for this systemd invocation already exists'
+  fi
+  printf '%s\n' "$candidate"
+}
+
+assert_guard_journal_path() {
+  local state=$1 backup_dir volume journal expected
+  backup_dir=$(jq -er '.backupDir' "$state")
+  volume=$(jq -er '.volume' "$state")
+  journal=$(jq -er '.guardJournal' "$state")
+  expected="$backup_dir/$volume.phase-a2b.json"
+  [[ $(realpath -m "$journal") == "$(realpath -m "$expected")" ]] ||
+    die 'guard journal path does not match the pinned guard path'
+}
+
+validate_execution_manifest() {
+  local state=$1
+  validate_controller_state "$state"
+  jq -e '
+    (.guard | type == "string" and startswith("/")) and
+    (.guardSha256 | type == "string" and test("^[a-f0-9]{64}$")) and
+    (.controllerPath | type == "string" and startswith("/")) and
+    (.controllerSha256 | type == "string" and test("^[a-f0-9]{64}$")) and
+    (.guardArgs | type == "array" and length > 0 and
+      all(.[]; (type == "string") and (test("[\u0000-\u001f]") | not))) and
+    (.verifier | type == "string" and startswith("/")) and
+    (.verifierSha256 | type == "string" and test("^[a-f0-9]{64}$")) and
+    (.candidateCompose | type == "string" and startswith("/")) and
+    (.envFile | type == "string" and startswith("/")) and
+    (.envFileSha256 | type == "string" and test("^[a-f0-9]{64}$")) and
+    (.dockerPath | type == "string" and startswith("/")) and
+    (.dockerSha256 | type == "string" and test("^[a-f0-9]{64}$")) and
+    (.dockerComposeVersionSha256 | type == "string" and test("^[a-f0-9]{64}$")) and
+    (.composePluginPath | type == "string" and startswith("/")) and
+    (.composePluginSha256 | type == "string" and test("^[a-f0-9]{64}$")) and
+    (.dockerConfigSha256 | type == "string" and test("^[a-f0-9]{64}$")) and
+    (.effectiveComposeSha256 | type == "string" and test("^[a-f0-9]{64}$")) and
+    (.backupDir | type == "string" and startswith("/")) and
+    (.lockRoot | type == "string" and startswith("/")) and
+    (.controllerHome | type == "string" and startswith("/")) and
+    (.fixedPath | type == "string" and test("^(/[A-Za-z0-9._-]+)+(:(/[A-Za-z0-9._-]+)+)*$")) and
+    (.dbContainer | type == "string" and test("^[A-Za-z0-9][A-Za-z0-9_.-]*$")) and
+    (.appContainer | type == "string" and test("^[A-Za-z0-9][A-Za-z0-9_.-]*$")) and
+    (.authorizationVolume | type == "string" and test("^[A-Za-z0-9][A-Za-z0-9_.-]*$")) and
+    (.appUrl | type == "string" and test("^http://127[.]0[.]0[.]1:[1-9][0-9]{0,4}$")) and
+    ((.appUrl | split(":")[-1] | tonumber) <= 65535) and
+    (.platform == "linux/amd64" or .platform == "linux/arm64")
+  ' "$state" >/dev/null || die 'execution manifest is malformed'
+  assert_guard_journal_path "$state"
+  validate_guard_arguments "$state"
+}
+
+assert_controller_execution_identity() {
+  local state=$1 recorded_path expected
+  recorded_path=$(jq -er '.controllerPath' "$state")
+  expected=$(jq -er '.controllerSha256' "$state")
+  [[ $(realpath "$recorded_path") == "$CONTROLLER_EXECUTABLE_PATH" ]] ||
+    die 'prepared controller path does not match the executing controller'
+  assert_owned_regular_file "$CONTROLLER_EXECUTABLE_PATH"
+  [[ $(sha256_file "$CONTROLLER_EXECUTABLE_PATH") == "$expected" ]] ||
+    die 'controller executable digest changed after preparation'
+}
+
+validate_guard_arguments() {
+  local state=$1 option value index=0
+  local -a args=()
+  local -A seen=() values=()
+  mapfile -d '' -t args < <(jq -j '.guardArgs[] | ., "\u0000"' "$state")
+  while ((index < ${#args[@]})); do
+    option=${args[$index]}
+    case "$option" in
+      --defer-app-restart)
+        [[ -z ${seen[$option]:-} ]] || die "duplicate guard argument: $option"
+        seen[$option]=1
+        ((index += 1))
+        ;;
+      --compose-file|--env-file|--db-container|--app-container|--volume|--authorization-volume|--backup-dir|--platform)
+        [[ -z ${seen[$option]:-} ]] || die "duplicate guard argument: $option"
+        ((index + 1 < ${#args[@]})) || die "guard argument requires a value: $option"
+        value=${args[$((index + 1))]}
+        [[ "$value" != --* ]] || die "guard argument requires a value: $option"
+        seen[$option]=1
+        values[$option]=$value
+        ((index += 2))
+        ;;
+      --prepare-new-install|--record-new-install|--authorize-writer|--db-service)
+        die "guard argument is incompatible with a source transition: $option"
+        ;;
+      *) die "unsupported guard argument: $option" ;;
+    esac
+  done
+  for option in --compose-file --env-file --db-container --app-container --volume \
+    --authorization-volume --backup-dir --platform; do
+    [[ -n ${seen[$option]:-} ]] || die "required guard argument is missing: $option"
+  done
+  [[ -n ${seen[--defer-app-restart]:-} ]] ||
+    die 'guard invocation must defer application restart until durable closure'
+  [[ ${values[--compose-file]} == "$(jq -er '.liveCompose' "$state")" ]] || die 'guard Compose path does not match the manifest'
+  [[ ${values[--env-file]} == "$(jq -er '.envFile' "$state")" ]] || die 'guard environment path does not match the manifest'
+  [[ ${values[--db-container]} == "$(jq -er '.dbContainer' "$state")" ]] || die 'guard database container does not match the manifest'
+  [[ ${values[--app-container]} == "$(jq -er '.appContainer' "$state")" ]] || die 'guard app container does not match the manifest'
+  [[ ${values[--volume]} == "$(jq -er '.volume' "$state")" ]] || die 'guard volume does not match the manifest'
+  [[ ${values[--authorization-volume]} == "$(jq -er '.authorizationVolume' "$state")" ]] || die 'guard authorization volume does not match the manifest'
+  [[ ${values[--backup-dir]} == "$(jq -er '.backupDir' "$state")" ]] || die 'guard backup directory does not match the manifest'
+  [[ ${values[--platform]} == "$(jq -er '.platform' "$state")" ]] || die 'guard platform does not match the manifest'
+}
+
+query_compose_plugin_path() {
+  local docker_path=$1
+  "$docker_path" info --format '{{json .ClientInfo.Plugins}}' |
+    jq -er '[.[] | select(.Name == "compose") | .Path] | if length == 1 then .[0] else error("Compose plugin identity is ambiguous") end'
+}
+
+assert_private_docker_config() {
+  local controller_home=$1 config_dir config_file
+  config_dir="$controller_home/docker"
+  config_file="$config_dir/config.json"
+  assert_owned_private_directory "$config_dir"
+  assert_owned_regular_file "$config_file"
+  [[ $(stat -c '%a' "$config_file") == 600 ]] || die 'Docker config mode must be 0600'
+  [[ $(find -P "$config_dir" -mindepth 1 -maxdepth 1 -printf x | wc -c) == 1 ]] ||
+    die 'Docker config directory must contain only the recorded config.json'
+}
+
+compose_model_signature() {
+  local state=$1 docker_path candidate env_file
+  docker_path=$(jq -er '.dockerPath' "$state")
+  candidate=$(jq -er '.candidateCompose' "$state")
+  env_file=$(jq -er '.envFile' "$state")
+  "$docker_path" compose --env-file "$env_file" -f "$candidate" config --no-interpolate |
+    sha256sum | awk '{print $1}'
+}
+
+verify_execution_inputs() {
+  local state=$1 field path_field digest_field path expected docker_path plugin_path config_path
+  validate_execution_manifest "$state"
+  assert_controller_execution_identity "$state"
+  assert_owned_private_directory "$(dirname "$state")"
+  assert_owned_private_directory "$(jq -er '.backupDir' "$state")"
+  assert_owned_private_directory "$(jq -er '.lockRoot' "$state")"
+  assert_owned_private_directory "$(jq -er '.controllerHome' "$state")"
+  assert_trusted_fixed_path "$(jq -er '.fixedPath' "$state")"
+  assert_private_docker_config "$(jq -er '.controllerHome' "$state")"
+  for field in guard verifier candidateCompose envFile; do
+    case "$field" in
+      guard) path_field=guard; digest_field=guardSha256 ;;
+      verifier) path_field=verifier; digest_field=verifierSha256 ;;
+      candidateCompose) path_field=candidateCompose; digest_field=candidateComposeSha256 ;;
+      envFile) path_field=envFile; digest_field=envFileSha256 ;;
+    esac
+    path=$(jq -er --arg field "$path_field" '.[$field]' "$state")
+    expected=$(jq -er --arg field "$digest_field" '.[$field]' "$state")
+    assert_owned_regular_file "$path"
+    [[ $(sha256_file "$path") == "$expected" ]] || die "$field digest changed after preparation"
+  done
+  docker_path=$(jq -er '.dockerPath' "$state")
+  [[ -f "$docker_path" && -x "$docker_path" && ! -L "$docker_path" ]] || die 'recorded Docker executable is unsafe'
+  [[ $(sha256_file "$docker_path") == "$(jq -er '.dockerSha256' "$state")" ]] || die 'Docker executable digest changed after preparation'
+  plugin_path=$(jq -er '.composePluginPath' "$state")
+  [[ -f "$plugin_path" && -x "$plugin_path" && ! -L "$plugin_path" ]] || die 'recorded Docker Compose plugin is unsafe'
+  [[ $(sha256_file "$plugin_path") == "$(jq -er '.composePluginSha256' "$state")" ]] || die 'Docker Compose plugin digest changed after preparation'
+  [[ $(query_compose_plugin_path "$docker_path") == "$plugin_path" ]] || die 'Docker Compose plugin path changed after preparation'
+  config_path="$(jq -er '.controllerHome' "$state")/docker/config.json"
+  [[ $(sha256_file "$config_path") == "$(jq -er '.dockerConfigSha256' "$state")" ]] || die 'Docker config changed after preparation'
+  [[ $("$docker_path" compose version --short | sha256sum | awk '{print $1}') == "$(jq -er '.dockerComposeVersionSha256' "$state")" ]] ||
+    die 'Docker Compose version changed after preparation'
+  [[ $(compose_model_signature "$state") == "$(jq -er '.effectiveComposeSha256' "$state")" ]] ||
+    die 'effective candidate Compose model changed after preparation'
+}
+
+copy_execution_input() {
+  local source=$1 target=$2 expected=$3 mode=$4 owner_policy=${5:-caller}
+  local source_owner source_mode
+  case "$owner_policy" in
+    caller)
+      assert_owned_regular_file "$source"
+      ;;
+    system-executable)
+      [[ -f "$source" && ! -L "$source" ]] ||
+        die "required system executable is missing or unsafe: $source"
+      source_owner=$(stat -c '%u' "$source")
+      [[ "$source_owner" == 0 || "$source_owner" == "$(id -u)" ]] ||
+        die "system executable has an untrusted owner: $source"
+      source_mode=$(stat -c '%a' "$source")
+      (( (8#$source_mode & 8#022) == 0 )) ||
+        die "system executable permits group/world writes: $source"
+      ;;
+    *) die "unknown execution-input owner policy: $owner_policy" ;;
+  esac
+  install -m "$mode" "$source" "$target"
+  fsync_path "$target"
+  [[ $(sha256_file "$target") == "$expected" ]] ||
+    die "execution input changed while binding: $source"
+}
+
+create_execution_bundle() {
+  local state=$1 base config_source docker_host fixed_path
+  [[ ${INVOCATION_ID:-} =~ ^[a-fA-F0-9]{32}$ ]] ||
+    die 'execution input binding requires a systemd InvocationID'
+  base="${state%.json}.inputs.$INVOCATION_ID"
+  ! path_present "$base" || die "execution input bundle already exists: $base"
+  mkdir -m 700 "$base"
+  mkdir -m 700 "$base/home" "$base/home/docker" "$base/home/docker/cli-plugins"
+
+  execution_guard="$base/guard"
+  execution_verifier="$base/verifier"
+  execution_candidate_compose="$base/candidate-compose.yml"
+  execution_source_snapshot="$base/source-compose.yml"
+  execution_env_file="$base/runtime.env"
+  execution_docker_path="$base/docker"
+  execution_compose_plugin="$base/home/docker/cli-plugins/docker-compose"
+  execution_controller_home="$base/home"
+
+  copy_execution_input "$(jq -er '.guard' "$state")" "$execution_guard" \
+    "$(jq -er '.guardSha256' "$state")" 700
+  copy_execution_input "$(jq -er '.verifier' "$state")" "$execution_verifier" \
+    "$(jq -er '.verifierSha256' "$state")" 700
+  copy_execution_input "$(jq -er '.candidateCompose' "$state")" "$execution_candidate_compose" \
+    "$(jq -er '.candidateComposeSha256' "$state")" "$(stat -c '%a' "$(jq -er '.candidateCompose' "$state")")"
+  copy_execution_input "$(jq -er '.sourceSnapshot' "$state")" "$execution_source_snapshot" \
+    "$(jq -er '.sourceSnapshotSha256' "$state")" "$(stat -c '%a' "$(jq -er '.sourceSnapshot' "$state")")"
+  copy_execution_input "$(jq -er '.envFile' "$state")" "$execution_env_file" \
+    "$(jq -er '.envFileSha256' "$state")" 600
+  copy_execution_input "$(jq -er '.dockerPath' "$state")" "$execution_docker_path" \
+    "$(jq -er '.dockerSha256' "$state")" 700 system-executable
+  copy_execution_input "$(jq -er '.composePluginPath' "$state")" "$execution_compose_plugin" \
+    "$(jq -er '.composePluginSha256' "$state")" 700 system-executable
+  config_source="$(jq -er '.controllerHome' "$state")/docker/config.json"
+  copy_execution_input "$config_source" "$execution_controller_home/docker/config.json" \
+    "$(jq -er '.dockerConfigSha256' "$state")" 600
+  fsync_path "$base/home/docker/cli-plugins"
+  fsync_path "$base/home/docker"
+  fsync_path "$base/home"
+  fsync_path "$base"
+  fsync_path "$(dirname "$base")"
+
+  docker_host=$(jq -er '.dockerEndpoint' "$state")
+  fixed_path=$(jq -er '.fixedPath' "$state")
+  [[ $(DOCKER_CONFIG="$execution_controller_home/docker" DOCKER_HOST="$docker_host" \
+      "$execution_docker_path" info --format '{{json .ClientInfo.Plugins}}' | \
+      jq -er '[.[] | select(.Name == "compose") | .Path] | if length == 1 then .[0] else error("Compose plugin identity is ambiguous") end') == \
+      "$execution_compose_plugin" ]] ||
+    die 'bound Docker Compose plugin path does not match the execution bundle'
+  [[ $(DOCKER_CONFIG="$execution_controller_home/docker" DOCKER_HOST="$docker_host" \
+      "$execution_docker_path" compose version --short | sha256sum | awk '{print $1}') == \
+      "$(jq -er '.dockerComposeVersionSha256' "$state")" ]] ||
+    die 'bound Docker Compose version differs from the prepared identity'
+  [[ $(DOCKER_CONFIG="$execution_controller_home/docker" DOCKER_HOST="$docker_host" \
+      "$execution_docker_path" compose --env-file "$execution_env_file" \
+      -f "$execution_candidate_compose" config --no-interpolate | sha256sum | awk '{print $1}') == \
+      "$(jq -er '.effectiveComposeSha256' "$state")" ]] ||
+    die 'bound candidate Compose model differs from the prepared model'
+  PATH="$(dirname "$execution_docker_path"):$fixed_path" command -v docker >/dev/null ||
+    die 'bound Docker executable is absent from the child PATH'
+}
+
+prepare_execution_state() {
+  local manifest=$1 state=$2 guard_journal docker_host fixed_path controller_home
+  local engine_id volume lock_root volume_fingerprint prepared
+  assert_owned_regular_file "$manifest"
+  [[ $(stat -c '%a' "$manifest") == 600 ]] || die 'preparation manifest mode must be 0600'
+  assert_owned_private_directory "$(dirname "$state")"
+  acquire_preparation_lock "$state"
+  after_preparation_lock
+  validate_execution_manifest "$manifest"
+  assert_controller_execution_identity "$manifest"
+  assert_controller_artifact_paths_separate "$manifest" "$state" "$manifest"
+  docker_host=$(jq -er '.dockerEndpoint' "$manifest")
+  fixed_path=$(jq -er '.fixedPath' "$manifest")
+  controller_home=$(jq -er '.controllerHome' "$manifest")
+  # Validate with the fixed bootstrap toolchain before manifest-controlled
+  # PATH bytes can influence any command resolution.
+  assert_trusted_fixed_path "$fixed_path"
+  sanitize_execution_environment "$docker_host" "$fixed_path" "$controller_home"
+  [[ $(jq -er '.phase' "$manifest") == prepared ]] || die 'preparation manifest must start in prepared phase'
+  engine_id=$(jq -er '.engineId' "$manifest")
+  volume=$(jq -er '.volume' "$manifest")
+  lock_root=$(jq -er '.lockRoot' "$manifest")
+  acquire_operation_lock "$engine_id" "$volume" "$lock_root"
+  claim_authoritative_state_path "$state" "$engine_id" "$volume" "$lock_root"
+  assert_live_engine_binding "$manifest" "$(jq -er '.dockerPath' "$manifest")"
+  verify_execution_inputs "$manifest"
+  volume_fingerprint=$(query_postgres_volume_fingerprint "$(jq -er '.dockerPath' "$manifest")" "$volume")
+  prepared=$(mktemp "$(dirname "$state")/.controller-prepared.XXXXXX")
+  trap 'rm -f "$prepared"' RETURN
+  jq --arg volumeFingerprint "$volume_fingerprint" \
+    '.volumeFingerprint = $volumeFingerprint' "$manifest" > "$prepared"
+  validate_execution_manifest "$prepared"
+  guard_journal=$(jq -er '.guardJournal' "$manifest")
+  [[ $(realpath -m "$state") != "$(realpath -m "$guard_journal")" ]] ||
+    die 'controller state path collides with the guard journal path'
+  # Preparation is only ever a fresh start or an idempotent re-preparation.
+  # Overwriting an active or terminal state would orphan its recovery
+  # ownership and incident evidence.
+  if path_present "$state"; then
+    validate_controller_state "$state"
+    [[ $(jq -er '.phase' "$state") == prepared ]] ||
+      die "refusing to overwrite controller state in phase $(jq -er '.phase' "$state")"
+    cmp -s "$state" "$prepared" ||
+      die 'refusing to replace an existing prepared controller state with different bytes'
+    return 0
+  fi
+  write_controller_state_atomic "$state" "$prepared"
+  trap - RETURN
+}
+
+capture_journal_cursor() {
+  journalctl --user -u "$CONTROLLER_UNIT" -n 0 --show-cursor --no-pager |
+    sed -n 's/^-- cursor: //p' | tail -1
+}
+
+record_controller_interruption() {
+  local signal=$1 temp
+  [[ -n ${controller_state:-} && -f ${controller_state:-} ]] || return 0
+  temp=$(mktemp "$(dirname "$controller_state")/.controller-interrupt.XXXXXX")
+  trap 'rm -f "$temp"' RETURN
+  jq --arg signal "$signal" '.lastInterruption = {signal:$signal, at:(now | todateiso8601)}' \
+    "$controller_state" > "$temp"
+  write_controller_state_atomic "$controller_state" "$temp"
+  trap - RETURN
+}
+
+persist_interrupted_state() {
+  record_controller_interruption "$1"
+}
+
+delegate_to_guard_journal() {
+  : # The execution loop sees resume_action=run-guard and invokes the pinned guard.
+}
+
+assert_source_state_unchanged() {
+  local verifier
+  verifier=${execution_verifier:-$(jq -er '.verifier' "$controller_state")}
+  run_source_verifier_hermetic "$controller_state" "$verifier" >/dev/null
+}
+
+stop_application_fail_closed() {
+  local docker_path app_container running
+  docker_path=${execution_docker_path:-$(jq -er '.dockerPath' "$controller_state")}
+  app_container=$(jq -er '.appContainer' "$controller_state")
+  "$docker_path" stop --time 60 "$app_container" >/dev/null 2>&1 ||
+    die "failed to stop application container $app_container"
+  running=$("$docker_path" inspect --format '{{.State.Running}}' "$app_container" 2>/dev/null) ||
+    die "could not verify stopped application container $app_container"
+  [[ "$running" == false ]] ||
+    die "application container remains running after stop: $app_container"
+}
+
+activate_application_for_verification() {
+  local state=$1 docker_path app_container running project_directory
+  docker_path=${execution_docker_path:-$(jq -er '.dockerPath' "$state")}
+  app_container=$(jq -er '.appContainer' "$state")
+  running=$("$docker_path" inspect --format '{{.State.Running}}' "$app_container" 2>/dev/null) ||
+    die "could not inspect application container before activation: $app_container"
+  [[ "$running" == true || "$running" == false ]] ||
+    die "application container has an invalid running state: $app_container"
+  [[ "$running" == false ]] || return 0
+
+  project_directory=$(dirname "$(jq -er '.liveCompose' "$state")")
+  "$docker_path" compose \
+    --project-directory "$project_directory" \
+    --env-file "$execution_env_file" \
+    -f "$execution_candidate_compose" \
+    up -d --no-deps --force-recreate app >/dev/null ||
+    return 1
+  running=$("$docker_path" inspect --format '{{.State.Running}}' "$app_container" 2>/dev/null) ||
+    return 1
+  [[ "$running" == true ]]
+}
+
+revalidate_completed_guard_journal() {
+  local state=$1
+  update_controller_phase "$state" closure-stop-pending isolated-app-health-requires-guard-revalidation
+  complete_closure_stop_pending "$state"
+}
+
+# Default systemd identity source. Focused fixtures override this function;
+# production resolves the live unit state from systemd itself.
+query_systemd_unit_identity() {
+  systemctl --user show "$CONTROLLER_UNIT" \
+    --property=ActiveState,InvocationID,MainPID,Type,RemainAfterExit,Restart,KillMode,TimeoutStartUSec,TimeoutStopUSec,RuntimeMaxUSec,UMask,Transient,WorkingDirectory 2>/dev/null
+}
+
+query_user_linger() {
+  loginctl show-user "$(id -u)" -p Linger --value 2>/dev/null
+}
+
+require_systemd_execution_context() {
+  [[ ${INVOCATION_ID:-} =~ ^[a-fA-F0-9]{32}$ ]] || die 'execution requires a systemd InvocationID'
+  [[ ${CONTROLLER_UNIT:-} =~ ^[A-Za-z0-9_.@:-]+\.service$ ]] || die 'execution requires an explicit systemd service unit'
+  # Environment variables are only claims: bind them to the queried unit so a
+  # inherited or forged environment cannot satisfy the execution boundary.
+  local queried q_active q_invocation q_main_pid q_type q_remain q_restart q_kill_mode
+  local q_timeout_start q_timeout_stop q_runtime_max q_umask q_transient q_working_directory
+  local expected_working_directory linger
+  queried=$(query_systemd_unit_identity) ||
+    die "could not query systemd identity for unit $CONTROLLER_UNIT"
+  q_active=$(sed -n 's/^ActiveState=//p' <<<"$queried" | head -n 1)
+  q_invocation=$(sed -n 's/^InvocationID=//p' <<<"$queried" | head -n 1)
+  q_main_pid=$(sed -n 's/^MainPID=//p' <<<"$queried" | head -n 1)
+  q_type=$(sed -n 's/^Type=//p' <<<"$queried" | head -n 1)
+  q_remain=$(sed -n 's/^RemainAfterExit=//p' <<<"$queried" | head -n 1)
+  q_restart=$(sed -n 's/^Restart=//p' <<<"$queried" | head -n 1)
+  q_kill_mode=$(sed -n 's/^KillMode=//p' <<<"$queried" | head -n 1)
+  q_timeout_start=$(sed -n 's/^TimeoutStartUSec=//p' <<<"$queried" | head -n 1)
+  q_timeout_stop=$(sed -n 's/^TimeoutStopUSec=//p' <<<"$queried" | head -n 1)
+  q_runtime_max=$(sed -n 's/^RuntimeMaxUSec=//p' <<<"$queried" | head -n 1)
+  q_umask=$(sed -n 's/^UMask=//p' <<<"$queried" | head -n 1)
+  q_transient=$(sed -n 's/^Transient=//p' <<<"$queried" | head -n 1)
+  q_working_directory=$(sed -n 's/^WorkingDirectory=//p' <<<"$queried" | head -n 1)
+  expected_working_directory=$(dirname "$(jq -er '.liveCompose' "$controller_state")")
+  [[ "$q_active" == active ]] ||
+    die "systemd unit $CONTROLLER_UNIT is not active (found ${q_active:-unknown})"
+  [[ -n "$q_invocation" && "$q_invocation" == "$INVOCATION_ID" ]] ||
+    die 'environment InvocationID does not match the queried systemd unit'
+  [[ "$q_main_pid" =~ ^[0-9]+$ && "$q_main_pid" == "$$" ]] ||
+    die 'systemd MainPID does not match this controller process'
+  [[ "$q_type" == exec && "$q_remain" == no && "$q_restart" == no ]] ||
+    die 'systemd unit type/restart policy does not match the controller contract'
+  [[ "$q_kill_mode" == mixed ]] || die 'systemd KillMode must be mixed'
+  [[ "$q_timeout_start" == infinity && "$q_timeout_stop" == infinity && "$q_runtime_max" == infinity ]] ||
+    die 'systemd unit time limits must be infinite'
+  [[ "$q_umask" == 0077 ]] || die 'systemd unit UMask must be 0077'
+  [[ "$q_transient" == yes ]] || die 'systemd unit must be transient'
+  [[ "$q_working_directory" == "$expected_working_directory" ]] ||
+    die 'systemd WorkingDirectory does not match the prepared Compose directory'
+  linger=$(query_user_linger) || die 'could not query user-manager linger state'
+  [[ "$linger" == yes ]] || die 'persistent user manager requires linger=yes'
+  systemd_controller_main_pid=$q_main_pid
+}
+
+execute_prepared_state() {
+  local state=$1 engine_id volume lock_root docker_host fixed_path controller_home
+  local candidate guard verifier guard_journal guard_stdout guard_stderr guard_evidence
+  local authorization_stdout authorization_stderr authorization_evidence authorization_artifact_base
+  local verify_stdout verify_stderr verify_evidence start_cursor end_cursor started_at ended_at
+  local guard_exit=0 authorization_exit=0 verify_exit=0 postprocess_exit=0 boot_id phase guard_artifact_base verify_artifact_base
+  local run_initial_guard=true run_authorization=true run_activation=true
+  local resume_closure_evidence=false
+  local -a guard_args authorization_args
+  controller_state=$state
+  validate_execution_manifest "$state"
+  docker_host=$(jq -er '.dockerEndpoint' "$state")
+  fixed_path=$(jq -er '.fixedPath' "$state")
+  controller_home=$(jq -er '.controllerHome' "$state")
+  # The recorded PATH cannot participate in validating its own trust.
+  assert_trusted_fixed_path "$fixed_path"
+  sanitize_execution_environment "$docker_host" "$fixed_path" "$controller_home"
+  # Identity is queried through the hermetic PATH, never from the inherited one.
+  require_systemd_execution_context
+  assert_controller_artifact_paths_separate "$state" "$state"
+  engine_id=$(jq -er '.engineId' "$state")
+  volume=$(jq -er '.volume' "$state")
+  lock_root=$(jq -er '.lockRoot' "$state")
+  acquire_operation_lock "$engine_id" "$volume" "$lock_root"
+  assert_live_engine_binding "$state" "$(jq -er '.dockerPath' "$state")"
+  verify_execution_inputs "$state"
+  assert_postgres_volume_binding "$state" "$(jq -er '.dockerPath' "$state")"
+  create_execution_bundle "$state"
+  boot_id=$(< /proc/sys/kernel/random/boot_id)
+  controller_boot_id=$boot_id
+  resume_action=''
+  resume_controller_state "$state"
+  case "$resume_action" in
+    publish-and-run)
+      candidate=$execution_candidate_compose
+      publish_candidate_under_lock "$state" "$candidate" "$lock_root" "$execution_source_snapshot"
+      ;;
+    run-guard) ;;
+    run-authorization) run_initial_guard=false ;;
+    run-activation|run-closure)
+      run_initial_guard=false
+      run_authorization=false
+      ;;
+    run-closure-stopped)
+      run_initial_guard=false
+      run_authorization=false
+      run_activation=false
+      resume_closure_evidence=true
+      ;;
+    source-restored) return 1 ;;
+    *) die "unsupported resume action: ${resume_action:-empty}" ;;
+  esac
+
+  guard=$execution_guard
+  verifier=$execution_verifier
+  guard_journal=$(jq -er '.guardJournal' "$state")
+  mapfile -t guard_args < <(jq -er '.guardArgs[]' "$state")
+  for ((phase = 0; phase + 1 < ${#guard_args[@]}; phase++)); do
+    if [[ ${guard_args[$phase]} == --env-file ]]; then
+      guard_args[$((phase + 1))]=$execution_env_file
+      break
+    fi
+  done
+  authorization_args=(--authorize-writer)
+  for phase in "${guard_args[@]}"; do
+    [[ "$phase" == --defer-app-restart ]] || authorization_args+=("$phase")
+  done
+
+  if [[ "$run_initial_guard" == true ]]; then
+  guard_artifact_base=$(select_process_artifact_base "$state" guard)
+  guard_stdout="$guard_artifact_base.guard.stdout.log"
+  guard_stderr="$guard_artifact_base.guard.stderr.log"
+  guard_evidence="$guard_artifact_base.guard.evidence.json"
+  install -m 600 /dev/null "$guard_stdout"
+  install -m 600 /dev/null "$guard_stderr"
+  start_cursor=$(capture_journal_cursor)
+  started_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  if [[ -n ${NOOSPHERE_CONTROLLER_TEST_SIGNAL_BEFORE_GUARD:-} ]]; then
+    handle_controller_signal "$NOOSPHERE_CONTROLLER_TEST_SIGNAL_BEFORE_GUARD"
+  fi
+  abort_if_interrupted || return $?
+  run_guard_with_inherited_lock "$state" "$engine_id" "$volume" "$lock_root" \
+    "$guard" "${guard_args[@]}" >"$guard_stdout" 2>"$guard_stderr" || guard_exit=$?
+  ended_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  end_cursor=$(capture_journal_cursor)
+  write_process_evidence_atomic "$guard_evidence" guard-exited "$guard_exit" \
+    "$guard_stdout" "$guard_stderr" "$INVOCATION_ID" "$boot_id" "$systemd_controller_main_pid" "$last_guard_pid" \
+    "$started_at" "$ended_at" "$start_cursor" "$end_cursor"
+  bind_process_evidence_to_state "$state" guardEvidence "$guard_evidence" \
+    "$INVOCATION_ID" "$boot_id" "$systemd_controller_main_pid" "$last_guard_pid"
+  update_controller_phase "$state" guard-exited
+  abort_if_interrupted || return $?
+  if ((guard_exit != 0)); then
+    resume_controller_state "$state"
+    return "$guard_exit"
+  fi
+  bind_guard_journal_to_state "$state" "$guard_journal"
+  abort_if_interrupted || return $?
+
+  # The complete pinned-guard journal and process evidence are the durable
+  # pre-authorization boundary. No writer marker exists and the app remains
+  # stopped until the next independently evidenced phase succeeds.
+  update_controller_phase "$state" authorization-running
+  abort_if_interrupted || return $?
+  else
+    assert_bound_guard_journal_unchanged "$state"
+  fi
+
+  if [[ "$run_authorization" == true ]]; then
+    authorization_artifact_base=$(select_process_artifact_base "$state" authorization)
+    authorization_stdout="$authorization_artifact_base.authorization.stdout.log"
+    authorization_stderr="$authorization_artifact_base.authorization.stderr.log"
+    authorization_evidence="$authorization_artifact_base.authorization.evidence.json"
+    install -m 600 /dev/null "$authorization_stdout"
+    install -m 600 /dev/null "$authorization_stderr"
+    start_cursor=$(capture_journal_cursor)
+    started_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+    abort_if_interrupted || return $?
+    run_guard_with_inherited_lock "$state" "$engine_id" "$volume" "$lock_root" \
+      "$guard" "${authorization_args[@]}" >"$authorization_stdout" 2>"$authorization_stderr" ||
+      authorization_exit=$?
+    ended_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+    end_cursor=$(capture_journal_cursor)
+    write_process_evidence_atomic "$authorization_evidence" authorization-running "$authorization_exit" \
+      "$authorization_stdout" "$authorization_stderr" "$INVOCATION_ID" "$boot_id" \
+      "$systemd_controller_main_pid" "$last_guard_pid" "$started_at" "$ended_at" "$start_cursor" "$end_cursor"
+    bind_process_evidence_to_state "$state" authorizationEvidence "$authorization_evidence" \
+      "$INVOCATION_ID" "$boot_id" "$systemd_controller_main_pid" "$last_guard_pid"
+    if [[ -n ${controller_signal:-} ]]; then
+      abort_if_interrupted || return $?
+    fi
+    if ((authorization_exit != 0)); then
+      begin_closure_incident "$state" writer-authorization
+      return "$authorization_exit"
+    fi
+    assert_bound_guard_journal_unchanged "$state"
+    update_controller_phase "$state" activation-running
+    if [[ -n ${NOOSPHERE_CONTROLLER_TEST_SIGNAL_AFTER_AUTHORIZATION:-} ]]; then
+      handle_controller_signal "$NOOSPHERE_CONTROLLER_TEST_SIGNAL_AFTER_AUTHORIZATION"
+    fi
+    abort_if_interrupted || return $?
+  else
+    validate_bound_process_evidence "$state" authorizationEvidence authorization-running
+  fi
+
+  # Allocate and durably create every verifier artifact before activation. A
+  # collision or storage failure therefore rejects while the writer is still
+  # stopped, rather than creating an unverified active writer.
+  verify_artifact_base=$(select_process_artifact_base "$state" verify)
+  verify_stdout="$verify_artifact_base.verify.stdout.log"
+  verify_stderr="$verify_artifact_base.verify.stderr.log"
+  verify_evidence="$verify_artifact_base.verify.evidence.json"
+  install -m 600 /dev/null "$verify_stdout"
+  install -m 600 /dev/null "$verify_stderr"
+  start_cursor=$(capture_journal_cursor)
+  started_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+  assert_bound_guard_journal_unchanged "$state"
+  if [[ "$run_activation" == true ]]; then
+    if ! activate_application_for_verification "$state"; then
+      begin_closure_incident "$state" app-activation
+      return 1
+    fi
+    if [[ $(jq -er '.phase' "$state") != closure-running ]]; then
+      update_controller_phase "$state" closure-running
+    fi
+    if ! abort_if_interrupted; then
+      begin_closure_incident "$state" interruption
+      return "$(signal_exit_code "$controller_signal")"
+    fi
+  else
+    # Evidence-pending recovery may re-run the verifier only while the writer
+    # remains stopped. It must never recreate or reactivate the failed writer.
+    stop_application_fail_closed
+  fi
+
+  abort_if_interrupted || return $?
+  run_verifier_hermetic "$state" "$guard_journal" "$volume" "$verifier" \
+    >"$verify_stdout" 2>"$verify_stderr" || verify_exit=$?
+  ended_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  if end_cursor=$(capture_journal_cursor); then
+    :
+  else
+    postprocess_exit=$?
+    begin_closure_incident "$state" postprocessing
+    return "$postprocess_exit"
+  fi
+  if ((verify_exit != 0)) && [[ "$resume_closure_evidence" == false ]]; then
+    # The writer-stop intent and observed stop precede every fallible evidence
+    # write. A full evidence disk cannot leave the candidate writer running.
+    begin_closure_evidence_pending "$state" verification
+  fi
+  if (
+    write_process_evidence_atomic "$verify_evidence" closure-running "$verify_exit" \
+      "$verify_stdout" "$verify_stderr" "$INVOCATION_ID" "$boot_id" "$systemd_controller_main_pid" "$last_verifier_pid" \
+      "$started_at" "$ended_at" "$start_cursor" "$end_cursor"
+  ); then
+    :
+  else
+    postprocess_exit=$?
+    if ((verify_exit == 0)); then
+      # A successful verifier still has a live writer, so postprocessing
+      # storage failure must durably stop it. A failed verifier has already
+      # entered closure-evidence-pending with an inspect-verified stop; retain
+      # that resumable evidence state instead of replacing it with a second
+      # incident.
+      begin_closure_incident "$state" postprocessing
+    fi
+    return "$postprocess_exit"
+  fi
+  if [[ "$resume_closure_evidence" == true ]]; then
+    complete_closure_evidence_pending "$state" "$verify_evidence" \
+      "$INVOCATION_ID" "$boot_id" "$systemd_controller_main_pid" "$last_verifier_pid"
+    abort_if_interrupted || return $?
+    ((verify_exit != 0)) && return "$verify_exit"
+    return 1
+  fi
+  if [[ -n ${controller_signal:-} ]]; then
+    if (
+      bind_process_evidence_to_state "$state" closureEvidence "$verify_evidence" \
+        "$INVOCATION_ID" "$boot_id" "$systemd_controller_main_pid" "$last_verifier_pid"
+    ); then
+      begin_closure_incident "$state" interruption
+      return "$(signal_exit_code "$controller_signal")"
+    else
+      postprocess_exit=$?
+      begin_closure_incident "$state" postprocessing
+      return "$postprocess_exit"
+    fi
+  fi
+  if ((verify_exit == 0)); then
+    if (
+      commit_closure_outcome "$state" "$verify_evidence" none 0 \
+        "$INVOCATION_ID" "$boot_id" "$systemd_controller_main_pid" "$last_verifier_pid"
+    ); then
+      :
+    else
+      postprocess_exit=$?
+      begin_closure_incident "$state" postprocessing
+      return "$postprocess_exit"
+    fi
+  else
+    complete_closure_evidence_pending "$state" "$verify_evidence" \
+      "$INVOCATION_ID" "$boot_id" "$systemd_controller_main_pid" "$last_verifier_pid"
+    return "$verify_exit"
+  fi
+}
+
+classify_closure_failure() {
+  local failure_class=$1 other_failures=$2
+  if [[ "$failure_class" == app-health && "$other_failures" == 0 ]]; then
+    printf 'completed-journal-revalidate\n'
+  else
+    printf 'incident-stop-app\n'
+  fi
+}
+
+controller_signal_active=false
+controller_test_hooks_enabled=false
+controller_fixture_root=''
+controller_signal=''
+controller_signal_forwarded=false
+controller_state_write_active=false
+controller_interruption_pending=false
+controller_wait_interrupted=false
+active_child_pid=''
+active_child_pgid=''
+guard_pid=''
+last_guard_pid=0
+last_verifier_pid=0
+controller_state=''
+systemd_controller_main_pid=0
+controller_boot_id=''
+execution_guard=''
+execution_verifier=''
+execution_candidate_compose=''
+execution_source_snapshot=''
+execution_env_file=''
+execution_docker_path=''
+execution_compose_plugin=''
+execution_controller_home=''
+resume_action=''
+
+signal_exit_code() {
+  case "$1" in
+    HUP) printf '129\n' ;;
+    INT) printf '130\n' ;;
+    TERM) printf '143\n' ;;
+    *) printf '1\n' ;;
+  esac
+}
+
+abort_if_interrupted() {
+  [[ -z ${controller_signal:-} ]] && return 0
+  return "$(signal_exit_code "$controller_signal")"
+}
+
+forward_latched_signal_to_active_child() {
+  [[ -n ${controller_signal:-} && ${controller_signal_forwarded:-false} == false ]] || return 0
+  [[ -n ${active_child_pid:-} ]] || return 0
+  if [[ -n ${active_child_pgid:-} ]] && kill -0 -- "-$active_child_pgid" 2>/dev/null; then
+    kill -s "$controller_signal" -- "-$active_child_pgid" 2>/dev/null || true
+    controller_signal_forwarded=true
+  elif kill -0 "$active_child_pid" 2>/dev/null; then
+    kill -s "$controller_signal" "$active_child_pid" 2>/dev/null || true
+    controller_signal_forwarded=true
+  fi
+}
+
+wait_for_process_group_empty() {
+  local pgid=$1
+  [[ -n "$pgid" ]] || return 0
+  while kill -0 -- "-$pgid" 2>/dev/null; do
+    sleep 0.02
+  done
+}
+
+wait_for_child_exit() {
+  local child_pid=$1 child_exit=0
+  while true; do
+    controller_wait_interrupted=false
+    child_exit=0
+    wait "$child_pid" || child_exit=$?
+    if [[ ${controller_wait_interrupted:-false} == true ]] &&
+      kill -0 "$child_pid" 2>/dev/null; then
+      # A trapped signal interrupts Bash's wait before the child necessarily
+      # exits. Keep its identity live and wait again until the child is reaped.
+      forward_latched_signal_to_active_child
+      continue
+    fi
+    return "$child_exit"
+  done
+}
+
+handle_controller_signal() {
+  local signal=$1
+  [[ "$controller_signal_active" == false ]] || return 0
+  controller_signal_active=true
+  controller_signal=$signal
+  controller_wait_interrupted=true
+  forward_latched_signal_to_active_child
+  if [[ ${controller_state_write_active:-false} == true ]]; then
+    controller_interruption_pending=true
+  else
+    persist_interrupted_state "$signal"
+  fi
+}
+
+main() {
+  local mode='' manifest='' state=''
+  while (($# > 0)); do
+    case "$1" in
+      --prepare) mode=prepare; shift ;;
+      --execute) mode=execute; shift ;;
+      --manifest) manifest=${2:?missing value}; shift 2 ;;
+      --state) state=${2:?missing value}; shift 2 ;;
+      --help|-h)
+        printf 'Usage: %s --prepare --manifest FILE --state FILE\n' "$0"
+        printf '       %s --execute --state FILE\n' "$0"
+        return
+        ;;
+      *) die "unknown argument: $1" ;;
+    esac
+  done
+  [[ -n "$state" && "$state" == /* ]] || die '--state must be an absolute path'
+  case "$mode" in
+    prepare)
+      [[ -n "$manifest" && "$manifest" == /* ]] || die '--manifest must be an absolute path'
+      prepare_execution_state "$manifest" "$state"
+      ;;
+    execute)
+      [[ -z "$manifest" ]] || die '--manifest is not valid with --execute'
+      trap 'handle_controller_signal TERM' TERM
+      trap 'handle_controller_signal INT' INT
+      trap 'handle_controller_signal HUP' HUP
+      execute_prepared_state "$state"
+      ;;
+    *) die 'exactly one of --prepare or --execute is required' ;;
+  esac
+}
+
+if [[ ${BASH_SOURCE[0]} == "$0" ]]; then
+  main "$@"
+fi

--- a/scripts/test-pgvector-transition-controller-docker.sh
+++ b/scripts/test-pgvector-transition-controller-docker.sh
@@ -79,6 +79,8 @@ manifest="$tmp_dir/manifest.json"
 state="$tmp_dir/controller.json"
 unit_base="noosphere-pgvector-controller-docker-$BASHPID-$RANDOM"
 unit="$unit_base.service"
+interruption_runner_pid=''
+recovery_state="$tmp_dir/recovery-incident.json"
 runtime_root=${XDG_RUNTIME_DIR:-/run/user/$(id -u)}
 docker_path=$(command -v docker)
 compose_plugin_path=$(docker info --format '{{json .ClientInfo.Plugins}}' |
@@ -100,7 +102,8 @@ printf '{}\n' > "$controller_home/docker/config.json"
 chmod 0600 "$env_file" "$controller_home/docker/config.json"
 
 unit_load_state() {
-  systemctl --user show "$unit" -p LoadState --value 2>/dev/null || printf 'not-found\n'
+  local queried_unit=${1:-$unit}
+  systemctl --user show "$queried_unit" -p LoadState --value 2>/dev/null || printf 'not-found\n'
 }
 
 cleanup_successfully() {
@@ -187,6 +190,7 @@ cleanup() {
     guard_run_id=$(jq -r '.runId // empty' "$backup_dir/$volume.phase-a2b.json" 2>/dev/null || true)
   fi
   systemctl --user stop "$unit" >/dev/null 2>&1 || true
+  [[ -z "$interruption_runner_pid" ]] || wait "$interruption_runner_pid" >/dev/null 2>&1 || true
   if [[ -n "$guard_run_id" ]]; then
     for id in $(docker ps -aq --filter "label=io.noosphere.pgvector-switch-run=$guard_run_id"); do
       docker rm -f "$id" >/dev/null 2>&1 || true
@@ -496,6 +500,122 @@ chmod 0600 "$manifest"
 "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
 cmp -s "$live_compose" "$source_snapshot"
 
+# Interrupt a real pinned-guard invocation after candidate publication while
+# its guard process group is stopped. TERM is delivered to the systemd MainPID,
+# forwarded by the controller, and released with CONT so the child is reaped
+# and its truthful interrupted evidence becomes durable.
+interruption_args=(
+  systemd-run
+  --user
+  --unit="$unit_base"
+  --wait
+  --collect
+  --quiet
+  --setenv="CONTROLLER_UNIT=$unit"
+  --setenv="XDG_STATE_HOME=$XDG_STATE_HOME"
+)
+while IFS= read -r property; do
+  interruption_args+=(--property="$property")
+done < <(bash -c 'source "$1"; systemd_properties "$2"' -- "$CONTROLLER" "$tmp_dir")
+interruption_args+=("$CONTROLLER" --execute --state "$state")
+"${interruption_args[@]}" >"$tmp_dir/interruption.out" 2>"$tmp_dir/interruption.err" &
+interruption_runner_pid=$!
+
+controller_main_pid=''
+guard_process_group=''
+for _ in $(seq 1 1200); do
+  controller_main_pid=$(systemctl --user show "$unit" -p MainPID --value 2>/dev/null || true)
+  if [[ "$controller_main_pid" =~ ^[1-9][0-9]*$ &&
+        $(jq -r '.phase // empty' "$state" 2>/dev/null || true) == candidate-published ]]; then
+    children_path="/proc/$controller_main_pid/task/$controller_main_pid/children"
+    if [[ -r "$children_path" ]]; then
+      for child_pid in $(<"$children_path"); do
+        child_pgid=$(ps -o pgid= -p "$child_pid" 2>/dev/null | tr -d ' ' || true)
+        if [[ "$child_pgid" == "$child_pid" ]]; then
+          guard_process_group=$child_pgid
+          break 2
+        fi
+      done
+    fi
+  fi
+  sleep 0.01
+done
+[[ "$guard_process_group" =~ ^[1-9][0-9]*$ ]] || {
+  echo 'Real-Docker interruption rehearsal did not capture the pinned guard process group.' >&2
+  exit 1
+}
+kill -STOP -- "-$guard_process_group"
+systemctl --user kill --kill-whom=main --signal=TERM "$unit"
+kill -CONT -- "-$guard_process_group"
+interruption_rc=0
+wait "$interruption_runner_pid" || interruption_rc=$?
+interruption_runner_pid=''
+[[ "$interruption_rc" == 143 ]] || {
+  echo "Interrupted real-Docker controller exited $interruption_rc instead of 143." >&2
+  exit 1
+}
+jq -e '
+  .phase == "guard-exited" and
+  .lastInterruption.signal == "TERM" and
+  (.guardEvidence.sha256 | test("^[a-f0-9]{64}$"))
+' "$state" >/dev/null
+for _ in $(seq 1 100); do
+  [[ $(unit_load_state) == not-found ]] && break
+  sleep 0.05
+done
+[[ $(unit_load_state) == not-found ]] || {
+  echo "Interrupted transient rehearsal unit still exists after --collect: $unit" >&2
+  exit 1
+}
+
+# A second real transient invocation owns recovery. With no completed guard
+# journal, guard-exited recovery verifies the source database, restores the
+# prepared source Compose bytes, and commits a terminal recovery incident.
+unit_base="noosphere-pgvector-controller-docker-recovery-$BASHPID-$RANDOM"
+unit="$unit_base.service"
+recovery_args=(
+  systemd-run
+  --user
+  --unit="$unit_base"
+  --wait
+  --collect
+  --quiet
+  --setenv="CONTROLLER_UNIT=$unit"
+  --setenv="XDG_STATE_HOME=$XDG_STATE_HOME"
+)
+while IFS= read -r property; do
+  recovery_args+=(--property="$property")
+done < <(bash -c 'source "$1"; systemd_properties "$2"' -- "$CONTROLLER" "$tmp_dir")
+recovery_args+=("$CONTROLLER" --execute --state "$state")
+recovery_rc=0
+"${recovery_args[@]}" >"$tmp_dir/recovery.out" 2>"$tmp_dir/recovery.err" || recovery_rc=$?
+[[ "$recovery_rc" != 0 ]] || {
+  echo 'Interrupted real-Docker controller unexpectedly reported recovery as transition success.' >&2
+  exit 1
+}
+jq -e '
+  .phase == "incident" and
+  .incidentClass == "pre-journal-source-restored" and
+  (.sourceRecoveryEvidence.sha256 | test("^[a-f0-9]{64}$"))
+' "$state" >/dev/null
+cmp -s "$live_compose" "$source_snapshot"
+[[ $(docker inspect "$db_container" --format '{{.Config.Image}}') == "$SOURCE_IMAGE" ]]
+mv "$state" "$recovery_state"
+for _ in $(seq 1 100); do
+  [[ $(unit_load_state) == not-found ]] && break
+  sleep 0.05
+done
+[[ $(unit_load_state) == not-found ]] || {
+  echo "Recovery transient rehearsal unit still exists after --collect: $unit" >&2
+  exit 1
+}
+echo 'Real-Docker interruption recovery rehearsal passed.'
+
+# Re-prepare the now-restored source model and prove the ordinary transition
+# still completes under a third, identity-distinct transient invocation.
+"$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
+unit_base="noosphere-pgvector-controller-docker-success-$BASHPID-$RANDOM"
+unit="$unit_base.service"
 systemd_args=(
   systemd-run
   --user
@@ -518,8 +638,8 @@ jq -e '
   (.closureEvidence.sha256 | test("^[a-f0-9]{64}$"))
 ' "$state" >/dev/null
 jq -e '.phase == "complete" and .mode == "switch"' "$guard_journal" >/dev/null
-[[ $(jq -er '.exitCode' "${state%.json}.guard.evidence.json") == 0 ]]
-[[ $(jq -er '.exitCode' "${state%.json}.verify.evidence.json") == 0 ]]
+[[ $(jq -er '.exitCode' "$(jq -er '.guardEvidence.path' "$state")") == 0 ]]
+[[ $(jq -er '.exitCode' "$(jq -er '.closureEvidence.path' "$state")") == 0 ]]
 cmp -s "$live_compose" "$candidate_compose"
 [[ $(docker inspect "$db_container" --format '{{.Config.Image}}') == "$CANDIDATE_IMAGE" ]]
 [[ $(docker inspect "$db_container" --format '{{.State.Running}}') == true ]]

--- a/scripts/test-pgvector-transition-controller-docker.sh
+++ b/scripts/test-pgvector-transition-controller-docker.sh
@@ -1,0 +1,536 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+CONTROLLER="$ROOT_DIR/scripts/run-pgvector-transition-controller.sh"
+GUARD="$ROOT_DIR/scripts/switch-pgvector-compose.sh"
+VERIFIER="$ROOT_DIR/scripts/verify-deploy.sh"
+
+cleanup_state_authority_record() {
+  local runtime_root=$1 authority=$2
+  case "$authority" in
+    "$runtime_root"/noosphere-pgvector-state-*.json) ;;
+    *) echo "Refusing unexpected rehearsal authority path: $authority" >&2; return 1 ;;
+  esac
+  if [[ -e "$authority" ]]; then
+    [[ -f "$authority" && ! -L "$authority" ]] || {
+      echo "Rehearsal authority record is not a safe regular file: $authority" >&2
+      return 1
+    }
+    rm -f -- "$authority"
+  fi
+  [[ ! -e "$authority" ]] || {
+    echo "Rehearsal authority record remains after cleanup: $authority" >&2
+    return 1
+  }
+}
+
+PLATFORM=${1:-linux/amd64}
+SOURCE_IMAGE='postgres@sha256:16bc17c64a573ef34162af9298258d1aec548232985b33ed7b1eac33ba35c229'
+CANDIDATE_IMAGE='ghcr.io/sweetsophia/noosphere-postgres-pgvector@sha256:12bc9b34226803a04811a3ddd06feac14121c2c7ce369aaddbd778d242751292'
+
+[[ "$PLATFORM" == linux/amd64 ]] || {
+  echo 'The controller Docker rehearsal currently supports linux/amd64 only.' >&2
+  exit 1
+}
+for path in "$CONTROLLER" "$GUARD" "$VERIFIER"; do
+  [[ -x "$path" && -f "$path" && ! -L "$path" ]] || {
+    echo "Required executable is missing or unsafe: $path" >&2
+    exit 1
+  }
+done
+for command in curl docker jq loginctl python3 sha256sum systemctl systemd-run; do
+  command -v "$command" >/dev/null 2>&1 || {
+    echo "Required command is missing: $command" >&2
+    exit 1
+  }
+done
+systemctl --user show-environment >/dev/null
+[[ $(loginctl show-user "$(id -u)" -p Linger --value) == yes ]] || {
+  echo 'Persistent user manager is required for the controller Docker rehearsal.' >&2
+  exit 1
+}
+docker image inspect "$SOURCE_IMAGE" >/dev/null
+docker image inspect "$CANDIDATE_IMAGE" >/dev/null
+
+run_id="controller-docker-$BASHPID-$(od -An -N4 -tx1 /dev/urandom | tr -d ' \n')"
+safe_id=${run_id//[^A-Za-z0-9]/-}
+safe_id=${safe_id,,}
+project="noosphere-a2b-$safe_id"
+db_container="$project-db"
+app_container="$project-app"
+volume="noosphere_a2b_${safe_id//-/_}"
+probe_volume="${volume}_mount_probe"
+authorization_volume="${volume}_authorization"
+tmp_dir=$(mktemp -d)
+live_compose="$tmp_dir/docker-compose.yml"
+source_snapshot="$tmp_dir/source-compose.yml"
+candidate_compose="$tmp_dir/candidate-compose.yml"
+env_file="$tmp_dir/runtime.env"
+backup_dir="$tmp_dir/backups"
+controller_home="$tmp_dir/home"
+manifest="$tmp_dir/manifest.json"
+state="$tmp_dir/controller.json"
+unit_base="noosphere-pgvector-controller-docker-$BASHPID-$RANDOM"
+unit="$unit_base.service"
+runtime_root=${XDG_RUNTIME_DIR:-/run/user/$(id -u)}
+docker_path=$(command -v docker)
+compose_plugin_path=$(docker info --format '{{json .ClientInfo.Plugins}}' |
+  jq -er '[.[] | select(.Name == "compose") | .Path] | if length == 1 then .[0] else error("Compose plugin identity is ambiguous") end')
+engine_id=$(docker info --format '{{.ID}}')
+docker_context=$(docker context show)
+docker_endpoint=$(docker context inspect "$docker_context" --format '{{(index .Endpoints "docker").Host}}')
+docker_endpoint="unix://$(realpath -m "${docker_endpoint#unix://}")"
+lock_key=$(printf '%s\0%s' "$engine_id" "$volume" | sha256sum | awk '{print $1}')
+lock_path="$runtime_root/noosphere-pgvector-switch-$lock_key.lock"
+state_authority_path="$runtime_root/noosphere-pgvector-state-$lock_key.json"
+app_port=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()')
+app_url="http://127.0.0.1:$app_port"
+guard_run_id=''
+
+mkdir -m 700 "$backup_dir" "$controller_home" "$controller_home/docker"
+printf 'NOOSPHERE_STAGE6B=1\n' > "$env_file"
+printf '{}\n' > "$controller_home/docker/config.json"
+chmod 0600 "$env_file" "$controller_home/docker/config.json"
+
+unit_load_state() {
+  systemctl --user show "$unit" -p LoadState --value 2>/dev/null || printf 'not-found\n'
+}
+
+cleanup_successfully() {
+  local id
+  if [[ -f "$backup_dir/$volume.phase-a2b.json" ]]; then
+    guard_run_id=$(jq -r '.runId // empty' "$backup_dir/$volume.phase-a2b.json")
+  fi
+  if [[ $(unit_load_state) != not-found ]]; then
+    systemctl --user stop "$unit"
+  fi
+  if [[ -n "$guard_run_id" ]]; then
+    while IFS= read -r id; do
+      [[ -z "$id" ]] || docker rm -f "$id" >/dev/null
+    done < <(docker ps -aq --filter "label=io.noosphere.pgvector-switch-run=$guard_run_id")
+    while IFS= read -r id; do
+      [[ -z "$id" ]] || docker volume rm "$id" >/dev/null
+    done < <(docker volume ls -q --filter "label=io.noosphere.pgvector-switch-run=$guard_run_id")
+  fi
+  docker compose --env-file "$env_file" -f "$live_compose" down --remove-orphans --volumes >/dev/null
+  for id in "$db_container" "$app_container"; do
+    docker container inspect "$id" >/dev/null 2>&1 || continue
+    docker rm -f "$id" >/dev/null
+  done
+  for id in "$volume" "$probe_volume" "$authorization_volume"; do
+    docker volume inspect "$id" >/dev/null 2>&1 || continue
+    docker volume rm "$id" >/dev/null
+  done
+  if docker network inspect "${project}_default" >/dev/null 2>&1; then
+    docker network rm "${project}_default" >/dev/null
+  fi
+  case "$lock_path" in
+    "$runtime_root"/noosphere-pgvector-switch-*.lock) rm -f -- "$lock_path" ;;
+    *) echo "Refusing unexpected fixture lock path: $lock_path" >&2; return 1 ;;
+  esac
+  cleanup_state_authority_record "$runtime_root" "$state_authority_path"
+}
+
+verify_zero_residue() {
+  local id
+  [[ $(unit_load_state) == not-found ]] || {
+    echo "Transient rehearsal unit remains after cleanup: $unit" >&2
+    return 1
+  }
+  for id in "$db_container" "$app_container"; do
+    ! docker container inspect "$id" >/dev/null 2>&1 || {
+      echo "Controller rehearsal container remains after cleanup: $id" >&2
+      return 1
+    }
+  done
+  for id in "$volume" "$probe_volume" "$authorization_volume"; do
+    ! docker volume inspect "$id" >/dev/null 2>&1 || {
+      echo "Controller rehearsal volume remains after cleanup: $id" >&2
+      return 1
+    }
+  done
+  ! docker network inspect "${project}_default" >/dev/null 2>&1 || {
+    echo "Controller rehearsal network remains after cleanup: ${project}_default" >&2
+    return 1
+  }
+  if [[ -n "$guard_run_id" ]]; then
+    [[ -z $(docker ps -aq --filter "label=io.noosphere.pgvector-switch-run=$guard_run_id") ]] || {
+      echo "Guard-labeled container residue remains for run $guard_run_id" >&2
+      return 1
+    }
+    [[ -z $(docker volume ls -q --filter "label=io.noosphere.pgvector-switch-run=$guard_run_id") ]] || {
+      echo "Guard-labeled volume residue remains for run $guard_run_id" >&2
+      return 1
+    }
+  fi
+  [[ ! -e "$lock_path" ]] || {
+    echo "Controller rehearsal lock remains after cleanup: $lock_path" >&2
+    return 1
+  }
+  [[ ! -e "$state_authority_path" ]] || {
+    echo "Controller rehearsal authority remains after cleanup: $state_authority_path" >&2
+    return 1
+  }
+}
+
+cleanup() {
+  local status=$? id
+  trap - EXIT INT TERM
+  if [[ -f "$backup_dir/$volume.phase-a2b.json" ]]; then
+    guard_run_id=$(jq -r '.runId // empty' "$backup_dir/$volume.phase-a2b.json" 2>/dev/null || true)
+  fi
+  systemctl --user stop "$unit" >/dev/null 2>&1 || true
+  if [[ -n "$guard_run_id" ]]; then
+    for id in $(docker ps -aq --filter "label=io.noosphere.pgvector-switch-run=$guard_run_id"); do
+      docker rm -f "$id" >/dev/null 2>&1 || true
+    done
+    for id in $(docker volume ls -q --filter "label=io.noosphere.pgvector-switch-run=$guard_run_id"); do
+      docker volume rm "$id" >/dev/null 2>&1 || true
+    done
+  fi
+  if [[ -f "$live_compose" ]]; then
+    docker compose --env-file "$env_file" -f "$live_compose" down --remove-orphans --volumes >/dev/null 2>&1 || true
+  fi
+  docker rm -f "$db_container" "$app_container" >/dev/null 2>&1 || true
+  docker volume rm "$volume" "$probe_volume" "$authorization_volume" >/dev/null 2>&1 || true
+  docker network rm "${project}_default" >/dev/null 2>&1 || true
+  systemctl --user reset-failed "$unit" >/dev/null 2>&1 || true
+  [[ "$lock_path" == "$runtime_root"/noosphere-pgvector-switch-*.lock ]] && rm -f -- "$lock_path"
+  cleanup_state_authority_record "$runtime_root" "$state_authority_path" || {
+    echo "Controller Docker rehearsal authority cleanup failed." >&2
+    status=1
+  }
+  if ((status == 0)); then
+    case "$tmp_dir" in
+      /tmp/tmp.*) rm -rf -- "$tmp_dir" ;;
+      *) echo "Refusing unexpected fixture cleanup path: $tmp_dir" >&2; return 1 ;;
+    esac
+  else
+    echo "Controller Docker rehearsal evidence retained after failure: $tmp_dir" >&2
+    [[ ! -f "${state%.json}.guard.stderr.log" ]] || tail -100 "${state%.json}.guard.stderr.log" >&2
+    [[ ! -f "${state%.json}.verify.stderr.log" ]] || tail -100 "${state%.json}.verify.stderr.log" >&2
+  fi
+  return "$status"
+}
+trap cleanup EXIT INT TERM
+
+[[ $(unit_load_state) == not-found ]] || {
+  echo "Transient rehearsal unit already exists: $unit" >&2
+  exit 1
+}
+
+cat > "$live_compose" <<YAML
+name: $project
+
+services:
+  db:
+    image: $SOURCE_IMAGE
+    platform: $PLATFORM
+    container_name: $db_container
+    environment:
+      POSTGRES_HOST_AUTH_METHOD: trust
+      POSTGRES_USER: noosphere
+      POSTGRES_DB: noosphere
+    volumes:
+      - $volume:/var/lib/postgresql/data
+      - $probe_volume:/var/lib/noosphere-a2b-mount-probe
+    healthcheck:
+      test: ["CMD-SHELL", "[ \"\$\$(cat /proc/1/comm 2>/dev/null)\" = postgres ] && [ \"\$\$(psql -XAtq -v ON_ERROR_STOP=1 -U noosphere -d noosphere -c 'SELECT 1;' 2>/dev/null)\" = 1 ]"]
+      interval: 2s
+      timeout: 2s
+      retries: 60
+  app:
+    image: $SOURCE_IMAGE
+    platform: $PLATFORM
+    user: "1001:1001"
+    container_name: $app_container
+    command:
+      - /bin/sh
+      - -ceu
+      - |
+          cat > /tmp/noosphere-health-handler.sh <<'HANDLER'
+          #!/bin/sh
+          printf 'HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nConnection: close\r\n\r\n{"status":"ok"}\n'
+          HANDLER
+          chmod 0700 /tmp/noosphere-health-handler.sh
+          exec nc -lk -p 8080 -e /tmp/noosphere-health-handler.sh
+    ports:
+      - "127.0.0.1:$app_port:8080"
+    depends_on:
+      db:
+        condition: service_healthy
+
+volumes:
+  $volume:
+    name: $volume
+    driver: local
+  $probe_volume:
+    name: $probe_volume
+    driver: local
+YAML
+install -m 600 "$live_compose" "$source_snapshot"
+
+cat > "$candidate_compose" <<YAML
+name: $project
+
+services:
+  db:
+    image: $CANDIDATE_IMAGE
+    platform: $PLATFORM
+    entrypoint:
+      - /bin/sh
+      - -ceu
+      - |
+          marker=/run/noosphere-pgvector/candidate-authorized
+          actual="\$\$(cat "\$\$marker" 2>/dev/null || true)"
+          if [ "\$\$actual" != '$CANDIDATE_IMAGE' ]; then
+            echo 'PostgreSQL candidate authorization is missing' >&2
+            exit 78
+          fi
+          exec /usr/local/bin/docker-entrypoint.sh "\$\$@"
+      - --
+    command: ["postgres"]
+    container_name: $db_container
+    environment:
+      POSTGRES_HOST_AUTH_METHOD: trust
+      POSTGRES_USER: noosphere
+      POSTGRES_DB: noosphere
+    volumes:
+      - $volume:/var/lib/postgresql/data
+      - $probe_volume:/var/lib/noosphere-a2b-mount-probe
+      - $authorization_volume:/run/noosphere-pgvector:ro
+    healthcheck:
+      test: ["CMD-SHELL", "[ \"\$\$(cat /proc/1/comm 2>/dev/null)\" = postgres ] && [ \"\$\$(psql -XAtq -v ON_ERROR_STOP=1 -U noosphere -d noosphere -c 'SELECT 1;' 2>/dev/null)\" = 1 ]"]
+      interval: 2s
+      timeout: 2s
+      retries: 60
+  app:
+    image: $SOURCE_IMAGE
+    platform: $PLATFORM
+    user: "1001:1001"
+    container_name: $app_container
+    entrypoint:
+      - /bin/sh
+      - -ceu
+      - |
+          marker=/run/noosphere-pgvector/writer-authorized
+          actual="\$\$(cat "\$\$marker" 2>/dev/null || true)"
+          if [ "\$\$actual" != '$CANDIDATE_IMAGE' ]; then
+            echo 'Noosphere writer authorization is incomplete' >&2
+            exit 78
+          fi
+          exec "\$\$@"
+      - --
+    command:
+      - /bin/sh
+      - -ceu
+      - |
+          cat > /tmp/noosphere-health-handler.sh <<'HANDLER'
+          #!/bin/sh
+          printf 'HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nConnection: close\r\n\r\n{"status":"ok"}\n'
+          HANDLER
+          chmod 0700 /tmp/noosphere-health-handler.sh
+          exec nc -lk -p 8080 -e /tmp/noosphere-health-handler.sh
+    ports:
+      - "127.0.0.1:$app_port:8080"
+    volumes:
+      - $authorization_volume:/run/noosphere-pgvector:ro
+    depends_on:
+      db:
+        condition: service_healthy
+
+volumes:
+  $volume:
+    name: $volume
+    driver: local
+  $probe_volume:
+    name: $probe_volume
+    driver: local
+  $authorization_volume:
+    name: $authorization_volume
+    external: true
+YAML
+chmod 0600 "$live_compose" "$source_snapshot" "$candidate_compose"
+
+docker compose --env-file "$env_file" -f "$live_compose" up -d
+for _ in $(seq 1 180); do
+  ready=$(docker exec "$db_container" psql -XAtq -v ON_ERROR_STOP=1 -U noosphere -d noosphere -c 'SELECT 1;' 2>/dev/null || true)
+  [[ "$ready" == 1 ]] && break
+  [[ $(docker inspect "$db_container" --format '{{.State.Running}}' 2>/dev/null || true) == true ]] || {
+    docker logs "$db_container" --tail 100 >&2 || true
+    echo 'Disposable source database exited before readiness.' >&2
+    exit 1
+  }
+  sleep 1
+done
+[[ $(docker exec "$db_container" psql -XAtq -v ON_ERROR_STOP=1 -U noosphere -d noosphere -c 'SELECT 1;') == 1 ]]
+for _ in $(seq 1 60); do
+  curl -fsS --max-time 2 "$app_url/api/health" >/dev/null 2>&1 && break
+  sleep 0.25
+done
+curl -fsS --max-time 5 "$app_url/api/health" >/dev/null
+
+docker exec -i "$db_container" psql -X -v ON_ERROR_STOP=1 -U noosphere -d noosphere <<'SQL'
+CREATE ROLE noosphere_migrator LOGIN NOSUPERUSER;
+ALTER DATABASE noosphere OWNER TO noosphere_migrator;
+ALTER SCHEMA public OWNER TO noosphere_migrator;
+SET ROLE noosphere_migrator;
+CREATE TABLE "_prisma_migrations" (
+  migration_name text PRIMARY KEY,
+  checksum text NOT NULL,
+  applied_steps_count integer NOT NULL,
+  finished_at timestamptz,
+  rolled_back_at timestamptz
+);
+INSERT INTO "_prisma_migrations"
+  (migration_name, checksum, applied_steps_count, finished_at, rolled_back_at)
+VALUES ('20260811_controller_stage6b', 'controller-stage6b-checksum', 1, '2026-08-11 00:00:00+00', NULL);
+CREATE TABLE "Topic" (id text PRIMARY KEY, name text NOT NULL);
+CREATE TABLE "Article" (id text PRIMARY KEY, title text NOT NULL, "deletedAt" timestamptz);
+CREATE TABLE "ApiKey" (id text PRIMARY KEY, name text NOT NULL);
+INSERT INTO "Topic" VALUES ('topic-1', 'Controller Stage 6B');
+INSERT INTO "Article" VALUES ('article-1', 'Pinned guard rehearsal', NULL);
+INSERT INTO "ApiKey" VALUES ('key-1', 'Fixture key');
+CREATE TABLE "MemoryCapture" (
+  id text PRIMARY KEY,
+  "userText" text NOT NULL,
+  "assistantText" text NOT NULL,
+  CONSTRAINT "MemoryCapture_bounded_content"
+    CHECK (
+      octet_length("userText") BETWEEN 1 AND 12000
+      AND octet_length("assistantText") BETWEEN 1 AND 12000
+      AND octet_length("userText") + octet_length("assistantText") <= 20000
+    )
+);
+INSERT INTO "MemoryCapture" VALUES ('capture-1', 'fixture user text', 'fixture assistant text');
+RESET ROLE;
+SQL
+
+guard_journal="$backup_dir/$volume.phase-a2b.json"
+docker_compose_version_sha=$(docker compose version --short | sha256sum | awk '{print $1}')
+effective_compose_sha=$(docker compose --env-file "$env_file" -f "$candidate_compose" config --no-interpolate | sha256sum | awk '{print $1}')
+
+jq -n \
+  --arg engineId "$engine_id" \
+  --arg dockerEndpoint "$docker_endpoint" \
+  --arg volume "$volume" \
+  --arg liveCompose "$live_compose" \
+  --arg sourceSnapshot "$source_snapshot" \
+  --arg sourceSnapshotSha256 "$(sha256sum "$source_snapshot" | awk '{print $1}')" \
+  --arg candidateCompose "$candidate_compose" \
+  --arg candidateComposeSha256 "$(sha256sum "$candidate_compose" | awk '{print $1}')" \
+  --arg envFile "$env_file" \
+  --arg envFileSha256 "$(sha256sum "$env_file" | awk '{print $1}')" \
+  --arg guard "$GUARD" \
+  --arg guardSha256 "$(sha256sum "$GUARD" | awk '{print $1}')" \
+  --arg controllerPath "$(realpath "$CONTROLLER")" \
+  --arg controllerSha256 "$(sha256sum "$CONTROLLER" | awk '{print $1}')" \
+  --arg verifier "$VERIFIER" \
+  --arg verifierSha256 "$(sha256sum "$VERIFIER" | awk '{print $1}')" \
+  --arg dockerPath "$docker_path" \
+  --arg dockerSha256 "$(sha256sum "$docker_path" | awk '{print $1}')" \
+  --arg dockerComposeVersionSha256 "$docker_compose_version_sha" \
+  --arg composePluginPath "$compose_plugin_path" \
+  --arg composePluginSha256 "$(sha256sum "$compose_plugin_path" | awk '{print $1}')" \
+  --arg dockerConfigSha256 "$(sha256sum "$controller_home/docker/config.json" | awk '{print $1}')" \
+  --arg effectiveComposeSha256 "$effective_compose_sha" \
+  --arg backupDir "$backup_dir" \
+  --arg lockRoot "$runtime_root" \
+  --arg controllerHome "$controller_home" \
+  --arg dbContainer "$db_container" \
+  --arg appContainer "$app_container" \
+  --arg authorizationVolume "$authorization_volume" \
+  --arg guardJournal "$guard_journal" \
+  --arg appUrl "$app_url" \
+  --arg platform "$PLATFORM" '
+    {
+      version:1, phase:"prepared", engineId:$engineId,
+      dockerEndpoint:$dockerEndpoint, volume:$volume,
+      liveCompose:$liveCompose, sourceSnapshot:$sourceSnapshot,
+      sourceSnapshotSha256:$sourceSnapshotSha256,
+      candidateCompose:$candidateCompose, candidateComposeSha256:$candidateComposeSha256,
+      envFile:$envFile, envFileSha256:$envFileSha256,
+      guard:$guard, guardSha256:$guardSha256,
+      controllerPath:$controllerPath, controllerSha256:$controllerSha256,
+      guardArgs:[
+        "--compose-file",$liveCompose,
+        "--env-file",$envFile,
+        "--db-container",$dbContainer,
+        "--app-container",$appContainer,
+        "--volume",$volume,
+        "--authorization-volume",$authorizationVolume,
+        "--backup-dir",$backupDir,
+        "--platform",$platform,
+        "--defer-app-restart"
+      ],
+      verifier:$verifier, verifierSha256:$verifierSha256,
+      dockerPath:$dockerPath, dockerSha256:$dockerSha256,
+      dockerComposeVersionSha256:$dockerComposeVersionSha256,
+      composePluginPath:$composePluginPath, composePluginSha256:$composePluginSha256,
+      dockerConfigSha256:$dockerConfigSha256,
+      effectiveComposeSha256:$effectiveComposeSha256,
+      backupDir:$backupDir, lockRoot:$lockRoot, controllerHome:$controllerHome,
+      fixedPath:"/usr/local/bin:/usr/bin:/bin",
+      dbContainer:$dbContainer, appContainer:$appContainer,
+      authorizationVolume:$authorizationVolume, platform:$platform,
+      guardJournal:$guardJournal, appUrl:$appUrl
+    }
+  ' > "$manifest"
+chmod 0600 "$manifest"
+
+"$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
+cmp -s "$live_compose" "$source_snapshot"
+
+systemd_args=(
+  systemd-run
+  --user
+  --unit="$unit_base"
+  --wait
+  --collect
+  --quiet
+  --setenv="CONTROLLER_UNIT=$unit"
+)
+while IFS= read -r property; do
+  systemd_args+=(--property="$property")
+done < <(bash -c 'source "$1"; systemd_properties "$2"' -- "$CONTROLLER" "$tmp_dir")
+systemd_args+=("$CONTROLLER" --execute --state "$state")
+"${systemd_args[@]}"
+
+jq -e '
+  .phase == "complete" and
+  (.guardEvidence.sha256 | test("^[a-f0-9]{64}$")) and
+  (.closureEvidence.sha256 | test("^[a-f0-9]{64}$"))
+' "$state" >/dev/null
+jq -e '.phase == "complete" and .mode == "switch"' "$guard_journal" >/dev/null
+[[ $(jq -er '.exitCode' "${state%.json}.guard.evidence.json") == 0 ]]
+[[ $(jq -er '.exitCode' "${state%.json}.verify.evidence.json") == 0 ]]
+cmp -s "$live_compose" "$candidate_compose"
+[[ $(docker inspect "$db_container" --format '{{.Config.Image}}') == "$CANDIDATE_IMAGE" ]]
+[[ $(docker inspect "$db_container" --format '{{.State.Running}}') == true ]]
+[[ $(docker inspect "$app_container" --format '{{.State.Running}}') == true ]]
+[[ $(docker inspect "$db_container" --format '{{range .Mounts}}{{if eq .Destination "/var/lib/postgresql/data"}}{{.Name}}{{end}}{{end}}') == "$volume" ]]
+[[ $(docker exec "$db_container" cat /run/noosphere-pgvector/candidate-authorized) == "$CANDIDATE_IMAGE" ]]
+[[ $(docker exec "$db_container" cat /run/noosphere-pgvector/writer-authorized) == "$CANDIDATE_IMAGE" ]]
+[[ $(docker exec "$db_container" psql -XAtq -v ON_ERROR_STOP=1 -U noosphere -d noosphere -c 'SELECT count(*) FROM "Topic";') == 1 ]]
+[[ $(docker exec "$db_container" psql -XAtq -v ON_ERROR_STOP=1 -U noosphere -d noosphere -c 'SELECT count(*) FROM "Article" WHERE "deletedAt" IS NULL;') == 1 ]]
+[[ $(docker exec "$db_container" psql -XAtq -v ON_ERROR_STOP=1 -U noosphere -d noosphere -c 'SELECT count(*) FROM "ApiKey";') == 1 ]]
+curl -fsS --max-time 5 "$app_url/api/health" | jq -e '.status == "ok"' >/dev/null
+
+for _ in $(seq 1 50); do
+  [[ $(unit_load_state) == not-found ]] && break
+  sleep 0.05
+done
+[[ $(unit_load_state) == not-found ]] || {
+  echo "Transient rehearsal unit still exists after --collect: $unit" >&2
+  exit 1
+}
+
+cleanup_successfully
+verify_zero_residue
+case "$tmp_dir" in
+  /tmp/tmp.*) rm -rf -- "$tmp_dir" ;;
+  *) echo "Refusing unexpected fixture cleanup path: $tmp_dir" >&2; exit 1 ;;
+esac
+trap - EXIT INT TERM
+echo 'PostgreSQL transition controller pinned-guard Docker rehearsal passed.'

--- a/scripts/test-pgvector-transition-controller-docker.sh
+++ b/scripts/test-pgvector-transition-controller-docker.sh
@@ -63,6 +63,12 @@ volume="noosphere_a2b_${safe_id//-/_}"
 probe_volume="${volume}_mount_probe"
 authorization_volume="${volume}_authorization"
 tmp_dir=$(mktemp -d)
+# Isolate durable state-authority records from the invoking user's real XDG
+# state namespace; the controller honors XDG_STATE_HOME, so the rehearsal's
+# durable claims live inside the disposable tmp_dir and are removed with it.
+XDG_STATE_HOME="$tmp_dir/xdg-state-home"
+install -d -m 700 "$XDG_STATE_HOME"
+export XDG_STATE_HOME
 live_compose="$tmp_dir/docker-compose.yml"
 source_snapshot="$tmp_dir/source-compose.yml"
 candidate_compose="$tmp_dir/candidate-compose.yml"
@@ -203,7 +209,15 @@ cleanup() {
   }
   if ((status == 0)); then
     case "$tmp_dir" in
-      /tmp/tmp.*) rm -rf -- "$tmp_dir" ;;
+      /tmp/tmp.*)
+        rm -rf -- "$tmp_dir"
+        # The isolated durable-authority root lives inside tmp_dir, so its
+        # removal must actually land before the rehearsal counts as clean.
+        [[ ! -e "$tmp_dir" ]] || {
+          echo "Controller rehearsal state root remains after cleanup: $tmp_dir" >&2
+          return 1
+        }
+        ;;
       *) echo "Refusing unexpected fixture cleanup path: $tmp_dir" >&2; return 1 ;;
     esac
   else
@@ -490,6 +504,7 @@ systemd_args=(
   --collect
   --quiet
   --setenv="CONTROLLER_UNIT=$unit"
+  --setenv="XDG_STATE_HOME=$XDG_STATE_HOME"
 )
 while IFS= read -r property; do
   systemd_args+=(--property="$property")

--- a/scripts/test-pgvector-transition-controller-systemd.sh
+++ b/scripts/test-pgvector-transition-controller-systemd.sh
@@ -1,0 +1,263 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+CONTROLLER="$ROOT_DIR/scripts/run-pgvector-transition-controller.sh"
+FIXTURE_SUITE="$ROOT_DIR/scripts/test-pgvector-transition-controller.sh"
+
+cleanup_state_authority_record() {
+  local runtime_root=$1 authority=$2
+  case "$authority" in
+    "$runtime_root"/noosphere-pgvector-state-*.json) ;;
+    *) echo "Refusing unexpected fixture authority path: $authority" >&2; return 1 ;;
+  esac
+  if [[ -e "$authority" ]]; then
+    [[ -f "$authority" && ! -L "$authority" ]] || {
+      echo "Fixture authority record is not a safe regular file: $authority" >&2
+      return 1
+    }
+    rm -f -- "$authority"
+  fi
+  [[ ! -e "$authority" ]] || {
+    echo "Fixture authority record remains after cleanup: $authority" >&2
+    return 1
+  }
+}
+
+[[ -x "$CONTROLLER" && -f "$FIXTURE_SUITE" ]] || {
+  echo 'Missing controller or focused fixture support.' >&2
+  exit 1
+}
+systemctl --user show-environment >/dev/null
+[[ $(loginctl show-user "$(id -u)" -p Linger --value) == yes ]] || {
+  echo 'Persistent user manager is required for the transient-unit fixture.' >&2
+  exit 1
+}
+
+# Load only reusable fixture builders. The focused suite's main block remains
+# inactive because it is sourced rather than executed.
+source "$FIXTURE_SUITE"
+source "$CONTROLLER"
+
+fixture_dir=$(mktemp -d)
+unit_base="noosphere-pgvector-controller-test-$BASHPID-$RANDOM"
+unit="$unit_base.service"
+manifest="$fixture_dir/manifest.json"
+state="$fixture_dir/controller.json"
+signal_unit=''
+signal_lock_path=''
+signal_state_authority_path=''
+systemd_runner_pid=''
+volume="fixture-volume-$BASHPID-$RANDOM"
+runtime_root=${XDG_RUNTIME_DIR:-/run/user/$(id -u)}
+lock_key=$(printf '%s\0%s' fixture-engine "$volume" | sha256sum | awk '{print $1}')
+lock_path="$runtime_root/noosphere-pgvector-switch-$lock_key.lock"
+state_authority_path="$runtime_root/noosphere-pgvector-state-$lock_key.json"
+
+cleanup() {
+  [[ -z "$signal_unit" ]] || systemctl --user stop "$signal_unit" >/dev/null 2>&1 || true
+  [[ -z "$signal_unit" ]] || systemctl --user reset-failed "$signal_unit" >/dev/null 2>&1 || true
+  systemctl --user stop "$unit" >/dev/null 2>&1 || true
+  systemctl --user reset-failed "$unit" >/dev/null 2>&1 || true
+  [[ -z "$systemd_runner_pid" ]] || wait "$systemd_runner_pid" >/dev/null 2>&1 || true
+  [[ "$lock_path" == "$runtime_root"/noosphere-pgvector-switch-*.lock ]] &&
+    rm -f -- "$lock_path"
+  [[ -z "$signal_lock_path" || "$signal_lock_path" != "$runtime_root"/noosphere-pgvector-switch-*.lock ]] ||
+    rm -f -- "$signal_lock_path"
+  local cleanup_rc=0
+  cleanup_state_authority_record "$runtime_root" "$state_authority_path" || cleanup_rc=$?
+  [[ -z "$signal_state_authority_path" ]] ||
+    cleanup_state_authority_record "$runtime_root" "$signal_state_authority_path" || cleanup_rc=$?
+  rm -rf -- "$fixture_dir"
+  return "$cleanup_rc"
+}
+trap cleanup EXIT
+
+unit_load_state() {
+  systemctl --user show "$unit" -p LoadState --value 2>/dev/null || printf 'not-found\n'
+}
+
+if [[ $(unit_load_state) != not-found ]]; then
+  echo "Transient fixture unit already exists: $unit" >&2
+  exit 1
+fi
+
+write_execution_fixture "$fixture_dir" "$manifest"
+jq --arg volume "$volume" '
+  .[0].Name = $volume |
+  .[0].Mountpoint = ("/var/lib/docker/volumes/" + $volume + "/_data")
+' "$fixture_dir/volume-inspect.json" > "$fixture_dir/volume-inspect.json.next"
+install -m 600 "$fixture_dir/volume-inspect.json.next" "$fixture_dir/volume-inspect.json"
+rm -f -- "$fixture_dir/volume-inspect.json.next"
+jq \
+  --arg volume "$volume" \
+  --arg lockRoot "$runtime_root" \
+  --arg journal "$fixture_dir/backup/$volume.phase-a2b.json" '
+    .volume = $volume |
+    .lockRoot = $lockRoot |
+    .guardJournal = $journal |
+    .guardArgs = [
+      "--compose-file", .liveCompose,
+      "--env-file", .envFile,
+      "--db-container", .dbContainer,
+      "--app-container", .appContainer,
+      "--backup-dir", .backupDir,
+      "--volume", $volume,
+      "--authorization-volume", .authorizationVolume,
+      "--platform", .platform,
+      "--defer-app-restart"
+    ]
+  ' "$manifest" > "$manifest.next"
+install -m 600 "$manifest.next" "$manifest"
+rm -f -- "$manifest.next"
+
+"$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
+: > "$fixture_dir/pause-candidate-verifier"
+
+systemd_args=(
+  systemd-run
+  --user
+  --unit="$unit_base"
+  --wait
+  --collect
+  --quiet
+  --setenv="CONTROLLER_UNIT=$unit"
+  --setenv=NOOSPHERE_CONTROLLER_BOOT_ID=fixture-boot
+  --setenv=NOOSPHERE_CONTROLLER_TEST_CURSOR=fixture-cursor
+)
+while IFS= read -r property; do
+  systemd_args+=(--property="$property")
+done < <(systemd_properties "$fixture_dir")
+systemd_args+=("$CONTROLLER" --execute --state "$state")
+"${systemd_args[@]}" >"$fixture_dir/systemd-run.out" 2>"$fixture_dir/systemd-run.err" &
+systemd_runner_pid=$!
+for _ in $(seq 1 200); do
+  [[ -e "$fixture_dir/candidate-verifier-paused" ]] && break
+  sleep 0.05
+done
+[[ -e "$fixture_dir/candidate-verifier-paused" ]] || {
+  echo 'Transient fixture did not hold the candidate verifier live for identity proof.' >&2
+  exit 1
+}
+
+unit_invocation=$(systemctl --user show "$unit" -p InvocationID --value)
+unit_main_pid=$(systemctl --user show "$unit" -p MainPID --value)
+[[ $(systemctl --user show "$unit" -p ActiveState --value) == active &&
+   "$unit_invocation" =~ ^[a-f0-9]{32}$ && "$unit_main_pid" =~ ^[1-9][0-9]*$ ]] || {
+  echo 'Transient fixture could not independently query its live systemd identity.' >&2
+  exit 1
+}
+authorization_evidence=$(jq -er '.authorizationEvidence.path' "$state")
+start_cursor=$(jq -er '.startCursor' "$authorization_evidence")
+end_cursor=$(jq -er '.endCursor' "$authorization_evidence")
+jq -e --arg invocation "$unit_invocation" --argjson mainPid "$unit_main_pid" '
+  .invocationId == $invocation and .controllerMainPid == $mainPid
+' "$authorization_evidence" >/dev/null || {
+  echo 'Durable authorization evidence does not match the independently queried systemd identity.' >&2
+  exit 1
+}
+for cursor in "$start_cursor" "$end_cursor"; do
+  queried_cursor=$(journalctl --user -u "$unit" --cursor "$cursor" -n 0 --show-cursor --no-pager |
+    sed -n 's/^-- cursor: //p' | tail -1)
+  [[ "$queried_cursor" == "$cursor" ]] || {
+    echo 'Durable authorization evidence contains a cursor not independently resolved in the live unit journal.' >&2
+    exit 1
+  }
+done
+: > "$fixture_dir/release-candidate-verifier"
+wait "$systemd_runner_pid"
+systemd_runner_pid=''
+
+jq -e '
+  .phase == "complete" and
+  (.guardEvidence.sha256 | test("^[a-f0-9]{64}$")) and
+  (.closureEvidence.sha256 | test("^[a-f0-9]{64}$"))
+' "$state" >/dev/null
+[[ $(<"$fixture_dir/docker-compose.yml") == 'candidate model' ]]
+[[ ! -e "$lock_path" || -f "$lock_path" ]]
+
+# --collect removes the unit after completion. A lingering unit object would
+# permit stale identity evidence to be mistaken for the next invocation.
+for _ in $(seq 1 50); do
+  [[ $(unit_load_state) == not-found ]] && break
+  sleep 0.05
+done
+if [[ $(unit_load_state) != not-found ]]; then
+  echo "Transient fixture unit still exists after --collect: $unit" >&2
+  exit 1
+fi
+cleanup_state_authority_record "$runtime_root" "$state_authority_path"
+
+# Exercise real user-manager signal ownership. TERM is delivered to the unit's
+# MainPID; the controller must forward it once to the sleeping guard, record the
+# interruption, exit 143, and remain incapable of a false complete state.
+signal_dir="$fixture_dir/signal"
+signal_manifest="$signal_dir/manifest.json"
+signal_state="$signal_dir/controller.json"
+signal_volume="fixture-signal-$BASHPID-$RANDOM"
+signal_base="noosphere-pgvector-controller-signal-$BASHPID-$RANDOM"
+signal_unit="$signal_base.service"
+mkdir -m 700 "$signal_dir"
+write_execution_fixture "$signal_dir" "$signal_manifest" sleep
+jq --arg volume "$signal_volume" '
+  .[0].Name = $volume |
+  .[0].Mountpoint = ("/var/lib/docker/volumes/" + $volume + "/_data")
+' "$signal_dir/volume-inspect.json" > "$signal_dir/volume-inspect.json.next"
+install -m 600 "$signal_dir/volume-inspect.json.next" "$signal_dir/volume-inspect.json"
+rm -f -- "$signal_dir/volume-inspect.json.next"
+signal_lock_key=$(printf '%s\0%s' fixture-engine "$signal_volume" | sha256sum | awk '{print $1}')
+signal_lock_path="$runtime_root/noosphere-pgvector-switch-$signal_lock_key.lock"
+signal_state_authority_path="$runtime_root/noosphere-pgvector-state-$signal_lock_key.json"
+jq --arg volume "$signal_volume" --arg lockRoot "$runtime_root" \
+  --arg journal "$signal_dir/backup/$signal_volume.phase-a2b.json" '
+    .volume = $volume |
+    .lockRoot = $lockRoot |
+    .guardJournal = $journal |
+    .guardArgs = [
+      "--compose-file", .liveCompose,
+      "--env-file", .envFile,
+      "--db-container", .dbContainer,
+      "--app-container", .appContainer,
+      "--volume", $volume,
+      "--authorization-volume", .authorizationVolume,
+      "--backup-dir", .backupDir,
+      "--platform", .platform,
+      "--defer-app-restart"
+    ]
+  ' "$signal_manifest" > "$signal_manifest.next"
+install -m 600 "$signal_manifest.next" "$signal_manifest"
+rm -f -- "$signal_manifest.next"
+"$CONTROLLER" --prepare --manifest "$signal_manifest" --state "$signal_state"
+
+signal_args=(
+  systemd-run --user --unit="$signal_base" --quiet
+  --setenv="CONTROLLER_UNIT=$signal_unit"
+  --setenv=NOOSPHERE_CONTROLLER_BOOT_ID=fixture-boot
+  --setenv='NOOSPHERE_CONTROLLER_TEST_CURSOR=s=fixture;i=1'
+)
+while IFS= read -r property; do
+  signal_args+=(--property="$property")
+done < <(systemd_properties "$signal_dir")
+signal_args+=("$CONTROLLER" --execute --state "$signal_state")
+"${signal_args[@]}"
+for _ in $(seq 1 100); do
+  [[ -e "$signal_dir/guard-running" ]] && break
+  sleep 0.05
+done
+[[ -e "$signal_dir/guard-running" ]] || {
+  echo 'Sleeping guard did not start under the real transient unit.' >&2
+  exit 1
+}
+systemctl --user kill --kill-whom=main --signal=TERM "$signal_unit"
+for _ in $(seq 1 100); do
+  [[ $(systemctl --user show "$signal_unit" -p ActiveState --value) != active ]] && break
+  sleep 0.05
+done
+[[ $(systemctl --user show "$signal_unit" -p ExecMainStatus --value) == 143 ]]
+[[ $(<"$signal_dir/guard-term-count") == 1 ]]
+jq -e '.phase != "complete" and .lastInterruption.signal == "TERM"' "$signal_state" >/dev/null
+systemctl --user reset-failed "$signal_unit" >/dev/null 2>&1 || true
+signal_unit=''
+cleanup_state_authority_record "$runtime_root" "$signal_state_authority_path"
+
+echo 'PostgreSQL transition controller transient-unit fixture passed.'

--- a/scripts/test-pgvector-transition-controller-systemd.sh
+++ b/scripts/test-pgvector-transition-controller-systemd.sh
@@ -68,6 +68,11 @@ cleanup() {
   cleanup_state_authority_record "$runtime_root" "$state_authority_path" || cleanup_rc=$?
   [[ -z "$signal_state_authority_path" ]] ||
     cleanup_state_authority_record "$runtime_root" "$signal_state_authority_path" || cleanup_rc=$?
+  # Remove the isolated durable-authority state root created by sourcing the
+  # focused suite (its own EXIT trap is replaced by this one).
+  case "${XDG_STATE_HOME:-}" in
+    /tmp/tmp.*) rm -rf -- "$XDG_STATE_HOME" ;;
+  esac
   rm -rf -- "$fixture_dir"
   return "$cleanup_rc"
 }
@@ -122,6 +127,7 @@ systemd_args=(
   --collect
   --quiet
   --setenv="CONTROLLER_UNIT=$unit"
+  --setenv="XDG_STATE_HOME=$XDG_STATE_HOME"
   --setenv=NOOSPHERE_CONTROLLER_BOOT_ID=fixture-boot
   --setenv=NOOSPHERE_CONTROLLER_TEST_CURSOR=fixture-cursor
 )
@@ -232,6 +238,7 @@ rm -f -- "$signal_manifest.next"
 signal_args=(
   systemd-run --user --unit="$signal_base" --quiet
   --setenv="CONTROLLER_UNIT=$signal_unit"
+  --setenv="XDG_STATE_HOME=$XDG_STATE_HOME"
   --setenv=NOOSPHERE_CONTROLLER_BOOT_ID=fixture-boot
   --setenv='NOOSPHERE_CONTROLLER_TEST_CURSOR=s=fixture;i=1'
 )

--- a/scripts/test-pgvector-transition-controller-systemd.sh
+++ b/scripts/test-pgvector-transition-controller-systemd.sh
@@ -247,7 +247,7 @@ while IFS= read -r property; do
 done < <(systemd_properties "$signal_dir")
 signal_args+=("$CONTROLLER" --execute --state "$signal_state")
 "${signal_args[@]}"
-for _ in $(seq 1 100); do
+for _ in $(seq 1 600); do
   [[ -e "$signal_dir/guard-running" ]] && break
   sleep 0.05
 done

--- a/scripts/test-pgvector-transition-controller.sh
+++ b/scripts/test-pgvector-transition-controller.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
+# Keep synthetic fixture inputs deterministic across interactive shells and
+# user-manager supervisors. Security-negative owners set unsafe modes explicitly.
+umask 0022
+# A failed unguarded command under `set -e` aborts the whole suite silently;
+# surface the exact offending command instead (R3-6 reconciliation).
+trap 'printf "fixture: unguarded command failed: %s (rc=%d)\n" "$BASH_COMMAND" "$?" >&2' ERR
 
 ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 CONTROLLER=${PGVECTOR_CONTROLLER_FIXTURE_SCRIPT:-"$ROOT_DIR/scripts/run-pgvector-transition-controller.sh"}
@@ -1160,6 +1166,25 @@ run_fixture_controller() {
     "$@" "$controller_exec" --execute --state "$state"
 }
 
+# Background variant for signal-delivery tests: the backgrounded subshell
+# execs the controller, so the recorded $! is the controller process itself.
+# Backgrounding run_fixture_controller (a function) instead leaves $! as a
+# wrapper subshell; kill -TERM then reaps the wrapper and orphans the live
+# controller, which later writes durable state after its test completed —
+# observed as whole-suite nondeterminism. Bash cannot exec with leading
+# environment assignments, so they are exported inside the subshell first;
+# the export side effects never reach the parent shell. `env` (passed via
+# "$@") execs the target without forking, preserving the PID.
+background_fixture_controller() {
+  local state=$1 controller_exec=$2
+  shift 2
+  export INVOCATION_ID=${NOOSPHERE_CONTROLLER_FIXTURE_INVOCATION_ID:-0123456789abcdef0123456789abcdef}
+  export CONTROLLER_UNIT=noosphere-pgvector-transition.service
+  export NOOSPHERE_CONTROLLER_BOOT_ID=fixture-boot
+  export NOOSPHERE_CONTROLLER_TEST_CURSOR=fixture-cursor
+  exec "$@" "$controller_exec" --execute --state "$state"
+}
+
 terminate_fixture_process() {
   local pid=${1:-} i
   [[ "$pid" =~ ^[1-9][0-9]*$ ]] || return 0
@@ -1280,19 +1305,40 @@ test_term_during_guard_records_and_recovers() (
   export XDG_RUNTIME_DIR="$fixture_dir/locks"
   shim=$(write_systemd_identity_shim "$fixture_dir")
   "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
-  run_fixture_controller "$state" "$shim" env >"$fixture_dir/controller.out" 2>"$fixture_dir/controller.err" &
+  background_fixture_controller "$state" "$shim" env >"$fixture_dir/controller.out" 2>"$fixture_dir/controller.err" &
   controller_pid=$!
-  for i in $(seq 1 100); do
+  for i in $(seq 1 600); do
     [[ -e "$fixture_dir/guard-running" ]] && break
     kill -0 "$controller_pid" 2>/dev/null || break
-    sleep 0.05
+    sleep 0.1
   done
-  [[ -e "$fixture_dir/guard-running" ]]
+  # Load-tolerant bounded wait (60s): under heavy host load the controller's
+  # pre-guard verification chain can exceed the old 5s window, and TERMing a
+  # controller that has not reached the guard phase corrupts the assertion.
+  [[ -e "$fixture_dir/guard-running" ]] || {
+    echo 'guard never reported running before the signal was sent' >&2
+    exit 1
+  }
   kill -TERM "$controller_pid"
   wait "$controller_pid" || rc=$?
   controller_pid=''
-  [[ "$rc" == 143 ]]
-  [[ $(jq -er '.phase' "$state") == guard-exited ]]
+  [[ "$rc" == 143 ]] || { echo "controller did not exit with signal-derived status after TERM (rc=$rc)" >&2; exit 1; }
+  # The backgrounded fixture wrapper can return 143 before the controller
+  # process has completed its final durable write, so an immediate single
+  # read races the state file. The controller contract guarantees
+  # phase=guard-exited after TERM-during-guard; poll the durable state with a
+  # bounded settle window instead of asserting one instantaneous read.
+  settled=''
+  phase_now=''
+  for i in $(seq 1 600); do
+    phase_now=$(jq -er '.phase // empty' "$state" 2>/dev/null || true)
+    if [[ "$phase_now" == guard-exited ]]; then settled=true; break; fi
+    sleep 0.1
+  done
+  [[ "$settled" == true ]] || {
+    echo "controller state never settled on guard-exited after TERM (last=${phase_now:-unreadable})" >&2
+    exit 1
+  }
   jq -e '
     .guardEvidence.path | type == "string" and startswith("/")
   ' "$state" >/dev/null
@@ -2232,9 +2278,9 @@ test_guard_signal_persists_child_evidence_before_return() (
   shim=$(write_systemd_identity_shim "$fixture_dir")
   "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
 
-  run_fixture_controller "$state" "$shim" env >"$fixture_dir/controller.out" 2>"$fixture_dir/controller.err" &
+  background_fixture_controller "$state" "$shim" env >"$fixture_dir/controller.out" 2>"$fixture_dir/controller.err" &
   controller_pid=$!
-  for i in $(seq 1 200); do
+  for i in $(seq 1 600); do
     [[ -e "$fixture_dir/guard-running" ]] && break
     kill -0 "$controller_pid" 2>/dev/null || break
     sleep 0.05
@@ -2253,6 +2299,14 @@ test_guard_signal_persists_child_evidence_before_return() (
     .guardEvidence.path == $path and .lastInterruption.signal == "TERM"
   ' "$state" >/dev/null || {
     echo 'TERM during guard returned before durable child evidence was bound' >&2
+    echo "---signal-flake-diagnostics begin (guard)---" >&2
+    echo "evidence_exists=$([[ -f "$evidence" ]] && echo yes || echo no) path=$evidence" >&2
+    [[ -f "$evidence" ]] && { echo 'evidence_content:' >&2; cat "$evidence" >&2; } || true
+    echo "state_exists=$([[ -f "$state" ]] && echo yes || echo no)" >&2
+    [[ -f "$state" ]] && { echo "state_phase=$(jq -r '.phase // "<none>"' "$state" 2>&1)" >&2; echo "state_interruption=$(jq -c '.lastInterruption // "<none>"' "$state" 2>&1)" >&2; echo "state_guard=$(jq -c '.guardEvidence // "<none>"' "$state" 2>&1)" >&2; } || true
+    echo "controller_err_tail:" >&2; tail -5 "$fixture_dir/controller.err" >&2 || true
+    echo 'fixture_listing:' >&2; ls -la "$fixture_dir" >&2
+    echo '---signal-flake-diagnostics end---' >&2
     exit 1
   }
 )
@@ -2269,9 +2323,9 @@ test_verifier_signal_persists_child_evidence_before_return() (
   shim=$(write_systemd_identity_shim "$fixture_dir")
   "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
 
-  run_fixture_controller "$state" "$shim" env >"$fixture_dir/controller.out" 2>"$fixture_dir/controller.err" &
+  background_fixture_controller "$state" "$shim" env >"$fixture_dir/controller.out" 2>"$fixture_dir/controller.err" &
   controller_pid=$!
-  for i in $(seq 1 200); do
+  for i in $(seq 1 600); do
     [[ -e "$fixture_dir/verifier-running" ]] && break
     kill -0 "$controller_pid" 2>/dev/null || break
     sleep 0.05
@@ -2290,6 +2344,14 @@ test_verifier_signal_persists_child_evidence_before_return() (
     .closureEvidence.path == $path and .lastInterruption.signal == "TERM"
   ' "$state" >/dev/null || {
     echo 'TERM during verifier returned before durable child evidence was bound' >&2
+    echo "---signal-flake-diagnostics begin (verifier)---" >&2
+    echo "evidence_exists=$([[ -f "$evidence" ]] && echo yes || echo no) path=$evidence" >&2
+    [[ -f "$evidence" ]] && { echo 'evidence_content:' >&2; cat "$evidence" >&2; } || true
+    echo "state_exists=$([[ -f "$state" ]] && echo yes || echo no)" >&2
+    [[ -f "$state" ]] && { echo "state_phase=$(jq -r '.phase // "<none>"' "$state" 2>&1)" >&2; echo "state_interruption=$(jq -c '.lastInterruption // "<none>"' "$state" 2>&1)" >&2; echo "state_closure=$(jq -c '.closureEvidence // "<none>"' "$state" 2>&1)" >&2; } || true
+    echo "controller_err_tail:" >&2; tail -5 "$fixture_dir/controller.err" >&2 || true
+    echo 'fixture_listing:' >&2; ls -la "$fixture_dir" >&2
+    echo '---signal-flake-diagnostics end---' >&2
     exit 1
   }
 )
@@ -2443,9 +2505,9 @@ assert_signal_wait_reaps_delayed_child() {
   export XDG_RUNTIME_DIR="$fixture_dir/locks"
   shim=$(write_systemd_identity_shim "$fixture_dir")
   "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
-  run_fixture_controller "$state" "$shim" env >"$fixture_dir/controller.out" 2>"$fixture_dir/controller.err" &
+  background_fixture_controller "$state" "$shim" env >"$fixture_dir/controller.out" 2>"$fixture_dir/controller.err" &
   controller_pid=$!
-  for i in $(seq 1 200); do
+  for i in $(seq 1 600); do
     [[ -e "$fixture_dir/$running_marker" ]] && break
     kill -0 "$controller_pid" 2>/dev/null || break
     sleep 0.05
@@ -2690,12 +2752,12 @@ test_signal_waits_for_guard_descendant_group() (
   shim=$(write_systemd_identity_shim "$fixture_dir")
   "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
 
-  run_fixture_controller "$state" "$shim" env >"$fixture_dir/controller.out" 2>"$fixture_dir/controller.err" &
+  background_fixture_controller "$state" "$shim" env >"$fixture_dir/controller.out" 2>"$fixture_dir/controller.err" &
   controller_pid=$!
-  for i in $(seq 1 200); do
+  for i in $(seq 1 600); do
     [[ -e "$fixture_dir/guard-descendant-running" ]] && break
     kill -0 "$controller_pid" 2>/dev/null || break
-    sleep 0.02
+    sleep 0.05
   done
   [[ -e "$fixture_dir/guard-descendant-running" ]]
   descendant_pid=$(<"$fixture_dir/guard-descendant-pid")
@@ -2706,9 +2768,9 @@ test_signal_waits_for_guard_descendant_group() (
   if [[ ! -e "$fixture_dir/guard-descendant-complete" ]] || kill -0 "$descendant_pid" 2>/dev/null; then
     returned_early=true
   fi
-  for i in $(seq 1 200); do
+  for i in $(seq 1 600); do
     [[ -e "$fixture_dir/guard-descendant-complete" ]] && ! kill -0 "$descendant_pid" 2>/dev/null && break
-    sleep 0.02
+    sleep 0.05
   done
   if kill -0 "$descendant_pid" 2>/dev/null; then
     kill "$descendant_pid" 2>/dev/null || true
@@ -2738,12 +2800,12 @@ test_concurrent_reprepare_cannot_replace_live_prepared_state() (
   chmod 0600 "$alternate"
   : > "$fixture_dir/pause-next-docker"
 
-  run_fixture_controller "$state" "$shim" env >"$fixture_dir/controller.out" 2>"$fixture_dir/controller.err" &
+  background_fixture_controller "$state" "$shim" env >"$fixture_dir/controller.out" 2>"$fixture_dir/controller.err" &
   controller_pid=$!
-  for i in $(seq 1 200); do
+  for i in $(seq 1 600); do
     [[ -e "$fixture_dir/docker-paused" ]] && break
     kill -0 "$controller_pid" 2>/dev/null || break
-    sleep 0.02
+    sleep 0.05
   done
   [[ -e "$fixture_dir/docker-paused" ]]
   "$CONTROLLER" --prepare --manifest "$alternate" --state "$state" >/dev/null 2>&1 || reprepare_rc=$?
@@ -2790,12 +2852,12 @@ test_verified_guard_bytes_cannot_be_replaced_before_use() (
   "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
   : > "$fixture_dir/pause-engine-info"
 
-  run_fixture_controller "$state" "$shim" env >"$fixture_dir/controller.out" 2>"$fixture_dir/controller.err" &
+  background_fixture_controller "$state" "$shim" env >"$fixture_dir/controller.out" 2>"$fixture_dir/controller.err" &
   controller_pid=$!
-  for i in $(seq 1 200); do
+  for i in $(seq 1 600); do
     [[ -e "$fixture_dir/engine-info-paused" ]] && break
     kill -0 "$controller_pid" 2>/dev/null || break
-    sleep 0.02
+    sleep 0.05
   done
   [[ -e "$fixture_dir/engine-info-paused" ]]
   cat > "$guard.next" <<'GUARD'
@@ -3320,6 +3382,7 @@ test_same_name_volume_replacement_is_rejected_after_preparation() (
   trap '[[ -z ${fixture_dir:-} ]] || rm -rf "$fixture_dir"' EXIT
 
   for field in Driver Mountpoint CreatedAt Scope Labels Options; do
+    _clear_authority_root_for_isolation
     fixture_dir=$(mktemp -d)
     manifest="$fixture_dir/manifest.json"
     state="$fixture_dir/controller.json"
@@ -3429,6 +3492,11 @@ test_successful_verifier_postprocessing_failure_stops_writer() (
   trap '[[ -z ${fixture_dir:-} ]] || rm -rf "$fixture_dir"' EXIT
 
   for failure in evidence cursor state; do
+    # Each iteration runs a real controller that claims the durable authority
+    # record for the shared fake engine+volume identity; the previous
+    # iteration's fixture is deleted, leaving a stale record that fail-closed
+    # --prepare correctly refuses. Isolate per iteration.
+    _clear_authority_root_for_isolation
     fixture_dir=$(mktemp -d)
     manifest="$fixture_dir/manifest.json"
     state="$fixture_dir/controller.json"
@@ -3495,6 +3563,10 @@ test_post_activation_signal_with_zero_exit_verifier_stops_writer() (
   trap 'terminate_fixture_process "${controller_pid:-}"; terminate_fixture_process "${child_pid:-}"; [[ -z ${fixture_dir:-} ]] || rm -rf "$fixture_dir"' EXIT
 
   for signal_spec in TERM:143 INT:130 HUP:129; do
+    # Per-iteration authority isolation (same rationale as the verifier
+    # postprocessing loop: stale records from deleted fixtures must not
+    # poison the next iteration's --prepare).
+    _clear_authority_root_for_isolation
     signal=${signal_spec%%:*}
     expected_rc=${signal_spec##*:}
     fixture_dir=$(mktemp -d)
@@ -3506,10 +3578,10 @@ test_post_activation_signal_with_zero_exit_verifier_stops_writer() (
     "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
 
     rc=0
-    run_fixture_controller "$state" "$shim" env --default-signal="$signal" \
+    background_fixture_controller "$state" "$shim" env --default-signal="$signal" \
       >"$fixture_dir/controller.out" 2>"$fixture_dir/controller.err" &
     controller_pid=$!
-    for i in $(seq 1 200); do
+    for i in $(seq 1 600); do
       [[ -e "$fixture_dir/candidate-verifier-running" ]] && break
       kill -0 "$controller_pid" 2>/dev/null || break
       sleep 0.05
@@ -3569,6 +3641,11 @@ test_source_recovery_signal_persists_process_evidence() (
   trap 'terminate_fixture_process "${controller_pid:-}"; terminate_fixture_process "${child_pid:-}"; [[ -z ${fixture_dir:-} ]] || rm -rf "$fixture_dir"' EXIT
 
   for case_name in ordinary interrupted; do
+    # Both cases claim the same fake engine+volume authority, but the first
+    # fixture directory is deleted before the second prepare. Clear only the
+    # suite-owned authority namespace so the interrupted case cannot inherit
+    # a stale record whose state path no longer exists.
+    _clear_authority_root_for_isolation
     if [[ "$case_name" == ordinary ]]; then
       verifier_mode=source-fail
       expected_rc=42
@@ -3589,12 +3666,12 @@ test_source_recovery_signal_persists_process_evidence() (
     expected_boot_cursor="b=${expected_boot//-/}"
 
     rc=0
-    run_fixture_controller "$state" "$shim" env \
+    background_fixture_controller "$state" "$shim" env \
       >"$fixture_dir/controller.out" 2>"$fixture_dir/controller.err" &
     controller_pid=$!
     observed_controller_pid=$controller_pid
     if [[ -n "$expected_signal" ]]; then
-      for i in $(seq 1 200); do
+      for i in $(seq 1 600); do
         [[ -e "$fixture_dir/source-verifier-running" ]] && break
         kill -0 "$controller_pid" 2>/dev/null || break
         sleep 0.05
@@ -3893,10 +3970,15 @@ test_engine_volume_identity_has_one_authoritative_state_path() (
 )
 
 test_production_rejects_ambient_test_hook_contamination() (
-  local hook_spec hook value fixture_dir='' manifest state live shim rc
+  local hook_spec hook value fixture_dir='' manifest state live shim rc auth_root
   local -a failures=()
-  trap '[[ -z ${fixture_dir:-} ]] || rm -rf "$fixture_dir"' EXIT
+  trap '[[ -z ${fixture_dir:-} ]] || rm -rf "$fixture_dir" "${auth_root:-}"' EXIT
 
+  # Each iteration uses a fresh XDG_STATE_HOME so the durable authority
+  # record left by the previous hook cannot be silently reclaimed under
+  # the same engine+volume with a different state path. Without this, the
+  # R3-1 explicit `*)` arm fires before this test reaches the
+  # production-hook rejection path it means to exercise.
   for hook_spec in \
     NOOSPHERE_CONTROLLER_TEST_INTERRUPT_AFTER_INTENT=1 \
     NOOSPHERE_CONTROLLER_TEST_SIGNAL_AFTER_GUARD_SPAWN=TERM \
@@ -3907,11 +3989,14 @@ test_production_rejects_ambient_test_hook_contamination() (
     hook=${hook_spec%%=*}
     value=${hook_spec#*=}
     fixture_dir=$(mktemp -d)
+    auth_root=$(mktemp -d)
+    chmod 700 "$auth_root"
     manifest="$fixture_dir/manifest.json"
     state="$fixture_dir/controller.json"
     live="$fixture_dir/docker-compose.yml"
     write_execution_fixture "$fixture_dir" "$manifest"
     export XDG_RUNTIME_DIR="$fixture_dir/locks"
+    export XDG_STATE_HOME="$auth_root"
     shim=$(write_systemd_identity_shim "$fixture_dir" disabled)
     "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
 
@@ -3931,6 +4016,7 @@ test_production_rejects_ambient_test_hook_contamination() (
     fi
 
     rm -rf "$fixture_dir"
+    rm -rf "$auth_root"
     fixture_dir=''
   done
 
@@ -3980,6 +4066,13 @@ test_state_authority_survives_runtime_loss_and_is_revalidated_at_execute() (
   fi
   rm -rf "$fixture_dir"
   fixture_dir=''
+
+  # The copied-state scenario above intentionally leaves a durable authority
+  # record for its fake engine+volume, then deletes the state path it names.
+  # The runtime-loss scenario below is independent but reuses that fake tuple;
+  # isolate the suite-owned namespace before starting it so the controller's
+  # fail-closed stale-record check cannot mask the behavior under test.
+  _clear_authority_root_for_isolation
 
   # Replace the entire disposable runtime root to model reboot/runtime loss.
   # The duplicate tuple must remain rejected, while both tuple dimensions have
@@ -4059,6 +4152,8 @@ test_post_authorization_pre_activation_failures_commit_fresh_stop_evidence() (
   trap '[[ -z ${fixture_dir:-} ]] || rm -rf "$fixture_dir"' EXIT
 
   for case_name in signal artifact-storage; do
+    # Per-iteration authority isolation (stale-record poisoning guard).
+    _clear_authority_root_for_isolation
     fixture_dir=$(mktemp -d)
     manifest="$fixture_dir/manifest.json"
     state="$fixture_dir/controller.json"
@@ -4164,6 +4259,13 @@ test_verifier_artifact_selector_collision_routes_through_closure_artifact_storag
   printf 'existing\n' > "$state_base.$invocation.verify.stdout.log"
   printf 'existing\n' > "$state_base.$invocation.verify.stderr.log"
   printf '{"existing":true}\n' > "$state_base.$invocation.verify.evidence.json"
+
+  # The docker shim (controller script L577-581) only writes the
+  # `incident-persisted-before-stop` sentinel when this hook file exists.
+  # Without it, the assertion below is a permanent no-op — a regression
+  # that publishes the terminal incident before stopping the writer
+  # would still pass. Mirror the sibling pattern at L4075.
+  : > "$fixture_dir/kill-controller-if-incident-before-stop"
 
   rc=0
   run_fixture_controller "$state" "$shim" env \
@@ -4473,6 +4575,7 @@ test_phase_owned_invariants_reject_unproved_states() (
     evidence-pending-without-stop-proof \
     source-incident-without-source-evidence \
     closure-incident-without-stop-proof; do
+    _clear_authority_root_for_isolation
     guard_mode=complete
     verifier_mode=success
     target_incident_class=''
@@ -4779,60 +4882,16 @@ test_xdg_state_home_cross_root_execute_rejected() (
     exit 1
   }
 )
-
-if [[ ${BASH_SOURCE[0]} == "$0" ]]; then
-  test_atomic_controller_state
-  test_source_restore_without_guard_journal
-  test_execution_environment_is_hermetic
-  test_closure_failure_classification
-  test_signal_handler_is_idempotent
-  test_reboot_recovers_prejournal_candidate_publication
-  test_valid_guard_journal_suppresses_outer_restore
-  test_shared_lock_is_inherited
-  test_candidate_publication_intent_is_recoverable
-  test_systemd_contract_has_no_automatic_kill
-  test_process_evidence_is_bounded_and_hashed
-  test_closure_outcome_never_false_completes
-  test_complete_entrypoint_with_disposable_commands
-  test_manifest_mutation_fails_before_publication
-  test_execution_requires_systemd_identity
-  test_guard_failure_before_journal_restores_source
-  test_guard_journal_prevents_outer_restore
-  test_verifier_failure_commits_incident_and_stops_app
-  test_evidence_failure_cannot_complete
-  test_term_during_guard_records_and_recovers
-  test_terminal_states_never_delegate_to_a_stale_guard_journal
-  test_systemd_identity_is_queried_not_asserted
-  test_prepare_refuses_to_overwrite_active_or_terminal_state
-  test_engine_identity_is_rebound_to_the_live_daemon
-  test_lock_root_must_match_the_guard_lock_contract
-  test_child_process_environment_and_docker_resolution_are_hermetic
-  test_latched_signal_before_guard_cannot_be_ignored
-  test_verifier_evidence_failure_stops_writer_before_storage
-  test_process_logs_are_fsynced_before_evidence_binding
-  test_complete_state_binds_guard_and_closure_evidence
-  test_systemd_safety_properties_and_linger_are_queried
-  test_signals_cannot_cross_spawn_or_complete_boundaries
-  test_source_recovery_verifier_is_hermetic_and_target_bound
-  test_complete_state_binds_immutable_guard_journal
-  test_process_evidence_separates_controller_and_child_identity
-  test_guard_arguments_are_semantically_bound_to_manifest
-  test_compose_plugin_and_docker_config_identity_are_bound
-  test_failed_prejournal_recovery_commits_durable_incident
-  test_process_evidence_rejects_impossible_chronology
-  test_source_snapshot_is_revalidated_before_publication
-  test_guard_journal_path_is_canonically_bound
-  test_fixed_path_toolchain_is_immutable_and_bound
-  test_controller_state_cannot_collide_with_guard_journal
-  test_ambient_test_overrides_cannot_falsify_production_evidence
-  test_docker_rehearsal_proves_cleanup_before_success
-  test_process_evidence_rejects_fractional_numbers
-  test_real_systemd_fixture_exercises_signal_delivery
-  test_production_execution_succeeds_without_ambient_fault_hooks
-  test_production_execution_succeeds_without_ambient_signal_hooks
 test_corrupt_phase_durable_state_rejected() (
-  local fixture_dir='' manifest state_a state_b rc auth
-  local engine_id=fixture-engine volume=fixture-volume
+  local fixture_dir="" manifest state_a state_b rc auth runtime_dir lock_key claim authority
+  # Test-unique engine+volume keeps this test from claiming the same
+  # durable authority namespace as earlier tests in the suite-level
+  # XDG_STATE_HOME root. Without isolation, the controller would read a
+  # record pointing at a path the earlier test has already rm-rf'd; the
+  # resulting empty `.phase` would fire the R3-1 `*)` arm with the wrong
+  # diagnostic for the wrong reason and mask the real failure this test
+  # means to exercise.
+  local engine_id=corrupt-phase-engine volume=corrupt-phase-volume
   local -a failures=()
   trap '[[ -z ${fixture_dir:-} ]] || rm -rf "$fixture_dir" "$auth"' EXIT
 
@@ -4842,31 +4901,185 @@ test_corrupt_phase_durable_state_rejected() (
   manifest="$fixture_dir/manifest.json"
   state_a="$fixture_dir/controller.json"
   state_b="$fixture_dir/controller-alt.json"
-  write_execution_fixture "$fixture_dir" "$manifest"
-  export XDG_RUNTIME_DIR="$fixture_dir/locks"
+  write_execution_fixture "$fixture_dir" "$manifest" complete success "$engine_id" "$volume"
+  # lockRoot in the manifest is $fixture_dir/locks; assert_live_engine_binding
+  # compares it against XDG_RUNTIME_DIR. Using a separate directory here would
+  # die with "recorded lock root does not match the guard engine-volume lock
+  # contract" before reaching the case arm we mean to exercise.
+  runtime_dir="$fixture_dir/locks"
+  install -d -m 700 "$runtime_dir"
+  export XDG_RUNTIME_DIR="$runtime_dir"
+  lock_key=$(printf '%s\0%s' "$engine_id" "$volume" | sha256sum | awk '{print $1}')
+  claim="$runtime_dir/noosphere-pgvector-state-$lock_key.json"
+  authority="$auth/noosphere-pgvector-controller/authority/state-$lock_key.json"
 
-  # Prepare once at state_a to seed the durable authority record.
+  # Prepare once at state_a to seed the durable authority record AND the
+  # runtime claim.
   XDG_STATE_HOME="$auth" "$CONTROLLER" --prepare --manifest "$manifest" --state "$state_a"
 
-  # Corrupt the state file's phase to a value outside the enum.
-  jq '.phase = "garbage"' "$state_a" > "$state_a.next"
+  # Reboot-shaped recovery: the runtime claim is wiped, the durable record
+  # remains. Without this step, the next prepare would die at the runtime
+  # claim check (controller L587) with "authoritative state ... already
+  # claimed by another path" — masking the L654 enum case the test means
+  # to exercise. Recreate the runtime dir before the second prepare so
+  # acquire_operation_lock sees a real directory.
+  rm -rf "$runtime_dir"
+  install -d -m 700 "$runtime_dir"
+
+  # Corrupt the state file phase to a value outside the enum.
+  jq ".phase = \"garbage\"" "$state_a" > "$state_a.next"
   install -m 600 "$state_a.next" "$state_a"
 
   # Run --prepare at a DIFFERENT state path so claim_authoritative_state_path
   # reads the durable record, sees recorded_path=state_a != current=state_b,
-  # and reaches the case statement at the active-phase enum. The current
-  # case statement only matches the 10 enum values, so .phase=garbage falls
-  # through to a reclaim that silently overwrites the durable record.
+  # and reaches the case statement at the active-phase enum. With the
+  # R3-1 fix the `*)` default arm fires; without it, the case silently
+  # falls through to a reclaim that overwrites the durable record.
   rc=0
   XDG_STATE_HOME="$auth" "$CONTROLLER" --prepare --manifest "$manifest" --state "$state_b" \
     >"$fixture_dir/alt.out" 2>"$fixture_dir/alt.err" || rc=$?
   if ((rc == 0)); then
-    failures+=('controller reclaimed a durable state with .phase=garbage; expected unrecognized-phase rejection')
+    failures+=("controller reclaimed a durable state with .phase=garbage; expected unrecognized-phase rejection")
   else
-    rg -qi 'phase|unrecognized|authoritative.*state|durable.*authority' \
-      "$fixture_dir/alt.err" ||
-      failures+=('corrupt-phase rejection lacked a phase or authority diagnostic')
+    grep -qiE "unrecognized phase" "$fixture_dir/alt.err" ||
+      failures+=("corrupt-phase rejection lacked the "unrecognized phase" diagnostic; stderr=$(tr "\n" " " < "$fixture_dir/alt.err")")
   fi
+
+  # A rejected alternate prepare must not publish a reboot-volatile claim for
+  # the rejected path or disturb the durable record for the authoritative
+  # state. Otherwise repairing and resuming state_a is poisoned until an
+  # operator manually deletes the stale runtime claim.
+  [[ ! -e "$claim" ]] ||
+    failures+=("corrupt-phase rejection left a runtime claim for the rejected alternate state")
+  [[ $(jq -er '.statePath' "$authority") == "$(realpath -m "$state_a")" ]] ||
+    failures+=("corrupt-phase rejection changed the durable authoritative state path")
+
+  jq '.phase = "prepared"' "$state_a" > "$state_a.next"
+  install -m 600 "$state_a.next" "$state_a"
+  rc=0
+  XDG_STATE_HOME="$auth" "$CONTROLLER" --prepare --manifest "$manifest" --state "$state_a" \
+    >"$fixture_dir/retry.out" 2>"$fixture_dir/retry.err" || rc=$?
+  ((rc == 0)) ||
+    failures+=("authoritative state could not resume after alternate rejection; stderr=$(tr "\n" " " < "$fixture_dir/retry.err")")
+
+  ((${#failures[@]} == 0)) || {
+    printf "%s\n" "${failures[@]}" >&2
+    exit 1
+  }
+)
+
+test_bound_transition_inputs_are_pairwise_distinct() (
+  local fixture_dir manifest state live rc=0
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf -- "$fixture_dir"' EXIT
+  manifest="$fixture_dir/manifest.json"
+  state="$fixture_dir/controller.json"
+  live="$fixture_dir/docker-compose.yml"
+  write_execution_fixture "$fixture_dir" "$manifest"
+  export XDG_RUNTIME_DIR="$fixture_dir/locks"
+
+  jq '.sourceSnapshot = .liveCompose' "$manifest" > "$manifest.next"
+  install -m 600 "$manifest.next" "$manifest"
+  "$CONTROLLER" --prepare --manifest "$manifest" --state "$state" \
+    >"$fixture_dir/prepare.out" 2>"$fixture_dir/prepare.err" || rc=$?
+
+  ((rc != 0)) || {
+    echo 'controller accepted sourceSnapshot aliasing liveCompose' >&2
+    exit 1
+  }
+  rg -qi 'bound transition inputs collide' "$fixture_dir/prepare.err" || {
+    echo "bound-input alias rejection lacked the pairwise-collision diagnostic: $(tr '\n' ' ' < "$fixture_dir/prepare.err")" >&2
+    exit 1
+  }
+  [[ ! -e "$state" && $(<"$live") == 'source model' ]]
+)
+
+test_invalid_complete_state_cannot_relinquish_durable_authority() (
+  local fixture_dir manifest state_a state_b auth runtime_dir engine_id volume lock_key claim authority rc=0
+  fixture_dir=$(mktemp -d)
+  auth=$(mktemp -d)
+  trap 'rm -rf -- "$fixture_dir" "$auth"' EXIT
+  chmod 700 "$auth"
+  manifest="$fixture_dir/manifest.json"
+  state_a="$fixture_dir/controller.json"
+  state_b="$fixture_dir/controller-next.json"
+  engine_id=invalid-complete-engine
+  volume=invalid-complete-volume
+  write_execution_fixture "$fixture_dir" "$manifest" complete success "$engine_id" "$volume"
+  runtime_dir="$fixture_dir/locks"
+  export XDG_RUNTIME_DIR="$runtime_dir"
+  lock_key=$(printf '%s\0%s' "$engine_id" "$volume" | sha256sum | awk '{print $1}')
+  claim="$runtime_dir/noosphere-pgvector-state-$lock_key.json"
+  authority="$auth/noosphere-pgvector-controller/authority/state-$lock_key.json"
+
+  XDG_STATE_HOME="$auth" "$CONTROLLER" --prepare --manifest "$manifest" --state "$state_a"
+  rm -f -- "$claim"
+  jq '.phase = "complete"' "$state_a" > "$state_a.next"
+  install -m 600 "$state_a.next" "$state_a"
+
+  XDG_STATE_HOME="$auth" "$CONTROLLER" --prepare --manifest "$manifest" --state "$state_b" \
+    >"$fixture_dir/reclaim.out" 2>"$fixture_dir/reclaim.err" || rc=$?
+  ((rc != 0)) || {
+    echo 'controller reclaimed authority from an evidentially invalid complete state' >&2
+    exit 1
+  }
+  rg -qi 'controller state is malformed|complete.*evidence' "$fixture_dir/reclaim.err" || {
+    echo "invalid-complete rejection lacked an evidence-validation diagnostic: $(tr '\n' ' ' < "$fixture_dir/reclaim.err")" >&2
+    exit 1
+  }
+  [[ ! -e "$claim" && ! -e "$state_b" ]]
+  [[ $(jq -er '.statePath' "$authority") == "$(realpath -m "$state_a")" ]]
+)
+
+test_durable_authority_reclaims_complete_or_missing_state() (
+  local case_name case_root auth runtime_dir fixture_a fixture_b fixture_dir manifest manifest_a manifest_b
+  local state_a state_b engine_id volume shim rc
+  local -a failures=() cleanup_roots=()
+  trap 'for cleanup_root in "${cleanup_roots[@]}"; do rm -rf -- "$cleanup_root"; done' EXIT
+
+  for case_name in complete missing; do
+    auth=$(mktemp -d)
+    case_root=$(mktemp -d)
+    cleanup_roots+=("$auth" "$case_root")
+    chmod 700 "$auth"
+    runtime_dir="$case_root/runtime"
+    fixture_a="$case_root/a"
+    fixture_b="$case_root/b"
+    install -d -m 700 "$runtime_dir" "$fixture_a" "$fixture_b"
+    manifest_a="$fixture_a/manifest.json"
+    manifest_b="$fixture_b/manifest.json"
+    state_a="$fixture_a/controller.json"
+    state_b="$fixture_b/controller.json"
+    engine_id="reclaim-$case_name-engine"
+    volume="reclaim-$case_name-volume"
+    write_execution_fixture "$fixture_a" "$manifest_a" complete success "$engine_id" "$volume"
+    write_execution_fixture "$fixture_b" "$manifest_b" complete success "$engine_id" "$volume"
+    for manifest in "$manifest_a" "$manifest_b"; do
+      jq --arg lockRoot "$runtime_dir" '.lockRoot = $lockRoot' "$manifest" > "$manifest.next"
+      install -m 600 "$manifest.next" "$manifest"
+    done
+    export XDG_RUNTIME_DIR="$runtime_dir"
+
+    XDG_STATE_HOME="$auth" "$CONTROLLER" --prepare --manifest "$manifest_a" --state "$state_a"
+    if [[ "$case_name" == complete ]]; then
+      fixture_dir=$fixture_a
+      shim=$(write_systemd_identity_shim "$fixture_a")
+      XDG_STATE_HOME="$auth" run_fixture_controller "$state_a" "$shim" env
+      [[ $(jq -er '.phase' "$state_a") == complete ]]
+    else
+      rm -f -- "$state_a"
+    fi
+
+    rc=0
+    XDG_STATE_HOME="$auth" "$CONTROLLER" --prepare --manifest "$manifest_b" --state "$state_b" \
+      >"$fixture_b/reclaim.out" 2>"$fixture_b/reclaim.err" || rc=$?
+    ((rc == 0)) ||
+      failures+=("$case_name durable state with retained runtime claim was not reclaimable; stderr=$(tr "\n" " " < "$fixture_b/reclaim.err")")
+    if ((rc == 0)); then
+      [[ $(jq -er '.phase' "$state_b") == prepared ]] ||
+        failures+=("$case_name reclaim did not publish a prepared replacement state")
+    fi
+  done
 
   ((${#failures[@]} == 0)) || {
     printf '%s\n' "${failures[@]}" >&2
@@ -4874,62 +5087,415 @@ test_corrupt_phase_durable_state_rejected() (
   }
 )
 
-  test_derived_evidence_paths_cannot_collide_with_bound_inputs
-  test_guard_signal_persists_child_evidence_before_return
-  test_verifier_signal_persists_child_evidence_before_return
-  test_terminal_state_requires_phase_specific_invariants
-  test_preparation_resolves_docker_only_after_hermetic_sanitization
-  test_controller_executable_is_bound_after_preparation
-  test_guard_signal_waits_until_child_is_reaped
-  test_closure_verifier_signal_waits_until_child_is_reaped
-  test_source_verifier_signal_waits_until_child_is_reaped
-  test_bootstrap_ignores_ambient_path
-  test_docker_config_namespace_rejects_descendants
-  test_complete_state_revalidates_durable_evidence
-  test_recovery_preserves_prior_process_evidence
-  test_closure_incident_remains_resumable_until_writer_is_stopped
-  test_bootstrap_blocks_bash_env_and_exported_functions
-  test_fixed_path_is_validated_before_installation
-  test_signal_waits_for_guard_descendant_group
-  test_concurrent_reprepare_cannot_replace_live_prepared_state
-  test_guard_requires_deferred_writer_restart
-  test_verified_guard_bytes_cannot_be_replaced_before_use
-  test_concurrent_first_preparation_is_no_replace
-  test_fixed_path_rejects_mutable_symlink_aliases
-  test_verifier_evidence_failure_remains_resumable
-  test_operation_lock_open_does_not_follow_symlinks
-  test_execution_bundle_accepts_trusted_root_owned_executables
-  test_bootstrap_utility_resolution_is_trusted_before_use
-  test_systemd_context_requires_transient_unit_provenance
-  test_writer_activation_lifecycle_is_ordered_and_evidence_bound
-  test_authorization_evidence_is_durable_before_activation
-  test_app_activation_failure_is_fail_closed_before_final_verification
-  test_term_after_activation_stops_writer_before_return
-  test_closure_evidence_pending_resume_never_reactivates_writer
-  test_missing_live_compose_commits_prejournal_restoration_incident
-  test_post_activation_artifact_setup_failure_stops_writer_durably
-  test_closure_evidence_pending_requires_verified_stop_before_persistence
-  test_same_name_volume_replacement_is_rejected_after_preparation
-  test_live_identity_checks_wait_for_the_shared_operation_lock
-  test_successful_verifier_postprocessing_failure_stops_writer
-  test_post_activation_signal_with_zero_exit_verifier_stops_writer
-  test_source_recovery_signal_persists_process_evidence
-  test_prejournal_recovery_refuses_unexpected_live_compose
-  test_complete_write_cannot_race_final_guard_journal_validation
-  test_engine_volume_identity_has_one_authoritative_state_path
-  test_production_rejects_ambient_test_hook_contamination
-  test_state_authority_survives_runtime_loss_and_is_revalidated_at_execute
-  test_post_authorization_pre_activation_failures_commit_fresh_stop_evidence
-  test_verifier_artifact_selector_collision_routes_through_closure_artifact_storage
-  test_source_recovery_artifacts_cannot_collide_with_bound_inputs
-  test_source_recovery_retry_preserves_prior_unbound_evidence
-  test_phase_owned_invariants_reject_unproved_states
-  test_disposable_rehearsals_clean_and_assert_state_authority
-  test_transient_systemd_fixture_independently_proves_identity_and_cursors
-  test_writer_stop_evidence_is_retry_distinct
-  test_invocation_suffixed_artifacts_cannot_collide_with_bound_inputs
-  test_xdg_state_home_cross_root_execute_rejected
-  test_corrupt_phase_durable_state_rejected
+test_cli_rejects_duplicate_or_mixed_modes() (
+  local fixture_dir case_name rc
+  local -a args failures=()
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf -- "$fixture_dir"' EXIT
 
+  for case_name in prepare-execute execute-prepare prepare-prepare execute-execute; do
+    case "$case_name" in
+      prepare-execute) args=(--prepare --execute --state "$fixture_dir/state.json") ;;
+      execute-prepare) args=(--execute --prepare --manifest "$fixture_dir/manifest.json" --state "$fixture_dir/state.json") ;;
+      prepare-prepare) args=(--prepare --prepare --manifest "$fixture_dir/manifest.json" --state "$fixture_dir/state.json") ;;
+      execute-execute) args=(--execute --execute --state "$fixture_dir/state.json") ;;
+    esac
+    rc=0
+    "$CONTROLLER" "${args[@]}" >"$fixture_dir/$case_name.out" 2>"$fixture_dir/$case_name.err" || rc=$?
+    ((rc != 0)) || failures+=("$case_name unexpectedly succeeded")
+    rg -qi 'exactly one of --prepare or --execute is required' "$fixture_dir/$case_name.err" ||
+      failures+=("$case_name did not reject duplicate/mixed mode flags at parse time; stderr=$(tr '\n' ' ' < "$fixture_dir/$case_name.err")")
+  done
+
+  ((${#failures[@]} == 0)) || {
+    printf '%s\n' "${failures[@]}" >&2
+    exit 1
+  }
+)
+
+test_execution_environment_removes_all_ambient_docker_compose_behavior() (
+  local name remaining=''
+  eval "$(extract_function sanitize_execution_environment)"
+
+  export DOCKER_DEFAULT_PLATFORM=linux/arm64
+  export DOCKER_API_VERSION=1.41
+  export COMPOSE_REMOVE_ORPHANS=1
+  export COMPOSE_IGNORE_ORPHANS=1
+
+  sanitize_execution_environment \
+    unix:///var/run/docker.sock /opt/noosphere-tools /tmp/controller-home
+
+  while IFS= read -r name; do
+    case "$name" in
+      DOCKER_CONFIG|DOCKER_HOST|COMPOSE_DISABLE_ENV_FILE) ;;
+      DOCKER_*|COMPOSE_*) remaining+="${remaining:+$'\n'}$name" ;;
+    esac
+  done < <(compgen -e)
+  [[ -z "$remaining" ]] || {
+    printf 'ambient Docker/Compose behavior variables survived sanitization:\n%s\n' \
+      "$remaining" >&2
+    exit 1
+  }
+)
+
+test_durable_authority_rejects_runtime_backed_state_home() (
+  local fixture_dir manifest state runtime_state_home rc=0
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf -- "$fixture_dir"' EXIT
+  manifest="$fixture_dir/manifest.json"
+  state="$fixture_dir/controller.json"
+  write_execution_fixture "$fixture_dir" "$manifest" complete success \
+    runtime-authority-engine runtime-authority-volume
+  export XDG_RUNTIME_DIR="$fixture_dir/locks"
+  runtime_state_home="$XDG_RUNTIME_DIR/xdg-state-home"
+  install -d -m 700 "$runtime_state_home"
+
+  XDG_STATE_HOME="$runtime_state_home" \
+    "$CONTROLLER" --prepare --manifest "$manifest" --state "$state" \
+      >"$fixture_dir/prepare.out" 2>"$fixture_dir/prepare.err" || rc=$?
+
+  ((rc != 0)) || {
+    echo 'controller accepted a reboot-volatile durable authority root under XDG_RUNTIME_DIR' >&2
+    exit 1
+  }
+  rg -qi 'durable.*authority|runtime.*state|reboot.*volatile' "$fixture_dir/prepare.err" || {
+    echo "runtime-backed authority rejection lacked a durability diagnostic: $(tr '\n' ' ' < "$fixture_dir/prepare.err")" >&2
+    exit 1
+  }
+  [[ ! -e "$state" ]]
+)
+
+test_bound_inputs_and_publication_reject_unsafe_write_modes() (
+  local fixture_dir safe_dir unsafe_dir source target
+  local -a failures=()
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf -- "$fixture_dir"' EXIT
+  safe_dir="$fixture_dir/safe"
+  unsafe_dir="$fixture_dir/unsafe"
+  install -d -m 700 "$safe_dir"
+  install -d -m 777 "$unsafe_dir"
+  target="$safe_dir/live-compose.yml"
+
+  eval "$(extract_function path_present)"
+  eval "$(extract_function assert_owned_regular_file)"
+  eval "$(extract_function publish_compose_atomic)"
+  eval "$(extract_function die)"
+  fsync_path() { :; }
+
+  source="$safe_dir/world-writable-source.yml"
+  printf 'candidate-file-mode\n' > "$source"
+  printf 'source-model\n' > "$target"
+  chmod 0666 "$source"
+  chmod 0600 "$target"
+  if (publish_compose_atomic "$source" "$target"); then
+    failures+=('publication accepted a group/world-writable bound input')
+  fi
+
+  source="$unsafe_dir/candidate.yml"
+  printf 'candidate-parent-mode\n' > "$source"
+  printf 'source-model\n' > "$target"
+  chmod 0600 "$source" "$target"
+  if (publish_compose_atomic "$source" "$target"); then
+    failures+=('publication accepted a bound input below a group/world-writable caller-owned parent')
+  fi
+
+  ((${#failures[@]} == 0)) || {
+    printf '%s\n' "${failures[@]}" >&2
+    exit 1
+  }
+  [[ $(<"$target") == source-model ]]
+)
+
+test_incident_classes_and_stop_proofs_are_closed_world() (
+  local fixture_dir manifest state mutated shim rc=0
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf -- "$fixture_dir"' EXIT
+  manifest="$fixture_dir/manifest.json"
+  state="$fixture_dir/controller.json"
+  mutated="$fixture_dir/unclassified-incident.json"
+  write_execution_fixture "$fixture_dir" "$manifest" complete fail
+  export XDG_RUNTIME_DIR="$fixture_dir/locks"
+  shim=$(write_systemd_identity_shim "$fixture_dir")
+  "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
+  run_fixture_controller "$state" "$shim" env \
+    >"$fixture_dir/controller.out" 2>"$fixture_dir/controller.err" || rc=$?
+  ((rc != 0))
+  jq -e '.phase == "incident" and .incidentClass == "closure-verification" and has("writerStopEvidence")' \
+    "$state" >/dev/null
+
+  jq '.incidentClass = "unclassified-post-authorization" | del(.writerStopEvidence)' \
+    "$state" > "$mutated"
+  chmod 0600 "$mutated"
+  if /bin/bash -c 'source "$1"; validate_controller_state "$2"' \
+    _ "$CONTROLLER" "$mutated" \
+      >"$fixture_dir/validate.out" 2>"$fixture_dir/validate.err"; then
+    echo 'controller accepted an unknown post-authorization incident class without writer-stop proof' >&2
+    exit 1
+  fi
+  rg -qi 'incident.*class|writer.*stop.*evidence' "$fixture_dir/validate.err" || {
+    echo "unclassified incident rejection lacked a class/stop-proof diagnostic: $(tr '\n' ' ' < "$fixture_dir/validate.err")" >&2
+    exit 1
+  }
+)
+
+test_real_docker_rehearsal_declares_interruption_resume_coverage() (
+  local execute_sites interruption_sites recovery_assertions
+  execute_sites=$(rg -F -c -- '--execute --state "$state"' "$DOCKER_FIXTURE" || printf '0\n')
+  interruption_sites=$(rg -c -i \
+    'systemctl --user kill|kill[[:space:]].*(TERM|KILL)|interrupt.*(controller|unit)' \
+    "$DOCKER_FIXTURE" || printf '0\n')
+  recovery_assertions=$(rg -c -i \
+    'candidate-published|source-recovery-running|pre-journal-source-restored|recovery rehearsal passed' \
+    "$DOCKER_FIXTURE" || printf '0\n')
+
+  [[ "$execute_sites" =~ ^[0-9]+$ && "$execute_sites" -ge 2 &&
+     "$interruption_sites" =~ ^[0-9]+$ && "$interruption_sites" -ge 1 &&
+     "$recovery_assertions" =~ ^[0-9]+$ && "$recovery_assertions" -ge 2 ]] || {
+    printf 'real-Docker rehearsal lacks an interruption/resume owner (execute=%s interrupt=%s recovery-assertions=%s)\n' \
+      "$execute_sites" "$interruption_sites" "$recovery_assertions" >&2
+    exit 1
+  }
+)
+
+# Per-test isolation helper: clear the durable authority namespace so a
+# prior test's stale record (pointing at an already-rm-rf'd fixture_dir)
+# cannot fire the R3-1 unrecognized-phase arm before the current test
+# exercises its own contract.
+_clear_authority_root_for_isolation() {
+  rm -rf -- "$XDG_STATE_HOME/noosphere-pgvector-controller"
+}
+
+if [[ ${BASH_SOURCE[0]} == "$0" ]]; then
+  _clear_authority_root_for_isolation
+  test_atomic_controller_state
+  _clear_authority_root_for_isolation
+  test_source_restore_without_guard_journal
+  _clear_authority_root_for_isolation
+  test_execution_environment_is_hermetic
+  _clear_authority_root_for_isolation
+  test_closure_failure_classification
+  _clear_authority_root_for_isolation
+  test_signal_handler_is_idempotent
+  _clear_authority_root_for_isolation
+  test_reboot_recovers_prejournal_candidate_publication
+  _clear_authority_root_for_isolation
+  test_valid_guard_journal_suppresses_outer_restore
+  _clear_authority_root_for_isolation
+  test_shared_lock_is_inherited
+  _clear_authority_root_for_isolation
+  test_candidate_publication_intent_is_recoverable
+  _clear_authority_root_for_isolation
+  test_systemd_contract_has_no_automatic_kill
+  _clear_authority_root_for_isolation
+  test_process_evidence_is_bounded_and_hashed
+  _clear_authority_root_for_isolation
+  test_closure_outcome_never_false_completes
+  _clear_authority_root_for_isolation
+  test_complete_entrypoint_with_disposable_commands
+  _clear_authority_root_for_isolation
+  test_manifest_mutation_fails_before_publication
+  _clear_authority_root_for_isolation
+  test_execution_requires_systemd_identity
+  _clear_authority_root_for_isolation
+  test_guard_failure_before_journal_restores_source
+  _clear_authority_root_for_isolation
+  test_guard_journal_prevents_outer_restore
+  _clear_authority_root_for_isolation
+  test_verifier_failure_commits_incident_and_stops_app
+  _clear_authority_root_for_isolation
+  test_evidence_failure_cannot_complete
+  _clear_authority_root_for_isolation
+  test_term_during_guard_records_and_recovers
+  _clear_authority_root_for_isolation
+  test_terminal_states_never_delegate_to_a_stale_guard_journal
+  _clear_authority_root_for_isolation
+  test_systemd_identity_is_queried_not_asserted
+  _clear_authority_root_for_isolation
+  test_prepare_refuses_to_overwrite_active_or_terminal_state
+  _clear_authority_root_for_isolation
+  test_engine_identity_is_rebound_to_the_live_daemon
+  _clear_authority_root_for_isolation
+  test_lock_root_must_match_the_guard_lock_contract
+  _clear_authority_root_for_isolation
+  test_child_process_environment_and_docker_resolution_are_hermetic
+  _clear_authority_root_for_isolation
+  test_latched_signal_before_guard_cannot_be_ignored
+  _clear_authority_root_for_isolation
+  test_verifier_evidence_failure_stops_writer_before_storage
+  _clear_authority_root_for_isolation
+  test_process_logs_are_fsynced_before_evidence_binding
+  _clear_authority_root_for_isolation
+  test_complete_state_binds_guard_and_closure_evidence
+  _clear_authority_root_for_isolation
+  test_systemd_safety_properties_and_linger_are_queried
+  _clear_authority_root_for_isolation
+  test_signals_cannot_cross_spawn_or_complete_boundaries
+  _clear_authority_root_for_isolation
+  test_source_recovery_verifier_is_hermetic_and_target_bound
+  _clear_authority_root_for_isolation
+  test_complete_state_binds_immutable_guard_journal
+  _clear_authority_root_for_isolation
+  test_process_evidence_separates_controller_and_child_identity
+  _clear_authority_root_for_isolation
+  test_guard_arguments_are_semantically_bound_to_manifest
+  _clear_authority_root_for_isolation
+  test_compose_plugin_and_docker_config_identity_are_bound
+  _clear_authority_root_for_isolation
+  test_failed_prejournal_recovery_commits_durable_incident
+  _clear_authority_root_for_isolation
+  test_process_evidence_rejects_impossible_chronology
+  _clear_authority_root_for_isolation
+  test_source_snapshot_is_revalidated_before_publication
+  _clear_authority_root_for_isolation
+  test_guard_journal_path_is_canonically_bound
+  _clear_authority_root_for_isolation
+  test_fixed_path_toolchain_is_immutable_and_bound
+  _clear_authority_root_for_isolation
+  test_controller_state_cannot_collide_with_guard_journal
+  _clear_authority_root_for_isolation
+  test_ambient_test_overrides_cannot_falsify_production_evidence
+  _clear_authority_root_for_isolation
+  test_docker_rehearsal_proves_cleanup_before_success
+  _clear_authority_root_for_isolation
+  test_process_evidence_rejects_fractional_numbers
+  _clear_authority_root_for_isolation
+  test_real_systemd_fixture_exercises_signal_delivery
+  _clear_authority_root_for_isolation
+  test_production_execution_succeeds_without_ambient_fault_hooks
+  _clear_authority_root_for_isolation
+  test_production_execution_succeeds_without_ambient_signal_hooks
+
+  _clear_authority_root_for_isolation
+  test_derived_evidence_paths_cannot_collide_with_bound_inputs
+  _clear_authority_root_for_isolation
+  test_guard_signal_persists_child_evidence_before_return
+  _clear_authority_root_for_isolation
+  test_verifier_signal_persists_child_evidence_before_return
+  _clear_authority_root_for_isolation
+  test_terminal_state_requires_phase_specific_invariants
+  _clear_authority_root_for_isolation
+  test_preparation_resolves_docker_only_after_hermetic_sanitization
+  _clear_authority_root_for_isolation
+  test_controller_executable_is_bound_after_preparation
+  _clear_authority_root_for_isolation
+  test_guard_signal_waits_until_child_is_reaped
+  _clear_authority_root_for_isolation
+  test_closure_verifier_signal_waits_until_child_is_reaped
+  _clear_authority_root_for_isolation
+  test_source_verifier_signal_waits_until_child_is_reaped
+  _clear_authority_root_for_isolation
+  test_bootstrap_ignores_ambient_path
+  _clear_authority_root_for_isolation
+  test_docker_config_namespace_rejects_descendants
+  _clear_authority_root_for_isolation
+  test_complete_state_revalidates_durable_evidence
+  _clear_authority_root_for_isolation
+  test_recovery_preserves_prior_process_evidence
+  _clear_authority_root_for_isolation
+  test_closure_incident_remains_resumable_until_writer_is_stopped
+  _clear_authority_root_for_isolation
+  test_bootstrap_blocks_bash_env_and_exported_functions
+  _clear_authority_root_for_isolation
+  test_fixed_path_is_validated_before_installation
+  _clear_authority_root_for_isolation
+  test_signal_waits_for_guard_descendant_group
+  _clear_authority_root_for_isolation
+  test_concurrent_reprepare_cannot_replace_live_prepared_state
+  _clear_authority_root_for_isolation
+  test_guard_requires_deferred_writer_restart
+  _clear_authority_root_for_isolation
+  test_verified_guard_bytes_cannot_be_replaced_before_use
+  _clear_authority_root_for_isolation
+  test_concurrent_first_preparation_is_no_replace
+  _clear_authority_root_for_isolation
+  test_fixed_path_rejects_mutable_symlink_aliases
+  _clear_authority_root_for_isolation
+  test_verifier_evidence_failure_remains_resumable
+  _clear_authority_root_for_isolation
+  test_operation_lock_open_does_not_follow_symlinks
+  _clear_authority_root_for_isolation
+  test_execution_bundle_accepts_trusted_root_owned_executables
+  _clear_authority_root_for_isolation
+  test_bootstrap_utility_resolution_is_trusted_before_use
+  _clear_authority_root_for_isolation
+  test_systemd_context_requires_transient_unit_provenance
+  _clear_authority_root_for_isolation
+  test_writer_activation_lifecycle_is_ordered_and_evidence_bound
+  _clear_authority_root_for_isolation
+  test_authorization_evidence_is_durable_before_activation
+  _clear_authority_root_for_isolation
+  test_app_activation_failure_is_fail_closed_before_final_verification
+  _clear_authority_root_for_isolation
+  test_term_after_activation_stops_writer_before_return
+  _clear_authority_root_for_isolation
+  test_closure_evidence_pending_resume_never_reactivates_writer
+  _clear_authority_root_for_isolation
+  test_missing_live_compose_commits_prejournal_restoration_incident
+  _clear_authority_root_for_isolation
+  test_post_activation_artifact_setup_failure_stops_writer_durably
+  _clear_authority_root_for_isolation
+  test_closure_evidence_pending_requires_verified_stop_before_persistence
+  _clear_authority_root_for_isolation
+  test_same_name_volume_replacement_is_rejected_after_preparation
+  _clear_authority_root_for_isolation
+  test_live_identity_checks_wait_for_the_shared_operation_lock
+  _clear_authority_root_for_isolation
+  test_successful_verifier_postprocessing_failure_stops_writer
+  _clear_authority_root_for_isolation
+  test_post_activation_signal_with_zero_exit_verifier_stops_writer
+  _clear_authority_root_for_isolation
+  test_source_recovery_signal_persists_process_evidence
+  _clear_authority_root_for_isolation
+  test_prejournal_recovery_refuses_unexpected_live_compose
+  _clear_authority_root_for_isolation
+  test_complete_write_cannot_race_final_guard_journal_validation
+  _clear_authority_root_for_isolation
+  test_engine_volume_identity_has_one_authoritative_state_path
+  _clear_authority_root_for_isolation
+  test_production_rejects_ambient_test_hook_contamination
+  _clear_authority_root_for_isolation
+  test_state_authority_survives_runtime_loss_and_is_revalidated_at_execute
+  _clear_authority_root_for_isolation
+  test_post_authorization_pre_activation_failures_commit_fresh_stop_evidence
+  _clear_authority_root_for_isolation
+  test_verifier_artifact_selector_collision_routes_through_closure_artifact_storage
+  _clear_authority_root_for_isolation
+  test_source_recovery_artifacts_cannot_collide_with_bound_inputs
+  _clear_authority_root_for_isolation
+  test_source_recovery_retry_preserves_prior_unbound_evidence
+  _clear_authority_root_for_isolation
+  test_phase_owned_invariants_reject_unproved_states
+  _clear_authority_root_for_isolation
+  test_disposable_rehearsals_clean_and_assert_state_authority
+  _clear_authority_root_for_isolation
+  test_transient_systemd_fixture_independently_proves_identity_and_cursors
+  _clear_authority_root_for_isolation
+  test_writer_stop_evidence_is_retry_distinct
+  _clear_authority_root_for_isolation
+  test_invocation_suffixed_artifacts_cannot_collide_with_bound_inputs
+  _clear_authority_root_for_isolation
+  test_xdg_state_home_cross_root_execute_rejected
+
+  _clear_authority_root_for_isolation
+  test_bound_transition_inputs_are_pairwise_distinct
+  _clear_authority_root_for_isolation
+  test_invalid_complete_state_cannot_relinquish_durable_authority
+  _clear_authority_root_for_isolation
+  test_durable_authority_reclaims_complete_or_missing_state
+  _clear_authority_root_for_isolation
+  test_corrupt_phase_durable_state_rejected
+  _clear_authority_root_for_isolation
+  test_cli_rejects_duplicate_or_mixed_modes
+
+  _clear_authority_root_for_isolation
+  test_execution_environment_removes_all_ambient_docker_compose_behavior
+  _clear_authority_root_for_isolation
+  test_durable_authority_rejects_runtime_backed_state_home
+  _clear_authority_root_for_isolation
+  test_bound_inputs_and_publication_reject_unsafe_write_modes
+  _clear_authority_root_for_isolation
+  test_incident_classes_and_stop_proofs_are_closed_world
+  _clear_authority_root_for_isolation
+  test_real_docker_rehearsal_declares_interruption_resume_coverage
   echo 'PostgreSQL transition controller focused fixtures passed.'
 fi

--- a/scripts/test-pgvector-transition-controller.sh
+++ b/scripts/test-pgvector-transition-controller.sh
@@ -3057,12 +3057,38 @@ test_authorization_evidence_is_durable_before_activation() (
     "$authorization_evidence" >/dev/null
 
   # The classified incident is terminal for this transition identity: a fresh
-  # execution must refuse instead of activating the writer.
+  # execution must refuse instead of activating the writer — and the refusal
+  # must come from terminal-incident handling, not from some unrelated fault
+  # (e.g. a regression in authorization that just happens to fail).
   NOOSPHERE_CONTROLLER_FIXTURE_INVOCATION_ID=fedcba9876543210fedcba9876543210 \
-    run_fixture_controller "$state" "$shim" env >/dev/null 2>&1 && {
+    run_fixture_controller "$state" "$shim" env \
+      >/dev/null 2>"$fixture_dir/refresh.err" && {
       echo 'classified closure interruption was resumable as a fresh execution' >&2
       exit 1
     }
+  # The diagnostic is intentionally shared with the closure-stop-pending resume
+  # path (controller L332) so any controller branch that requires operator
+  # resolution for a classified closure-interruption emits the same string.
+  # Combined with the .incidentClass jq assertion below, this confirms the
+  # refusal came from terminal-incident handling for the right class.
+  grep -q "controller incident requires operator resolution: closure-interruption" \
+    "$fixture_dir/refresh.err" || {
+      echo 'fresh execution refused for a reason other than terminal-incident classification' >&2
+      sed 's/^/  refresh.err: /' "$fixture_dir/refresh.err" >&2
+      exit 1
+    }
+  jq -e '.phase == "incident" and .incidentClass == "closure-interruption"' \
+    "$state" >/dev/null || {
+      echo 'fresh execution mutated the terminal incident classification' >&2
+      exit 1
+    }
+  jq -e '.writerStopEvidence
+         | (.path | type == "string" and startswith("/"))
+           and (.sha256 | type == "string" and test("^[a-f0-9]{64}$"))' \
+    "$state" >/dev/null || {
+      echo 'fresh execution corrupted the durable writer-stop evidence' >&2
+      exit 1
+  }
   [[ $(paste -sd, "$fixture_dir/lifecycle.log") == transition,authorize ]] || {
     echo 'writer activated despite the classified closure interruption' >&2
     exit 1
@@ -4102,6 +4128,78 @@ test_post_authorization_pre_activation_failures_commit_fresh_stop_evidence() (
   }
 )
 
+# RED owner: the controller's select_process_artifact_base for the verify
+# role must surface per-invocation collisions through the caller's
+# if-! wrapper so the verifier-allocation path routes through
+# begin_closure_incident artifact-storage. Today the function uses die()
+# which exits the whole controller and bypasses the wrapper, leaving the
+# phase at activation-running with no stop/incident so a later execution
+# can reactivate. The fix is to convert die to return 1 so the caller can
+# route the failure through begin_closure_incident artifact-storage.
+test_verifier_artifact_selector_collision_routes_through_closure_artifact_storage() (
+  local fixture_dir='' manifest state shim rc invocation control_tail lifecycle
+  local phase incident_class
+  local -a failures=()
+  trap '[[ -z ${fixture_dir:-} ]] || rm -rf "$fixture_dir"' EXIT
+
+  fixture_dir=$(mktemp -d)
+  manifest="$fixture_dir/manifest.json"
+  state="$fixture_dir/controller.json"
+  write_execution_fixture "$fixture_dir" "$manifest"
+  export XDG_RUNTIME_DIR="$fixture_dir/locks"
+  shim=$(write_systemd_identity_shim "$fixture_dir")
+  invocation=${NOOSPHERE_CONTROLLER_FIXTURE_INVOCATION_ID:-0123456789abcdef0123456789abcdef}
+
+  "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
+
+  # The selector uses ${state%.json} as the artifact base, so pre-create
+  # canonical and suffixed verifier artifacts at the *stripped* path.
+  local state_base=${state%.json}
+  printf 'existing\n' > "$state_base.verify.stdout.log"
+  printf 'existing\n' > "$state_base.verify.stderr.log"
+  printf '{"existing":true}\n' > "$state_base.verify.evidence.json"
+  # Pre-create suffixed verifier artifacts for the test INVOCATION_ID so
+  # the selector dies with 'process evidence path for this systemd
+  # invocation already exists'.
+  printf 'existing\n' > "$state_base.$invocation.verify.stdout.log"
+  printf 'existing\n' > "$state_base.$invocation.verify.stderr.log"
+  printf '{"existing":true}\n' > "$state_base.$invocation.verify.evidence.json"
+
+  rc=0
+  run_fixture_controller "$state" "$shim" env \
+    >"$fixture_dir/controller.out" 2>"$fixture_dir/controller.err" || rc=$?
+  ((rc != 0)) ||
+    failures+=('verifier selector collision unexpectedly reported success')
+
+  phase=$(jq -er '.phase // empty' "$state" 2>/dev/null || true)
+  incident_class=$(jq -er '.incidentClass // empty' "$state" 2>/dev/null || true)
+  if [[ "$phase" != incident ]]; then
+    failures+=("verifier selector collision left phase=$phase (expected incident)")
+  fi
+  if [[ "$incident_class" != closure-artifact-storage ]]; then
+    failures+=("verifier selector collision produced incidentClass=$incident_class (expected closure-artifact-storage)")
+  fi
+
+  # The writer was authorized before the selector ran; the controller must
+  # ALSO have stopped and inspect-verified it before publishing the
+  # terminal incident. A die() that bypasses the wrapper would leave the
+  # writer running and no stop evidence.
+  if [[ -f "$fixture_dir/app-control.log" ]]; then
+    control_tail=$(tail -n 2 "$fixture_dir/app-control.log" | paste -sd, -)
+  else
+    control_tail=''
+  fi
+  [[ "$control_tail" == stop,inspect:false ]] ||
+    failures+=("verifier selector collision lacked a fresh inspect-verified stop (control_tail=$control_tail)")
+  [[ ! -e "$fixture_dir/incident-persisted-before-stop" ]] ||
+    failures+=('verifier selector collision published terminal incident before stopping the writer')
+
+  ((${#failures[@]} == 0)) || {
+    printf '%s\n' "${failures[@]}" >&2
+    exit 1
+  }
+)
+
 # RED owner: the controller's assert_controller_artifact_paths_separate must
 # include source-recovery artifact paths (stdout.log, stderr.log, evidence.json)
 # in its controlled-path array so that a derived source-recovery path that
@@ -4637,6 +4735,51 @@ PROBE
   }
 )
 
+test_xdg_state_home_cross_root_execute_rejected() (
+  local fixture_dir='' manifest state shim rc auth_a auth_b
+  local -a failures=()
+  trap '[[ -z ${fixture_dir:-} ]] || rm -rf "$fixture_dir" "$auth_a" "$auth_b"' EXIT
+
+  auth_a=$(mktemp -d)
+  auth_b=$(mktemp -d)
+  chmod 700 "$auth_a" "$auth_b"
+  fixture_dir=$(mktemp -d)
+  manifest="$fixture_dir/manifest.json"
+  state="$fixture_dir/controller.json"
+  write_execution_fixture "$fixture_dir" "$manifest"
+  export XDG_RUNTIME_DIR="$fixture_dir/locks"
+  shim=$(write_systemd_identity_shim "$fixture_dir")
+
+  # Prepare under XDG_STATE_HOME=A: durable authority record must live under A.
+  XDG_STATE_HOME="$auth_a" "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
+  if [[ ! -d "$auth_a/noosphere-pgvector-controller/authority" ]]; then
+    failures+=('prepare under XDG_STATE_HOME=A did not create a durable authority root')
+  fi
+
+  # Execute under XDG_STATE_HOME=B: cross-root reclaim must die with an
+  # authority-root diagnostic and must not create a record under B.
+  rc=0
+  XDG_STATE_HOME="$auth_b" run_fixture_controller "$state" "$shim" env \
+    >"$fixture_dir/controller.out" 2>"$fixture_dir/controller.err" || rc=$?
+  if ((rc == 0)); then
+    failures+=('execute under a different XDG_STATE_HOME succeeded; expected authority-root rejection')
+  else
+    rg -qi 'authoritative.*state|state.*authorit|durable.*authority.*root|engine.*volume.*state.*(claim|own)|authority root' \
+      "$fixture_dir/controller.err" ||
+      failures+=('cross-root execute rejection lacked an authority-root diagnostic')
+  fi
+
+  # Controller must die before writing the record under the new root.
+  if [[ -d "$auth_b/noosphere-pgvector-controller/authority" ]]; then
+    failures+=('cross-root execute created a durable authority record under the wrong root')
+  fi
+
+  ((${#failures[@]} == 0)) || {
+    printf '%s\n' "${failures[@]}" >&2
+    exit 1
+  }
+)
+
 if [[ ${BASH_SOURCE[0]} == "$0" ]]; then
   test_atomic_controller_state
   test_source_restore_without_guard_journal
@@ -4687,6 +4830,50 @@ if [[ ${BASH_SOURCE[0]} == "$0" ]]; then
   test_real_systemd_fixture_exercises_signal_delivery
   test_production_execution_succeeds_without_ambient_fault_hooks
   test_production_execution_succeeds_without_ambient_signal_hooks
+test_corrupt_phase_durable_state_rejected() (
+  local fixture_dir='' manifest state_a state_b rc auth
+  local engine_id=fixture-engine volume=fixture-volume
+  local -a failures=()
+  trap '[[ -z ${fixture_dir:-} ]] || rm -rf "$fixture_dir" "$auth"' EXIT
+
+  auth=$(mktemp -d)
+  chmod 700 "$auth"
+  fixture_dir=$(mktemp -d)
+  manifest="$fixture_dir/manifest.json"
+  state_a="$fixture_dir/controller.json"
+  state_b="$fixture_dir/controller-alt.json"
+  write_execution_fixture "$fixture_dir" "$manifest"
+  export XDG_RUNTIME_DIR="$fixture_dir/locks"
+
+  # Prepare once at state_a to seed the durable authority record.
+  XDG_STATE_HOME="$auth" "$CONTROLLER" --prepare --manifest "$manifest" --state "$state_a"
+
+  # Corrupt the state file's phase to a value outside the enum.
+  jq '.phase = "garbage"' "$state_a" > "$state_a.next"
+  install -m 600 "$state_a.next" "$state_a"
+
+  # Run --prepare at a DIFFERENT state path so claim_authoritative_state_path
+  # reads the durable record, sees recorded_path=state_a != current=state_b,
+  # and reaches the case statement at the active-phase enum. The current
+  # case statement only matches the 10 enum values, so .phase=garbage falls
+  # through to a reclaim that silently overwrites the durable record.
+  rc=0
+  XDG_STATE_HOME="$auth" "$CONTROLLER" --prepare --manifest "$manifest" --state "$state_b" \
+    >"$fixture_dir/alt.out" 2>"$fixture_dir/alt.err" || rc=$?
+  if ((rc == 0)); then
+    failures+=('controller reclaimed a durable state with .phase=garbage; expected unrecognized-phase rejection')
+  else
+    rg -qi 'phase|unrecognized|authoritative.*state|durable.*authority' \
+      "$fixture_dir/alt.err" ||
+      failures+=('corrupt-phase rejection lacked a phase or authority diagnostic')
+  fi
+
+  ((${#failures[@]} == 0)) || {
+    printf '%s\n' "${failures[@]}" >&2
+    exit 1
+  }
+)
+
   test_derived_evidence_paths_cannot_collide_with_bound_inputs
   test_guard_signal_persists_child_evidence_before_return
   test_verifier_signal_persists_child_evidence_before_return
@@ -4733,6 +4920,7 @@ if [[ ${BASH_SOURCE[0]} == "$0" ]]; then
   test_production_rejects_ambient_test_hook_contamination
   test_state_authority_survives_runtime_loss_and_is_revalidated_at_execute
   test_post_authorization_pre_activation_failures_commit_fresh_stop_evidence
+  test_verifier_artifact_selector_collision_routes_through_closure_artifact_storage
   test_source_recovery_artifacts_cannot_collide_with_bound_inputs
   test_source_recovery_retry_preserves_prior_unbound_evidence
   test_phase_owned_invariants_reject_unproved_states
@@ -4740,6 +4928,8 @@ if [[ ${BASH_SOURCE[0]} == "$0" ]]; then
   test_transient_systemd_fixture_independently_proves_identity_and_cursors
   test_writer_stop_evidence_is_retry_distinct
   test_invocation_suffixed_artifacts_cannot_collide_with_bound_inputs
+  test_xdg_state_home_cross_root_execute_rejected
+  test_corrupt_phase_durable_state_rejected
 
   echo 'PostgreSQL transition controller focused fixtures passed.'
 fi

--- a/scripts/test-pgvector-transition-controller.sh
+++ b/scripts/test-pgvector-transition-controller.sh
@@ -5207,9 +5207,11 @@ test_bound_inputs_and_publication_reject_unsafe_write_modes() (
 )
 
 test_incident_classes_and_stop_proofs_are_closed_world() (
-  local fixture_dir manifest state mutated shim rc=0
+  local fixture_dir='' manifest state mutated shim rc=0 proof_phase verifier_mode
+  local -a run_env=()
+  local -a failures=()
   fixture_dir=$(mktemp -d)
-  trap 'rm -rf -- "$fixture_dir"' EXIT
+  trap '[[ -z ${fixture_dir:-} ]] || rm -rf -- "$fixture_dir"' EXIT
   manifest="$fixture_dir/manifest.json"
   state="$fixture_dir/controller.json"
   mutated="$fixture_dir/unclassified-incident.json"
@@ -5234,6 +5236,62 @@ test_incident_classes_and_stop_proofs_are_closed_world() (
   fi
   rg -qi 'incident.*class|writer.*stop.*evidence' "$fixture_dir/validate.err" || {
     echo "unclassified incident rejection lacked a class/stop-proof diagnostic: $(tr '\n' ' ' < "$fixture_dir/validate.err")" >&2
+    exit 1
+  }
+
+  rm -rf -- "$fixture_dir"
+  fixture_dir=''
+  for proof_phase in closure-stop-pending closure-evidence-pending; do
+    _clear_authority_root_for_isolation
+    fixture_dir=$(mktemp -d)
+    manifest="$fixture_dir/manifest.json"
+    state="$fixture_dir/controller.json"
+    mutated="$fixture_dir/unclassified-$proof_phase.json"
+    verifier_mode=fail
+    run_env=()
+    if [[ "$proof_phase" == closure-evidence-pending ]]; then
+      run_env=(NOOSPHERE_CONTROLLER_TEST_FAIL_EVIDENCE=closure-running)
+    fi
+    write_execution_fixture "$fixture_dir" "$manifest" complete "$verifier_mode"
+    export XDG_RUNTIME_DIR="$fixture_dir/locks"
+    shim=$(write_phase_snapshot_shim "$fixture_dir")
+    "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
+
+    rc=0
+    run_fixture_controller "$state" "$shim" env \
+      "${run_env[@]}" \
+      "NOOSPHERE_CONTROLLER_TEST_CAPTURE_PHASE=$proof_phase" \
+      >"$fixture_dir/controller.out" 2>"$fixture_dir/controller.err" || rc=$?
+    if [[ "$rc" != 86 || ! -e "$fixture_dir/controller-phase-snapshot-captured" ]]; then
+      failures+=("controller did not produce the $proof_phase baseline")
+      rm -rf -- "$fixture_dir"
+      fixture_dir=''
+      continue
+    fi
+    if ! /bin/bash -c 'source "$1"; validate_controller_state "$2"' \
+      _ "$CONTROLLER" "$state" >"$fixture_dir/baseline.out" 2>"$fixture_dir/baseline.err"; then
+      failures+=("controller rejected its own valid $proof_phase baseline")
+      rm -rf -- "$fixture_dir"
+      fixture_dir=''
+      continue
+    fi
+
+    jq '.incidentClass = "unclassified-post-authorization"' "$state" > "$mutated"
+    chmod 0600 "$mutated"
+    if /bin/bash -c 'source "$1"; validate_controller_state "$2"' \
+      _ "$CONTROLLER" "$mutated" >"$fixture_dir/validate.out" 2>"$fixture_dir/validate.err"; then
+      failures+=("controller accepted an unsupported incident class in phase $proof_phase")
+    elif ! rg -q 'incident class is unsupported or unrecognized: unclassified-post-authorization' \
+      "$fixture_dir/validate.err"; then
+      failures+=("unsupported incident class in phase $proof_phase lacked the class diagnostic")
+    fi
+
+    rm -rf -- "$fixture_dir"
+    fixture_dir=''
+  done
+
+  ((${#failures[@]} == 0)) || {
+    printf '%s\n' "${failures[@]}" >&2
     exit 1
   }
 )

--- a/scripts/test-pgvector-transition-controller.sh
+++ b/scripts/test-pgvector-transition-controller.sh
@@ -11,6 +11,13 @@ DOCKER_FIXTURE="$ROOT_DIR/scripts/test-pgvector-transition-controller-docker.sh"
   exit 1
 }
 
+# Isolate durable state-authority records from the invoking user's real XDG
+# state namespace: the controller honors XDG_STATE_HOME, so every fixture in
+# this suite claims and reclaims authority inside this disposable root.
+XDG_STATE_HOME=$(mktemp -d)
+export XDG_STATE_HOME
+trap 'rm -rf -- "$XDG_STATE_HOME"' EXIT
+
 extract_function() {
   local name=$1 definition
   definition=$(
@@ -183,6 +190,7 @@ write_fixture_controller_state() {
       engineId: "fixture-engine",
       dockerEndpoint: "unix:///fixture/docker.sock",
       volume: "fixture-volume",
+      appContainer: "fixture-app",
       liveCompose: $liveCompose,
       sourceSnapshot: $sourceSnapshot,
       sourceSnapshotSha256: $sourceSnapshotSha256,
@@ -207,7 +215,7 @@ test_reboot_recovers_prejournal_candidate_publication() (
   write_fixture_controller_state "$state" candidate-published "$live" "$source" "$source_sha" "$guard_journal"
 
   for helper in path_present assert_owned_regular_file sha256_file \
-    write_controller_state_atomic validate_controller_state update_controller_phase \
+    write_controller_state_atomic validate_controller_state validate_evidence_binding update_controller_phase \
     restore_source_without_guard_journal restore_source_compose_snapshot resume_controller_state; do
     eval "$(extract_function "$helper")"
   done
@@ -248,7 +256,7 @@ test_valid_guard_journal_suppresses_outer_restore() (
   write_fixture_controller_state "$state" candidate-published "$live" "$source" "$source_sha" "$guard_journal"
 
   for helper in path_present assert_owned_regular_file sha256_file \
-    write_controller_state_atomic validate_controller_state update_controller_phase \
+    write_controller_state_atomic validate_controller_state validate_evidence_binding update_controller_phase \
     restore_source_without_guard_journal restore_source_compose_snapshot resume_controller_state; do
     eval "$(extract_function "$helper")"
   done
@@ -330,7 +338,7 @@ test_candidate_publication_intent_is_recoverable() (
   chmod 0600 "$state"
 
   for helper in path_present assert_owned_regular_file sha256_file \
-    write_controller_state_atomic validate_controller_state update_controller_phase \
+    write_controller_state_atomic validate_controller_state validate_evidence_binding update_controller_phase \
     ensure_regular_lock_file acquire_operation_lock assert_operation_lock_held publish_compose_atomic \
     publish_candidate_under_lock; do
     eval "$(extract_function "$helper")"
@@ -417,14 +425,42 @@ test_closure_outcome_never_false_completes() (
   chmod 0600 "$stdout_file" "$stderr_file"
   source_sha=$(sha256sum "$source" | awk '{print $1}')
   write_fixture_controller_state "$state" closure-running "$live" "$source" "$source_sha" "$guard_journal"
-  jq '.authorizationEvidence = {
-    path: "/fixture/authorization-evidence.json",
-    sha256: ("a" * 64)
-  }' "$state" > "$state.next"
+  # A real closure-running state carries the proofs of every phase its
+  # mechanism has passed: the guard ran (guardEvidence), authorization
+  # succeeded (authorizationEvidence), and the writer was stopped with a
+  # verified stop before closure could be retried (writerStopEvidence).
+  # Real evidence bytes: every bound proof must exist on disk as an owned
+  # 0600 evidence object whose digest matches the binding, mirroring what the
+  # controller itself persists for guard, authorization, and writer stop.
+  make_fixture_evidence() {
+    local target=$1 phase=$2 container=${3:-}
+    if [[ -n "$container" ]]; then
+      jq -n --arg phase "$phase" --arg container "$container" \
+        '{version:1,phase:$phase,container:$container,stopExitCode:0,
+          inspectRunning:false}' > "$target"
+    else
+      jq -n --arg phase "$phase" '{version:1,phase:$phase}' > "$target"
+    fi
+    chmod 0600 "$target"
+  }
+  make_fixture_evidence "$fixture_dir/authorization-evidence.json" authorization-running
+  make_fixture_evidence "$fixture_dir/guard-evidence.json" guard-exited
+  make_fixture_evidence "$fixture_dir/writer-stop-evidence.json" closure-stop-pending \
+    "$(jq -er '.appContainer // "fixture-app"' "$state")"
+  jq --arg apath "$fixture_dir/authorization-evidence.json" \
+     --arg asha "$(sha256sum "$fixture_dir/authorization-evidence.json" | awk '{print $1}')" \
+     --arg gpath "$fixture_dir/guard-evidence.json" \
+     --arg gsha "$(sha256sum "$fixture_dir/guard-evidence.json" | awk '{print $1}')" \
+     --arg wpath "$fixture_dir/writer-stop-evidence.json" \
+     --arg wsha "$(sha256sum "$fixture_dir/writer-stop-evidence.json" | awk '{print $1}')" \
+    '.authorizationEvidence = {path:$apath,sha256:$asha} |
+     .guardEvidence = {path:$gpath,sha256:$gsha} |
+     .writerStopEvidence = {path:$wpath,sha256:$wsha}' \
+    "$state" > "$state.next"
   install -m 600 "$state.next" "$state"
 
   for helper in path_present assert_owned_regular_file sha256_file \
-    write_controller_state_atomic validate_controller_state update_controller_phase \
+    write_controller_state_atomic validate_controller_state validate_evidence_binding update_controller_phase \
     write_process_evidence_atomic validate_process_evidence classify_closure_failure \
     bind_process_evidence_to_state begin_closure_incident begin_closure_evidence_pending \
     complete_closure_evidence_pending complete_closure_stop_pending \
@@ -1288,7 +1324,7 @@ test_terminal_states_never_delegate_to_a_stale_guard_journal() (
   source_sha=$(sha256sum "$source" | awk '{print $1}')
 
   for helper in path_present assert_owned_regular_file sha256_file \
-    write_controller_state_atomic validate_controller_state update_controller_phase \
+    write_controller_state_atomic validate_controller_state validate_evidence_binding update_controller_phase \
     restore_source_without_guard_journal restore_source_compose_snapshot resume_controller_state; do
     eval "$(extract_function "$helper")"
   done
@@ -2266,7 +2302,7 @@ test_terminal_state_requires_phase_specific_invariants() (
   state="$fixture_dir/controller.json"
   write_execution_fixture "$fixture_dir" "$manifest"
 
-  for helper in assert_owned_regular_file validate_controller_state; do
+  for helper in assert_owned_regular_file sha256_file validate_controller_state validate_evidence_binding; do
     eval "$(extract_function "$helper")"
   done
   die() { printf 'fixture: %s\n' "$*" >&2; exit 1; }
@@ -3004,7 +3040,15 @@ test_authorization_evidence_is_durable_before_activation() (
     echo 'authorization boundary did not return the latched signal exit' >&2
     exit 1
   }
-  [[ $(jq -er '.phase' "$state") == activation-running && ! -e "$fixture_dir/app-started" ]] || {
+  # A latched signal at the pre-activation boundary fails closed: the authorized
+  # writer is freshly stopped and the state carries a classified closure
+  # interruption incident instead of a silently resumable activation phase.
+  jq -e '.phase == "incident" and .incidentClass == "closure-interruption"' \
+    "$state" >/dev/null || {
+    echo 'pre-activation signal did not commit a classified closure interruption' >&2
+    exit 1
+  }
+  [[ ! -e "$fixture_dir/app-started" ]] || {
     echo 'writer activation began before authorization evidence was durable' >&2
     exit 1
   }
@@ -3012,11 +3056,17 @@ test_authorization_evidence_is_durable_before_activation() (
   jq -e '.phase == "authorization-running" and .exitCode == 0' \
     "$authorization_evidence" >/dev/null
 
+  # The classified incident is terminal for this transition identity: a fresh
+  # execution must refuse instead of activating the writer.
   NOOSPHERE_CONTROLLER_FIXTURE_INVOCATION_ID=fedcba9876543210fedcba9876543210 \
-    run_fixture_controller "$state" "$shim" env >/dev/null 2>&1 || resume_rc=$?
-  ((resume_rc == 0))
-  [[ $(jq -er '.phase' "$state") == complete ]]
-  [[ $(paste -sd, "$fixture_dir/lifecycle.log") == transition,authorize,activate,verify ]]
+    run_fixture_controller "$state" "$shim" env >/dev/null 2>&1 && {
+      echo 'classified closure interruption was resumable as a fresh execution' >&2
+      exit 1
+    }
+  [[ $(paste -sd, "$fixture_dir/lifecycle.log") == transition,authorize ]] || {
+    echo 'writer activated despite the classified closure interruption' >&2
+    exit 1
+  }
 )
 
 test_app_activation_failure_is_fail_closed_before_final_verification() (
@@ -3126,7 +3176,7 @@ test_missing_live_compose_commits_prejournal_restoration_incident() (
   write_fixture_controller_state "$state" candidate-published "$live" "$source" "$source_sha" "$guard_journal"
 
   for helper in path_present assert_owned_regular_file sha256_file \
-    write_controller_state_atomic validate_controller_state update_controller_phase \
+    write_controller_state_atomic validate_controller_state validate_evidence_binding update_controller_phase \
     restore_source_compose_snapshot resume_controller_state; do
     eval "$(extract_function "$helper")"
   done
@@ -4237,10 +4287,15 @@ test_source_recovery_retry_preserves_prior_unbound_evidence() (
   stderr_inode=$(stat -c '%i' "$prior_stderr")
   expected_stdout_sha=$(sha256sum /dev/null | awk '{print $1}')
   expected_stderr_sha=$(printf 'source verification failed\n' | sha256sum | awk '{print $1}')
-  jq -e --arg stdoutSha "$expected_stdout_sha" --arg stderrSha "$expected_stderr_sha" '
+  # Boot provenance is the REAL host boot id: ambient NOOSPHERE_CONTROLLER_BOOT_ID
+  # is untrusted noise (see test_ambient_test_overrides_cannot_falsify_production_evidence
+  # and test_source_recovery_signal_persists_process_evidence), so the evidence
+  # must carry the kernel boot id, never the ambient override.
+  jq -e --arg boot "$(</proc/sys/kernel/random/boot_id)" \
+    --arg stdoutSha "$expected_stdout_sha" --arg stderrSha "$expected_stderr_sha" '
     .phase == "source-recovery-running" and .exitCode == 42 and
     .invocationId == "0123456789abcdef0123456789abcdef" and
-    .bootId == "fixture-boot" and
+    .bootId == $boot and
     (.controllerMainPid | type == "number" and . > 0) and
     (.childPid | type == "number" and . > 0) and
     .controllerMainPid != .childPid and
@@ -4288,10 +4343,11 @@ test_source_recovery_retry_preserves_prior_unbound_evidence() (
     .phase == "incident" and .incidentClass == "pre-journal-source-verification" and
     .sourceRecoveryEvidence.sha256 == $evidenceSha
   ' "$state" >/dev/null &&
-  jq -e --arg stdoutSha "$expected_stdout_sha" --arg stderrSha "$expected_stderr_sha" '
+  jq -e --arg boot "$(</proc/sys/kernel/random/boot_id)" \
+    --arg stdoutSha "$expected_stdout_sha" --arg stderrSha "$expected_stderr_sha" '
     .phase == "source-recovery-running" and .exitCode == 42 and
     .invocationId == "fedcba9876543210fedcba9876543210" and
-    .bootId == "fixture-boot" and
+    .bootId == $boot and
     (.controllerMainPid | type == "number" and . > 0) and
     (.childPid | type == "number" and . > 0) and
     .controllerMainPid != .childPid and
@@ -4472,6 +4528,115 @@ test_transient_systemd_fixture_independently_proves_identity_and_cursors() (
   timeout 180s "$SYSTEMD_FIXTURE"
 )
 
+test_writer_stop_evidence_is_retry_distinct() (
+  # Re-review round 2, finding 1: the writer-stop proof must reuse the
+  # retry-distinct allocation scheme so a crash between evidence publication
+  # and phase advance can never overwrite the prior truthful stop record.
+  # Probes run in child bash so the controller's real die() exits only the
+  # probe, keeping the test's own assertions in control.
+  local fixture_dir base first second rc=0
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf "$fixture_dir"' EXIT
+  base="$fixture_dir/controller"
+  {
+    extract_function path_present
+    extract_function select_process_artifact_base
+    extract_function die
+  } > "$fixture_dir/functions.sh"
+  cat > "$fixture_dir/probe.sh" <<'PROBE'
+source "$1"
+select_process_artifact_base "$2" writer-stop
+PROBE
+
+  # First stop owns the canonical path when no prior artifacts exist.
+  first=$(bash "$fixture_dir/probe.sh" "$fixture_dir/functions.sh" "$base")
+  [[ "$first" == "$base" ]] || {
+    echo "first writer-stop allocation was not canonical: $first" >&2
+    exit 1
+  }
+
+  # After the canonical evidence exists, a later invocation with a distinct
+  # InvocationID must allocate a distinct base instead of reusing canonical.
+  printf '{"version":1,"stopExitCode":0}\n' > "$base.writer-stop.evidence.json"
+  second=$(INVOCATION_ID=0123456789abcdef0123456789abcdef \
+    bash "$fixture_dir/probe.sh" "$fixture_dir/functions.sh" "$base")
+  [[ "$second" == "$base.0123456789abcdef0123456789abcdef" ]] || {
+    echo "retry writer-stop allocation was not InvocationID-distinct: $second" >&2
+    exit 1
+  }
+  [[ "$(cat "$base.writer-stop.evidence.json")" == '{"version":1,"stopExitCode":0}' ]] || {
+    echo "prior canonical writer-stop evidence did not survive the retry allocation" >&2
+    exit 1
+  }
+
+  # An unsafe InvocationID must be rejected, never used inside a path.
+  INVOCATION_ID=../escape \
+    bash "$fixture_dir/probe.sh" "$fixture_dir/functions.sh" "$base" \
+    >/dev/null 2>"$fixture_dir/unsafe.err" || rc=$?
+  ((rc != 0)) || { echo "unsafe InvocationID was accepted" >&2; exit 1; }
+  rg -q 'unsafe for evidence paths' "$fixture_dir/unsafe.err" || {
+    echo "unsafe InvocationID lacked its diagnostic" >&2
+    exit 1
+  }
+)
+
+test_invocation_suffixed_artifacts_cannot_collide_with_bound_inputs() (
+  # Re-review round 2, findings 1-2: the collision matrix must also cover the
+  # InvocationID-suffixed artifact paths a retrying invocation will use.
+  local fixture_dir manifest state rc=0
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf "$fixture_dir"' EXIT
+  manifest="$fixture_dir/manifest.json"
+  state="$fixture_dir/controller.json"
+  write_execution_fixture "$fixture_dir" "$manifest"
+
+  # Point the bound live Compose input at the invocation-suffixed writer-stop
+  # evidence path so the separation check must reject it at execute time.
+  local original_path suffixed
+  original_path=$(jq -er '.liveCompose' "$manifest")
+  suffixed="${state%.json}.0123456789abcdef0123456789abcdef.writer-stop.evidence.json"
+  cp "$original_path" "$suffixed"
+  jq --arg p "$suffixed" --arg old "$original_path" \
+    '.liveCompose = $p |
+     .guardArgs = [.guardArgs[] | if . == $old then $p else . end]' \
+    "$manifest" > "$manifest.tmp" && mv "$manifest.tmp" "$manifest"
+  chmod 0600 "$manifest"
+
+  {
+    extract_function die
+    extract_function assert_controller_artifact_paths_separate
+  } > "$fixture_dir/functions.sh"
+  cat > "$fixture_dir/probe.sh" <<'PROBE'
+source "$1"
+assert_controller_artifact_paths_separate "$2" "$3" "$2"
+PROBE
+  INVOCATION_ID=0123456789abcdef0123456789abcdef \
+    bash "$fixture_dir/probe.sh" "$fixture_dir/functions.sh" "$manifest" "$state" \
+    >"$fixture_dir/check.out" 2>"$fixture_dir/check.err" || rc=$?
+  ((rc != 0)) || {
+    echo "invocation-suffixed writer-stop path was accepted as bound live-compose input" >&2
+    exit 1
+  }
+  rg -qi 'collid' "$fixture_dir/check.err" || {
+    echo "invocation-suffixed collision lacked a specific diagnostic" >&2
+    exit 1
+  }
+
+  # Control: the same state passes when the bound input is moved off every
+  # controlled path, proving the rejection came from the suffix entry.
+  jq --arg p "$original_path" --arg old "$suffixed" \
+    '.liveCompose = $p |
+     .guardArgs = [.guardArgs[] | if . == $old then $p else . end]' \
+    "$manifest" > "$manifest.tmp" && mv "$manifest.tmp" "$manifest"
+  chmod 0600 "$manifest"
+  INVOCATION_ID=0123456789abcdef0123456789abcdef \
+    bash "$fixture_dir/probe.sh" "$fixture_dir/functions.sh" "$manifest" "$state" \
+    >"$fixture_dir/control.out" 2>"$fixture_dir/control.err" || {
+    echo "control run with no collision was rejected: $(cat "$fixture_dir/control.err")" >&2
+    exit 1
+  }
+)
+
 if [[ ${BASH_SOURCE[0]} == "$0" ]]; then
   test_atomic_controller_state
   test_source_restore_without_guard_journal
@@ -4573,6 +4738,8 @@ if [[ ${BASH_SOURCE[0]} == "$0" ]]; then
   test_phase_owned_invariants_reject_unproved_states
   test_disposable_rehearsals_clean_and_assert_state_authority
   test_transient_systemd_fixture_independently_proves_identity_and_cursors
+  test_writer_stop_evidence_is_retry_distinct
+  test_invocation_suffixed_artifacts_cannot_collide_with_bound_inputs
 
   echo 'PostgreSQL transition controller focused fixtures passed.'
 fi

--- a/scripts/test-pgvector-transition-controller.sh
+++ b/scripts/test-pgvector-transition-controller.sh
@@ -1,0 +1,4578 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+CONTROLLER=${PGVECTOR_CONTROLLER_FIXTURE_SCRIPT:-"$ROOT_DIR/scripts/run-pgvector-transition-controller.sh"}
+SYSTEMD_FIXTURE="$ROOT_DIR/scripts/test-pgvector-transition-controller-systemd.sh"
+DOCKER_FIXTURE="$ROOT_DIR/scripts/test-pgvector-transition-controller-docker.sh"
+
+[[ -f "$CONTROLLER" ]] || {
+  echo "Missing transition controller: $CONTROLLER" >&2
+  exit 1
+}
+
+extract_function() {
+  local name=$1 definition
+  definition=$(
+    awk -v signature="${name}() {" '
+      $0 == signature { emit = 1 }
+      emit { print }
+      emit && $0 == "}" { exit }
+    ' "$CONTROLLER"
+  )
+  [[ -n "$definition" ]] || {
+    echo "Missing controller helper: $name" >&2
+    exit 1
+  }
+  printf '%s\n' "$definition"
+}
+
+cleanup_state_authority_record() {
+  local runtime_root=$1 authority=$2
+  case "$authority" in
+    "$runtime_root"/noosphere-pgvector-state-*.json) ;;
+    *) echo "Refusing unexpected fixture authority path: $authority" >&2; return 1 ;;
+  esac
+  if [[ -e "$authority" ]]; then
+    [[ -f "$authority" && ! -L "$authority" ]] || {
+      echo "Fixture authority record is not a safe regular file: $authority" >&2
+      return 1
+    }
+    rm -f -- "$authority"
+  fi
+  [[ ! -e "$authority" ]] || {
+    echo "Fixture authority record remains after cleanup: $authority" >&2
+    return 1
+  }
+}
+
+test_atomic_controller_state() (
+  local fixture_dir state temp fsync_log
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf "$fixture_dir"' EXIT
+  state="$fixture_dir/controller.json"
+  temp="$fixture_dir/state.tmp"
+  fsync_log="$fixture_dir/fsync.log"
+
+  eval "$(extract_function path_present)"
+  eval "$(extract_function assert_owned_regular_file)"
+  eval "$(extract_function write_controller_state_atomic)"
+
+  fsync_path() {
+    printf '%s\n' "$1" >> "$fsync_log"
+  }
+  die() {
+    printf 'fixture: %s\n' "$*" >&2
+    exit 1
+  }
+
+  printf '{"phase":"prepared"}\n' > "$temp"
+  write_controller_state_atomic "$state" "$temp"
+
+  [[ $(stat -c '%a' "$state") == 600 ]]
+  [[ $(jq -er '.phase' "$state") == prepared ]]
+  [[ $(sed -n '1p' "$fsync_log") == "$state.tmp" || -s "$fsync_log" ]]
+  [[ $(tail -n 1 "$fsync_log") == "$fixture_dir" ]]
+)
+
+test_source_restore_without_guard_journal() (
+  local fixture_dir live source expected_source
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf "$fixture_dir"' EXIT
+  live="$fixture_dir/docker-compose.yml"
+  source="$fixture_dir/source-compose.yml"
+  printf 'candidate\n' > "$live"
+  printf 'source\n' > "$source"
+  chmod 0644 "$live" "$source"
+  expected_source=$(sha256sum "$source" | awk '{print $1}')
+
+  eval "$(extract_function path_present)"
+  eval "$(extract_function assert_owned_regular_file)"
+  eval "$(extract_function sha256_file)"
+  eval "$(extract_function restore_source_without_guard_journal)"
+
+  fsync_path() { :; }
+  die() {
+    printf 'fixture: %s\n' "$*" >&2
+    exit 1
+  }
+  assert_source_state_unchanged() { :; }
+
+  restore_source_without_guard_journal "$live" "$source" "$expected_source"
+  [[ $(<"$live") == source ]]
+  [[ $(stat -c '%a' "$live") == 644 ]]
+)
+
+test_execution_environment_is_hermetic() (
+  eval "$(extract_function sanitize_execution_environment)"
+
+  export DOCKER_CONTEXT=hostile DOCKER_CONFIG=/tmp/hostile
+  export COMPOSE_FILE=wrong.yml COMPOSE_PROJECT_NAME=wrong
+  export COMPOSE_PROFILES=hybrid COMPOSE_ENV_FILES=wrong.env
+  export COMPOSE_PROJECT_DIR=/tmp/wrong COMPOSE_PATH_SEPARATOR=';'
+
+  sanitize_execution_environment \
+    unix:///var/run/docker.sock /opt/noosphere-tools /tmp/controller-home
+
+  [[ ${DOCKER_HOST:-} == unix:///var/run/docker.sock ]]
+  [[ -z ${DOCKER_CONTEXT:-} ]]
+  [[ ${DOCKER_CONFIG:-} == /tmp/controller-home/docker ]]
+  [[ ${COMPOSE_DISABLE_ENV_FILE:-} == 1 ]]
+  [[ -z ${COMPOSE_FILE:-}${COMPOSE_PROJECT_NAME:-}${COMPOSE_PROFILES:-} ]]
+  [[ -z ${COMPOSE_ENV_FILES:-}${COMPOSE_PROJECT_DIR:-}${COMPOSE_PATH_SEPARATOR:-} ]]
+  [[ $PATH == /opt/noosphere-tools ]]
+)
+
+test_closure_failure_classification() (
+  eval "$(extract_function classify_closure_failure)"
+
+  [[ $(classify_closure_failure app-health 0) == completed-journal-revalidate ]]
+  [[ $(classify_closure_failure identity 0) == incident-stop-app ]]
+  [[ $(classify_closure_failure extension 0) == incident-stop-app ]]
+  [[ $(classify_closure_failure counts 0) == incident-stop-app ]]
+  [[ $(classify_closure_failure infrastructure 0) == incident-stop-app ]]
+  [[ $(classify_closure_failure app-health 1) == incident-stop-app ]]
+)
+
+test_signal_handler_is_idempotent() (
+  local fixture_dir count_file
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf "$fixture_dir"' EXIT
+  count_file="$fixture_dir/cleanup-count"
+  printf '0\n' > "$count_file"
+
+  eval "$(extract_function forward_latched_signal_to_active_child)"
+  eval "$(extract_function handle_controller_signal)"
+
+  controller_signal_active=false
+  controller_signal=''
+  guard_pid=''
+  persist_interrupted_state() {
+    local count
+    count=$(<"$count_file")
+    printf '%s\n' "$((count + 1))" > "$count_file"
+  }
+
+  handle_controller_signal TERM
+  handle_controller_signal TERM
+  [[ $(<"$count_file") == 1 ]]
+  [[ "$controller_signal" == TERM ]] || {
+    echo 'signal handler did not latch the first signal for phase-boundary enforcement' >&2
+    exit 1
+  }
+)
+
+write_fixture_controller_state() {
+  local target=$1 phase=$2 live_compose=$3 source_snapshot=$4 source_sha=$5 guard_journal=$6
+  local candidate_sha
+  if [[ -f "$live_compose" ]]; then
+    candidate_sha=$(sha256sum "$live_compose" | awk '{print $1}')
+  else
+    candidate_sha=$(printf 'c%.0s' {1..64})
+  fi
+  jq -n \
+    --arg phase "$phase" \
+    --arg liveCompose "$live_compose" \
+    --arg sourceSnapshot "$source_snapshot" \
+    --arg sourceSnapshotSha256 "$source_sha" \
+    --arg candidateComposeSha256 "$candidate_sha" \
+    --arg guardJournal "$guard_journal" \
+    '{
+      version: 1,
+      phase: $phase,
+      engineId: "fixture-engine",
+      dockerEndpoint: "unix:///fixture/docker.sock",
+      volume: "fixture-volume",
+      liveCompose: $liveCompose,
+      sourceSnapshot: $sourceSnapshot,
+      sourceSnapshotSha256: $sourceSnapshotSha256,
+      candidateComposeSha256: $candidateComposeSha256,
+      guardJournal: $guardJournal
+    }' > "$target"
+  chmod 0600 "$target"
+}
+
+test_reboot_recovers_prejournal_candidate_publication() (
+  local fixture_dir state live source guard_journal source_sha
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf "$fixture_dir"' EXIT
+  state="$fixture_dir/controller.json"
+  live="$fixture_dir/docker-compose.yml"
+  source="$fixture_dir/source-compose.yml"
+  guard_journal="$fixture_dir/guard.json"
+  printf 'candidate\n' > "$live"
+  printf 'source\n' > "$source"
+  chmod 0644 "$live" "$source"
+  source_sha=$(sha256sum "$source" | awk '{print $1}')
+  write_fixture_controller_state "$state" candidate-published "$live" "$source" "$source_sha" "$guard_journal"
+
+  for helper in path_present assert_owned_regular_file sha256_file \
+    write_controller_state_atomic validate_controller_state update_controller_phase \
+    restore_source_without_guard_journal restore_source_compose_snapshot resume_controller_state; do
+    eval "$(extract_function "$helper")"
+  done
+
+  fsync_path() { :; }
+  die() {
+    printf 'fixture: %s\n' "$*" >&2
+    exit 1
+  }
+  assert_source_state_unchanged() { :; }
+  run_source_recovery_verifier_with_evidence() { :; }
+  delegate_to_guard_journal() {
+    echo 'Unexpected guard-journal delegation' >&2
+    exit 1
+  }
+
+  resume_controller_state "$state"
+  [[ $(<"$live") == source ]]
+  [[ $(jq -er '.phase' "$state") == incident ]]
+  [[ $(jq -er '.incidentClass' "$state") == pre-journal-source-restored ]]
+)
+
+test_valid_guard_journal_suppresses_outer_restore() (
+  local fixture_dir state live source guard_journal source_sha delegated
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf "$fixture_dir"' EXIT
+  state="$fixture_dir/controller.json"
+  live="$fixture_dir/docker-compose.yml"
+  source="$fixture_dir/source-compose.yml"
+  guard_journal="$fixture_dir/guard.json"
+  delegated="$fixture_dir/delegated"
+  printf 'candidate\n' > "$live"
+  printf 'source\n' > "$source"
+  printf '{"phase":"preparing"}\n' > "$guard_journal"
+  chmod 0644 "$live" "$source"
+  chmod 0600 "$guard_journal"
+  source_sha=$(sha256sum "$source" | awk '{print $1}')
+  write_fixture_controller_state "$state" candidate-published "$live" "$source" "$source_sha" "$guard_journal"
+
+  for helper in path_present assert_owned_regular_file sha256_file \
+    write_controller_state_atomic validate_controller_state update_controller_phase \
+    restore_source_without_guard_journal restore_source_compose_snapshot resume_controller_state; do
+    eval "$(extract_function "$helper")"
+  done
+
+  fsync_path() { :; }
+  die() { exit 1; }
+  assert_source_state_unchanged() { exit 1; }
+  delegate_to_guard_journal() { : > "$delegated"; }
+
+  resume_controller_state "$state"
+  [[ -e "$delegated" ]]
+  [[ $(<"$live") == candidate ]]
+  [[ $(jq -er '.phase' "$state") == candidate-published ]]
+)
+
+test_shared_lock_is_inherited() (
+  local fixture_dir manifest lock_root lock_path expected_key inherited child_marker
+  fixture_dir=$(mktemp -d)
+  trap 'exec 8>&-; rm -rf "$fixture_dir"' EXIT
+  manifest="$fixture_dir/manifest.json"
+  write_execution_fixture "$fixture_dir" "$manifest"
+  lock_root="$fixture_dir/locks"
+
+  eval "$(extract_function path_present)"
+  eval "$(extract_function fsync_path)"
+  eval "$(extract_function ensure_regular_lock_file)"
+  eval "$(extract_function acquire_operation_lock)"
+  eval "$(extract_function assert_operation_lock_held)"
+  eval "$(extract_function child_path_for_state)"
+  eval "$(extract_function assert_recorded_docker_resolution)"
+  eval "$(extract_function forward_latched_signal_to_active_child)"
+  eval "$(extract_function wait_for_child_exit)"
+  eval "$(extract_function wait_for_process_group_empty)"
+  eval "$(extract_function run_guard_with_inherited_lock)"
+  die() {
+    printf 'fixture: %s\n' "$*" >&2
+    exit 1
+  }
+
+  active_child_pid=''
+  guard_pid=''
+  last_guard_pid=0
+  acquire_operation_lock fixture-engine fixture-volume "$lock_root"
+  expected_key=$(printf '%s\0%s' fixture-engine fixture-volume | sha256sum | awk '{print $1}')
+  lock_path="$lock_root/noosphere-pgvector-switch-$expected_key.lock"
+  [[ ${NOOSPHERE_A2B_LOCK_FD:-} == 8 ]]
+  [[ ${NOOSPHERE_A2B_LOCK_PATH:-} == "$lock_path" ]]
+  inherited=$(readlink "/proc/$BASHPID/fd/8")
+  [[ "$inherited" == "$lock_path" ]]
+  if (exec 9>"$lock_path"; flock -n 9); then
+    echo 'Second controller acquired the active engine-volume lock' >&2
+    exit 1
+  fi
+  child_marker="$fixture_dir/child-saw-lock"
+  run_guard_with_inherited_lock "$manifest" fixture-engine fixture-volume "$lock_root" \
+    bash -c '[[ ${NOOSPHERE_A2B_LOCK_FD:-} == 8 ]] && [[ $(readlink /proc/$$/fd/8) == "$1" ]] && : > "$2"' \
+    bash "$lock_path" "$child_marker"
+  [[ -e "$child_marker" ]]
+)
+
+test_candidate_publication_intent_is_recoverable() (
+  local fixture_dir state live source candidate guard_journal source_sha candidate_sha
+  fixture_dir=$(mktemp -d)
+  trap 'exec 8>&-; rm -rf "$fixture_dir"' EXIT
+  state="$fixture_dir/controller.json"
+  live="$fixture_dir/docker-compose.yml"
+  source="$fixture_dir/source-compose.yml"
+  candidate="$fixture_dir/candidate-compose.yml"
+  guard_journal="$fixture_dir/guard.json"
+  printf 'source\n' > "$live"
+  printf 'source\n' > "$source"
+  printf 'candidate\n' > "$candidate"
+  chmod 0644 "$live" "$source" "$candidate"
+  source_sha=$(sha256sum "$source" | awk '{print $1}')
+  candidate_sha=$(sha256sum "$candidate" | awk '{print $1}')
+  write_fixture_controller_state "$state" prepared "$live" "$source" "$source_sha" "$guard_journal"
+  jq --arg digest "$candidate_sha" '.candidateComposeSha256 = $digest' "$state" > "$state.next"
+  mv "$state.next" "$state"
+  chmod 0600 "$state"
+
+  for helper in path_present assert_owned_regular_file sha256_file \
+    write_controller_state_atomic validate_controller_state update_controller_phase \
+    ensure_regular_lock_file acquire_operation_lock assert_operation_lock_held publish_compose_atomic \
+    publish_candidate_under_lock; do
+    eval "$(extract_function "$helper")"
+  done
+  fsync_path() { :; }
+  die() { printf 'fixture: %s\n' "$*" >&2; exit 1; }
+
+  acquire_operation_lock fixture-engine fixture-volume "$fixture_dir"
+  export NOOSPHERE_CONTROLLER_TEST_INTERRUPT_AFTER_INTENT=1
+  if (publish_candidate_under_lock "$state" "$candidate" "$fixture_dir"); then
+    echo 'Injected publication interruption unexpectedly succeeded' >&2
+    exit 1
+  fi
+  [[ $(jq -er '.phase' "$state") == candidate-published ]]
+  [[ $(<"$live") == source ]]
+)
+
+test_systemd_contract_has_no_automatic_kill() (
+  local properties
+  eval "$(extract_function systemd_properties)"
+  properties=$(systemd_properties /srv/noosphere-controller)
+  for required in \
+    Type=exec RemainAfterExit=no Restart=no KillMode=mixed \
+    TimeoutStartSec=infinity TimeoutStopSec=infinity RuntimeMaxSec=infinity \
+    UMask=0077 WorkingDirectory=/srv/noosphere-controller; do
+    printf '%s\n' "$properties" | grep -Fx "$required" >/dev/null || {
+      echo "Missing systemd property: $required" >&2
+      exit 1
+    }
+  done
+)
+
+test_process_evidence_is_bounded_and_hashed() (
+  local fixture_dir evidence stdout_file stderr_file stdout_sha stderr_sha
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf "$fixture_dir"' EXIT
+  evidence="$fixture_dir/process-evidence.json"
+  stdout_file="$fixture_dir/stdout.log"
+  stderr_file="$fixture_dir/stderr.log"
+  printf 'guard output\n' > "$stdout_file"
+  printf 'guard diagnostic\n' > "$stderr_file"
+  chmod 0600 "$stdout_file" "$stderr_file"
+  stdout_sha=$(sha256sum "$stdout_file" | awk '{print $1}')
+  stderr_sha=$(sha256sum "$stderr_file" | awk '{print $1}')
+
+  for helper in path_present assert_owned_regular_file sha256_file \
+    write_controller_state_atomic write_process_evidence_atomic; do
+    eval "$(extract_function "$helper")"
+  done
+  fsync_path() { :; }
+  die() { exit 1; }
+
+  write_process_evidence_atomic "$evidence" guard-exited 17 \
+    "$stdout_file" "$stderr_file" invocation123 boot456 700 789 \
+    2026-08-10T00:00:00Z 2026-08-10T00:01:00Z cursor-start cursor-end
+
+  [[ $(stat -c '%a' "$evidence") == 600 ]]
+  [[ $(jq -er '.phase' "$evidence") == guard-exited ]]
+  [[ $(jq -er '.exitCode' "$evidence") == 17 ]]
+  [[ $(jq -er '.stdoutSha256' "$evidence") == "$stdout_sha" ]]
+  [[ $(jq -er '.stderrSha256' "$evidence") == "$stderr_sha" ]]
+  [[ $(jq -er '.controllerMainPid' "$evidence") == 700 ]]
+  [[ $(jq -er '.childPid' "$evidence") == 789 ]]
+  [[ $(jq -er '.startCursor' "$evidence") == cursor-start ]]
+  [[ $(jq -er '.endCursor' "$evidence") == cursor-end ]]
+)
+
+test_closure_outcome_never_false_completes() (
+  local fixture_dir state live source guard_journal source_sha evidence stdout_file stderr_file
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf "$fixture_dir"' EXIT
+  state="$fixture_dir/controller.json"
+  live="$fixture_dir/docker-compose.yml"
+  source="$fixture_dir/source-compose.yml"
+  guard_journal="$fixture_dir/guard.json"
+  evidence="$fixture_dir/evidence.json"
+  stdout_file="$fixture_dir/stdout.log"
+  stderr_file="$fixture_dir/stderr.log"
+  printf 'source\n' > "$live"
+  printf 'source\n' > "$source"
+  printf 'verify failed\n' > "$stdout_file"
+  printf 'identity mismatch\n' > "$stderr_file"
+  chmod 0644 "$live" "$source"
+  chmod 0600 "$stdout_file" "$stderr_file"
+  source_sha=$(sha256sum "$source" | awk '{print $1}')
+  write_fixture_controller_state "$state" closure-running "$live" "$source" "$source_sha" "$guard_journal"
+  jq '.authorizationEvidence = {
+    path: "/fixture/authorization-evidence.json",
+    sha256: ("a" * 64)
+  }' "$state" > "$state.next"
+  install -m 600 "$state.next" "$state"
+
+  for helper in path_present assert_owned_regular_file sha256_file \
+    write_controller_state_atomic validate_controller_state update_controller_phase \
+    write_process_evidence_atomic validate_process_evidence classify_closure_failure \
+    bind_process_evidence_to_state begin_closure_incident begin_closure_evidence_pending \
+    complete_closure_evidence_pending complete_closure_stop_pending \
+    commit_closure_outcome; do
+    eval "$(extract_function "$helper")"
+  done
+  fsync_path() { :; }
+  die() { printf 'fixture: %s\n' "$*" >&2; exit 1; }
+  stop_application_fail_closed() { : > "$fixture_dir/app-stopped"; }
+  revalidate_completed_guard_journal() { exit 1; }
+
+  write_process_evidence_atomic "$evidence" closure-running 17 \
+    "$stdout_file" "$stderr_file" invocation123 boot456 700 789 \
+    2026-08-10T00:00:00Z 2026-08-10T00:01:00Z cursor-start cursor-end
+  commit_closure_outcome "$state" "$evidence" identity 1
+  [[ $(jq -er '.phase' "$state") == incident ]]
+  [[ $(jq -er '.incidentClass' "$state") == closure-identity ]]
+  [[ -e "$fixture_dir/app-stopped" ]]
+)
+
+write_execution_fixture() {
+  local fixture_dir=$1 manifest=$2 guard_mode=${3:-complete} verifier_mode=${4:-success}
+  local engine_id=${5:-fixture-engine} volume=${6:-fixture-volume}
+  local live="$fixture_dir/docker-compose.yml" source="$fixture_dir/source-compose.yml"
+  local candidate="$fixture_dir/candidate-compose.yml" env_file="$fixture_dir/runtime.env"
+  local fake_docker="$fixture_dir/docker" guard="$fixture_dir/guard" verifier="$fixture_dir/verifier"
+  local compose_plugin="$fixture_dir/docker-compose-plugin" config_file="$fixture_dir/home/docker/config.json"
+  local backup="$fixture_dir/backup" lock_root="$fixture_dir/locks" controller_home="$fixture_dir/home"
+  local guard_journal="$backup/$volume.phase-a2b.json"
+  mkdir -p "$backup" "$lock_root" "$controller_home/docker"
+  chmod 0700 "$fixture_dir" "$backup" "$lock_root" "$controller_home" "$controller_home/docker"
+  printf '%s\n' "$engine_id" > "$fixture_dir/engine-id"
+  jq -n --arg volume "$volume" '[{
+    Name:$volume,
+    Driver:"local",
+    Mountpoint:("/var/lib/docker/volumes/" + $volume + "/_data"),
+    CreatedAt:"2026-08-15T00:00:00Z",
+    Scope:"local",
+    Labels:{fixture:"original"},
+    Options:null
+  }]' > "$fixture_dir/volume-inspect.json"
+  printf 'source model\n' > "$live"
+  printf 'source model\n' > "$source"
+  printf 'candidate model\n' > "$candidate"
+  printf 'DATABASE_URL=fixture\n' > "$env_file"
+  printf '%s\n' "$guard_mode" > "$fixture_dir/guard-mode"
+  printf '#!/usr/bin/env bash\nprintf "fixture compose plugin\\n"\n' > "$compose_plugin"
+  printf '{}\n' > "$config_file"
+  chmod 0644 "$live" "$source" "$candidate"
+  chmod 0600 "$env_file" "$config_file"
+  chmod 0700 "$compose_plugin"
+
+  {
+    printf '#!/usr/bin/env bash\nfixture_root=%q\n' "$fixture_dir"
+    cat <<'DOCKER'
+set -euo pipefail
+root=${NOOSPHERE_CONTROLLER_FIXTURE_ROOT:-$fixture_root}
+operation_lock_state=unheld
+if [[ ${NOOSPHERE_A2B_LOCK_FD:-} =~ ^[0-9]+$ && -n ${NOOSPHERE_A2B_LOCK_PATH:-} &&
+      $(readlink "/proc/$$/fd/$NOOSPHERE_A2B_LOCK_FD" 2>/dev/null || true) == "$NOOSPHERE_A2B_LOCK_PATH" ]]; then
+  exec 9<>"$NOOSPHERE_A2B_LOCK_PATH"
+  if ! flock -n 9; then
+    operation_lock_state=held
+  fi
+  exec 9>&-
+fi
+if [[ -e "$root/pause-engine-info" && ! -e "$root/pause-engine-info-consumed" &&
+      ${DOCKER_CONFIG:-} == *.inputs.* &&
+      ${1:-} == info && ${*:-} == *ClientInfo.Plugins* ]]; then
+  : > "$root/pause-engine-info-consumed"
+  : > "$root/engine-info-paused"
+  while [[ ! -e "$root/release-engine-info" ]]; do sleep 0.02; done
+fi
+if [[ -e "$root/pause-next-docker" && ! -e "$root/pause-consumed" ]]; then
+  : > "$root/pause-consumed"
+  : > "$root/docker-paused"
+  while [[ ! -e "$root/release-docker" ]]; do sleep 0.02; done
+fi
+if [[ ${1:-} == info ]]; then
+  printf 'info:%s\n' "$operation_lock_state" >> "$root/live-identity.log"
+  if [[ ${*:-} == *ClientInfo.Plugins* ]]; then
+    plugin="$DOCKER_CONFIG/cli-plugins/docker-compose"
+    [[ -f "$plugin" ]] || plugin="$root/docker-compose-plugin"
+    printf '[{"Name":"compose","Path":"%s","Version":"v2.fixture"}]\n' "$plugin"
+  else
+    : > "$root/engine-info-seen"
+    cat "$root/engine-id"
+  fi
+elif [[ ${1:-} == volume && ${2:-} == inspect ]]; then
+  printf 'volume-inspect:%s\n' "$operation_lock_state" >> "$root/live-identity.log"
+  : > "$root/volume-inspect-seen"
+  cat "$root/volume-inspect.json"
+elif [[ ${1:-} == compose && ${2:-} == version ]]; then
+  printf 'compose-version:%s\n' "$operation_lock_state" >> "$root/live-identity.log"
+  printf 'v2.fixture\n'
+elif [[ ${1:-} == compose ]]; then
+  if [[ " $* " == *" config "* ]]; then
+    printf 'compose-config:%s\n' "$operation_lock_state" >> "$root/live-identity.log"
+    printf 'candidate model\n'
+  elif [[ " $* " == *" up "* && " $* " == *" app "* ]]; then
+    printf 'activate\n' >> "$root/lifecycle.log"
+    [[ -e "$root/writer-authorized" ]]
+    [[ ! -e "$root/fail-activation" ]] || exit 71
+    : > "$root/app-started"
+    rm -f "$root/app-stopped"
+    if [[ -e "$root/signal-after-activation" ]]; then
+      kill -TERM "$PPID"
+    fi
+  else
+    printf 'unexpected fake Docker Compose arguments: %s\n' "$*" >&2
+    exit 1
+  fi
+elif [[ ${1:-} == stop ]]; then
+  if [[ -e "$root/kill-controller-if-incident-before-stop" &&
+        $(jq -er '.phase' "$root/controller.json") == incident ]]; then
+    : > "$root/incident-persisted-before-stop"
+    kill -KILL "$PPID"
+    exit 137
+  fi
+  printf 'stop\n' >> "$root/app-control.log"
+  : > "$root/app-stopped"
+  exit 0
+elif [[ ${1:-} == inspect ]]; then
+  if [[ -e "$root/app-stopped" ]]; then
+    printf 'inspect:false\n' >> "$root/app-control.log"
+    printf 'false\n'
+  else
+    printf 'inspect:true\n' >> "$root/app-control.log"
+    printf 'true\n'
+  fi
+else
+  printf 'unexpected fake Docker arguments: %s\n' "$*" >&2
+  exit 1
+fi
+DOCKER
+  } > "$fake_docker"
+  {
+    printf '#!/usr/bin/env bash\nfixture_root=%q\n' "$fixture_dir"
+    cat <<'GUARD'
+set -euo pipefail
+root=${NOOSPHERE_CONTROLLER_FIXTURE_ROOT:-$fixture_root}
+[[ ${NOOSPHERE_A2B_LOCK_FD:-} == 8 ]]
+[[ -e /proc/$$/fd/8 ]]
+backup=''
+volume=''
+compose_file=''
+authorize_writer=false
+fixture_mode=$(<"$root/guard-mode")
+while (($# > 0)); do
+  case "$1" in
+    --backup-dir) backup=$2; shift 2 ;;
+    --compose-file) compose_file=$2; shift 2 ;;
+    --volume) volume=$2; shift 2 ;;
+    --authorize-writer) authorize_writer=true; shift ;;
+    *) shift ;;
+  esac
+done
+[[ -n "$backup" && -n "$volume" ]]
+if [[ "$authorize_writer" == true ]]; then
+  printf 'authorize\n' >> "$root/lifecycle.log"
+  [[ -e "$root/app-stopped" ]]
+  [[ -f "$backup/$volume.phase-a2b.json" ]]
+  : > "$root/writer-authorized"
+  exit 0
+fi
+printf 'transition\n' >> "$root/lifecycle.log"
+: > "$root/app-stopped"
+case "$fixture_mode" in
+  prejournal-fail) exit 23 ;;
+  third-state-fail)
+    [[ -n "$compose_file" ]]
+    printf 'unexpected third state\n' > "$compose_file"
+    exit 23
+    ;;
+  journal-fail)
+    printf '{"phase":"preparing","mode":"switch"}\n' > "$backup/$volume.phase-a2b.json"
+    chmod 0600 "$backup/$volume.phase-a2b.json"
+    exit 24
+    ;;
+  sleep)
+    : > "$root/guard-running"
+    sleep 3600 &
+    sleeper=$!
+    trap 'kill "$sleeper" >/dev/null 2>&1 || true; printf "1\n" > "$root/guard-term-count"; exit 143' TERM INT HUP
+    wait "$sleeper"
+    ;;
+  delayed-term)
+    printf '%s\n' "$$" > "$root/guard-pid"
+    : > "$root/guard-running"
+    trap 'printf "1\n" > "$root/guard-term-count"; sleep 1; : > "$root/guard-delay-complete"; exit 143' TERM INT HUP
+    while :; do sleep 0.1; done
+    ;;
+  descendant-term)
+    printf '%s\n' "$$" > "$root/guard-pid"
+    : > "$root/guard-running"
+    (
+      trap '' TERM INT HUP
+      printf '%s\n' "$BASHPID" > "$root/guard-descendant-pid"
+      [[ -e "/proc/$BASHPID/fd/8" ]]
+      : > "$root/guard-descendant-running"
+      sleep 1
+      : > "$root/guard-descendant-complete"
+    ) &
+    descendant=$!
+    trap 'exit 143' TERM INT HUP
+    wait "$descendant"
+    ;;
+  env-check)
+    [[ -z ${HOSTILE_CHILD_ENV:-} ]]
+    [[ $(basename "$(command -v docker)") == docker ]]
+    [[ ${DOCKER_HOST:-} == unix:///fixture/docker.sock ]]
+    printf '{"phase":"complete","mode":"switch"}\n' > "$backup/$volume.phase-a2b.json"
+    chmod 0600 "$backup/$volume.phase-a2b.json"
+    ;;
+  complete)
+    printf '{"phase":"complete","mode":"switch"}\n' > "$backup/$volume.phase-a2b.json"
+    chmod 0600 "$backup/$volume.phase-a2b.json"
+    ;;
+  *) exit 25 ;;
+esac
+GUARD
+  } > "$guard"
+  if [[ "$verifier_mode" == success ]]; then
+    {
+      printf '#!/usr/bin/env bash\nfixture_root=%q\n' "$fixture_dir"
+      cat <<'VERIFIER'
+set -euo pipefail
+case ${NOOSPHERE_EXPECTED_POSTGRES_IMAGE_MODE:-} in
+  source)
+    root=${NOOSPHERE_CONTROLLER_FIXTURE_ROOT:-$fixture_root}
+    : > "$root/source-verifier-succeeded"
+    printf 'source verified\n'
+    ;;
+  candidate)
+    [[ -f ${NOOSPHERE_POSTGRES_EVIDENCE:-} ]]
+    root=${NOOSPHERE_CONTROLLER_FIXTURE_ROOT:-$fixture_root}
+    [[ -e "$root/app-started" ]]
+    printf 'verify\n' >> "$root/lifecycle.log"
+    if [[ -e "$root/pause-candidate-verifier" ]]; then
+      : > "$root/candidate-verifier-paused"
+      while [[ ! -e "$root/release-candidate-verifier" ]]; do sleep 0.02; done
+    fi
+    printf 'candidate verified\n'
+    ;;
+  *) exit 41 ;;
+esac
+VERIFIER
+    } > "$verifier"
+  elif [[ "$verifier_mode" == env-check ]]; then
+    {
+      printf '#!/usr/bin/env bash\nfixture_root=%q\n' "$fixture_dir"
+      cat <<'VERIFIER'
+set -euo pipefail
+[[ -z ${HOSTILE_CHILD_ENV:-} ]]
+[[ $(basename "$(command -v docker)") == docker ]]
+[[ ${DOCKER_HOST:-} == unix:///fixture/docker.sock ]]
+[[ ${NOOSPHERE_APP_URL:-} == http://127.0.0.1:16578 ]]
+case ${NOOSPHERE_EXPECTED_POSTGRES_IMAGE_MODE:-} in
+  source) printf 'source verified\n' ;;
+  candidate)
+    [[ -f ${NOOSPHERE_POSTGRES_EVIDENCE:-} ]]
+    root=${NOOSPHERE_CONTROLLER_FIXTURE_ROOT:-$fixture_root}
+    [[ -e "$root/app-started" ]]
+    printf 'verify\n' >> "$root/lifecycle.log"
+    printf 'candidate verified\n'
+    ;;
+  *) exit 41 ;;
+esac
+VERIFIER
+    } > "$verifier"
+  elif [[ "$verifier_mode" == mutate-journal ]]; then
+    cat > "$verifier" <<'VERIFIER'
+#!/usr/bin/env bash
+set -euo pipefail
+[[ ${NOOSPHERE_EXPECTED_POSTGRES_IMAGE_MODE:-} == candidate ]]
+[[ -f ${NOOSPHERE_POSTGRES_EVIDENCE:-} ]]
+printf '{"phase":"complete","mode":"switch","mutatedAfterVerification":true}\n' \
+  > "$NOOSPHERE_POSTGRES_EVIDENCE"
+chmod 0600 "$NOOSPHERE_POSTGRES_EVIDENCE"
+printf 'candidate verified before journal mutation\n'
+VERIFIER
+  elif [[ "$verifier_mode" == sleep ]]; then
+    {
+      printf '#!/usr/bin/env bash\nfixture_root=%q\n' "$fixture_dir"
+      cat <<'VERIFIER'
+set -euo pipefail
+case ${NOOSPHERE_EXPECTED_POSTGRES_IMAGE_MODE:-} in
+  source)
+    printf 'source verified\n'
+    ;;
+  candidate)
+    root=${NOOSPHERE_CONTROLLER_FIXTURE_ROOT:-$fixture_root}
+    : > "$root/verifier-running"
+    sleep 3600 &
+    sleeper=$!
+    trap 'kill "$sleeper" >/dev/null 2>&1 || true; printf "1\n" > "$root/verifier-term-count"; exit 143' TERM INT HUP
+    wait "$sleeper"
+    ;;
+  *) exit 41 ;;
+esac
+VERIFIER
+    } > "$verifier"
+  elif [[ "$verifier_mode" == delayed-term ]]; then
+    {
+      printf '#!/usr/bin/env -S --default-signal=TERM --default-signal=INT --default-signal=HUP bash\nfixture_root=%q\n' "$fixture_dir"
+      cat <<'VERIFIER'
+set -euo pipefail
+mode=${NOOSPHERE_EXPECTED_POSTGRES_IMAGE_MODE:-missing}
+root=${NOOSPHERE_CONTROLLER_FIXTURE_ROOT:-$fixture_root}
+trap 'printf "1\n" > "$root/'"$mode"'-verifier-term-count"; sleep 1; : > "$root/'"$mode"'-verifier-delay-complete"; exit 143' TERM INT HUP
+printf '%s\n' "$$" > "$root/$mode-verifier-pid"
+: > "$root/$mode-verifier-running"
+while :; do sleep 0.1; done
+VERIFIER
+    } > "$verifier"
+  elif [[ "$verifier_mode" == signal-zero ]]; then
+    {
+      printf '#!/usr/bin/env -S --default-signal=TERM --default-signal=INT --default-signal=HUP bash\nfixture_root=%q\n' "$fixture_dir"
+      cat <<'VERIFIER'
+set -euo pipefail
+case ${NOOSPHERE_EXPECTED_POSTGRES_IMAGE_MODE:-} in
+  source)
+    printf 'source verified\n'
+    ;;
+  candidate)
+    root=${NOOSPHERE_CONTROLLER_FIXTURE_ROOT:-$fixture_root}
+    [[ -f ${NOOSPHERE_POSTGRES_EVIDENCE:-} ]]
+    [[ -e "$root/app-started" ]]
+    printf 'verify\n' >> "$root/lifecycle.log"
+    trap ': > "$root/candidate-verifier-signal-zero"; sleep 1; : > "$root/candidate-verifier-signal-zero-complete"; exit 0' TERM INT HUP
+    printf '%s\n' "$$" > "$root/candidate-verifier-pid"
+    : > "$root/candidate-verifier-running"
+    while :; do sleep 0.1; done
+    ;;
+  *) exit 41 ;;
+esac
+VERIFIER
+    } > "$verifier"
+  elif [[ "$verifier_mode" == fail ]]; then
+    {
+      printf '#!/usr/bin/env bash\nfixture_root=%q\n' "$fixture_dir"
+      cat <<'VERIFIER'
+set -euo pipefail
+if [[ ${NOOSPHERE_EXPECTED_POSTGRES_IMAGE_MODE:-} == source ]]; then
+  printf 'source verified\n'
+  exit 0
+fi
+root=${NOOSPHERE_CONTROLLER_FIXTURE_ROOT:-$fixture_root}
+[[ -e "$root/app-started" ]]
+printf 'verify\n' >> "$root/lifecycle.log"
+printf 'candidate verification failed\n' >&2
+exit 31
+VERIFIER
+    } > "$verifier"
+  elif [[ "$verifier_mode" == source-fail ]]; then
+    {
+      printf '#!/usr/bin/env bash\nfixture_root=%q\n' "$fixture_dir"
+      cat <<'VERIFIER'
+set -euo pipefail
+case ${NOOSPHERE_EXPECTED_POSTGRES_IMAGE_MODE:-} in
+  source)
+    root=${NOOSPHERE_CONTROLLER_FIXTURE_ROOT:-$fixture_root}
+    printf '%s\n' "$$" > "$root/source-verifier-pid"
+    : > "$root/source-verifier-running"
+    printf 'source verification failed\n' >&2
+    exit 42
+    ;;
+  candidate)
+    [[ -f ${NOOSPHERE_POSTGRES_EVIDENCE:-} ]]
+    printf 'candidate verified\n'
+    ;;
+  *) exit 41 ;;
+esac
+VERIFIER
+    } > "$verifier"
+  else
+    echo "Invalid fixture verifier mode: $verifier_mode" >&2
+    return 1
+  fi
+  chmod 0700 "$fake_docker" "$guard" "$verifier"
+
+  jq -n \
+    --arg liveCompose "$live" \
+    --arg sourceSnapshot "$source" \
+    --arg sourceSnapshotSha256 "$(sha256sum "$source" | awk '{print $1}')" \
+    --arg candidateCompose "$candidate" \
+    --arg candidateComposeSha256 "$(sha256sum "$candidate" | awk '{print $1}')" \
+    --arg envFile "$env_file" \
+    --arg envFileSha256 "$(sha256sum "$env_file" | awk '{print $1}')" \
+    --arg guard "$guard" \
+    --arg guardSha256 "$(sha256sum "$guard" | awk '{print $1}')" \
+    --arg controllerPath "$(realpath "$CONTROLLER")" \
+    --arg controllerSha256 "$(sha256sum "$CONTROLLER" | awk '{print $1}')" \
+    --arg verifier "$verifier" \
+    --arg verifierSha256 "$(sha256sum "$verifier" | awk '{print $1}')" \
+    --arg dockerPath "$fake_docker" \
+    --arg dockerSha256 "$(sha256sum "$fake_docker" | awk '{print $1}')" \
+    --arg engineId "$engine_id" \
+    --arg volume "$volume" \
+    --arg volumeFingerprint "$("$fake_docker" volume inspect "$volume" | jq -Sc '.[0] | {Name,Driver,Mountpoint,CreatedAt,Scope,Labels,Options}' | sha256sum | awk '{print $1}')" \
+    --arg dockerComposeVersionSha256 "$("$fake_docker" compose version --short | sha256sum | awk '{print $1}')" \
+    --arg composePluginPath "$compose_plugin" \
+    --arg composePluginSha256 "$(sha256sum "$compose_plugin" | awk '{print $1}')" \
+    --arg dockerConfigSha256 "$(sha256sum "$config_file" | awk '{print $1}')" \
+    --arg effectiveComposeSha256 "$("$fake_docker" compose --env-file "$env_file" -f "$candidate" config --no-interpolate | sha256sum | awk '{print $1}')" \
+    --arg backupDir "$backup" \
+    --arg lockRoot "$lock_root" \
+    --arg controllerHome "$controller_home" \
+    --arg guardJournal "$guard_journal" \
+    '{
+      version:1, phase:"prepared", engineId:$engineId,
+      dockerEndpoint:"unix:///fixture/docker.sock", volume:$volume,
+      volumeFingerprint:$volumeFingerprint,
+      liveCompose:$liveCompose, sourceSnapshot:$sourceSnapshot,
+      sourceSnapshotSha256:$sourceSnapshotSha256,
+      candidateCompose:$candidateCompose, candidateComposeSha256:$candidateComposeSha256,
+      envFile:$envFile, envFileSha256:$envFileSha256,
+      guard:$guard, guardSha256:$guardSha256,
+      controllerPath:$controllerPath, controllerSha256:$controllerSha256,
+      guardArgs:[
+        "--compose-file",$liveCompose,
+        "--env-file",$envFile,
+        "--db-container","fixture-db",
+        "--app-container","fixture-app",
+        "--volume",$volume,
+        "--authorization-volume","fixture-authorization",
+        "--backup-dir",$backupDir,
+        "--platform","linux/amd64",
+        "--defer-app-restart"
+      ],
+      verifier:$verifier, verifierSha256:$verifierSha256,
+      dockerPath:$dockerPath, dockerSha256:$dockerSha256,
+      dockerComposeVersionSha256:$dockerComposeVersionSha256,
+      composePluginPath:$composePluginPath, composePluginSha256:$composePluginSha256,
+      dockerConfigSha256:$dockerConfigSha256,
+      effectiveComposeSha256:$effectiveComposeSha256,
+      backupDir:$backupDir, lockRoot:$lockRoot, controllerHome:$controllerHome,
+      fixedPath:"/usr/bin:/bin", dbContainer:"fixture-db", appContainer:"fixture-app",
+      authorizationVolume:"fixture-authorization", platform:"linux/amd64",
+      appUrl:"http://127.0.0.1:16578",
+      guardJournal:$guardJournal
+    }' > "$manifest"
+  chmod 0600 "$manifest"
+}
+
+test_complete_entrypoint_with_disposable_commands() (
+  local fixture_dir manifest state live shim
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf "$fixture_dir"' EXIT
+  manifest="$fixture_dir/manifest.json"
+  state="$fixture_dir/controller.json"
+  live="$fixture_dir/docker-compose.yml"
+  write_execution_fixture "$fixture_dir" "$manifest"
+  export XDG_RUNTIME_DIR="$fixture_dir/locks"
+  shim=$(write_systemd_identity_shim "$fixture_dir")
+
+  "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
+  INVOCATION_ID=0123456789abcdef0123456789abcdef \
+    CONTROLLER_UNIT=noosphere-pgvector-transition.service \
+    NOOSPHERE_CONTROLLER_BOOT_ID=fixture-boot \
+    NOOSPHERE_CONTROLLER_TEST_CURSOR=fixture-cursor \
+    "$shim" --execute --state "$state"
+
+  [[ $(jq -er '.phase' "$state") == complete ]]
+  [[ $(<"$live") == 'candidate model' ]]
+  [[ $(jq -er '.exitCode' "${state%.json}.guard.evidence.json") == 0 ]]
+  [[ $(jq -er '.exitCode' "${state%.json}.verify.evidence.json") == 0 ]]
+)
+
+test_manifest_mutation_fails_before_publication() (
+  local fixture_dir manifest state live env_file shim
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf "$fixture_dir"' EXIT
+  manifest="$fixture_dir/manifest.json"
+  state="$fixture_dir/controller.json"
+  live="$fixture_dir/docker-compose.yml"
+  env_file="$fixture_dir/runtime.env"
+  write_execution_fixture "$fixture_dir" "$manifest"
+  export XDG_RUNTIME_DIR="$fixture_dir/locks"
+  shim=$(write_systemd_identity_shim "$fixture_dir")
+  "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
+  printf 'MUTATED=1\n' >> "$env_file"
+
+  if INVOCATION_ID=0123456789abcdef0123456789abcdef \
+    CONTROLLER_UNIT=noosphere-pgvector-transition.service \
+    NOOSPHERE_CONTROLLER_BOOT_ID=fixture-boot \
+    NOOSPHERE_CONTROLLER_TEST_CURSOR=fixture-cursor \
+    "$shim" --execute --state "$state" >/dev/null 2>&1; then
+    echo 'Mutated execution manifest unexpectedly reached publication' >&2
+    exit 1
+  fi
+  [[ $(jq -er '.phase' "$state") == prepared ]]
+  [[ $(<"$live") == 'source model' ]]
+)
+
+test_execution_requires_systemd_identity() (
+  local fixture_dir manifest state live shim
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf "$fixture_dir"' EXIT
+  manifest="$fixture_dir/manifest.json"
+  state="$fixture_dir/controller.json"
+  live="$fixture_dir/docker-compose.yml"
+  write_execution_fixture "$fixture_dir" "$manifest"
+  export XDG_RUNTIME_DIR="$fixture_dir/locks"
+  shim=$(write_systemd_identity_shim "$fixture_dir")
+  "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
+
+  if env -u INVOCATION_ID -u CONTROLLER_UNIT \
+    "$shim" --execute --state "$state" >/dev/null 2>&1; then
+    echo 'Controller executed outside systemd identity boundary' >&2
+    exit 1
+  fi
+  [[ $(jq -er '.phase' "$state") == prepared ]]
+  [[ $(<"$live") == 'source model' ]]
+)
+
+write_systemd_identity_shim() {
+  local fixture_dir=$1 test_hooks=${2:-enabled} shim="$fixture_dir/controller-exec"
+  {
+    printf '#!/usr/bin/env bash\nset -Eeuo pipefail\nsource "%s"\n' "$CONTROLLER"
+    if [[ "$test_hooks" == enabled ]]; then
+      printf 'controller_test_hooks_enabled=true\n'
+      printf 'controller_fixture_root=%q\n' "$fixture_dir"
+    fi
+    cat <<'SHIM'
+query_systemd_unit_identity() {
+  printf '%s\n' \
+    ActiveState=active \
+    "InvocationID=${INVOCATION_ID:-missing}" \
+    "MainPID=$$" \
+    Type=exec \
+    RemainAfterExit=no \
+    Restart=no \
+    KillMode=mixed \
+    TimeoutStartUSec=infinity \
+    TimeoutStopUSec=infinity \
+    RuntimeMaxUSec=infinity \
+    UMask=0077 \
+    Transient=yes \
+    "WorkingDirectory=$(dirname "$(jq -er '.liveCompose' "$controller_state")")"
+}
+query_user_linger() {
+  printf 'yes\n'
+}
+capture_journal_cursor() {
+  if [[ ${controller_test_hooks_enabled:-false} == true &&
+        -e "$controller_fixture_root/fail-cursor-after-successful-verifier" &&
+        ! -e "$controller_fixture_root/cursor-failure-consumed" &&
+        -f "$controller_fixture_root/lifecycle.log" &&
+        $(tail -n 1 "$controller_fixture_root/lifecycle.log") == verify ]]; then
+    : > "$controller_fixture_root/cursor-failure-consumed"
+    return 74
+  fi
+  journalctl --user -n 0 --show-cursor --no-pager |
+    sed -n 's/^-- cursor: //p' | tail -1
+}
+main "$@"
+SHIM
+  } > "$shim"
+  chmod 0700 "$shim"
+  printf '%s\n' "$shim"
+}
+
+write_guard_journal_race_shim() {
+  local fixture_dir=$1 shim
+  shim=$(write_systemd_identity_shim "$fixture_dir")
+  sed -i '$d' "$shim"
+  cat >> "$shim" <<'SHIM'
+mv() {
+  local source=${@: -2:1} target=${@: -1} publish_complete=false
+  if [[ -e "$controller_fixture_root/mutate-journal-before-complete-write" &&
+        "$target" == "$controller_state" &&
+        -f "$source" &&
+        $(jq -r '.phase // empty' "$source") == complete ]]; then
+    : > "$controller_fixture_root/cooperative-mutator-attempted-at-complete-write"
+    (
+      exec 9<>"$NOOSPHERE_A2B_LOCK_PATH"
+      if flock -n 9; then
+        : > "$controller_fixture_root/cooperative-mutator-acquired-at-complete-write"
+      else
+        : > "$controller_fixture_root/cooperative-mutator-blocked-at-complete-write"
+      fi
+    )
+    publish_complete=true
+  fi
+  command mv "$@"
+  if [[ "$publish_complete" == true && -f "$target" &&
+        $(jq -r '.phase // empty' "$target") == complete ]]; then
+    : > "$controller_fixture_root/complete-state-published"
+  fi
+}
+main "$@"
+SHIM
+  chmod 0700 "$shim"
+  printf '%s\n' "$shim"
+}
+
+write_complete_state_failure_shim() {
+  local fixture_dir=$1 shim
+  shim=$(write_systemd_identity_shim "$fixture_dir")
+  sed -i '$d' "$shim"
+  cat >> "$shim" <<'SHIM'
+eval "$(declare -f write_controller_state_atomic | sed '1s/write_controller_state_atomic/original_write_controller_state_atomic/')"
+write_controller_state_atomic() {
+  local target=$1 source=$2
+  if [[ -e "$controller_fixture_root/fail-complete-state-write" &&
+        "$target" == "$controller_state" &&
+        $(jq -r '.phase // empty' "$source") == complete ]]; then
+    : > "$controller_fixture_root/complete-state-write-failure-consumed"
+    return 74
+  fi
+  original_write_controller_state_atomic "$@"
+}
+main "$@"
+SHIM
+  chmod 0700 "$shim"
+  printf '%s\n' "$shim"
+}
+
+write_post_authorization_artifact_failure_shim() {
+  local fixture_dir=$1 shim
+  shim=$(write_systemd_identity_shim "$fixture_dir")
+  sed -i '$d' "$shim"
+  cat >> "$shim" <<'SHIM'
+install() {
+  local source=${@: -2:1}
+  if [[ -e "$controller_fixture_root/fail-next-artifact-storage-after-authorization" &&
+        ! -e "$controller_fixture_root/post-authorization-artifact-failure-consumed" &&
+        "$source" == /dev/null &&
+        -f "$controller_fixture_root/lifecycle.log" &&
+        $(tail -n 1 "$controller_fixture_root/lifecycle.log") == authorize &&
+        ! -e "$controller_fixture_root/app-started" ]]; then
+    : > "$controller_fixture_root/post-authorization-artifact-failure-consumed"
+    return 74
+  fi
+  command install "$@"
+}
+main "$@"
+SHIM
+  chmod 0700 "$shim"
+  printf '%s\n' "$shim"
+}
+
+
+write_source_recovery_evidence_publication_crash_shim() {
+  local fixture_dir=$1 shim
+  shim=$(write_systemd_identity_shim "$fixture_dir")
+  sed -i '$d' "$shim"
+  cat >> "$shim" <<'SHIM'
+eval "$(declare -f write_process_evidence_atomic | sed '1s/write_process_evidence_atomic/original_write_process_evidence_atomic/')"
+write_process_evidence_atomic() {
+  local target=$1 phase=$2
+  original_write_process_evidence_atomic "$@"
+  if [[ "$phase" == source-recovery-running &&
+        -e "$controller_fixture_root/crash-after-source-evidence-publication" &&
+        ! -e "$controller_fixture_root/source-evidence-publication-crash-consumed" ]]; then
+    printf '%s\n' "$target" > "$controller_fixture_root/unbound-source-evidence-path"
+    : > "$controller_fixture_root/source-evidence-publication-crash-consumed"
+    exit 86
+  fi
+}
+main "$@"
+SHIM
+  chmod 0700 "$shim"
+  printf '%s\n' "$shim"
+}
+
+write_phase_snapshot_shim() {
+  local fixture_dir=$1 shim
+  shim=$(write_systemd_identity_shim "$fixture_dir")
+  sed -i '$d' "$shim"
+  cat >> "$shim" <<'SHIM'
+eval "$(declare -f update_controller_phase | sed '1s/update_controller_phase/original_update_controller_phase/')"
+update_controller_phase() {
+  local state=$1 phase=$2 incident_class=${3:-}
+  original_update_controller_phase "$@"
+  if [[ ${NOOSPHERE_CONTROLLER_TEST_CAPTURE_PHASE:-} == "$phase" &&
+        ( -z ${NOOSPHERE_CONTROLLER_TEST_CAPTURE_INCIDENT_CLASS:-} ||
+          ${NOOSPHERE_CONTROLLER_TEST_CAPTURE_INCIDENT_CLASS:-} == "$incident_class" ) ]]; then
+    : > "$controller_fixture_root/controller-phase-snapshot-captured"
+    exit 86
+  fi
+}
+main "$@"
+SHIM
+  chmod 0700 "$shim"
+  printf '%s\n' "$shim"
+}
+
+run_fixture_controller() {
+  local state=$1 controller_exec=$2
+  shift 2
+  INVOCATION_ID=${NOOSPHERE_CONTROLLER_FIXTURE_INVOCATION_ID:-0123456789abcdef0123456789abcdef} \
+    CONTROLLER_UNIT=noosphere-pgvector-transition.service \
+    NOOSPHERE_CONTROLLER_BOOT_ID=fixture-boot \
+    NOOSPHERE_CONTROLLER_TEST_CURSOR=fixture-cursor \
+    "$@" "$controller_exec" --execute --state "$state"
+}
+
+terminate_fixture_process() {
+  local pid=${1:-} i
+  [[ "$pid" =~ ^[1-9][0-9]*$ ]] || return 0
+  if kill -0 "$pid" 2>/dev/null; then
+    kill -TERM "$pid" 2>/dev/null || true
+    for i in $(seq 1 100); do
+      kill -0 "$pid" 2>/dev/null || break
+      sleep 0.02
+    done
+  fi
+  if kill -0 "$pid" 2>/dev/null; then
+    kill -KILL "$pid" 2>/dev/null || true
+    for i in $(seq 1 100); do
+      kill -0 "$pid" 2>/dev/null || break
+      sleep 0.02
+    done
+  fi
+  wait "$pid" 2>/dev/null || true
+}
+
+wait_fixture_process_bounded() {
+  local pid=$1 limit=${2:-750} i state
+  for i in $(seq 1 "$limit"); do
+    if [[ ! -r "/proc/$pid/stat" ]]; then
+      if wait "$pid"; then return 0; else return $?; fi
+    fi
+    state=$(awk '{print $3}' "/proc/$pid/stat" 2>/dev/null || true)
+    if [[ "$state" == Z ]]; then
+      if wait "$pid"; then return 0; else return $?; fi
+    fi
+    sleep 0.02
+  done
+  return 124
+}
+
+test_guard_failure_before_journal_restores_source() (
+  local fixture_dir manifest state live shim rc=0
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf "$fixture_dir"' EXIT
+  manifest="$fixture_dir/manifest.json"
+  state="$fixture_dir/controller.json"
+  live="$fixture_dir/docker-compose.yml"
+  write_execution_fixture "$fixture_dir" "$manifest" prejournal-fail
+  export XDG_RUNTIME_DIR="$fixture_dir/locks"
+  shim=$(write_systemd_identity_shim "$fixture_dir")
+  "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
+  run_fixture_controller "$state" "$shim" env || rc=$?
+  [[ "$rc" == 23 ]]
+  [[ $(jq -er '.phase' "$state") == incident ]]
+  [[ $(jq -er '.incidentClass' "$state") == pre-journal-source-restored ]]
+  [[ $(<"$live") == 'source model' ]]
+)
+
+test_guard_journal_prevents_outer_restore() (
+  local fixture_dir manifest state live journal shim rc=0
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf "$fixture_dir"' EXIT
+  manifest="$fixture_dir/manifest.json"
+  state="$fixture_dir/controller.json"
+  live="$fixture_dir/docker-compose.yml"
+  journal="$fixture_dir/backup/fixture-volume.phase-a2b.json"
+  write_execution_fixture "$fixture_dir" "$manifest" journal-fail
+  export XDG_RUNTIME_DIR="$fixture_dir/locks"
+  shim=$(write_systemd_identity_shim "$fixture_dir")
+  "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
+  run_fixture_controller "$state" "$shim" env || rc=$?
+  [[ "$rc" == 24 ]]
+  [[ $(jq -er '.phase' "$state") == guard-exited ]]
+  [[ $(jq -er '.phase' "$journal") == preparing ]]
+  [[ $(<"$live") == 'candidate model' ]]
+)
+
+test_verifier_failure_commits_incident_and_stops_app() (
+  local fixture_dir manifest state live shim rc=0
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf "$fixture_dir"' EXIT
+  manifest="$fixture_dir/manifest.json"
+  state="$fixture_dir/controller.json"
+  live="$fixture_dir/docker-compose.yml"
+  write_execution_fixture "$fixture_dir" "$manifest" complete fail
+  export XDG_RUNTIME_DIR="$fixture_dir/locks"
+  shim=$(write_systemd_identity_shim "$fixture_dir")
+  "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
+  run_fixture_controller "$state" "$shim" env || rc=$?
+  [[ "$rc" == 31 ]]
+  [[ $(jq -er '.phase' "$state") == incident ]]
+  [[ $(jq -er '.incidentClass' "$state") == closure-verification ]]
+  [[ -e "$fixture_dir/app-stopped" ]]
+  [[ $(<"$live") == 'candidate model' ]]
+)
+
+test_evidence_failure_cannot_complete() (
+  local fixture_dir manifest state live shim rc=0
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf "$fixture_dir"' EXIT
+  manifest="$fixture_dir/manifest.json"
+  state="$fixture_dir/controller.json"
+  live="$fixture_dir/docker-compose.yml"
+  write_execution_fixture "$fixture_dir" "$manifest"
+  export XDG_RUNTIME_DIR="$fixture_dir/locks"
+  shim=$(write_systemd_identity_shim "$fixture_dir")
+  "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
+  run_fixture_controller "$state" "$shim" env NOOSPHERE_CONTROLLER_TEST_FAIL_EVIDENCE=guard-exited || rc=$?
+  ((rc != 0))
+  [[ $(jq -er '.phase' "$state") == candidate-published ]]
+  [[ $(jq -er '.phase' "$fixture_dir/backup/fixture-volume.phase-a2b.json") == complete ]]
+  [[ $(<"$live") == 'candidate model' ]]
+)
+
+test_term_during_guard_records_and_recovers() (
+  local fixture_dir manifest state live shim controller_pid rc=0 resume_rc=0 i
+  fixture_dir=$(mktemp -d)
+  trap '[[ -z ${controller_pid:-} ]] || kill "$controller_pid" 2>/dev/null || true; rm -rf "$fixture_dir"' EXIT
+  manifest="$fixture_dir/manifest.json"
+  state="$fixture_dir/controller.json"
+  live="$fixture_dir/docker-compose.yml"
+  write_execution_fixture "$fixture_dir" "$manifest" sleep
+  export XDG_RUNTIME_DIR="$fixture_dir/locks"
+  shim=$(write_systemd_identity_shim "$fixture_dir")
+  "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
+  run_fixture_controller "$state" "$shim" env >"$fixture_dir/controller.out" 2>"$fixture_dir/controller.err" &
+  controller_pid=$!
+  for i in $(seq 1 100); do
+    [[ -e "$fixture_dir/guard-running" ]] && break
+    kill -0 "$controller_pid" 2>/dev/null || break
+    sleep 0.05
+  done
+  [[ -e "$fixture_dir/guard-running" ]]
+  kill -TERM "$controller_pid"
+  wait "$controller_pid" || rc=$?
+  controller_pid=''
+  [[ "$rc" == 143 ]]
+  [[ $(jq -er '.phase' "$state") == guard-exited ]]
+  jq -e '
+    .guardEvidence.path | type == "string" and startswith("/")
+  ' "$state" >/dev/null
+  [[ $(jq -er '.lastInterruption.signal' "$state") == TERM ]]
+  [[ $(<"$live") == 'candidate model' ]]
+
+  NOOSPHERE_CONTROLLER_FIXTURE_INVOCATION_ID=fedcba9876543210fedcba9876543210 \
+    run_fixture_controller "$state" "$shim" env || resume_rc=$?
+  ((resume_rc != 0))
+  [[ $(jq -er '.phase' "$state") == incident ]]
+  [[ $(jq -er '.incidentClass' "$state") == pre-journal-source-restored ]]
+  [[ $(<"$live") == 'source model' ]]
+)
+
+
+test_terminal_states_never_delegate_to_a_stale_guard_journal() (
+  local fixture_dir state live source guard_journal source_sha delegated terminal_phase
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf "$fixture_dir"' EXIT
+  live="$fixture_dir/docker-compose.yml"
+  source="$fixture_dir/source-compose.yml"
+  guard_journal="$fixture_dir/guard.json"
+  delegated="$fixture_dir/delegated"
+  printf 'candidate\n' > "$live"
+  printf 'source\n' > "$source"
+  printf '{"phase":"complete","mode":"switch"}\n' > "$guard_journal"
+  chmod 0644 "$live" "$source"
+  chmod 0600 "$guard_journal"
+  source_sha=$(sha256sum "$source" | awk '{print $1}')
+
+  for helper in path_present assert_owned_regular_file sha256_file \
+    write_controller_state_atomic validate_controller_state update_controller_phase \
+    restore_source_without_guard_journal restore_source_compose_snapshot resume_controller_state; do
+    eval "$(extract_function "$helper")"
+  done
+  fsync_path() { :; }
+  die() { printf 'fixture: %s\n' "$*" >&2; exit 1; }
+  assert_source_state_unchanged() { :; }
+  delegate_to_guard_journal() { : > "$delegated"; }
+
+  for terminal_phase in incident complete; do
+    state="$fixture_dir/controller-$terminal_phase.json"
+    write_fixture_controller_state "$state" "$terminal_phase" "$live" "$source" "$source_sha" "$guard_journal"
+    if (resume_controller_state "$state"); then
+      echo "terminal phase $terminal_phase resumed through the stale guard journal" >&2
+      exit 1
+    fi
+    [[ ! -e "$delegated" ]] || {
+      echo "terminal phase $terminal_phase reached guard-journal delegation" >&2
+      exit 1
+    }
+    [[ $(jq -er '.phase' "$state") == "$terminal_phase" ]]
+    [[ $(<"$live") == candidate ]]
+  done
+)
+
+test_systemd_identity_is_queried_not_asserted() (
+  local fixture_dir state
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf "$fixture_dir"' EXIT
+  state="$fixture_dir/controller.json"
+  printf '{"liveCompose":"%s/docker-compose.yml"}\n' "$fixture_dir" > "$state"
+  chmod 0600 "$state"
+  eval "$(extract_function require_systemd_execution_context)"
+  die() { printf 'fixture: %s\n' "$*" >&2; exit 1; }
+  export INVOCATION_ID=0123456789abcdef0123456789abcdef
+  export CONTROLLER_UNIT=noosphere-pgvector-transition.service
+  controller_state=$state
+  query_user_linger() { printf 'yes\n'; }
+
+  query_systemd_unit_identity() {
+    printf '%s\n' ActiveState=active InvocationID=ffffffffffffffffffffffffffffffff \
+      "MainPID=$$" Type=exec RemainAfterExit=no Restart=no KillMode=mixed \
+      TimeoutStartUSec=infinity TimeoutStopUSec=infinity RuntimeMaxUSec=infinity \
+      UMask=0077 Transient=yes "WorkingDirectory=$fixture_dir"
+  }
+  if (require_systemd_execution_context); then
+    echo 'systemd identity accepted from the environment despite a queried mismatch' >&2
+    exit 1
+  fi
+
+  query_systemd_unit_identity() {
+    printf '%s\n' ActiveState=active "InvocationID=$INVOCATION_ID" \
+      "MainPID=$$" Type=exec RemainAfterExit=no Restart=no KillMode=mixed \
+      TimeoutStartUSec=infinity TimeoutStopUSec=infinity RuntimeMaxUSec=infinity \
+      UMask=0077 Transient=yes "WorkingDirectory=$fixture_dir"
+  }
+  (require_systemd_execution_context) || {
+    echo 'matching queried systemd identity was refused' >&2
+    exit 1
+  }
+
+  query_systemd_unit_identity() {
+    printf '%s\n' ActiveState=inactive "InvocationID=$INVOCATION_ID" \
+      "MainPID=$$" Type=exec RemainAfterExit=no Restart=no KillMode=mixed \
+      TimeoutStartUSec=infinity TimeoutStopUSec=infinity RuntimeMaxUSec=infinity \
+      UMask=0077 Transient=yes "WorkingDirectory=$fixture_dir"
+  }
+  if (require_systemd_execution_context); then
+    echo 'inactive systemd unit identity was accepted' >&2
+    exit 1
+  fi
+)
+
+test_prepare_refuses_to_overwrite_active_or_terminal_state() (
+  local fixture_dir manifest state phase state_inode
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf "$fixture_dir"' EXIT
+  manifest="$fixture_dir/manifest.json"
+  state="$fixture_dir/controller.json"
+  write_execution_fixture "$fixture_dir" "$manifest"
+  export XDG_RUNTIME_DIR="$fixture_dir/locks"
+
+  for helper in path_present assert_owned_regular_file assert_owned_private_directory \
+    sha256_file write_controller_state_atomic validate_controller_state \
+    ensure_regular_lock_file acquire_preparation_lock after_preparation_lock \
+    acquire_operation_lock assert_operation_lock_held claim_authoritative_state_path \
+    query_postgres_volume_fingerprint \
+    assert_trusted_fixed_path assert_guard_journal_path \
+    validate_execution_manifest validate_guard_arguments query_compose_plugin_path \
+    assert_private_docker_config compose_model_signature verify_execution_inputs \
+    assert_controller_execution_identity \
+    assert_live_engine_binding assert_controller_artifact_paths_separate \
+    sanitize_execution_environment prepare_execution_state; do
+    eval "$(extract_function "$helper")"
+  done
+  fsync_path() { :; }
+  die() { printf 'fixture: %s\n' "$*" >&2; exit 1; }
+  query_live_engine_id() { printf 'fixture-engine\n'; }
+  CONTROLLER_EXECUTABLE_PATH=$(jq -er '.controllerPath' "$manifest")
+
+  # Complete-state evidence has its own exact durable-validation fixtures.
+  # This preparation guard covers active phases plus the incident terminal.
+  for phase in candidate-published guard-exited closure-running incident; do
+    jq --arg phase "$phase" '
+      .phase = $phase |
+      if $phase == "incident" then
+        .incidentClass = "fixture-terminal-state"
+      else . end
+    ' "$manifest" > "$state"
+    chmod 0600 "$state"
+    if (prepare_execution_state "$manifest" "$state"); then
+      echo "preparation overwrote $phase controller state" >&2
+      exit 1
+    fi
+    [[ $(jq -er '.phase' "$state") == "$phase" ]]
+  done
+
+  rm -f "$state"
+  (prepare_execution_state "$manifest" "$state")
+  state_inode=$(stat -c '%i' "$state")
+  (prepare_execution_state "$manifest" "$state") || {
+    echo 'idempotent re-preparation in prepared state was refused' >&2
+    exit 1
+  }
+  [[ $(jq -er '.phase' "$state") == prepared ]]
+  [[ $(stat -c '%i' "$state") == "$state_inode" ]]
+)
+
+test_engine_identity_is_rebound_to_the_live_daemon() (
+  local fixture_dir manifest state live shim rc=0
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf "$fixture_dir"' EXIT
+  manifest="$fixture_dir/manifest.json"
+  state="$fixture_dir/controller.json"
+  live="$fixture_dir/docker-compose.yml"
+  write_execution_fixture "$fixture_dir" "$manifest"
+  export XDG_RUNTIME_DIR="$fixture_dir/locks"
+  shim=$(write_systemd_identity_shim "$fixture_dir")
+  "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
+
+  printf 'mutated-engine\n' > "$fixture_dir/engine-id"
+  run_fixture_controller "$state" "$shim" env >/dev/null 2>&1 || rc=$?
+  [[ "$rc" != 0 ]] || {
+    echo 'controller proceeded with a stale Docker engine identity' >&2
+    exit 1
+  }
+  [[ $(jq -er '.phase' "$state") == prepared ]]
+  [[ $(<"$live") == 'source model' ]]
+)
+
+test_lock_root_must_match_the_guard_lock_contract() (
+  local fixture_dir manifest state live shim rc=0
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf "$fixture_dir"' EXIT
+  manifest="$fixture_dir/manifest.json"
+  state="$fixture_dir/controller.json"
+  live="$fixture_dir/docker-compose.yml"
+  write_execution_fixture "$fixture_dir" "$manifest"
+  export XDG_RUNTIME_DIR="$fixture_dir/locks"
+  shim=$(write_systemd_identity_shim "$fixture_dir")
+  mkdir -p "$fixture_dir/other-root"
+  chmod 0700 "$fixture_dir/other-root"
+  "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
+
+  if INVOCATION_ID=0123456789abcdef0123456789abcdef \
+    CONTROLLER_UNIT=noosphere-pgvector-transition.service \
+    NOOSPHERE_CONTROLLER_BOOT_ID=fixture-boot \
+    NOOSPHERE_CONTROLLER_TEST_CURSOR=fixture-cursor \
+    XDG_RUNTIME_DIR="$fixture_dir/other-root" \
+    "$shim" --execute --state "$state" >/dev/null 2>&1; then
+    echo 'controller accepted a lock root outside the guard contract' >&2
+    exit 1
+  fi
+  [[ $(jq -er '.phase' "$state") == prepared ]]
+  [[ $(<"$live") == 'source model' ]]
+)
+
+test_child_process_environment_and_docker_resolution_are_hermetic() (
+  local fixture_dir manifest state shim rc=0
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf "$fixture_dir"' EXIT
+  manifest="$fixture_dir/manifest.json"
+  state="$fixture_dir/controller.json"
+  write_execution_fixture "$fixture_dir" "$manifest" env-check env-check
+  export XDG_RUNTIME_DIR="$fixture_dir/locks"
+  shim=$(write_systemd_identity_shim "$fixture_dir")
+  "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
+
+  run_fixture_controller "$state" "$shim" env HOSTILE_CHILD_ENV=present || rc=$?
+  [[ "$rc" == 0 ]] || {
+    echo 'guard/verifier child inherited hostile state or resolved another Docker executable' >&2
+    exit 1
+  }
+  [[ $(jq -er '.phase' "$state") == complete ]]
+)
+
+test_latched_signal_before_guard_cannot_be_ignored() (
+  local fixture_dir manifest state live shim rc=0
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf "$fixture_dir"' EXIT
+  manifest="$fixture_dir/manifest.json"
+  state="$fixture_dir/controller.json"
+  live="$fixture_dir/docker-compose.yml"
+  write_execution_fixture "$fixture_dir" "$manifest"
+  export XDG_RUNTIME_DIR="$fixture_dir/locks"
+  shim=$(write_systemd_identity_shim "$fixture_dir")
+  "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
+
+  run_fixture_controller "$state" "$shim" env \
+    NOOSPHERE_CONTROLLER_TEST_SIGNAL_BEFORE_GUARD=TERM || rc=$?
+  [[ "$rc" == 143 ]] || {
+    echo "latched pre-guard TERM was ignored (exit=$rc)" >&2
+    exit 1
+  }
+  [[ $(jq -er '.phase' "$state") == candidate-published ]]
+  [[ $(jq -er '.lastInterruption.signal' "$state") == TERM ]]
+  [[ ! -e "$fixture_dir/backup/fixture-volume.phase-a2b.json" ]]
+  [[ $(<"$live") == 'candidate model' ]]
+)
+
+test_verifier_evidence_failure_stops_writer_before_storage() (
+  local fixture_dir manifest state live shim rc=0
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf "$fixture_dir"' EXIT
+  manifest="$fixture_dir/manifest.json"
+  state="$fixture_dir/controller.json"
+  live="$fixture_dir/docker-compose.yml"
+  write_execution_fixture "$fixture_dir" "$manifest" complete fail
+  export XDG_RUNTIME_DIR="$fixture_dir/locks"
+  shim=$(write_systemd_identity_shim "$fixture_dir")
+  "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
+
+  run_fixture_controller "$state" "$shim" env \
+    NOOSPHERE_CONTROLLER_TEST_FAIL_EVIDENCE=closure-running || rc=$?
+  ((rc != 0))
+  [[ $(jq -er '.phase' "$state") == closure-evidence-pending ]] || {
+    echo 'verifier failure did not remain resumable after writer stop' >&2
+    exit 1
+  }
+  [[ $(jq -er '.incidentClass' "$state") == closure-verification ]]
+  [[ -e "$fixture_dir/app-stopped" ]] || {
+    echo 'verifier evidence failure left the app writer running' >&2
+    exit 1
+  }
+  [[ $(<"$live") == 'candidate model' ]]
+)
+
+test_process_logs_are_fsynced_before_evidence_binding() (
+  local fixture_dir evidence stdout_file stderr_file fsync_log first second
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf "$fixture_dir"' EXIT
+  evidence="$fixture_dir/process-evidence.json"
+  stdout_file="$fixture_dir/stdout.log"
+  stderr_file="$fixture_dir/stderr.log"
+  fsync_log="$fixture_dir/fsync.log"
+  printf 'output\n' > "$stdout_file"
+  printf 'diagnostic\n' > "$stderr_file"
+  chmod 0600 "$stdout_file" "$stderr_file"
+
+  for helper in path_present assert_owned_regular_file sha256_file \
+    write_controller_state_atomic write_process_evidence_atomic; do
+    eval "$(extract_function "$helper")"
+  done
+  fsync_path() { printf '%s\n' "$1" >> "$fsync_log"; }
+  die() { printf 'fixture: %s\n' "$*" >&2; exit 1; }
+
+  write_process_evidence_atomic "$evidence" closure-running 0 \
+    "$stdout_file" "$stderr_file" invocation123 boot456 700 789 \
+    2026-08-10T00:00:00Z 2026-08-10T00:01:00Z cursor-start cursor-end
+  first=$(sed -n '1p' "$fsync_log")
+  second=$(sed -n '2p' "$fsync_log")
+  [[ "$first" == "$stdout_file" && "$second" == "$stderr_file" ]] || {
+    echo 'process logs were hashed/bound before both log files were fsynced' >&2
+    exit 1
+  }
+)
+
+test_complete_state_binds_guard_and_closure_evidence() (
+  local fixture_dir manifest state shim
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf "$fixture_dir"' EXIT
+  manifest="$fixture_dir/manifest.json"
+  state="$fixture_dir/controller.json"
+  write_execution_fixture "$fixture_dir" "$manifest"
+  export XDG_RUNTIME_DIR="$fixture_dir/locks"
+  shim=$(write_systemd_identity_shim "$fixture_dir")
+  "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
+  run_fixture_controller "$state" "$shim" env
+
+  jq -e '
+    .phase == "complete" and
+    (.guardEvidence.path | endswith(".guard.evidence.json")) and
+    (.guardEvidence.sha256 | test("^[a-f0-9]{64}$")) and
+    (.closureEvidence.path | endswith(".verify.evidence.json")) and
+    (.closureEvidence.sha256 | test("^[a-f0-9]{64}$")) and
+    (.guardEvidence.stdout.sha256 | test("^[a-f0-9]{64}$")) and
+    (.guardEvidence.stderr.sha256 | test("^[a-f0-9]{64}$")) and
+    (.closureEvidence.stdout.sha256 | test("^[a-f0-9]{64}$")) and
+    (.closureEvidence.stderr.sha256 | test("^[a-f0-9]{64}$"))
+  ' "$state" >/dev/null || {
+    echo 'complete state does not durably bind guard and closure evidence/logs' >&2
+    exit 1
+  }
+)
+
+test_systemd_safety_properties_and_linger_are_queried() (
+  local fixture_dir state
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf "$fixture_dir"' EXIT
+  state="$fixture_dir/controller.json"
+  printf '{"liveCompose":"%s/docker-compose.yml"}\n' "$fixture_dir" > "$state"
+  chmod 0600 "$state"
+
+  eval "$(extract_function require_systemd_execution_context)"
+  die() { printf 'fixture: %s\n' "$*" >&2; exit 1; }
+  export INVOCATION_ID=0123456789abcdef0123456789abcdef
+  export CONTROLLER_UNIT=noosphere-pgvector-transition.service
+  controller_state=$state
+
+  query_user_linger() { printf 'yes\n'; }
+  query_systemd_unit_identity() {
+    printf '%s\n' \
+      ActiveState=active \
+      "InvocationID=$INVOCATION_ID" \
+      "MainPID=$$" \
+      Type=exec \
+      RemainAfterExit=no \
+      Restart=always \
+      KillMode=control-group \
+      TimeoutStartUSec=5s \
+      TimeoutStopUSec=5s \
+      RuntimeMaxUSec=5s \
+      UMask=0022 \
+      "WorkingDirectory=$fixture_dir"
+  }
+  if (require_systemd_execution_context); then
+    echo 'unsafe systemd unit properties were accepted' >&2
+    exit 1
+  fi
+
+  query_systemd_unit_identity() {
+    printf '%s\n' \
+      ActiveState=active \
+      "InvocationID=$INVOCATION_ID" \
+      "MainPID=$$" \
+      Type=exec \
+      RemainAfterExit=no \
+      Restart=no \
+      KillMode=mixed \
+      TimeoutStartUSec=infinity \
+      TimeoutStopUSec=infinity \
+      RuntimeMaxUSec=infinity \
+      UMask=0077 \
+      "WorkingDirectory=$fixture_dir"
+  }
+  query_user_linger() { printf 'no\n'; }
+  if (require_systemd_execution_context); then
+    echo 'non-persistent user manager was accepted' >&2
+    exit 1
+  fi
+)
+
+test_signals_cannot_cross_spawn_or_complete_boundaries() (
+  local fixture_dir manifest state shim rc=0
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf "$fixture_dir"' EXIT
+  manifest="$fixture_dir/manifest.json"
+  state="$fixture_dir/controller.json"
+  write_execution_fixture "$fixture_dir" "$manifest"
+  export XDG_RUNTIME_DIR="$fixture_dir/locks"
+  shim=$(write_systemd_identity_shim "$fixture_dir")
+  "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
+
+  run_fixture_controller "$state" "$shim" env \
+    NOOSPHERE_CONTROLLER_TEST_SIGNAL_AFTER_GUARD_SPAWN=TERM || rc=$?
+  [[ "$rc" == 143 ]] || {
+    echo "TERM latched across guard spawn was ignored (exit=$rc)" >&2
+    exit 1
+  }
+  [[ $(jq -er '.lastInterruption.signal' "$state") == TERM ]]
+  [[ $(jq -er '.phase' "$state") != complete ]]
+
+  rm -f -- "$state" "$fixture_dir/backup/fixture-volume.phase-a2b.json"
+  printf 'source model\n' > "$fixture_dir/docker-compose.yml"
+  "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
+  rc=0
+  NOOSPHERE_CONTROLLER_FIXTURE_INVOCATION_ID=fedcba9876543210fedcba9876543210 \
+    run_fixture_controller "$state" "$shim" env \
+    NOOSPHERE_CONTROLLER_TEST_SIGNAL_BEFORE_COMPLETE=TERM || rc=$?
+  [[ "$rc" == 143 ]] || {
+    echo "TERM before complete was ignored (exit=$rc)" >&2
+    exit 1
+  }
+  [[ $(jq -er '.lastInterruption.signal' "$state") == TERM ]]
+  [[ $(jq -er '.phase' "$state") != complete ]]
+)
+
+test_source_recovery_verifier_is_hermetic_and_target_bound() (
+  local fixture_dir manifest
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf "$fixture_dir"' EXIT
+  manifest="$fixture_dir/manifest.json"
+  write_execution_fixture "$fixture_dir" "$manifest" complete env-check
+
+  for helper in child_path_for_state assert_recorded_docker_resolution \
+    forward_latched_signal_to_active_child wait_for_child_exit wait_for_process_group_empty \
+    run_source_verifier_hermetic \
+    assert_source_state_unchanged; do
+    eval "$(extract_function "$helper")"
+  done
+  die() { printf 'fixture: %s\n' "$*" >&2; exit 1; }
+  controller_state=$manifest
+  export HOSTILE_CHILD_ENV=present
+  export NOOSPHERE_APP_URL=http://127.0.0.1:6578
+
+  (assert_source_state_unchanged) || {
+    echo 'source recovery verifier inherited hostile inputs or missed the recorded endpoint' >&2
+    exit 1
+  }
+)
+
+test_complete_state_binds_immutable_guard_journal() (
+  local fixture_dir manifest state shim journal expected_sha rc=0
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf "$fixture_dir"' EXIT
+  manifest="$fixture_dir/manifest.json"
+  state="$fixture_dir/controller.json"
+  journal="$fixture_dir/backup/fixture-volume.phase-a2b.json"
+  write_execution_fixture "$fixture_dir" "$manifest"
+  export XDG_RUNTIME_DIR="$fixture_dir/locks"
+  shim=$(write_systemd_identity_shim "$fixture_dir")
+  "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
+  run_fixture_controller "$state" "$shim" env
+  expected_sha=$(sha256sum "$journal" | awk '{print $1}')
+  jq -e --arg path "$journal" --arg sha "$expected_sha" '
+    .phase == "complete" and
+    .guardJournalEvidence.path == $path and
+    .guardJournalEvidence.phase == "complete" and
+    .guardJournalEvidence.sha256 == $sha
+  ' "$state" >/dev/null || {
+    echo 'complete state does not bind the durable complete guard journal' >&2
+    exit 1
+  }
+
+  rm -f -- "$state" "$journal"
+  printf 'source model\n' > "$fixture_dir/docker-compose.yml"
+  write_execution_fixture "$fixture_dir" "$manifest" complete mutate-journal
+  "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
+  NOOSPHERE_CONTROLLER_FIXTURE_INVOCATION_ID=fedcba9876543210fedcba9876543210 \
+    run_fixture_controller "$state" "$shim" env || rc=$?
+  ((rc != 0)) || {
+    echo 'controller completed after the bound guard journal changed' >&2
+    exit 1
+  }
+  [[ $(jq -er '.phase' "$state") != complete ]]
+)
+
+test_process_evidence_separates_controller_and_child_identity() (
+  local fixture_dir manifest state shim guard_evidence closure_evidence
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf "$fixture_dir"' EXIT
+  manifest="$fixture_dir/manifest.json"
+  state="$fixture_dir/controller.json"
+  write_execution_fixture "$fixture_dir" "$manifest"
+  export XDG_RUNTIME_DIR="$fixture_dir/locks"
+  shim=$(write_systemd_identity_shim "$fixture_dir")
+  "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
+  run_fixture_controller "$state" "$shim" env
+  guard_evidence="${state%.json}.guard.evidence.json"
+  closure_evidence="${state%.json}.verify.evidence.json"
+
+  jq -e --arg invocation 0123456789abcdef0123456789abcdef '
+    .phase == "guard-exited" and
+    .invocationId == $invocation and
+    (.controllerMainPid | type == "number" and . > 0) and
+    (.childPid | type == "number" and . > 0) and
+    .controllerMainPid != .childPid
+  ' "$guard_evidence" >/dev/null || {
+    echo 'guard evidence does not separate controller MainPID from child PID' >&2
+    exit 1
+  }
+  jq -e --arg invocation 0123456789abcdef0123456789abcdef \
+    --argjson controller_pid "$(jq -er '.controllerMainPid' "$guard_evidence")" '
+    .phase == "closure-running" and
+    .invocationId == $invocation and
+    .controllerMainPid == $controller_pid and
+    (.childPid | type == "number" and . > 0) and
+    .controllerMainPid != .childPid
+  ' "$closure_evidence" >/dev/null || {
+    echo 'closure evidence is not bound to the same systemd controller identity' >&2
+    exit 1
+  }
+)
+
+test_guard_arguments_are_semantically_bound_to_manifest() (
+  local fixture_dir manifest state
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf "$fixture_dir"' EXIT
+  manifest="$fixture_dir/manifest.json"
+  state="$fixture_dir/controller.json"
+  write_execution_fixture "$fixture_dir" "$manifest"
+  export XDG_RUNTIME_DIR="$fixture_dir/locks"
+
+  jq '.guardArgs = [
+    "--record-new-install",
+    "--compose-file", .liveCompose,
+    "--db-container", .dbContainer,
+    "--app-container", .appContainer,
+    "--volume", .volume,
+    "--backup-dir", .backupDir,
+    "--platform", .platform
+  ]' "$manifest" > "$manifest.next"
+  install -m 600 "$manifest.next" "$manifest"
+  if "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"; then
+    echo 'source-transition controller accepted --record-new-install guard mode' >&2
+    exit 1
+  fi
+
+  rm -f -- "$state"
+  write_execution_fixture "$fixture_dir" "$manifest"
+  jq '.guardArgs = [
+    "--compose-file", "/tmp/not-the-recorded-compose.yml",
+    "--env-file", .envFile,
+    "--db-container", .dbContainer,
+    "--app-container", .appContainer,
+    "--volume", .volume,
+    "--authorization-volume", .authorizationVolume,
+    "--backup-dir", .backupDir,
+    "--platform", .platform
+  ]' "$manifest" > "$manifest.next"
+  install -m 600 "$manifest.next" "$manifest"
+  if "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"; then
+    echo 'guard arguments were not tied to the recorded Compose path' >&2
+    exit 1
+  fi
+)
+
+test_compose_plugin_and_docker_config_identity_are_bound() (
+  local fixture_dir manifest state live shim plugin config_file rc=0
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf "$fixture_dir"' EXIT
+  manifest="$fixture_dir/manifest.json"
+  state="$fixture_dir/controller.json"
+  live="$fixture_dir/docker-compose.yml"
+  plugin="$fixture_dir/docker-compose-plugin"
+  config_file="$fixture_dir/home/docker/config.json"
+  write_execution_fixture "$fixture_dir" "$manifest"
+  printf '#!/usr/bin/env bash\nprintf "fixture compose plugin\\n"\n' > "$plugin"
+  chmod 0700 "$plugin"
+  printf '{}\n' > "$config_file"
+  chmod 0600 "$config_file"
+  jq \
+    --arg plugin "$plugin" \
+    --arg pluginSha256 "$(sha256sum "$plugin" | awk '{print $1}')" \
+    --arg configSha256 "$(sha256sum "$config_file" | awk '{print $1}')" '
+      .composePluginPath = $plugin |
+      .composePluginSha256 = $pluginSha256 |
+      .dockerConfigSha256 = $configSha256
+    ' "$manifest" > "$manifest.next"
+  install -m 600 "$manifest.next" "$manifest"
+  export XDG_RUNTIME_DIR="$fixture_dir/locks"
+  shim=$(write_systemd_identity_shim "$fixture_dir")
+  "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
+
+  printf '# changed plugin\n' >> "$plugin"
+  printf '{"cliPluginsExtraDirs":["/tmp/hostile"]}\n' > "$config_file"
+  run_fixture_controller "$state" "$shim" env >/dev/null 2>&1 || rc=$?
+  ((rc != 0)) || {
+    echo 'controller accepted changed Compose plugin and Docker config identities' >&2
+    exit 1
+  }
+  [[ $(jq -er '.phase' "$state") == prepared ]]
+  [[ $(<"$live") == 'source model' ]]
+)
+
+test_failed_prejournal_recovery_commits_durable_incident() (
+  local fixture_dir manifest state live shim rc=0
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf "$fixture_dir"' EXIT
+  manifest="$fixture_dir/manifest.json"
+  state="$fixture_dir/controller.json"
+  live="$fixture_dir/docker-compose.yml"
+  write_execution_fixture "$fixture_dir" "$manifest" prejournal-fail source-fail
+  export XDG_RUNTIME_DIR="$fixture_dir/locks"
+  shim=$(write_systemd_identity_shim "$fixture_dir")
+  "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
+
+  run_fixture_controller "$state" "$shim" env >/dev/null 2>&1 || rc=$?
+  ((rc != 0)) || {
+    echo 'failed source recovery unexpectedly returned success' >&2
+    exit 1
+  }
+  [[ $(jq -er '.phase' "$state") == incident ]] || {
+    echo 'failed source recovery remained automatically retryable' >&2
+    exit 1
+  }
+  [[ $(jq -er '.incidentClass' "$state") == pre-journal-source-verification ]]
+  [[ $(<"$live") == 'candidate model' ]]
+)
+
+test_process_evidence_rejects_impossible_chronology() (
+  local fixture_dir evidence stdout_file stderr_file
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf "$fixture_dir"' EXIT
+  evidence="$fixture_dir/process-evidence.json"
+  stdout_file="$fixture_dir/stdout.log"
+  stderr_file="$fixture_dir/stderr.log"
+  printf 'output\n' > "$stdout_file"
+  printf 'diagnostic\n' > "$stderr_file"
+  chmod 0600 "$stdout_file" "$stderr_file"
+
+  for helper in path_present assert_owned_regular_file sha256_file \
+    write_controller_state_atomic write_process_evidence_atomic \
+    validate_process_evidence; do
+    eval "$(extract_function "$helper")"
+  done
+  fsync_path() { :; }
+  die() { printf 'fixture: %s\n' "$*" >&2; exit 1; }
+
+  write_process_evidence_atomic "$evidence" guard-exited 0 \
+    "$stdout_file" "$stderr_file" invocation123 boot456 700 789 \
+    2026-08-10T00:02:00Z 2026-08-10T00:01:00Z cursor-start cursor-end
+  if (validate_process_evidence "$evidence"); then
+    echo 'process evidence accepted an end timestamp before its start' >&2
+    exit 1
+  fi
+
+  jq '.startedAt = "not-rfc3339" | .endedAt = "also-not-rfc3339"' \
+    "$evidence" > "$evidence.next"
+  install -m 600 "$evidence.next" "$evidence"
+  if (validate_process_evidence "$evidence"); then
+    echo 'process evidence accepted non-RFC3339 timestamps' >&2
+    exit 1
+  fi
+)
+
+test_source_snapshot_is_revalidated_before_publication() (
+  local fixture_dir manifest state live source shim rc=0
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf "$fixture_dir"' EXIT
+  manifest="$fixture_dir/manifest.json"
+  state="$fixture_dir/controller.json"
+  live="$fixture_dir/docker-compose.yml"
+  source="$fixture_dir/source-compose.yml"
+  write_execution_fixture "$fixture_dir" "$manifest"
+  export XDG_RUNTIME_DIR="$fixture_dir/locks"
+  shim=$(write_systemd_identity_shim "$fixture_dir")
+  "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
+  printf 'mutated recovery source\n' > "$source"
+
+  run_fixture_controller "$state" "$shim" env >/dev/null 2>&1 || rc=$?
+  ((rc != 0)) || {
+    echo 'controller published candidate state after its recovery snapshot changed' >&2
+    exit 1
+  }
+  [[ $(jq -er '.phase' "$state") == prepared ]]
+  [[ $(<"$live") == 'source model' ]]
+)
+
+test_guard_journal_path_is_canonically_bound() (
+  local fixture_dir manifest state
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf "$fixture_dir"' EXIT
+  manifest="$fixture_dir/manifest.json"
+  state="$fixture_dir/controller.json"
+  write_execution_fixture "$fixture_dir" "$manifest"
+  export XDG_RUNTIME_DIR="$fixture_dir/locks"
+  jq '.guardJournal = (.backupDir + "/wrong-sibling.phase-a2b.json")' \
+    "$manifest" > "$manifest.next"
+  install -m 600 "$manifest.next" "$manifest"
+
+  if "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"; then
+    echo 'controller accepted a guard journal path different from the pinned guard path' >&2
+    exit 1
+  fi
+)
+
+test_fixed_path_toolchain_is_immutable_and_bound() (
+  local fixture_dir manifest state live tool_dir marker shim rc=0
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf "$fixture_dir"' EXIT
+  manifest="$fixture_dir/manifest.json"
+  state="$fixture_dir/controller.json"
+  live="$fixture_dir/docker-compose.yml"
+  tool_dir="$fixture_dir/toolbin"
+  marker="$fixture_dir/replacement-sha256sum-used"
+  mkdir -m 700 "$tool_dir"
+  write_execution_fixture "$fixture_dir" "$manifest"
+  jq --arg fixedPath "$tool_dir:/usr/bin:/bin" '.fixedPath = $fixedPath' \
+    "$manifest" > "$manifest.next"
+  install -m 600 "$manifest.next" "$manifest"
+  export XDG_RUNTIME_DIR="$fixture_dir/locks"
+  shim=$(write_systemd_identity_shim "$fixture_dir")
+  if ! "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"; then
+    return 0
+  fi
+
+  cat > "$tool_dir/sha256sum" <<WRAPPER
+#!/usr/bin/env bash
+set -euo pipefail
+: > "$marker"
+exec /usr/bin/sha256sum "\$@"
+WRAPPER
+  chmod 0700 "$tool_dir/sha256sum"
+  run_fixture_controller "$state" "$shim" env >/dev/null 2>&1 || rc=$?
+  ((rc != 0)) || {
+    echo 'controller executed a critical utility introduced into fixedPath after preparation' >&2
+    exit 1
+  }
+  [[ ! -e "$marker" ]]
+  [[ $(jq -er '.phase' "$state") == prepared ]]
+  [[ $(<"$live") == 'source model' ]]
+)
+
+test_controller_state_cannot_collide_with_guard_journal() (
+  local fixture_dir manifest journal
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf "$fixture_dir"' EXIT
+  manifest="$fixture_dir/manifest.json"
+  write_execution_fixture "$fixture_dir" "$manifest"
+  export XDG_RUNTIME_DIR="$fixture_dir/locks"
+  journal=$(jq -er '.guardJournal' "$manifest")
+
+  if "$CONTROLLER" --prepare --manifest "$manifest" --state "$journal"; then
+    echo 'controller state was allowed to overwrite the future guard journal path' >&2
+    exit 1
+  fi
+)
+
+test_ambient_test_overrides_cannot_falsify_production_evidence() (
+  local fixture_dir manifest state shim actual_boot guard_evidence closure_evidence
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf "$fixture_dir"' EXIT
+  manifest="$fixture_dir/manifest.json"
+  state="$fixture_dir/controller.json"
+  write_execution_fixture "$fixture_dir" "$manifest"
+  export XDG_RUNTIME_DIR="$fixture_dir/locks"
+  shim=$(write_systemd_identity_shim "$fixture_dir")
+  "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
+
+  INVOCATION_ID=0123456789abcdef0123456789abcdef \
+    CONTROLLER_UNIT=noosphere-pgvector-transition.service \
+    NOOSPHERE_CONTROLLER_BOOT_ID=forged-boot-id \
+    NOOSPHERE_CONTROLLER_TEST_CURSOR=forged-journal-cursor \
+    "$shim" --execute --state "$state"
+  actual_boot=$(< /proc/sys/kernel/random/boot_id)
+  guard_evidence="${state%.json}.guard.evidence.json"
+  closure_evidence="${state%.json}.verify.evidence.json"
+  jq -e --arg boot "$actual_boot" '
+    .bootId == $boot and
+    .startCursor != "forged-journal-cursor" and
+    .endCursor != "forged-journal-cursor"
+  ' "$guard_evidence" >/dev/null || {
+    echo 'guard evidence accepted forged ambient boot or cursor overrides' >&2
+    exit 1
+  }
+  jq -e --arg boot "$actual_boot" '
+    .bootId == $boot and
+    .startCursor != "forged-journal-cursor" and
+    .endCursor != "forged-journal-cursor"
+  ' "$closure_evidence" >/dev/null || {
+    echo 'closure evidence accepted forged ambient boot or cursor overrides' >&2
+    exit 1
+  }
+)
+
+test_docker_rehearsal_proves_cleanup_before_success() (
+  local cleanup_line residue_line success_line
+  cleanup_line=$(awk '$0 == "cleanup_successfully" { print NR; exit }' "$DOCKER_FIXTURE")
+  residue_line=$(awk '$0 == "verify_zero_residue" { print NR; exit }' "$DOCKER_FIXTURE")
+  success_line=$(awk '$0 == "echo '\''PostgreSQL transition controller pinned-guard Docker rehearsal passed.'\''" { print NR; exit }' "$DOCKER_FIXTURE")
+  [[ -n "$cleanup_line" && -n "$residue_line" && -n "$success_line" &&
+     "$cleanup_line" -lt "$residue_line" && "$residue_line" -lt "$success_line" ]] || {
+    echo 'Docker rehearsal still reports success before explicit cleanup and zero-residue proof' >&2
+    exit 1
+  }
+)
+
+test_process_evidence_rejects_fractional_numbers() (
+  local fixture_dir evidence stdout_file stderr_file accepted=0 expression
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf "$fixture_dir"' EXIT
+  evidence="$fixture_dir/process-evidence.json"
+  stdout_file="$fixture_dir/stdout.log"
+  stderr_file="$fixture_dir/stderr.log"
+  printf 'output\n' > "$stdout_file"
+  printf 'diagnostic\n' > "$stderr_file"
+  chmod 0600 "$stdout_file" "$stderr_file"
+
+  for helper in path_present assert_owned_regular_file sha256_file \
+    write_controller_state_atomic write_process_evidence_atomic \
+    validate_process_evidence; do
+    eval "$(extract_function "$helper")"
+  done
+  fsync_path() { :; }
+  die() { printf 'fixture: %s\n' "$*" >&2; exit 1; }
+  write_process_evidence_atomic "$evidence" guard-exited 0 \
+    "$stdout_file" "$stderr_file" invocation123 boot456 700 789 \
+    2026-08-10T00:00:00Z 2026-08-10T00:01:00Z cursor-start cursor-end
+
+  for expression in '.exitCode = 0.5' '.controllerMainPid = 700.5'; do
+    jq "$expression" "$evidence" > "$evidence.next"
+    install -m 600 "$evidence.next" "$evidence"
+    if (validate_process_evidence "$evidence"); then
+      ((accepted += 1))
+    fi
+  done
+  ((accepted == 0)) || {
+    echo 'process evidence accepted fractional exit-code or PID values' >&2
+    exit 1
+  }
+)
+
+test_real_systemd_fixture_exercises_signal_delivery() (
+  rg -q -- 'systemctl --user kill .*--signal=TERM|systemctl --user kill --signal=TERM' \
+    "$SYSTEMD_FIXTURE" || {
+    echo 'real transient-systemd fixture still does not deliver TERM' >&2
+    exit 1
+  }
+)
+
+test_production_execution_succeeds_without_ambient_fault_hooks() (
+  local fixture_dir manifest state live shim rc=0
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf "$fixture_dir"' EXIT
+  manifest="$fixture_dir/manifest.json"
+  state="$fixture_dir/controller.json"
+  live="$fixture_dir/docker-compose.yml"
+  write_execution_fixture "$fixture_dir" "$manifest"
+  export XDG_RUNTIME_DIR="$fixture_dir/locks"
+  shim=$(write_systemd_identity_shim "$fixture_dir" disabled)
+  "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
+
+  run_fixture_controller "$state" "$shim" env >/dev/null 2>&1 || rc=$?
+  [[ "$rc" == 0 && $(jq -er '.phase' "$state") == complete ]] || {
+    echo 'clean production execution failed without ambient controller fault hooks' >&2
+    exit 1
+  }
+  [[ $(<"$live") == 'candidate model' ]]
+)
+
+test_production_execution_succeeds_without_ambient_signal_hooks() (
+  local fixture_dir manifest state live shim rc=0
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf "$fixture_dir"' EXIT
+  manifest="$fixture_dir/manifest.json"
+  state="$fixture_dir/controller.json"
+  live="$fixture_dir/docker-compose.yml"
+  write_execution_fixture "$fixture_dir" "$manifest"
+  export XDG_RUNTIME_DIR="$fixture_dir/locks"
+  shim=$(write_systemd_identity_shim "$fixture_dir" disabled)
+  "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
+
+  run_fixture_controller "$state" "$shim" env >/dev/null 2>&1 || rc=$?
+  [[ "$rc" == 0 && $(jq -er '.phase' "$state") == complete ]] || {
+    echo 'clean production execution failed without ambient controller signal hooks' >&2
+    exit 1
+  }
+  [[ $(<"$live") == 'candidate model' ]]
+)
+
+test_derived_evidence_paths_cannot_collide_with_bound_inputs() (
+  local fixture_dir manifest state live old_env collision_env shim rc=0
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf "$fixture_dir"' EXIT
+  manifest="$fixture_dir/manifest.json"
+  state="$fixture_dir/controller.json"
+  live="$fixture_dir/docker-compose.yml"
+  old_env="$fixture_dir/runtime.env"
+  collision_env="${state%.json}.guard.stdout.log"
+  write_execution_fixture "$fixture_dir" "$manifest"
+  mv "$old_env" "$collision_env"
+  jq --arg old "$old_env" --arg collision "$collision_env" \
+    --arg digest "$(sha256sum "$collision_env" | awk '{print $1}')" '
+      .envFile = $collision |
+      .envFileSha256 = $digest |
+      .guardArgs = (.guardArgs | map(if . == $old then $collision else . end))
+    ' "$manifest" > "$manifest.next"
+  install -m 600 "$manifest.next" "$manifest"
+  export XDG_RUNTIME_DIR="$fixture_dir/locks"
+  shim=$(write_systemd_identity_shim "$fixture_dir")
+
+  if "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"; then
+    run_fixture_controller "$state" "$shim" env >/dev/null 2>&1 || rc=$?
+    ((rc != 0)) || {
+      echo 'derived guard stdout path overwrote a manifest-bound input' >&2
+      exit 1
+    }
+  fi
+  [[ $(<"$collision_env") == 'DATABASE_URL=fixture' ]] || {
+    echo 'derived controller artifact path modified a bound input before rejection' >&2
+    exit 1
+  }
+  [[ $(<"$live") == 'source model' ]]
+)
+
+test_guard_signal_persists_child_evidence_before_return() (
+  local fixture_dir manifest state shim controller_pid='' rc=0 i evidence
+  fixture_dir=$(mktemp -d)
+  trap '[[ -z ${controller_pid:-} ]] || kill "$controller_pid" 2>/dev/null || true; rm -rf "$fixture_dir"' EXIT
+  manifest="$fixture_dir/manifest.json"
+  state="$fixture_dir/controller.json"
+  evidence="${state%.json}.guard.evidence.json"
+  write_execution_fixture "$fixture_dir" "$manifest" sleep
+  export XDG_RUNTIME_DIR="$fixture_dir/locks"
+  shim=$(write_systemd_identity_shim "$fixture_dir")
+  "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
+
+  run_fixture_controller "$state" "$shim" env >"$fixture_dir/controller.out" 2>"$fixture_dir/controller.err" &
+  controller_pid=$!
+  for i in $(seq 1 200); do
+    [[ -e "$fixture_dir/guard-running" ]] && break
+    kill -0 "$controller_pid" 2>/dev/null || break
+    sleep 0.05
+  done
+  [[ -e "$fixture_dir/guard-running" ]]
+  kill -TERM "$controller_pid"
+  wait "$controller_pid" || rc=$?
+  controller_pid=''
+  [[ "$rc" == 143 ]]
+  [[ -f "$evidence" ]] && jq -e '
+    .phase == "guard-exited" and .exitCode == 143 and
+    (.childPid | type == "number" and . > 0) and
+    (.stdoutSha256 | test("^[a-f0-9]{64}$")) and
+    (.stderrSha256 | test("^[a-f0-9]{64}$"))
+  ' "$evidence" >/dev/null && jq -e --arg path "$evidence" '
+    .guardEvidence.path == $path and .lastInterruption.signal == "TERM"
+  ' "$state" >/dev/null || {
+    echo 'TERM during guard returned before durable child evidence was bound' >&2
+    exit 1
+  }
+)
+
+test_verifier_signal_persists_child_evidence_before_return() (
+  local fixture_dir manifest state shim controller_pid='' rc=0 i evidence
+  fixture_dir=$(mktemp -d)
+  trap '[[ -z ${controller_pid:-} ]] || kill "$controller_pid" 2>/dev/null || true; rm -rf "$fixture_dir"' EXIT
+  manifest="$fixture_dir/manifest.json"
+  state="$fixture_dir/controller.json"
+  evidence="${state%.json}.verify.evidence.json"
+  write_execution_fixture "$fixture_dir" "$manifest" complete sleep
+  export XDG_RUNTIME_DIR="$fixture_dir/locks"
+  shim=$(write_systemd_identity_shim "$fixture_dir")
+  "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
+
+  run_fixture_controller "$state" "$shim" env >"$fixture_dir/controller.out" 2>"$fixture_dir/controller.err" &
+  controller_pid=$!
+  for i in $(seq 1 200); do
+    [[ -e "$fixture_dir/verifier-running" ]] && break
+    kill -0 "$controller_pid" 2>/dev/null || break
+    sleep 0.05
+  done
+  [[ -e "$fixture_dir/verifier-running" ]]
+  kill -TERM "$controller_pid"
+  wait "$controller_pid" || rc=$?
+  controller_pid=''
+  [[ "$rc" == 143 ]]
+  [[ -f "$evidence" ]] && jq -e '
+    .phase == "closure-running" and .exitCode == 143 and
+    (.childPid | type == "number" and . > 0) and
+    (.stdoutSha256 | test("^[a-f0-9]{64}$")) and
+    (.stderrSha256 | test("^[a-f0-9]{64}$"))
+  ' "$evidence" >/dev/null && jq -e --arg path "$evidence" '
+    .closureEvidence.path == $path and .lastInterruption.signal == "TERM"
+  ' "$state" >/dev/null || {
+    echo 'TERM during verifier returned before durable child evidence was bound' >&2
+    exit 1
+  }
+)
+
+test_terminal_state_requires_phase_specific_invariants() (
+  local fixture_dir manifest state accepted=0 expression
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf "$fixture_dir"' EXIT
+  manifest="$fixture_dir/manifest.json"
+  state="$fixture_dir/controller.json"
+  write_execution_fixture "$fixture_dir" "$manifest"
+
+  for helper in assert_owned_regular_file validate_controller_state; do
+    eval "$(extract_function "$helper")"
+  done
+  die() { printf 'fixture: %s\n' "$*" >&2; exit 1; }
+
+  for expression in \
+    '.phase = "complete" | del(.guardEvidence, .closureEvidence, .guardJournalEvidence)' \
+    '.phase = "incident" | del(.incidentClass)'; do
+    jq "$expression" "$manifest" > "$state"
+    chmod 0600 "$state"
+    if (validate_controller_state "$state"); then
+      ((accepted += 1))
+    fi
+  done
+  ((accepted == 0)) || {
+    echo 'controller accepted a terminal state without its phase-specific evidence' >&2
+    exit 1
+  }
+)
+
+test_preparation_resolves_docker_only_after_hermetic_sanitization() (
+  local fixture_dir manifest state live fake_docker ambient_plugin ambient_config shim rc=0
+  local ambient_version_sha ambient_model_sha
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf "$fixture_dir"' EXIT
+  manifest="$fixture_dir/manifest.json"
+  state="$fixture_dir/controller.json"
+  live="$fixture_dir/docker-compose.yml"
+  fake_docker="$fixture_dir/docker"
+  ambient_plugin="$fixture_dir/docker-compose-plugin-ambient"
+  ambient_config="$fixture_dir/ambient-docker"
+  write_execution_fixture "$fixture_dir" "$manifest"
+  mkdir -m 700 "$ambient_config"
+  printf '{}\n' > "$ambient_config/config.json"
+  chmod 0600 "$ambient_config/config.json"
+  printf '#!/usr/bin/env bash\nprintf "ambient compose plugin\\n"\n' > "$ambient_plugin"
+  chmod 0700 "$ambient_plugin"
+
+  cat > "$fake_docker" <<'DOCKER'
+#!/usr/bin/env bash
+set -euo pipefail
+root=$(dirname "$0")
+mode=recorded
+if [[ ${DOCKER_HOST:-} == unix:///ambient/docker.sock &&
+      ${DOCKER_CONFIG:-} == "$root/ambient-docker" ]]; then
+  mode=ambient
+fi
+if [[ ${1:-} == info ]]; then
+  if [[ ${*:-} == *ClientInfo.Plugins* ]]; then
+    if [[ "$mode" == ambient ]]; then
+      printf '[{"Name":"compose","Path":"%s","Version":"v2.ambient"}]\n' "$root/docker-compose-plugin-ambient"
+    else
+      printf '[{"Name":"compose","Path":"%s","Version":"v2.fixture"}]\n' "$root/docker-compose-plugin"
+    fi
+  elif [[ "$mode" == ambient ]]; then
+    printf 'ambient-engine\n'
+  else
+    printf 'fixture-engine\n'
+  fi
+elif [[ ${1:-} == compose && ${2:-} == version ]]; then
+  [[ "$mode" == ambient ]] && printf 'v2.ambient\n' || printf 'v2.fixture\n'
+elif [[ ${1:-} == compose ]]; then
+  [[ "$mode" == ambient ]] && printf 'ambient model\n' || printf 'candidate model\n'
+else
+  exit 1
+fi
+DOCKER
+  chmod 0700 "$fake_docker"
+  ambient_version_sha=$(printf 'v2.ambient\n' | sha256sum | awk '{print $1}')
+  ambient_model_sha=$(printf 'ambient model\n' | sha256sum | awk '{print $1}')
+  jq --arg engine ambient-engine \
+    --arg dockerSha "$(sha256sum "$fake_docker" | awk '{print $1}')" \
+    --arg versionSha "$ambient_version_sha" \
+    --arg plugin "$ambient_plugin" \
+    --arg pluginSha "$(sha256sum "$ambient_plugin" | awk '{print $1}')" \
+    --arg modelSha "$ambient_model_sha" '
+      .engineId = $engine |
+      .dockerSha256 = $dockerSha |
+      .dockerComposeVersionSha256 = $versionSha |
+      .composePluginPath = $plugin |
+      .composePluginSha256 = $pluginSha |
+      .effectiveComposeSha256 = $modelSha
+    ' "$manifest" > "$manifest.next"
+  install -m 600 "$manifest.next" "$manifest"
+  export XDG_RUNTIME_DIR="$fixture_dir/locks"
+  shim=$(write_systemd_identity_shim "$fixture_dir")
+
+  if env DOCKER_HOST=unix:///ambient/docker.sock DOCKER_CONFIG="$ambient_config" \
+    "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"; then
+    run_fixture_controller "$state" "$shim" env >/dev/null 2>&1 || rc=$?
+    ((rc != 0)) && [[ $(jq -er '.phase' "$state") == prepared ]] && \
+      [[ $(<"$live") == 'source model' ]] || {
+      echo 'ambient preparation context did not diverge from sanitized execution as expected' >&2
+      exit 1
+    }
+    echo 'preparation certified ambient Docker and Compose identity before sanitization' >&2
+    exit 1
+  fi
+)
+
+test_controller_executable_is_bound_after_preparation() (
+  local fixture_dir manifest state live shim controller_copy rc=0
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf "$fixture_dir"' EXIT
+  controller_copy="$fixture_dir/controller"
+  cp "$CONTROLLER" "$controller_copy"
+  chmod 0700 "$controller_copy"
+  CONTROLLER=$controller_copy
+  manifest="$fixture_dir/manifest.json"
+  state="$fixture_dir/controller-state.json"
+  live="$fixture_dir/docker-compose.yml"
+  write_execution_fixture "$fixture_dir" "$manifest"
+  export XDG_RUNTIME_DIR="$fixture_dir/locks"
+  shim=$(write_systemd_identity_shim "$fixture_dir")
+  if "$CONTROLLER" --prepare --manifest "$manifest" --state "$controller_copy" \
+    >/dev/null 2>&1; then
+    echo 'controller state path overwrote the bound controller executable' >&2
+    exit 1
+  fi
+  "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
+  printf '\n# mutated after preparation\n' >> "$controller_copy"
+
+  run_fixture_controller "$state" "$shim" env >/dev/null 2>&1 || rc=$?
+  ((rc != 0)) && [[ $(jq -er '.phase' "$state") == prepared ]] &&
+    [[ $(<"$live") == 'source model' ]] || {
+    echo 'changed controller executable consumed a valid prepared state' >&2
+    exit 1
+  }
+)
+
+assert_signal_wait_reaps_delayed_child() {
+  local guard_mode=$1 verifier_mode=$2 running_marker=$3 complete_marker=$4 pid_file=$5 expected_rc=$6
+  local fixture_dir manifest state shim controller_pid='' child_pid='' rc=0 i
+  fixture_dir=$(mktemp -d)
+  trap '[[ -z ${controller_pid:-} ]] || kill "$controller_pid" 2>/dev/null || true; [[ -z ${child_pid:-} ]] || kill -KILL "$child_pid" 2>/dev/null || true; rm -rf "$fixture_dir"' RETURN
+  manifest="$fixture_dir/manifest.json"
+  state="$fixture_dir/controller.json"
+  write_execution_fixture "$fixture_dir" "$manifest" "$guard_mode" "$verifier_mode"
+  export XDG_RUNTIME_DIR="$fixture_dir/locks"
+  shim=$(write_systemd_identity_shim "$fixture_dir")
+  "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
+  run_fixture_controller "$state" "$shim" env >"$fixture_dir/controller.out" 2>"$fixture_dir/controller.err" &
+  controller_pid=$!
+  for i in $(seq 1 200); do
+    [[ -e "$fixture_dir/$running_marker" ]] && break
+    kill -0 "$controller_pid" 2>/dev/null || break
+    sleep 0.05
+  done
+  [[ -e "$fixture_dir/$running_marker" ]]
+  child_pid=$(<"$fixture_dir/$pid_file")
+  kill -TERM "$controller_pid"
+  wait "$controller_pid" || rc=$?
+  controller_pid=''
+  [[ "$rc" == "$expected_rc" ]]
+  [[ -e "$fixture_dir/$complete_marker" ]] || {
+    echo "controller returned before delayed child was reaped: $running_marker" >&2
+    exit 1
+  }
+  if kill -0 "$child_pid" 2>/dev/null; then
+    echo "delayed child remains alive after controller return: $child_pid" >&2
+    exit 1
+  fi
+  child_pid=''
+  trap - RETURN
+  rm -rf "$fixture_dir"
+}
+
+test_guard_signal_waits_until_child_is_reaped() (
+  assert_signal_wait_reaps_delayed_child delayed-term success \
+    guard-running guard-delay-complete guard-pid 143
+)
+
+test_closure_verifier_signal_waits_until_child_is_reaped() (
+  assert_signal_wait_reaps_delayed_child complete delayed-term \
+    candidate-verifier-running candidate-verifier-delay-complete candidate-verifier-pid 143
+)
+
+test_source_verifier_signal_waits_until_child_is_reaped() (
+  assert_signal_wait_reaps_delayed_child prejournal-fail delayed-term \
+    source-verifier-running source-verifier-delay-complete source-verifier-pid 143
+)
+
+test_bootstrap_ignores_ambient_path() (
+  local fixture_dir hostile_bin marker
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf "$fixture_dir"' EXIT
+  hostile_bin="$fixture_dir/bin"
+  marker="$fixture_dir/ambient-bash-ran"
+  mkdir "$hostile_bin"
+  cat > "$hostile_bin/bash" <<SH
+#!/bin/sh
+: > "$marker"
+exec /bin/bash "\$@"
+SH
+  chmod 0700 "$hostile_bin/bash"
+
+  PATH="$hostile_bin:/usr/bin:/bin" "$CONTROLLER" --help >/dev/null
+  [[ ! -e "$marker" ]] || {
+    echo 'controller bootstrap selected Bash from ambient PATH' >&2
+    exit 1
+  }
+)
+
+test_docker_config_namespace_rejects_descendants() (
+  local fixture_dir manifest state docker_config mutated rc=0
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf "$fixture_dir"' EXIT
+  manifest="$fixture_dir/manifest.json"
+  write_execution_fixture "$fixture_dir" "$manifest"
+  state="$fixture_dir/home/docker/controller.json"
+  export XDG_RUNTIME_DIR="$fixture_dir/locks"
+
+  "$CONTROLLER" --prepare --manifest "$manifest" --state "$state" >/dev/null 2>&1 || rc=$?
+  ((rc != 0)) || {
+    echo 'controller state was accepted beneath the one-file Docker config directory' >&2
+    exit 1
+  }
+
+  state="$fixture_dir/controller.json"
+  docker_config="$fixture_dir/home/docker"
+  mutated="$fixture_dir/docker-config-backup.json"
+  jq --arg backup "$docker_config" '
+    .backupDir = $backup |
+    .guardJournal = ($backup + "/fixture-volume.phase-a2b.json") |
+    .guardArgs[13] = $backup
+  ' "$manifest" > "$mutated"
+  install -m 600 "$mutated" "$manifest"
+  rc=0
+  "$CONTROLLER" --prepare --manifest "$manifest" --state "$state" >/dev/null 2>&1 || rc=$?
+  ((rc != 0)) || {
+    echo 'guard backup namespace was accepted as the one-file Docker config directory' >&2
+    exit 1
+  }
+)
+
+test_complete_state_revalidates_durable_evidence() (
+  local fixture_dir manifest state shim mutated rc=0
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf "$fixture_dir"' EXIT
+  manifest="$fixture_dir/manifest.json"
+  state="$fixture_dir/controller.json"
+  mutated="$fixture_dir/mutated.json"
+  write_execution_fixture "$fixture_dir" "$manifest"
+  export XDG_RUNTIME_DIR="$fixture_dir/locks"
+  shim=$(write_systemd_identity_shim "$fixture_dir")
+  "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
+  run_fixture_controller "$state" "$shim" env
+  jq '.guardEvidence.path = "/nonexistent/guard-evidence.json"' "$state" > "$mutated"
+  install -m 600 "$mutated" "$state"
+
+  bash -c 'source "$1"; validate_controller_state "$2"' _ "$CONTROLLER" "$state" >/dev/null 2>&1 || rc=$?
+  ((rc != 0)) || {
+    echo 'complete state accepted nonexistent durable process evidence' >&2
+    exit 1
+  }
+)
+
+test_recovery_preserves_prior_process_evidence() (
+  local fixture_dir manifest state shim guard_evidence prior_sha rc=0
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf "$fixture_dir"' EXIT
+  manifest="$fixture_dir/manifest.json"
+  state="$fixture_dir/controller.json"
+  write_execution_fixture "$fixture_dir" "$manifest"
+  export XDG_RUNTIME_DIR="$fixture_dir/locks"
+  shim=$(write_systemd_identity_shim "$fixture_dir")
+  "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
+  run_fixture_controller "$state" "$shim" env
+  guard_evidence=$(jq -er '.guardEvidence.path' "$state")
+  prior_sha=$(sha256sum "$guard_evidence" | awk '{print $1}')
+  jq '.phase = "closure-running"' "$state" > "$fixture_dir/recovery.json"
+  install -m 600 "$fixture_dir/recovery.json" "$state"
+
+  NOOSPHERE_CONTROLLER_FIXTURE_INVOCATION_ID=fedcba9876543210fedcba9876543210 \
+    run_fixture_controller "$state" "$shim" env >/dev/null 2>&1 || rc=$?
+  ((rc == 0))
+  [[ $(sha256sum "$guard_evidence" | awk '{print $1}') == "$prior_sha" ]] || {
+    echo 'recovery overwrote previously durable guard process evidence' >&2
+    exit 1
+  }
+)
+
+test_closure_incident_remains_resumable_until_writer_is_stopped() (
+  local fixture_dir state stop_count phase_after_first count_after_resume
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf "$fixture_dir"' EXIT
+  state="$fixture_dir/controller.json"
+  stop_count="$fixture_dir/stop-count"
+  printf '0\n' > "$stop_count"
+  printf '{"phase":"closure-running","guardJournal":"%s"}\n' \
+    "$fixture_dir/missing-guard-journal.json" > "$state"
+  chmod 0600 "$state"
+
+  eval "$(extract_function begin_closure_incident)"
+  eval "$(extract_function complete_closure_stop_pending)"
+  eval "$(extract_function resume_controller_state)"
+  path_present() { [[ -e "$1" || -L "$1" ]]; }
+  validate_controller_state() { :; }
+  update_controller_phase() {
+    local target=$1 phase=$2 incident_class=$3
+    jq --arg phase "$phase" --arg incidentClass "$incident_class" \
+      '.phase = $phase | .incidentClass = $incidentClass' "$target" > "$target.next"
+    install -m 600 "$target.next" "$target"
+  }
+  stop_application_fail_closed() {
+    local count
+    count=$(<"$stop_count")
+    count=$((count + 1))
+    printf '%s\n' "$count" > "$stop_count"
+    ((count > 1))
+  }
+  assert_owned_regular_file() { :; }
+  delegate_to_guard_journal() { return 1; }
+  die() { printf 'fixture: %s\n' "$*" >&2; exit 1; }
+
+  (begin_closure_incident "$state" verification) >/dev/null 2>&1 || true
+  phase_after_first=$(jq -er '.phase' "$state")
+  (resume_controller_state "$state") >/dev/null 2>&1 || true
+  count_after_resume=$(<"$stop_count")
+
+  [[ "$phase_after_first" != incident && "$count_after_resume" == 2 ]] || {
+    echo 'closure incident became terminal before a verified app stop could be resumed' >&2
+    exit 1
+  }
+)
+
+test_bootstrap_blocks_bash_env_and_exported_functions() (
+  local fixture_dir bash_env_marker function_marker bash_env
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf "$fixture_dir"' EXIT
+  bash_env_marker="$fixture_dir/bash-env-ran"
+  function_marker="$fixture_dir/exported-function-ran"
+  bash_env="$fixture_dir/bash-env"
+  printf ': > %q\n' "$bash_env_marker" > "$bash_env"
+  realpath() {
+    : > "$function_marker"
+    /usr/bin/realpath "$@"
+  }
+  export function_marker
+  export -f realpath
+
+  BASH_ENV="$bash_env" "$CONTROLLER" --help >/dev/null
+  [[ ! -e "$bash_env_marker" && ! -e "$function_marker" ]] || {
+    echo 'ambient Bash startup code executed before controller sanitization' >&2
+    exit 1
+  }
+)
+
+test_fixed_path_is_validated_before_installation() (
+  local fixture_dir manifest state tool_dir marker rc=0
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf "$fixture_dir"' EXIT
+  manifest="$fixture_dir/manifest.json"
+  state="$fixture_dir/controller.json"
+  tool_dir="$fixture_dir/hostile-bin"
+  marker="$fixture_dir/hostile-jq-ran"
+  mkdir -m 700 "$tool_dir"
+  write_execution_fixture "$fixture_dir" "$manifest"
+  cat > "$tool_dir/jq" <<SH
+#!/bin/bash
+: > "$marker"
+exec /usr/bin/jq "\$@"
+SH
+  chmod 0700 "$tool_dir/jq"
+  jq --arg fixedPath "$tool_dir:/usr/bin:/bin" '.fixedPath = $fixedPath' \
+    "$manifest" > "$manifest.next"
+  install -m 600 "$manifest.next" "$manifest"
+  export XDG_RUNTIME_DIR="$fixture_dir/locks"
+
+  "$CONTROLLER" --prepare --manifest "$manifest" --state "$state" >/dev/null 2>&1 || rc=$?
+  ((rc != 0))
+  [[ ! -e "$marker" ]] || {
+    echo 'manifest fixedPath executed a utility before its trust boundary was validated' >&2
+    exit 1
+  }
+)
+
+test_signal_waits_for_guard_descendant_group() (
+  local fixture_dir manifest state shim controller_pid='' descendant_pid='' rc=0 i returned_early=false
+  fixture_dir=$(mktemp -d)
+  trap '[[ -z ${controller_pid:-} ]] || kill "$controller_pid" 2>/dev/null || true; [[ -z ${descendant_pid:-} ]] || kill "$descendant_pid" 2>/dev/null || true; rm -rf "$fixture_dir"' EXIT
+  manifest="$fixture_dir/manifest.json"
+  state="$fixture_dir/controller.json"
+  write_execution_fixture "$fixture_dir" "$manifest" descendant-term
+  export XDG_RUNTIME_DIR="$fixture_dir/locks"
+  shim=$(write_systemd_identity_shim "$fixture_dir")
+  "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
+
+  run_fixture_controller "$state" "$shim" env >"$fixture_dir/controller.out" 2>"$fixture_dir/controller.err" &
+  controller_pid=$!
+  for i in $(seq 1 200); do
+    [[ -e "$fixture_dir/guard-descendant-running" ]] && break
+    kill -0 "$controller_pid" 2>/dev/null || break
+    sleep 0.02
+  done
+  [[ -e "$fixture_dir/guard-descendant-running" ]]
+  descendant_pid=$(<"$fixture_dir/guard-descendant-pid")
+  kill -TERM "$controller_pid"
+  wait "$controller_pid" || rc=$?
+  controller_pid=''
+  [[ "$rc" == 143 ]]
+  if [[ ! -e "$fixture_dir/guard-descendant-complete" ]] || kill -0 "$descendant_pid" 2>/dev/null; then
+    returned_early=true
+  fi
+  for i in $(seq 1 200); do
+    [[ -e "$fixture_dir/guard-descendant-complete" ]] && ! kill -0 "$descendant_pid" 2>/dev/null && break
+    sleep 0.02
+  done
+  if kill -0 "$descendant_pid" 2>/dev/null; then
+    kill "$descendant_pid" 2>/dev/null || true
+  fi
+  descendant_pid=''
+  [[ "$returned_early" == false ]] || {
+    echo 'controller returned while descendant transition work retained the operation lock' >&2
+    exit 1
+  }
+)
+
+test_concurrent_reprepare_cannot_replace_live_prepared_state() (
+  local fixture_dir manifest alternate state shim controller_pid='' reprepare_rc=0 controller_rc=0 i
+  local before_sha after_sha before_inode after_inode
+  fixture_dir=$(mktemp -d)
+  trap '[[ -z ${controller_pid:-} ]] || kill "$controller_pid" 2>/dev/null || true; rm -rf "$fixture_dir"' EXIT
+  manifest="$fixture_dir/manifest.json"
+  alternate="$fixture_dir/alternate.json"
+  state="$fixture_dir/controller.json"
+  write_execution_fixture "$fixture_dir" "$manifest"
+  export XDG_RUNTIME_DIR="$fixture_dir/locks"
+  shim=$(write_systemd_identity_shim "$fixture_dir")
+  "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
+  before_sha=$(sha256sum "$state" | awk '{print $1}')
+  before_inode=$(stat -c '%i' "$state")
+  jq '.appUrl = "http://127.0.0.1:26578"' "$manifest" > "$alternate"
+  chmod 0600 "$alternate"
+  : > "$fixture_dir/pause-next-docker"
+
+  run_fixture_controller "$state" "$shim" env >"$fixture_dir/controller.out" 2>"$fixture_dir/controller.err" &
+  controller_pid=$!
+  for i in $(seq 1 200); do
+    [[ -e "$fixture_dir/docker-paused" ]] && break
+    kill -0 "$controller_pid" 2>/dev/null || break
+    sleep 0.02
+  done
+  [[ -e "$fixture_dir/docker-paused" ]]
+  "$CONTROLLER" --prepare --manifest "$alternate" --state "$state" >/dev/null 2>&1 || reprepare_rc=$?
+  after_sha=$(sha256sum "$state" | awk '{print $1}')
+  after_inode=$(stat -c '%i' "$state")
+  : > "$fixture_dir/release-docker"
+  wait "$controller_pid" || controller_rc=$?
+  controller_pid=''
+  ((controller_rc == 0))
+
+  ((reprepare_rc != 0)) && [[ "$before_sha" == "$after_sha" && "$before_inode" == "$after_inode" ]] || {
+    echo 'concurrent preparation replaced a live prepared controller state' >&2
+    exit 1
+  }
+)
+
+test_guard_requires_deferred_writer_restart() (
+  local fixture_dir manifest state
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf "$fixture_dir"' EXIT
+  manifest="$fixture_dir/manifest.json"
+  state="$fixture_dir/controller.json"
+  write_execution_fixture "$fixture_dir" "$manifest"
+  jq '.guardArgs |= map(select(. != "--defer-app-restart"))' "$manifest" > "$manifest.next"
+  install -m 600 "$manifest.next" "$manifest"
+  export XDG_RUNTIME_DIR="$fixture_dir/locks"
+
+  if "$CONTROLLER" --prepare --manifest "$manifest" --state "$state" >/dev/null 2>&1; then
+    echo 'controller accepted a guard invocation that can restart the writer before closure is durable' >&2
+    exit 1
+  fi
+)
+
+test_verified_guard_bytes_cannot_be_replaced_before_use() (
+  local fixture_dir manifest state shim guard controller_pid='' rc=0 i
+  fixture_dir=$(mktemp -d)
+  trap '[[ -z ${controller_pid:-} ]] || kill "$controller_pid" 2>/dev/null || true; rm -rf "$fixture_dir"' EXIT
+  manifest="$fixture_dir/manifest.json"
+  state="$fixture_dir/controller.json"
+  guard="$fixture_dir/guard"
+  write_execution_fixture "$fixture_dir" "$manifest"
+  export XDG_RUNTIME_DIR="$fixture_dir/locks"
+  shim=$(write_systemd_identity_shim "$fixture_dir")
+  "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
+  : > "$fixture_dir/pause-engine-info"
+
+  run_fixture_controller "$state" "$shim" env >"$fixture_dir/controller.out" 2>"$fixture_dir/controller.err" &
+  controller_pid=$!
+  for i in $(seq 1 200); do
+    [[ -e "$fixture_dir/engine-info-paused" ]] && break
+    kill -0 "$controller_pid" 2>/dev/null || break
+    sleep 0.02
+  done
+  [[ -e "$fixture_dir/engine-info-paused" ]]
+  cat > "$guard.next" <<'GUARD'
+#!/usr/bin/env bash
+: > "$(dirname "$0")/replacement-guard-ran"
+exit 23
+GUARD
+  chmod 0700 "$guard.next"
+  mv -f "$guard.next" "$guard"
+  : > "$fixture_dir/release-engine-info"
+  wait "$controller_pid" || rc=$?
+  controller_pid=''
+
+  [[ ! -e "$fixture_dir/replacement-guard-ran" ]] || {
+    echo 'verified guard path replacement executed after input validation' >&2
+    exit 1
+  }
+  ((rc == 0)) || {
+    echo 'bound original guard bytes did not complete after pathname replacement' >&2
+    exit 1
+  }
+)
+
+test_concurrent_first_preparation_is_no_replace() (
+  local fixture_dir manifest alternate state first_pid second_pid first_rc=0 second_rc=0
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf "$fixture_dir"' EXIT
+  manifest="$fixture_dir/manifest.json"
+  alternate="$fixture_dir/alternate.json"
+  state="$fixture_dir/controller.json"
+  write_execution_fixture "$fixture_dir" "$manifest"
+  jq '.appUrl = "http://127.0.0.1:26578"' "$manifest" > "$alternate"
+  chmod 0600 "$alternate"
+  export XDG_RUNTIME_DIR="$fixture_dir/locks"
+
+  "$CONTROLLER" --prepare --manifest "$manifest" --state "$state" >/dev/null 2>&1 &
+  first_pid=$!
+  "$CONTROLLER" --prepare --manifest "$alternate" --state "$state" >/dev/null 2>&1 &
+  second_pid=$!
+  wait "$first_pid" || first_rc=$?
+  wait "$second_pid" || second_rc=$?
+
+  if ! (( (first_rc == 0 && second_rc != 0) || (first_rc != 0 && second_rc == 0) )); then
+    echo 'concurrent first preparations did not produce exactly one durable winner' >&2
+    exit 1
+  fi
+  [[ $(jq -er '.appUrl' "$state") == http://127.0.0.1:16578 ||
+     $(jq -er '.appUrl' "$state") == http://127.0.0.1:26578 ]]
+)
+
+test_fixed_path_rejects_mutable_symlink_aliases() (
+  local fixture_dir manifest state alias
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf "$fixture_dir"' EXIT
+  manifest="$fixture_dir/manifest.json"
+  state="$fixture_dir/controller.json"
+  alias="$fixture_dir/system-bin"
+  write_execution_fixture "$fixture_dir" "$manifest"
+  ln -s /usr/bin "$alias"
+  jq --arg fixedPath "$alias:/bin" '.fixedPath = $fixedPath' "$manifest" > "$manifest.next"
+  install -m 600 "$manifest.next" "$manifest"
+  export XDG_RUNTIME_DIR="$fixture_dir/locks"
+
+  if "$CONTROLLER" --prepare --manifest "$manifest" --state "$state" >/dev/null 2>&1; then
+    echo 'fixed PATH accepted a mutable symlink alias after validating only its target' >&2
+    exit 1
+  fi
+)
+
+test_verifier_evidence_failure_remains_resumable() (
+  local fixture_dir manifest state shim rc=0 phase
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf "$fixture_dir"' EXIT
+  manifest="$fixture_dir/manifest.json"
+  state="$fixture_dir/controller.json"
+  write_execution_fixture "$fixture_dir" "$manifest" complete fail
+  export XDG_RUNTIME_DIR="$fixture_dir/locks"
+  shim=$(write_systemd_identity_shim "$fixture_dir")
+  "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
+
+  run_fixture_controller "$state" "$shim" env \
+    NOOSPHERE_CONTROLLER_TEST_FAIL_EVIDENCE=closure-running >/dev/null 2>&1 || rc=$?
+  ((rc != 0))
+  phase=$(jq -er '.phase' "$state")
+  [[ "$phase" == closure-evidence-pending && -e "$fixture_dir/app-stopped" ]] || {
+    echo 'verifier evidence storage failure became terminal before durable evidence binding' >&2
+    exit 1
+  }
+)
+
+test_operation_lock_open_does_not_follow_symlinks() (
+  local fixture_dir lock_root victim lock_key lock_path rc=0
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf "$fixture_dir"' EXIT
+  lock_root="$fixture_dir/locks"
+  victim="$fixture_dir/victim"
+  mkdir -m 700 "$lock_root"
+  printf 'do-not-truncate\n' > "$victim"
+  chmod 0600 "$victim"
+  lock_key=$(printf '%s\0%s' fixture-engine fixture-volume | sha256sum | awk '{print $1}')
+  lock_path="$lock_root/noosphere-pgvector-switch-$lock_key.lock"
+  ln -s "$victim" "$lock_path"
+
+  eval "$(extract_function acquire_operation_lock)"
+  die() { printf 'fixture: %s\n' "$*" >&2; exit 1; }
+  (acquire_operation_lock fixture-engine fixture-volume "$lock_root") >/dev/null 2>&1 || rc=$?
+
+  ((rc != 0)) && [[ $(<"$victim") == do-not-truncate ]] || {
+    echo 'operation lock followed a pre-existing symlink and truncated its target' >&2
+    exit 1
+  }
+)
+
+test_execution_bundle_accepts_trusted_root_owned_executables() (
+  local fixture_dir source target expected rc=0
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf "$fixture_dir"' EXIT
+  source=/usr/bin/docker
+  target="$fixture_dir/bound-docker"
+  [[ $(stat -c '%u' "$source") == 0 ]] || {
+    echo 'root-owned executable fixture source is not root-owned' >&2
+    exit 1
+  }
+  expected=$(sha256sum "$source" | awk '{print $1}')
+
+  for helper in assert_owned_regular_file sha256_file copy_execution_input; do
+    eval "$(extract_function "$helper")"
+  done
+  fsync_path() { :; }
+  die() { printf 'fixture: %s\n' "$*" >&2; exit 1; }
+
+  (copy_execution_input "$source" "$target" "$expected" 700 system-executable) || rc=$?
+  ((rc == 0)) && [[ $(sha256_file "$target") == "$expected" ]] || {
+    echo 'execution bundle rejected a trusted root-owned system executable' >&2
+    exit 1
+  }
+)
+
+test_bootstrap_utility_resolution_is_trusted_before_use() (
+  local fixture_dir controller_copy hostile_bin marker
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf "$fixture_dir"' EXIT
+  controller_copy="$fixture_dir/controller"
+  hostile_bin="$fixture_dir/hostile-bin"
+  marker="$fixture_dir/hostile-realpath-ran"
+  mkdir -m 700 "$hostile_bin"
+  sed "s|/usr/local/bin|$hostile_bin|" "$CONTROLLER" > "$controller_copy"
+  chmod 0700 "$controller_copy"
+  cat > "$hostile_bin/realpath" <<SH
+#!/bin/sh
+: > "$marker"
+exec /usr/bin/realpath "\$@"
+SH
+  chmod 0700 "$hostile_bin/realpath"
+
+  "$controller_copy" --help >/dev/null
+  [[ ! -e "$marker" ]] || {
+    echo 'controller executed a PATH-resolved bootstrap utility before proving its directory trusted' >&2
+    exit 1
+  }
+)
+
+test_systemd_context_requires_transient_unit_provenance() (
+  local fixture_dir manifest
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf "$fixture_dir"' EXIT
+  manifest="$fixture_dir/manifest.json"
+  write_execution_fixture "$fixture_dir" "$manifest"
+  eval "$(extract_function require_systemd_execution_context)"
+  controller_state="$manifest"
+  INVOCATION_ID=0123456789abcdef0123456789abcdef
+  CONTROLLER_UNIT=noosphere-pgvector-transition.service
+  query_systemd_unit_identity() {
+    printf '%s\n' \
+      ActiveState=active \
+      "InvocationID=$INVOCATION_ID" \
+      "MainPID=$$" \
+      Type=exec \
+      RemainAfterExit=no \
+      Restart=no \
+      KillMode=mixed \
+      TimeoutStartUSec=infinity \
+      TimeoutStopUSec=infinity \
+      RuntimeMaxUSec=infinity \
+      UMask=0077 \
+      Transient=no \
+      "WorkingDirectory=$(dirname "$(jq -er '.liveCompose' "$controller_state")")"
+  }
+  query_user_linger() { printf 'yes\n'; }
+  die() { printf 'fixture: %s\n' "$*" >&2; exit 1; }
+
+  if (require_systemd_execution_context); then
+    echo 'persistent systemd service satisfied the transient execution contract' >&2
+    exit 1
+  fi
+)
+
+test_writer_activation_lifecycle_is_ordered_and_evidence_bound() (
+  local fixture_dir manifest state shim rc=0 authorization_evidence
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf "$fixture_dir"' EXIT
+  manifest="$fixture_dir/manifest.json"
+  state="$fixture_dir/controller.json"
+  write_execution_fixture "$fixture_dir" "$manifest"
+  export XDG_RUNTIME_DIR="$fixture_dir/locks"
+  shim=$(write_systemd_identity_shim "$fixture_dir")
+  "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
+
+  run_fixture_controller "$state" "$shim" env >/dev/null 2>&1 || rc=$?
+  ((rc == 0)) || {
+    echo 'controller could not complete the deferred-writer activation lifecycle' >&2
+    exit 1
+  }
+  [[ $(paste -sd, "$fixture_dir/lifecycle.log") == transition,authorize,activate,verify ]] || {
+    echo 'writer authorization, activation, and final verification ran out of order' >&2
+    exit 1
+  }
+  authorization_evidence=$(jq -er '.authorizationEvidence.path' "$state")
+  jq -e '
+    .phase == "complete" and
+    (.authorizationEvidence.sha256 | test("^[a-f0-9]{64}$")) and
+    (.closureEvidence.sha256 | test("^[a-f0-9]{64}$"))
+  ' "$state" >/dev/null
+  jq -e '.phase == "authorization-running" and .exitCode == 0' \
+    "$authorization_evidence" >/dev/null
+)
+
+test_authorization_evidence_is_durable_before_activation() (
+  local fixture_dir manifest state shim rc=0 resume_rc=0 authorization_evidence
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf "$fixture_dir"' EXIT
+  manifest="$fixture_dir/manifest.json"
+  state="$fixture_dir/controller.json"
+  write_execution_fixture "$fixture_dir" "$manifest"
+  export XDG_RUNTIME_DIR="$fixture_dir/locks"
+  shim=$(write_systemd_identity_shim "$fixture_dir")
+  "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
+
+  run_fixture_controller "$state" "$shim" env \
+    NOOSPHERE_CONTROLLER_TEST_SIGNAL_AFTER_AUTHORIZATION=TERM >/dev/null 2>&1 || rc=$?
+  [[ "$rc" == 143 ]] || {
+    echo 'authorization boundary did not return the latched signal exit' >&2
+    exit 1
+  }
+  [[ $(jq -er '.phase' "$state") == activation-running && ! -e "$fixture_dir/app-started" ]] || {
+    echo 'writer activation began before authorization evidence was durable' >&2
+    exit 1
+  }
+  authorization_evidence=$(jq -er '.authorizationEvidence.path' "$state")
+  jq -e '.phase == "authorization-running" and .exitCode == 0' \
+    "$authorization_evidence" >/dev/null
+
+  NOOSPHERE_CONTROLLER_FIXTURE_INVOCATION_ID=fedcba9876543210fedcba9876543210 \
+    run_fixture_controller "$state" "$shim" env >/dev/null 2>&1 || resume_rc=$?
+  ((resume_rc == 0))
+  [[ $(jq -er '.phase' "$state") == complete ]]
+  [[ $(paste -sd, "$fixture_dir/lifecycle.log") == transition,authorize,activate,verify ]]
+)
+
+test_app_activation_failure_is_fail_closed_before_final_verification() (
+  local fixture_dir manifest state shim rc=0
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf "$fixture_dir"' EXIT
+  manifest="$fixture_dir/manifest.json"
+  state="$fixture_dir/controller.json"
+  write_execution_fixture "$fixture_dir" "$manifest"
+  : > "$fixture_dir/fail-activation"
+  export XDG_RUNTIME_DIR="$fixture_dir/locks"
+  shim=$(write_systemd_identity_shim "$fixture_dir")
+  "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
+
+  run_fixture_controller "$state" "$shim" env >/dev/null 2>&1 || rc=$?
+  ((rc != 0))
+  jq -e '
+    .phase == "incident" and
+    .incidentClass == "closure-app-activation" and
+    (.authorizationEvidence.sha256 | test("^[a-f0-9]{64}$")) and
+    has("closureEvidence") == false
+  ' "$state" >/dev/null || {
+    echo 'failed app activation did not preserve a fail-closed durable incident' >&2
+    exit 1
+  }
+  [[ -e "$fixture_dir/app-stopped" ]]
+  [[ $(paste -sd, "$fixture_dir/lifecycle.log") == transition,authorize,activate ]] || {
+    echo 'final verifier ran despite failed app activation' >&2
+    exit 1
+  }
+)
+
+test_term_after_activation_stops_writer_before_return() (
+  local fixture_dir manifest state shim rc=0
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf "$fixture_dir"' EXIT
+  manifest="$fixture_dir/manifest.json"
+  state="$fixture_dir/controller.json"
+  write_execution_fixture "$fixture_dir" "$manifest"
+  : > "$fixture_dir/signal-after-activation"
+  export XDG_RUNTIME_DIR="$fixture_dir/locks"
+  shim=$(write_systemd_identity_shim "$fixture_dir")
+  "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
+
+  run_fixture_controller "$state" "$shim" env >/dev/null 2>&1 || rc=$?
+  [[ "$rc" == 143 ]]
+  [[ -e "$fixture_dir/app-stopped" ]] || {
+    echo 'TERM after app activation returned with the writer still running' >&2
+    exit 1
+  }
+  jq -e '
+    .phase == "incident" and
+    .incidentClass == "closure-interruption" and
+    has("closureEvidence") == false
+  ' "$state" >/dev/null || {
+    echo 'TERM after app activation did not commit a fail-closed interruption incident' >&2
+    exit 1
+  }
+)
+
+test_closure_evidence_pending_resume_never_reactivates_writer() (
+  local fixture_dir manifest state shim rc=0 resume_rc=0 activation_count
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf "$fixture_dir"' EXIT
+  manifest="$fixture_dir/manifest.json"
+  state="$fixture_dir/controller.json"
+  write_execution_fixture "$fixture_dir" "$manifest" complete fail
+  export XDG_RUNTIME_DIR="$fixture_dir/locks"
+  shim=$(write_systemd_identity_shim "$fixture_dir")
+  "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
+
+  run_fixture_controller "$state" "$shim" env \
+    NOOSPHERE_CONTROLLER_TEST_FAIL_EVIDENCE=closure-running >/dev/null 2>&1 || rc=$?
+  ((rc != 0))
+  [[ $(jq -er '.phase' "$state") == closure-evidence-pending ]]
+  [[ -e "$fixture_dir/app-stopped" ]]
+  activation_count=$(rg -c '^activate$' "$fixture_dir/lifecycle.log")
+  [[ "$activation_count" == 1 ]]
+
+  NOOSPHERE_CONTROLLER_FIXTURE_INVOCATION_ID=fedcba9876543210fedcba9876543210 \
+    run_fixture_controller "$state" "$shim" env >/dev/null 2>&1 || resume_rc=$?
+  ((resume_rc != 0))
+  activation_count=$(rg -c '^activate$' "$fixture_dir/lifecycle.log")
+  [[ "$activation_count" == 1 ]] || {
+    echo 'closure-evidence-pending resume reactivated the failed writer' >&2
+    exit 1
+  }
+  [[ -e "$fixture_dir/app-stopped" ]]
+  jq -e '
+    .phase == "incident" and
+    .incidentClass == "closure-verification" and
+    (.closureEvidence.sha256 | test("^[a-f0-9]{64}$"))
+  ' "$state" >/dev/null
+)
+
+test_missing_live_compose_commits_prejournal_restoration_incident() (
+  local fixture_dir state live source guard_journal source_sha rc=0
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf "$fixture_dir"' EXIT
+  state="$fixture_dir/controller.json"
+  live="$fixture_dir/docker-compose.yml"
+  source="$fixture_dir/source-compose.yml"
+  guard_journal="$fixture_dir/guard.json"
+  printf 'source\n' > "$source"
+  chmod 0644 "$source"
+  source_sha=$(sha256sum "$source" | awk '{print $1}')
+  write_fixture_controller_state "$state" candidate-published "$live" "$source" "$source_sha" "$guard_journal"
+
+  for helper in path_present assert_owned_regular_file sha256_file \
+    write_controller_state_atomic validate_controller_state update_controller_phase \
+    restore_source_compose_snapshot resume_controller_state; do
+    eval "$(extract_function "$helper")"
+  done
+  fsync_path() { :; }
+  assert_source_state_unchanged() { :; }
+  run_source_recovery_verifier_with_evidence() { :; }
+  delegate_to_guard_journal() { exit 1; }
+  die() { printf 'fixture: %s\n' "$*" >&2; exit 1; }
+
+  (resume_controller_state "$state") >/dev/null 2>&1 || rc=$?
+  ((rc != 0))
+  jq -e '
+    .phase == "incident" and
+    .incidentClass == "pre-journal-source-restoration"
+  ' "$state" >/dev/null || {
+    echo 'missing live Compose bypassed durable pre-journal restoration classification' >&2
+    exit 1
+  }
+)
+
+test_post_activation_artifact_setup_failure_stops_writer_durably() (
+  local fixture_dir manifest state shim activation_count control_tail rc=0
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf "$fixture_dir"' EXIT
+  manifest="$fixture_dir/manifest.json"
+  state="$fixture_dir/controller.json"
+  write_execution_fixture "$fixture_dir" "$manifest"
+  export XDG_RUNTIME_DIR="$fixture_dir/locks"
+  shim=$(write_post_authorization_artifact_failure_shim "$fixture_dir")
+  "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
+  : > "$fixture_dir/fail-next-artifact-storage-after-authorization"
+  : > "$fixture_dir/kill-controller-if-incident-before-stop"
+
+  run_fixture_controller "$state" "$shim" env \
+    >"$fixture_dir/controller.out" 2>"$fixture_dir/controller.err" || rc=$?
+  ((rc != 0))
+  [[ -e "$fixture_dir/post-authorization-artifact-failure-consumed" ]] || {
+    echo 'artifact-storage fixture missed the semantic post-authorization allocation boundary' >&2
+    exit 1
+  }
+  activation_count=$(rg -c '^activate$' "$fixture_dir/lifecycle.log" || printf '0\n')
+  case "$activation_count" in
+    0)
+      [[ -e "$fixture_dir/app-stopped" ]] || {
+        echo 'pre-activation artifact rejection did not preserve the stopped writer' >&2
+        exit 1
+      }
+      ;;
+    1)
+      control_tail=$(tail -n 2 "$fixture_dir/app-control.log" 2>/dev/null | paste -sd, -)
+      [[ "$control_tail" == stop,inspect:false ]] || {
+        echo 'post-activation artifact setup failure did not verify the writer stop' >&2
+        exit 1
+      }
+      jq -e '
+        .phase == "incident" and
+        (.incidentClass | type == "string" and startswith("closure-"))
+      ' "$state" >/dev/null || {
+        echo 'post-activation artifact setup failure lacks durable verified stop state' >&2
+        exit 1
+      }
+      ;;
+    *)
+      echo 'artifact collision fixture activated the writer more than once' >&2
+      exit 1
+      ;;
+  esac
+)
+
+test_closure_evidence_pending_requires_verified_stop_before_persistence() (
+  local fixture_dir state stopped kill_on_pending=true rc=0
+  local -a failures=()
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf "$fixture_dir"' EXIT
+  state="$fixture_dir/controller.json"
+  stopped="$fixture_dir/app-stopped"
+  printf '{"phase":"closure-running"}\n' > "$state"
+  chmod 0600 "$state"
+
+  eval "$(extract_function begin_closure_evidence_pending)"
+  update_controller_phase() {
+    local target=$1 phase=$2 incident_class=${3:-} temp
+    temp="$target.next"
+    jq --arg phase "$phase" --arg incidentClass "$incident_class" \
+      '.phase = $phase | .incidentClass = $incidentClass' "$target" > "$temp"
+    mv "$temp" "$target"
+    if [[ "$phase" == closure-evidence-pending && "$kill_on_pending" == true ]]; then
+      kill -KILL "$BASHPID"
+    fi
+  }
+  stop_application_fail_closed() { : > "$stopped"; }
+
+  (begin_closure_evidence_pending "$state" verification) >/dev/null 2>&1 || rc=$?
+  [[ "$rc" == 137 ]]
+  [[ -e "$stopped" ]] ||
+    failures+=('closure-evidence-pending became durable before the writer stop was verified')
+  [[ $(jq -er '.phase' "$state") == closure-evidence-pending ]]
+
+  printf '{"phase":"closure-running"}\n' > "$state"
+  kill_on_pending=false
+  stop_application_fail_closed() { return 1; }
+  rc=0
+  (begin_closure_evidence_pending "$state" verification) >/dev/null 2>&1 || rc=$?
+  ((rc != 0))
+  [[ $(jq -er '.phase' "$state") != closure-evidence-pending ]] ||
+    failures+=('closure-evidence-pending became durable after stop verification failed')
+  ((${#failures[@]} == 0)) || {
+    printf '%s\n' "${failures[@]}" >&2
+    exit 1
+  }
+)
+
+test_same_name_volume_replacement_is_rejected_after_preparation() (
+  local fixture_dir='' manifest state shim expected_fingerprint live_fingerprint field
+  trap '[[ -z ${fixture_dir:-} ]] || rm -rf "$fixture_dir"' EXIT
+
+  for field in Driver Mountpoint CreatedAt Scope Labels Options; do
+    fixture_dir=$(mktemp -d)
+    manifest="$fixture_dir/manifest.json"
+    state="$fixture_dir/controller.json"
+    write_execution_fixture "$fixture_dir" "$manifest"
+    export XDG_RUNTIME_DIR="$fixture_dir/locks"
+    shim=$(write_systemd_identity_shim "$fixture_dir")
+    "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
+
+    expected_fingerprint=$(jq -er '.volumeFingerprint' "$state")
+    live_fingerprint=$(jq -Sc '.[0] | {Name,Driver,Mountpoint,CreatedAt,Scope,Labels,Options}' \
+      "$fixture_dir/volume-inspect.json" | sha256sum | awk '{print $1}')
+    [[ "$expected_fingerprint" == "$live_fingerprint" ]] || {
+      echo 'prepared volume fingerprint does not match the canonical inspection oracle' >&2
+      exit 1
+    }
+
+    case "$field" in
+      Driver) jq '.[0].Driver = "replacement-driver"' "$fixture_dir/volume-inspect.json" ;;
+      Mountpoint) jq '.[0].Mountpoint = "/var/lib/docker/volumes/replaced-fixture-volume/_data"' "$fixture_dir/volume-inspect.json" ;;
+      CreatedAt) jq '.[0].CreatedAt = "2026-08-15T00:00:01Z"' "$fixture_dir/volume-inspect.json" ;;
+      Scope) jq '.[0].Scope = "replacement-scope"' "$fixture_dir/volume-inspect.json" ;;
+      Labels) jq '.[0].Labels = {"fixture":"replacement"}' "$fixture_dir/volume-inspect.json" ;;
+      Options) jq '.[0].Options = {"type":"none","o":"bind","device":"/replacement"}' "$fixture_dir/volume-inspect.json" ;;
+    esac > "$fixture_dir/volume-inspect.next"
+    mv "$fixture_dir/volume-inspect.next" "$fixture_dir/volume-inspect.json"
+    live_fingerprint=$(jq -Sc '.[0] | {Name,Driver,Mountpoint,CreatedAt,Scope,Labels,Options}' \
+      "$fixture_dir/volume-inspect.json" | sha256sum | awk '{print $1}')
+    [[ "$live_fingerprint" != "$expected_fingerprint" ]]
+    rm -f "$fixture_dir/volume-inspect-seen" "$fixture_dir/live-identity.log"
+
+    if run_fixture_controller "$state" "$shim" env \
+      >"$fixture_dir/controller.out" 2>"$fixture_dir/controller.err"; then
+      echo "same-name PostgreSQL volume replacement escaped the prepared fingerprint: $field" >&2
+      exit 1
+    fi
+    [[ -e "$fixture_dir/volume-inspect-seen" ]] || {
+      echo "execution did not inspect the replaced PostgreSQL volume: $field" >&2
+      exit 1
+    }
+    rg -i 'PostgreSQL volume fingerprint.*(changed|differs|does not match)' \
+      "$fixture_dir/controller.err" >/dev/null || {
+      echo "volume replacement failed for an unrelated mechanism: $field" >&2
+      exit 1
+    }
+    [[ $(jq -er '.phase' "$state") == prepared ]]
+    [[ $(<"$fixture_dir/docker-compose.yml") == 'source model' ]]
+    rm -rf "$fixture_dir"
+    fixture_dir=''
+  done
+)
+
+test_live_identity_checks_wait_for_the_shared_operation_lock() (
+  local fixture_dir manifest state shim prepare_unheld execute_unheld call_class rc=0
+  local -a failures=()
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf "$fixture_dir"' EXIT
+  manifest="$fixture_dir/manifest.json"
+  state="$fixture_dir/controller.json"
+  write_execution_fixture "$fixture_dir" "$manifest"
+  export XDG_RUNTIME_DIR="$fixture_dir/locks"
+  shim=$(write_systemd_identity_shim "$fixture_dir")
+
+  rm -f "$fixture_dir/live-identity.log"
+  "$CONTROLLER" --prepare --manifest "$manifest" --state "$state" \
+    >"$fixture_dir/prepare.out" 2>"$fixture_dir/prepare.err" || rc=$?
+  ((rc == 0)) || {
+    echo 'lock-order preparation fixture failed before its live-call oracle' >&2
+    exit 1
+  }
+  prepare_unheld=$(rg ':unheld$' "$fixture_dir/live-identity.log" || true)
+  for call_class in info volume-inspect compose-version compose-config; do
+    rg -q "^$call_class:" "$fixture_dir/live-identity.log" ||
+      failures+=("preparation omitted required live identity call: $call_class")
+  done
+  if [[ -n "$prepare_unheld" ]]; then
+    failures+=('preparation issued live Docker/Compose identity calls without the shared operation lock')
+  fi
+
+  rm -f "$fixture_dir/live-identity.log"
+  rc=0
+  run_fixture_controller "$state" "$shim" env \
+    >"$fixture_dir/execute.out" 2>"$fixture_dir/execute.err" || rc=$?
+  ((rc == 0)) || {
+    echo 'lock-order execution fixture failed before its live-call oracle' >&2
+    exit 1
+  }
+  execute_unheld=$(rg ':unheld$' "$fixture_dir/live-identity.log" || true)
+  for call_class in info volume-inspect compose-version compose-config; do
+    rg -q "^$call_class:" "$fixture_dir/live-identity.log" ||
+      failures+=("execution omitted required live identity call: $call_class")
+  done
+  if [[ -n "$execute_unheld" ]]; then
+    failures+=('execution issued live Docker/Compose identity calls without the shared operation lock')
+  fi
+
+  ((${#failures[@]} == 0)) || {
+    printf '%s\n' "${failures[@]}" >&2
+    [[ -z "$prepare_unheld" ]] || printf '%s\n' "$prepare_unheld" >&2
+    [[ -z "$execute_unheld" ]] || printf '%s\n' "$execute_unheld" >&2
+    exit 1
+  }
+)
+
+test_successful_verifier_postprocessing_failure_stops_writer() (
+  local failure fixture_dir='' manifest state shim rc phase control_tail
+  local -a failures=()
+  trap '[[ -z ${fixture_dir:-} ]] || rm -rf "$fixture_dir"' EXIT
+
+  for failure in evidence cursor state; do
+    fixture_dir=$(mktemp -d)
+    manifest="$fixture_dir/manifest.json"
+    state="$fixture_dir/controller.json"
+    write_execution_fixture "$fixture_dir" "$manifest"
+    export XDG_RUNTIME_DIR="$fixture_dir/locks"
+    if [[ "$failure" == state ]]; then
+      shim=$(write_complete_state_failure_shim "$fixture_dir")
+    else
+      shim=$(write_systemd_identity_shim "$fixture_dir")
+    fi
+    "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
+    [[ "$failure" != cursor ]] || : > "$fixture_dir/fail-cursor-after-successful-verifier"
+    [[ "$failure" != state ]] || : > "$fixture_dir/fail-complete-state-write"
+
+    rc=0
+    if [[ "$failure" == evidence ]]; then
+      run_fixture_controller "$state" "$shim" env \
+        NOOSPHERE_CONTROLLER_TEST_FAIL_EVIDENCE=closure-running \
+        >"$fixture_dir/controller.out" 2>"$fixture_dir/controller.err" || rc=$?
+      rg -Fq 'test evidence failure at phase closure-running' "$fixture_dir/controller.err" ||
+        failures+=("successful verifier evidence fixture missed its injected failure")
+    elif [[ "$failure" == cursor ]]; then
+      run_fixture_controller "$state" "$shim" env \
+        >"$fixture_dir/controller.out" 2>"$fixture_dir/controller.err" || rc=$?
+      [[ -e "$fixture_dir/cursor-failure-consumed" ]] ||
+        failures+=("successful verifier cursor fixture missed its injected failure")
+    else
+      run_fixture_controller "$state" "$shim" env \
+        >"$fixture_dir/controller.out" 2>"$fixture_dir/controller.err" || rc=$?
+      [[ -e "$fixture_dir/complete-state-write-failure-consumed" ]] ||
+        failures+=("successful verifier state fixture missed its injected failure")
+    fi
+    ((rc != 0)) || failures+=("successful verifier $failure failure reported success")
+    rg -q '^verify$' "$fixture_dir/lifecycle.log" ||
+      failures+=("successful verifier $failure failure happened before verification succeeded")
+    [[ -e "$fixture_dir/app-stopped" ]] ||
+      failures+=("successful verifier $failure failure left the writer running")
+    control_tail=$(tail -n 2 "$fixture_dir/app-control.log" 2>/dev/null | paste -sd, -)
+    [[ "$control_tail" == stop,inspect:false ]] ||
+      failures+=("successful verifier $failure failure did not inspect-verify the writer stop")
+    phase=$(jq -r '.phase // empty' "$state")
+    if [[ "$failure" == state ]]; then
+      [[ "$phase" != complete ]] ||
+        failures+=("successful verifier state-storage failure exposed complete")
+    else
+      [[ "$phase" == closure-stop-pending || "$phase" == closure-evidence-pending || "$phase" == incident ]] ||
+        failures+=("successful verifier $failure failure lacks durable closure stop intent (phase=$phase)")
+    fi
+
+    rm -rf "$fixture_dir"
+    fixture_dir=''
+  done
+
+  ((${#failures[@]} == 0)) || {
+    printf '%s\n' "${failures[@]}" >&2
+    exit 1
+  }
+)
+
+test_post_activation_signal_with_zero_exit_verifier_stops_writer() (
+  local fixture_dir='' manifest state shim controller_pid='' child_pid='' evidence='' rc i control_tail
+  local signal expected_rc signal_spec
+  local -a failures=()
+  trap 'terminate_fixture_process "${controller_pid:-}"; terminate_fixture_process "${child_pid:-}"; [[ -z ${fixture_dir:-} ]] || rm -rf "$fixture_dir"' EXIT
+
+  for signal_spec in TERM:143 INT:130 HUP:129; do
+    signal=${signal_spec%%:*}
+    expected_rc=${signal_spec##*:}
+    fixture_dir=$(mktemp -d)
+    manifest="$fixture_dir/manifest.json"
+    state="$fixture_dir/controller.json"
+    write_execution_fixture "$fixture_dir" "$manifest" complete signal-zero
+    export XDG_RUNTIME_DIR="$fixture_dir/locks"
+    shim=$(write_systemd_identity_shim "$fixture_dir")
+    "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
+
+    rc=0
+    run_fixture_controller "$state" "$shim" env --default-signal="$signal" \
+      >"$fixture_dir/controller.out" 2>"$fixture_dir/controller.err" &
+    controller_pid=$!
+    for i in $(seq 1 200); do
+      [[ -e "$fixture_dir/candidate-verifier-running" ]] && break
+      kill -0 "$controller_pid" 2>/dev/null || break
+      sleep 0.05
+    done
+    [[ -e "$fixture_dir/candidate-verifier-running" ]]
+    child_pid=$(<"$fixture_dir/candidate-verifier-pid")
+    kill -s "$signal" "$controller_pid"
+    wait_fixture_process_bounded "$controller_pid" || rc=$?
+    if ((rc == 124)); then
+      failures+=("post-activation $signal controller exceeded the bounded wait")
+      terminate_fixture_process "$controller_pid"
+    fi
+    controller_pid=''
+
+    [[ "$rc" == "$expected_rc" ]] ||
+      failures+=("post-activation $signal returned $rc instead of $expected_rc")
+    [[ -e "$fixture_dir/candidate-verifier-signal-zero" ]] ||
+      failures+=("post-activation signal fixture did not exercise a verifier that handled $signal and exited zero")
+    [[ -e "$fixture_dir/candidate-verifier-signal-zero-complete" ]] ||
+      failures+=("post-activation $signal fixture returned before the zero-exit verifier completed")
+    evidence=$(jq -r '.closureEvidence.path // empty' "$state")
+    [[ -n "$evidence" && -f "$evidence" && $(jq -er '.exitCode' "$evidence") == 0 ]] ||
+      failures+=("post-activation $signal fixture did not record the verifier zero exit")
+    [[ -e "$fixture_dir/app-stopped" ]] ||
+      failures+=("post-activation $signal returned after a zero-exit verifier with the writer still running")
+    control_tail=$(tail -n 2 "$fixture_dir/app-control.log" 2>/dev/null | paste -sd, -)
+    [[ "$control_tail" == stop,inspect:false ]] ||
+      failures+=("post-activation $signal did not inspect-verify the writer stop after the verifier exited zero")
+    jq -e --arg signal "$signal" '
+      .phase == "incident" and
+      .incidentClass == "closure-interruption" and
+      .lastInterruption.signal == $signal
+    ' "$state" >/dev/null ||
+      failures+=("post-activation $signal with a zero-exit verifier lacks a durable interruption incident")
+    if kill -0 "$child_pid" 2>/dev/null; then
+      failures+=("post-activation $signal verifier remains alive after controller return")
+      terminate_fixture_process "$child_pid"
+    fi
+    child_pid=''
+
+    rm -rf "$fixture_dir"
+    fixture_dir=''
+  done
+
+  ((${#failures[@]} == 0)) || {
+    printf '%s\n' "${failures[@]}" >&2
+    exit 1
+  }
+)
+
+test_source_recovery_signal_persists_process_evidence() (
+  local case_name verifier_mode expected_rc expected_signal fixture_dir='' manifest state shim
+  local controller_pid='' observed_controller_pid='' child_pid='' evidence='' rc i
+  local expected_evidence expected_stdout expected_stderr evidence_sha stdout_sha stderr_sha
+  local expected_boot expected_boot_cursor
+  local -a failures=()
+  trap 'terminate_fixture_process "${controller_pid:-}"; terminate_fixture_process "${child_pid:-}"; [[ -z ${fixture_dir:-} ]] || rm -rf "$fixture_dir"' EXIT
+
+  for case_name in ordinary interrupted; do
+    if [[ "$case_name" == ordinary ]]; then
+      verifier_mode=source-fail
+      expected_rc=42
+      expected_signal=''
+    else
+      verifier_mode=delayed-term
+      expected_rc=143
+      expected_signal=TERM
+    fi
+    fixture_dir=$(mktemp -d)
+    manifest="$fixture_dir/manifest.json"
+    state="$fixture_dir/controller.json"
+    write_execution_fixture "$fixture_dir" "$manifest" prejournal-fail "$verifier_mode"
+    export XDG_RUNTIME_DIR="$fixture_dir/locks"
+    shim=$(write_systemd_identity_shim "$fixture_dir")
+    "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
+    expected_boot=$(< /proc/sys/kernel/random/boot_id)
+    expected_boot_cursor="b=${expected_boot//-/}"
+
+    rc=0
+    run_fixture_controller "$state" "$shim" env \
+      >"$fixture_dir/controller.out" 2>"$fixture_dir/controller.err" &
+    controller_pid=$!
+    observed_controller_pid=$controller_pid
+    if [[ -n "$expected_signal" ]]; then
+      for i in $(seq 1 200); do
+        [[ -e "$fixture_dir/source-verifier-running" ]] && break
+        kill -0 "$controller_pid" 2>/dev/null || break
+        sleep 0.05
+      done
+      [[ -e "$fixture_dir/source-verifier-running" ]]
+      child_pid=$(<"$fixture_dir/source-verifier-pid")
+      kill -s "$expected_signal" "$controller_pid"
+    fi
+    wait_fixture_process_bounded "$controller_pid" || rc=$?
+    if ((rc == 124)); then
+      failures+=("source recovery $case_name controller exceeded the bounded wait")
+      terminate_fixture_process "$controller_pid"
+    fi
+    controller_pid=''
+    [[ -n "$child_pid" ]] || child_pid=$(<"$fixture_dir/source-verifier-pid")
+
+    [[ "$rc" == "$expected_rc" ]] ||
+      failures+=("source recovery $case_name failure collapsed to exit $rc instead of $expected_rc")
+    expected_evidence="${state%.json}.source-recovery.evidence.json"
+    expected_stdout="${state%.json}.source-recovery.stdout.log"
+    expected_stderr="${state%.json}.source-recovery.stderr.log"
+    evidence=$(jq -r '.sourceRecoveryEvidence.path // empty' "$state")
+    if [[ "$evidence" != "$expected_evidence" || ! -f "$expected_evidence" ||
+          ! -f "$expected_stdout" || ! -f "$expected_stderr" ]]; then
+      failures+=("source recovery $case_name failure returned without its exact process/log artifacts")
+    else
+      local expected_stdout_sha expected_stderr_sha
+      evidence_sha=$(sha256sum "$expected_evidence" | awk '{print $1}')
+      stdout_sha=$(sha256sum "$expected_stdout" | awk '{print $1}')
+      stderr_sha=$(sha256sum "$expected_stderr" | awk '{print $1}')
+      expected_stdout_sha=$(printf '' | sha256sum | awk '{print $1}')
+      if [[ "$case_name" == ordinary ]]; then
+        expected_stderr_sha=$(printf 'source verification failed\n' | sha256sum | awk '{print $1}')
+      else
+        expected_stderr_sha=$(printf 'Terminated%17ssleep 0.1\n' '' | sha256sum | awk '{print $1}')
+      fi
+      [[ "$stdout_sha" == "$expected_stdout_sha" && "$stderr_sha" == "$expected_stderr_sha" ]] ||
+        failures+=("source recovery $case_name logs do not match the independently expected bytes")
+      jq -e \
+        --argjson exitCode "$expected_rc" \
+        --arg invocation 0123456789abcdef0123456789abcdef \
+        --arg boot "$expected_boot" \
+        --arg bootCursor "$expected_boot_cursor" \
+        --argjson controllerPid "$observed_controller_pid" \
+        --argjson childPid "$child_pid" \
+        --arg stdout "$expected_stdout" \
+        --arg stderr "$expected_stderr" \
+        --arg stdoutSha "$expected_stdout_sha" \
+        --arg stderrSha "$expected_stderr_sha" '
+          .phase == "source-recovery-running" and .exitCode == $exitCode and
+          .invocationId == $invocation and .bootId == $boot and
+          .controllerMainPid == $controllerPid and .childPid == $childPid and
+          (.startCursor | type == "string" and contains($bootCursor)) and
+          (.endCursor | type == "string" and contains($bootCursor)) and
+          .startCursor != "fixture-cursor" and .endCursor != "fixture-cursor" and
+          .startCursor != "forged-journal-cursor" and
+          .endCursor != "forged-journal-cursor" and
+          .stdout == $stdout and .stderr == $stderr and
+          .stdoutSha256 == $stdoutSha and .stderrSha256 == $stderrSha
+        ' "$expected_evidence" >/dev/null ||
+        failures+=("source recovery $case_name evidence is not bound to the exact process and log bytes")
+      jq -e \
+        --arg path "$expected_evidence" \
+        --arg sha "$evidence_sha" \
+        --arg stdout "$expected_stdout" \
+        --arg stdoutSha "$expected_stdout_sha" \
+        --arg stderr "$expected_stderr" \
+        --arg stderrSha "$expected_stderr_sha" '
+          .sourceRecoveryEvidence == {
+            path:$path, sha256:$sha,
+            stdout:{path:$stdout,sha256:$stdoutSha},
+            stderr:{path:$stderr,sha256:$stderrSha}
+          }
+        ' "$state" >/dev/null ||
+        failures+=("source recovery $case_name evidence/log digests are not durably bound")
+    fi
+    if [[ "$case_name" == ordinary ]]; then
+      rg -Fq 'source verification failed' "$expected_stderr" 2>/dev/null ||
+        failures+=("ordinary source recovery failure did not preserve verifier stderr")
+      jq -e '.phase == "incident" and .incidentClass == "pre-journal-source-verification"' "$state" >/dev/null ||
+        failures+=("ordinary source recovery failure lacks its durable verification incident")
+    else
+      jq -e '.lastInterruption.signal == "TERM"' "$state" >/dev/null ||
+        failures+=("source recovery TERM is missing from durable interruption state")
+      [[ -e "$fixture_dir/source-verifier-delay-complete" ]] ||
+        failures+=("source recovery controller returned before the signaled verifier completed")
+    fi
+    if kill -0 "$child_pid" 2>/dev/null; then
+      failures+=("source recovery $case_name verifier remains alive after controller return")
+    fi
+    child_pid=''
+
+    rm -rf "$fixture_dir"
+    fixture_dir=''
+  done
+
+  ((${#failures[@]} == 0)) || {
+    printf '%s\n' "${failures[@]}" >&2
+    exit 1
+  }
+)
+
+test_prejournal_recovery_refuses_unexpected_live_compose() (
+  local fixture_dir manifest state live shim rc=0 guard_evidence incident_class expected_live_sha
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf "$fixture_dir"' EXIT
+  manifest="$fixture_dir/manifest.json"
+  state="$fixture_dir/controller.json"
+  live="$fixture_dir/docker-compose.yml"
+  write_execution_fixture "$fixture_dir" "$manifest" third-state-fail
+  export XDG_RUNTIME_DIR="$fixture_dir/locks"
+  shim=$(write_systemd_identity_shim "$fixture_dir")
+  "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
+
+  run_fixture_controller "$state" "$shim" env \
+    >"$fixture_dir/controller.out" 2>"$fixture_dir/controller.err" || rc=$?
+  ((rc != 0))
+  [[ -e "$fixture_dir/source-verifier-succeeded" ]] || {
+    echo 'third-state recovery fixture did not prove source verification succeeded' >&2
+    exit 1
+  }
+  guard_evidence=$(jq -r '.guardEvidence.path // empty' "$state")
+  [[ -n "$guard_evidence" && -f "$guard_evidence" &&
+     $(jq -er '.exitCode' "$guard_evidence") == 23 ]] || {
+    echo 'third-state recovery fixture did not preserve the intended pre-journal guard failure' >&2
+    exit 1
+  }
+  expected_live_sha=$(printf 'unexpected third state\n' | sha256sum | awk '{print $1}')
+  [[ $(sha256sum "$live" | awk '{print $1}') == "$expected_live_sha" ]] || {
+    echo 'pre-journal recovery overwrote an unexpected third-state live Compose file' >&2
+    exit 1
+  }
+  incident_class=$(jq -r '.incidentClass // empty' "$state")
+  [[ $(jq -r '.phase // empty' "$state") == incident &&
+     "$incident_class" =~ ^pre-journal-.*(compose|model).*(diverg|unexpected|mismatch) ]] || {
+    echo "unexpected third-state live Compose lacks a semantic divergence incident (class=$incident_class)" >&2
+    exit 1
+  }
+  rg -i 'live Compose.*(unexpected|diverg|differ|mismatch|neither|not match)' \
+    "$fixture_dir/controller.err" >/dev/null || {
+    echo 'third-state recovery rejection lacks an explicit live-Compose divergence diagnostic' >&2
+    exit 1
+  }
+)
+
+test_complete_write_cannot_race_final_guard_journal_validation() (
+  local fixture_dir manifest state journal shim rc=0 phase lock_key lock_path
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf "$fixture_dir"' EXIT
+  manifest="$fixture_dir/manifest.json"
+  state="$fixture_dir/controller.json"
+  journal="$fixture_dir/backup/fixture-volume.phase-a2b.json"
+  write_execution_fixture "$fixture_dir" "$manifest"
+  export XDG_RUNTIME_DIR="$fixture_dir/locks"
+  shim=$(write_guard_journal_race_shim "$fixture_dir")
+  "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
+  : > "$fixture_dir/mutate-journal-before-complete-write"
+
+  run_fixture_controller "$state" "$shim" env \
+    >"$fixture_dir/controller.out" 2>"$fixture_dir/controller.err" || rc=$?
+  [[ -e "$fixture_dir/cooperative-mutator-attempted-at-complete-write" ]] || {
+    echo 'cooperative journal actor did not contend at the final complete-state write boundary' >&2
+    exit 1
+  }
+  rg -q '^verify$' "$fixture_dir/lifecycle.log" || {
+    echo 'guard-journal race fixture failed before successful closure verification' >&2
+    exit 1
+  }
+  phase=$(jq -r '.phase // empty' "$state")
+  [[ -e "$fixture_dir/cooperative-mutator-blocked-at-complete-write" &&
+     ! -e "$fixture_dir/cooperative-mutator-acquired-at-complete-write" ]] || {
+    echo 'cooperative journal actor acquired the engine-volume lock during complete publication' >&2
+    exit 1
+  }
+  ((rc == 0)) && [[ "$phase" == complete && -e "$fixture_dir/complete-state-published" ]] || {
+    echo 'controller did not publish complete under the cooperative lock boundary' >&2
+    exit 1
+  }
+  jq -e --arg sha "$(sha256sum "$journal" | awk '{print $1}')" '
+    .phase == "complete" and .guardJournalEvidence.sha256 == $sha
+  ' "$state" >/dev/null || {
+    echo 'complete state and guard journal are not bound under the cooperative lock boundary' >&2
+    exit 1
+  }
+  [[ ! -e "$fixture_dir/app-stopped" ]] || {
+    echo 'successful cooperative-lock publication unexpectedly stopped the verified writer' >&2
+    exit 1
+  }
+  lock_key=$(printf '%s\0%s' "$(jq -er '.engineId' "$state")" "$(jq -er '.volume' "$state")" |
+    sha256sum | awk '{print $1}')
+  lock_path="$(jq -er '.lockRoot' "$state")/noosphere-pgvector-switch-$lock_key.lock"
+  exec 9<>"$lock_path"
+  flock -n 9 || {
+    echo 'cooperative journal actor could not acquire the lock after controller exit' >&2
+    exit 1
+  }
+  flock -u 9
+  exec 9>&-
+)
+
+test_engine_volume_identity_has_one_authoritative_state_path() (
+  local fixture_dir shared_lock primary_dir volume_control_dir engine_control_dir duplicate_dir
+  local primary_manifest volume_control_manifest engine_control_manifest duplicate_manifest
+  local first_state volume_control_state engine_control_state second_state rc=0
+  local first_sha first_inode first_mode first_live_sha manifest
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf "$fixture_dir"' EXIT
+  shared_lock="$fixture_dir/authority-locks"
+  primary_dir="$fixture_dir/primary"
+  volume_control_dir="$fixture_dir/same-engine-different-volume"
+  engine_control_dir="$fixture_dir/different-engine-same-volume"
+  duplicate_dir="$fixture_dir/duplicate"
+  mkdir -p "$shared_lock" "$primary_dir" "$volume_control_dir" "$engine_control_dir" "$duplicate_dir"
+  chmod 0700 "$shared_lock" "$primary_dir" "$volume_control_dir" "$engine_control_dir" "$duplicate_dir"
+  primary_manifest="$primary_dir/manifest.json"
+  volume_control_manifest="$volume_control_dir/manifest.json"
+  engine_control_manifest="$engine_control_dir/manifest.json"
+  duplicate_manifest="$duplicate_dir/manifest.json"
+  first_state="$primary_dir/controller.json"
+  volume_control_state="$volume_control_dir/controller.json"
+  engine_control_state="$engine_control_dir/controller.json"
+  second_state="$duplicate_dir/controller.json"
+
+  write_execution_fixture "$primary_dir" "$primary_manifest" complete success \
+    fixture-engine fixture-volume
+  write_execution_fixture "$volume_control_dir" "$volume_control_manifest" complete success \
+    fixture-engine fixture-volume-b
+  write_execution_fixture "$engine_control_dir" "$engine_control_manifest" complete success \
+    fixture-engine-b fixture-volume
+  write_execution_fixture "$duplicate_dir" "$duplicate_manifest" complete success \
+    fixture-engine fixture-volume
+  for manifest in "$primary_manifest" "$volume_control_manifest" \
+    "$engine_control_manifest" "$duplicate_manifest"; do
+    jq --arg lockRoot "$shared_lock" '.lockRoot = $lockRoot' "$manifest" > "$manifest.next"
+    install -m 600 "$manifest.next" "$manifest"
+  done
+  export XDG_RUNTIME_DIR="$shared_lock"
+
+  "$CONTROLLER" --prepare --manifest "$primary_manifest" --state "$first_state"
+  first_sha=$(sha256sum "$first_state" | awk '{print $1}')
+  first_inode=$(stat -c '%i' "$first_state")
+  first_mode=$(stat -c '%a' "$first_state")
+  first_live_sha=$(sha256sum "$primary_dir/docker-compose.yml" | awk '{print $1}')
+
+  rc=0
+  "$CONTROLLER" --prepare --manifest "$volume_control_manifest" --state "$volume_control_state" \
+    >"$fixture_dir/volume-control.out" 2>"$fixture_dir/volume-control.err" || rc=$?
+  ((rc == 0)) && jq -e '
+    .phase == "prepared" and .engineId == "fixture-engine" and .volume == "fixture-volume-b"
+  ' "$volume_control_state" >/dev/null || {
+    echo 'unique-authority implementation rejected the same engine with a different volume' >&2
+    exit 1
+  }
+
+  rc=0
+  "$CONTROLLER" --prepare --manifest "$engine_control_manifest" --state "$engine_control_state" \
+    >"$fixture_dir/engine-control.out" 2>"$fixture_dir/engine-control.err" || rc=$?
+  ((rc == 0)) && jq -e '
+    .phase == "prepared" and .engineId == "fixture-engine-b" and .volume == "fixture-volume"
+  ' "$engine_control_state" >/dev/null || {
+    echo 'unique-authority implementation rejected a different engine with the same volume name' >&2
+    exit 1
+  }
+
+  rc=0
+  "$CONTROLLER" --prepare --manifest "$duplicate_manifest" --state "$second_state" \
+    >"$fixture_dir/second-prepare.out" 2>"$fixture_dir/second-prepare.err" || rc=$?
+  if ((rc == 0)); then
+    echo 'one Docker-engine/PostgreSQL-volume identity accepted two authoritative state paths' >&2
+    exit 1
+  fi
+  rg -i 'authoritative.*state.*(engine|volume)|engine.*volume.*state.*(authoritative|claimed|owned)' \
+    "$fixture_dir/second-prepare.err" >/dev/null || {
+    echo 'alternate-state preparation failed without the unique-authority diagnostic' >&2
+    exit 1
+  }
+  jq -e '
+    .phase == "prepared" and
+    .engineId == "fixture-engine" and
+    .volume == "fixture-volume"
+  ' "$first_state" >/dev/null
+  [[ $(sha256sum "$first_state" | awk '{print $1}') == "$first_sha" &&
+     $(stat -c '%i' "$first_state") == "$first_inode" &&
+     $(stat -c '%a' "$first_state") == "$first_mode" ]] || {
+    echo 'alternate-state rejection mutated the first authoritative state' >&2
+    exit 1
+  }
+  [[ ! -e "$second_state" ]] || {
+    echo 'rejected alternate state path still became a durable authority' >&2
+    exit 1
+  }
+  [[ $(sha256sum "$primary_dir/docker-compose.yml" | awk '{print $1}') == "$first_live_sha" ]] || {
+    echo 'alternate-state rejection changed the primary live Compose bytes' >&2
+    exit 1
+  }
+)
+
+test_production_rejects_ambient_test_hook_contamination() (
+  local hook_spec hook value fixture_dir='' manifest state live shim rc
+  local -a failures=()
+  trap '[[ -z ${fixture_dir:-} ]] || rm -rf "$fixture_dir"' EXIT
+
+  for hook_spec in \
+    NOOSPHERE_CONTROLLER_TEST_INTERRUPT_AFTER_INTENT=1 \
+    NOOSPHERE_CONTROLLER_TEST_SIGNAL_AFTER_GUARD_SPAWN=TERM \
+    NOOSPHERE_CONTROLLER_TEST_FAIL_EVIDENCE=guard-exited \
+    NOOSPHERE_CONTROLLER_TEST_SIGNAL_AFTER_AUTHORIZATION=TERM \
+    NOOSPHERE_CONTROLLER_TEST_SIGNAL_BEFORE_COMPLETE=TERM \
+    NOOSPHERE_CONTROLLER_TEST_SIGNAL_BEFORE_GUARD=TERM; do
+    hook=${hook_spec%%=*}
+    value=${hook_spec#*=}
+    fixture_dir=$(mktemp -d)
+    manifest="$fixture_dir/manifest.json"
+    state="$fixture_dir/controller.json"
+    live="$fixture_dir/docker-compose.yml"
+    write_execution_fixture "$fixture_dir" "$manifest"
+    export XDG_RUNTIME_DIR="$fixture_dir/locks"
+    shim=$(write_systemd_identity_shim "$fixture_dir" disabled)
+    "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
+
+    rc=0
+    run_fixture_controller "$state" "$shim" env "$hook=$value" \
+      >"$fixture_dir/controller.out" 2>"$fixture_dir/controller.err" || rc=$?
+    if ((rc == 0)); then
+      failures+=("production execution silently accepted ambient $hook")
+    else
+      rg -qi 'NOOSPHERE_CONTROLLER_TEST_|test hook.*(ambient|contamin|production)' \
+        "$fixture_dir/controller.err" ||
+        failures+=("production rejection of $hook lacked a test-hook contamination diagnostic")
+      [[ $(jq -r '.phase // empty' "$state") == prepared ]] ||
+        failures+=("production rejection of $hook advanced durable state")
+      [[ $(<"$live") == 'source model' ]] ||
+        failures+=("production rejection of $hook changed live Compose")
+    fi
+
+    rm -rf "$fixture_dir"
+    fixture_dir=''
+  done
+
+  ((${#failures[@]} == 0)) || {
+    printf '%s\n' "${failures[@]}" >&2
+    exit 1
+  }
+)
+
+test_state_authority_survives_runtime_loss_and_is_revalidated_at_execute() (
+  local fixture_dir='' manifest state copied_state live shim rc
+  local shared lost_runtime primary volume_control engine_control duplicate manifest_path
+  local primary_manifest volume_control_manifest engine_control_manifest duplicate_manifest
+  local primary_state volume_control_state engine_control_state duplicate_state
+  local -a failures=()
+  trap '[[ -z ${fixture_dir:-} ]] || rm -rf "$fixture_dir"' EXIT
+
+  # Execution must reject a byte-identical prepared state copied to a different
+  # path. This proves the behavioral authority check without depending on the
+  # authority record's filename or JSON representation.
+  fixture_dir=$(mktemp -d)
+  manifest="$fixture_dir/manifest.json"
+  state="$fixture_dir/controller.json"
+  copied_state="$fixture_dir/copied-controller.json"
+  live="$fixture_dir/docker-compose.yml"
+  write_execution_fixture "$fixture_dir" "$manifest"
+  export XDG_RUNTIME_DIR="$fixture_dir/locks"
+  shim=$(write_systemd_identity_shim "$fixture_dir")
+  "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
+  install -m 600 "$state" "$copied_state"
+
+  rc=0
+  run_fixture_controller "$copied_state" "$shim" env \
+    >"$fixture_dir/controller.out" 2>"$fixture_dir/controller.err" || rc=$?
+  if ((rc == 0)); then
+    failures+=('execution accepted a copied prepared state at a second authority path')
+  else
+    rg -qi 'authoritative.*state|state.*authorit|engine.*volume.*state.*(claim|own)' \
+      "$fixture_dir/controller.err" ||
+      failures+=('copied-state rejection lacked an engine-volume authority diagnostic')
+    [[ $(jq -r '.phase // empty' "$copied_state") == prepared ]] ||
+      failures+=('copied-state authority rejection advanced the copied state')
+    [[ $(jq -r '.phase // empty' "$state") == prepared ]] ||
+      failures+=('copied-state authority rejection damaged the primary state')
+    [[ $(<"$live") == 'source model' ]] ||
+      failures+=('copied-state authority rejection changed live Compose')
+  fi
+  rm -rf "$fixture_dir"
+  fixture_dir=''
+
+  # Replace the entire disposable runtime root to model reboot/runtime loss.
+  # The duplicate tuple must remain rejected, while both tuple dimensions have
+  # independent controls proving the implementation is not globally exclusive.
+  fixture_dir=$(mktemp -d)
+  shared="$fixture_dir/runtime"
+  lost_runtime="$fixture_dir/runtime-lost"
+  primary="$fixture_dir/primary"
+  volume_control="$fixture_dir/same-engine-different-volume"
+  engine_control="$fixture_dir/different-engine-same-volume"
+  duplicate="$fixture_dir/duplicate"
+  mkdir -m 700 "$shared" "$primary" "$volume_control" "$engine_control" "$duplicate"
+  primary_manifest="$primary/manifest.json"
+  volume_control_manifest="$volume_control/manifest.json"
+  engine_control_manifest="$engine_control/manifest.json"
+  duplicate_manifest="$duplicate/manifest.json"
+  primary_state="$primary/controller.json"
+  volume_control_state="$volume_control/controller.json"
+  engine_control_state="$engine_control/controller.json"
+  duplicate_state="$duplicate/controller.json"
+  write_execution_fixture "$primary" "$primary_manifest" complete success fixture-engine fixture-volume
+  write_execution_fixture "$volume_control" "$volume_control_manifest" complete success fixture-engine fixture-volume-b
+  write_execution_fixture "$engine_control" "$engine_control_manifest" complete success fixture-engine-b fixture-volume
+  write_execution_fixture "$duplicate" "$duplicate_manifest" complete success fixture-engine fixture-volume
+  for manifest_path in "$primary_manifest" "$volume_control_manifest" \
+    "$engine_control_manifest" "$duplicate_manifest"; do
+    jq --arg lockRoot "$shared" '.lockRoot = $lockRoot' "$manifest_path" > "$manifest_path.next"
+    install -m 600 "$manifest_path.next" "$manifest_path"
+  done
+  export XDG_RUNTIME_DIR="$shared"
+  "$CONTROLLER" --prepare --manifest "$primary_manifest" --state "$primary_state"
+  mv "$shared" "$lost_runtime"
+  mkdir -m 700 "$shared"
+
+  rc=0
+  "$CONTROLLER" --prepare --manifest "$volume_control_manifest" --state "$volume_control_state" \
+    >"$fixture_dir/volume-control.out" 2>"$fixture_dir/volume-control.err" || rc=$?
+  ((rc == 0)) && jq -e '
+    .phase == "prepared" and .engineId == "fixture-engine" and .volume == "fixture-volume-b"
+  ' "$volume_control_state" >/dev/null ||
+    failures+=('runtime-loss authority rejected the same engine with a different volume')
+
+  rc=0
+  "$CONTROLLER" --prepare --manifest "$engine_control_manifest" --state "$engine_control_state" \
+    >"$fixture_dir/engine-control.out" 2>"$fixture_dir/engine-control.err" || rc=$?
+  ((rc == 0)) && jq -e '
+    .phase == "prepared" and .engineId == "fixture-engine-b" and .volume == "fixture-volume"
+  ' "$engine_control_state" >/dev/null ||
+    failures+=('runtime-loss authority rejected a different engine with the same volume')
+
+  rc=0
+  "$CONTROLLER" --prepare --manifest "$duplicate_manifest" --state "$duplicate_state" \
+    >"$fixture_dir/duplicate.out" 2>"$fixture_dir/duplicate.err" || rc=$?
+  if ((rc == 0)); then
+    failures+=('runtime-directory loss erased the unique engine-volume state authority')
+  else
+    rg -qi 'authoritative.*state|state.*authorit|engine.*volume.*state.*(claim|own)' \
+      "$fixture_dir/duplicate.err" ||
+      failures+=('runtime-loss duplicate rejection lacked an engine-volume authority diagnostic')
+    [[ ! -e "$duplicate_state" ]] ||
+      failures+=('reboot-simulation rejection still created a second state history')
+    jq -e '.phase == "prepared" and .engineId == "fixture-engine" and .volume == "fixture-volume"' \
+      "$primary_state" >/dev/null ||
+      failures+=('reboot-simulation rejection damaged the primary state history')
+  fi
+
+  ((${#failures[@]} == 0)) || {
+    printf '%s\n' "${failures[@]}" >&2
+    exit 1
+  }
+)
+
+test_post_authorization_pre_activation_failures_commit_fresh_stop_evidence() (
+  local case_name fixture_dir='' manifest state shim rc phase control_tail lifecycle expected_class
+  local authorization_evidence
+  local -a failures=()
+  trap '[[ -z ${fixture_dir:-} ]] || rm -rf "$fixture_dir"' EXIT
+
+  for case_name in signal artifact-storage; do
+    fixture_dir=$(mktemp -d)
+    manifest="$fixture_dir/manifest.json"
+    state="$fixture_dir/controller.json"
+    write_execution_fixture "$fixture_dir" "$manifest"
+    export XDG_RUNTIME_DIR="$fixture_dir/locks"
+    if [[ "$case_name" == artifact-storage ]]; then
+      shim=$(write_post_authorization_artifact_failure_shim "$fixture_dir")
+    else
+      shim=$(write_systemd_identity_shim "$fixture_dir")
+    fi
+    "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
+    [[ "$case_name" != artifact-storage ]] ||
+      : > "$fixture_dir/fail-next-artifact-storage-after-authorization"
+    : > "$fixture_dir/kill-controller-if-incident-before-stop"
+
+    rc=0
+    if [[ "$case_name" == signal ]]; then
+      run_fixture_controller "$state" "$shim" env \
+        NOOSPHERE_CONTROLLER_TEST_SIGNAL_AFTER_AUTHORIZATION=TERM \
+        >"$fixture_dir/controller.out" 2>"$fixture_dir/controller.err" || rc=$?
+      [[ "$rc" == 143 ]] ||
+        failures+=("post-authorization signal returned $rc instead of 143")
+    else
+      run_fixture_controller "$state" "$shim" env \
+        >"$fixture_dir/controller.out" 2>"$fixture_dir/controller.err" || rc=$?
+      ((rc != 0)) ||
+        failures+=('post-authorization artifact-storage failure unexpectedly reported success')
+      [[ -e "$fixture_dir/post-authorization-artifact-failure-consumed" ]] ||
+        failures+=('post-authorization artifact-storage fixture missed the semantic allocation boundary')
+    fi
+
+    lifecycle=$(paste -sd, "$fixture_dir/lifecycle.log" 2>/dev/null || true)
+    [[ "$lifecycle" == transition,authorize ]] ||
+      failures+=("post-authorization $case_name did not stop at the pre-activation boundary")
+    authorization_evidence=$(jq -r '.authorizationEvidence.path // empty' "$state")
+    [[ -n "$authorization_evidence" && -f "$authorization_evidence" &&
+       $(jq -er '.exitCode' "$authorization_evidence") == 0 ]] ||
+      failures+=("post-authorization $case_name lacked successful authorization evidence")
+    if [[ -f "$fixture_dir/app-control.log" ]]; then
+      control_tail=$(tail -n 2 "$fixture_dir/app-control.log" | paste -sd, -)
+    else
+      control_tail=''
+    fi
+    [[ "$control_tail" == stop,inspect:false ]] ||
+      failures+=("post-authorization $case_name lacked a fresh inspect-verified stop")
+    [[ ! -e "$fixture_dir/incident-persisted-before-stop" ]] ||
+      failures+=("post-authorization $case_name published terminal incident before stopping the writer")
+    phase=$(jq -r '.phase // empty' "$state")
+    if [[ "$case_name" == signal ]]; then
+      expected_class=closure-interruption
+    else
+      expected_class=closure-artifact-storage
+    fi
+    jq -e --arg incidentClass "$expected_class" '
+      .phase == "incident" and
+      .incidentClass == $incidentClass
+    ' "$state" >/dev/null ||
+      failures+=("post-authorization $case_name lacked exact $expected_class classification (phase=$phase)")
+
+    rm -rf "$fixture_dir"
+    fixture_dir=''
+  done
+
+  ((${#failures[@]} == 0)) || {
+    printf '%s\n' "${failures[@]}" >&2
+    exit 1
+  }
+)
+
+# RED owner: the controller's assert_controller_artifact_paths_separate must
+# include source-recovery artifact paths (stdout.log, stderr.log, evidence.json)
+# in its controlled-path array so that a derived source-recovery path that
+# collides with any bound transition input is rejected during --prepare.
+# Currently the controller omits source-recovery paths from the controlled
+# array, so this test fails (RED) until the controller is fixed.
+test_source_recovery_artifacts_cannot_collide_with_bound_inputs() (
+  local artifact_role input_class fixture_dir='' manifest state rc derived_path
+  local -a failures=()
+  # NOTE: controller-executable, compose-plugin, and guard-journal are excluded
+  # because the controller validates their identity/consistency BEFORE the
+  # collision check runs, so a path collision can never be reached for them.
+  local -a input_classes=(
+    live-compose source-snapshot candidate-compose env-file
+    guard-executable verifier-executable docker-executable manifest
+    docker-config
+  )
+  trap '[[ -z ${fixture_dir:-} ]] || rm -rf "$fixture_dir"' EXIT
+
+  for artifact_role in stdout stderr evidence; do
+    for input_class in "${input_classes[@]}"; do
+      fixture_dir=$(mktemp -d)
+      manifest="$fixture_dir/manifest.json"
+      state="$fixture_dir/controller.json"
+      write_execution_fixture "$fixture_dir" "$manifest"
+
+      # Derive the source-recovery artifact path the controller will use at
+      # execution time: ${state%.json}.source-recovery.{stdout,stderr,evidence}
+      case "$artifact_role" in
+        stdout) derived_path="${state%.json}.source-recovery.stdout.log" ;;
+        stderr) derived_path="${state%.json}.source-recovery.stderr.log" ;;
+        evidence) derived_path="${state%.json}.source-recovery.evidence.json" ;;
+      esac
+
+      # Create the collision: point the bound input at the derived artifact path
+      # so the controller's path-separation check must reject it.
+      case "$input_class" in
+        live-compose)
+          original_path=$(jq -er '.liveCompose' "$manifest")
+          cp "$original_path" "$derived_path"
+          jq --arg p "$derived_path" --arg old "$original_path" \
+            '.liveCompose = $p |
+             .guardArgs = [.guardArgs[] | if . == $old then $p else . end]' \
+            "$manifest" > "$manifest.tmp" &&
+            mv "$manifest.tmp" "$manifest"
+          chmod 0600 "$manifest"
+          ;;
+        # Update the live compose file content check: the live compose file
+        # is now at the derived path, so the original file is unchanged.
+        source-snapshot)
+          cp "$(jq -er '.sourceSnapshot' "$manifest")" "$derived_path"
+          jq --arg p "$derived_path" \
+            --arg s "$(sha256sum "$derived_path" | awk '{print $1}')" \
+            '.sourceSnapshot = $p | .sourceSnapshotSha256 = $s' \
+            "$manifest" > "$manifest.tmp" && mv "$manifest.tmp" "$manifest"
+          chmod 0600 "$manifest"
+          ;;
+        candidate-compose)
+          cp "$(jq -er '.candidateCompose' "$manifest")" "$derived_path"
+          jq --arg p "$derived_path" \
+            --arg s "$(sha256sum "$derived_path" | awk '{print $1}')" \
+            '.candidateCompose = $p | .candidateComposeSha256 = $s' \
+            "$manifest" > "$manifest.tmp" && mv "$manifest.tmp" "$manifest"
+          chmod 0600 "$manifest"
+          ;;
+        env-file)
+          original_path=$(jq -er '.envFile' "$manifest")
+          cp "$original_path" "$derived_path"
+          jq --arg p "$derived_path" --arg old "$original_path" \
+            --arg s "$(sha256sum "$derived_path" | awk '{print $1}')" \
+            '.envFile = $p | .envFileSha256 = $s |
+             .guardArgs = [.guardArgs[] | if . == $old then $p else . end]' \
+            "$manifest" > "$manifest.tmp" && mv "$manifest.tmp" "$manifest"
+          chmod 0600 "$manifest"
+          ;;
+        guard-executable)
+          cp "$(jq -er '.guard' "$manifest")" "$derived_path"
+          chmod 0700 "$derived_path"
+          jq --arg p "$derived_path" \
+            --arg s "$(sha256sum "$derived_path" | awk '{print $1}')" \
+            '.guard = $p | .guardSha256 = $s' \
+            "$manifest" > "$manifest.tmp" && mv "$manifest.tmp" "$manifest"
+          chmod 0600 "$manifest"
+          ;;
+        verifier-executable)
+          cp "$(jq -er '.verifier' "$manifest")" "$derived_path"
+          chmod 0700 "$derived_path"
+          jq --arg p "$derived_path" \
+            --arg s "$(sha256sum "$derived_path" | awk '{print $1}')" \
+            '.verifier = $p | .verifierSha256 = $s' \
+            "$manifest" > "$manifest.tmp" && mv "$manifest.tmp" "$manifest"
+          chmod 0600 "$manifest"
+          ;;
+        docker-executable)
+          cp "$(jq -er '.dockerPath' "$manifest")" "$derived_path"
+          chmod 0700 "$derived_path"
+          jq --arg p "$derived_path" \
+            --arg s "$(sha256sum "$derived_path" | awk '{print $1}')" \
+            '.dockerPath = $p | .dockerSha256 = $s' \
+            "$manifest" > "$manifest.tmp" && mv "$manifest.tmp" "$manifest"
+          chmod 0600 "$manifest"
+          ;;
+        manifest)
+          # The manifest itself is the bound input; place it at the derived
+          # source-recovery artifact path.
+          cp "$manifest" "$derived_path"
+          manifest=$derived_path
+          ;;
+        docker-config)
+          # Place the state path inside the Docker config directory so that
+          # the derived source-recovery artifact path falls inside it too.
+          # The controller's namespace check must reject this.
+          local docker_home
+          docker_home=$(jq -er '.controllerHome' "$manifest")
+          mkdir -p "$docker_home/docker"
+          state="$docker_home/docker/controller.json"
+          # Re-derive with the new state path
+          case "$artifact_role" in
+            stdout) derived_path="${state%.json}.source-recovery.stdout.log" ;;
+            stderr) derived_path="${state%.json}.source-recovery.stderr.log" ;;
+            evidence) derived_path="${state%.json}.source-recovery.evidence.json" ;;
+          esac
+          ;;
+      esac
+
+      export XDG_RUNTIME_DIR="$fixture_dir/locks"
+      rc=0
+      "$CONTROLLER" --prepare --manifest "$manifest" --state "$state" \
+        >"$fixture_dir/prepare.out" 2>"$fixture_dir/prepare.err" || rc=$?
+      if ((rc == 0)); then
+        failures+=("source-recovery $artifact_role path was accepted as bound $input_class input")
+      else
+        rg -qi 'collid' "$fixture_dir/prepare.err" ||
+          failures+=("source-recovery $artifact_role/$input_class collision lacked a specific diagnostic")
+        [[ ! -e "$state" ]] ||
+          failures+=("source-recovery $artifact_role/$input_class collision still created controller state")
+      fi
+
+      rm -rf "$fixture_dir"
+      fixture_dir=''
+    done
+  done
+
+  ((${#failures[@]} == 0)) || {
+    printf '%s\n' "${failures[@]}" >&2
+    exit 1
+  }
+)
+
+test_source_recovery_retry_preserves_prior_unbound_evidence() (
+  local fixture_dir manifest state crash_shim retry_shim rc=0 prior_evidence prior_stdout prior_stderr
+  local evidence_sha stdout_sha stderr_sha evidence_inode stdout_inode stderr_inode new_evidence
+  local new_stdout new_stderr expected_stdout_sha expected_stderr_sha
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf "$fixture_dir"' EXIT
+  manifest="$fixture_dir/manifest.json"
+  state="$fixture_dir/controller.json"
+  write_execution_fixture "$fixture_dir" "$manifest" prejournal-fail source-fail
+  export XDG_RUNTIME_DIR="$fixture_dir/locks"
+  crash_shim=$(write_source_recovery_evidence_publication_crash_shim "$fixture_dir")
+  "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
+  : > "$fixture_dir/crash-after-source-evidence-publication"
+
+  run_fixture_controller "$state" "$crash_shim" env \
+    >"$fixture_dir/first.out" 2>"$fixture_dir/first.err" || rc=$?
+  [[ "$rc" == 86 && -e "$fixture_dir/source-evidence-publication-crash-consumed" ]] || {
+    echo "source-recovery crash-window fixture returned $rc instead of 86" >&2
+    exit 1
+  }
+  jq -e '.phase == "source-recovery-running" and has("sourceRecoveryEvidence") == false' \
+    "$state" >/dev/null || {
+    echo 'source-recovery crash did not preserve the real pre-binding durable phase' >&2
+    exit 1
+  }
+  prior_evidence=$(<"$fixture_dir/unbound-source-evidence-path")
+  prior_stdout=$(jq -er '.stdout' "$prior_evidence")
+  prior_stderr=$(jq -er '.stderr' "$prior_evidence")
+  evidence_sha=$(sha256sum "$prior_evidence" | awk '{print $1}')
+  stdout_sha=$(sha256sum "$prior_stdout" | awk '{print $1}')
+  stderr_sha=$(sha256sum "$prior_stderr" | awk '{print $1}')
+  evidence_inode=$(stat -c '%i' "$prior_evidence")
+  stdout_inode=$(stat -c '%i' "$prior_stdout")
+  stderr_inode=$(stat -c '%i' "$prior_stderr")
+  expected_stdout_sha=$(sha256sum /dev/null | awk '{print $1}')
+  expected_stderr_sha=$(printf 'source verification failed\n' | sha256sum | awk '{print $1}')
+  jq -e --arg stdoutSha "$expected_stdout_sha" --arg stderrSha "$expected_stderr_sha" '
+    .phase == "source-recovery-running" and .exitCode == 42 and
+    .invocationId == "0123456789abcdef0123456789abcdef" and
+    .bootId == "fixture-boot" and
+    (.controllerMainPid | type == "number" and . > 0) and
+    (.childPid | type == "number" and . > 0) and
+    .controllerMainPid != .childPid and
+    (.startCursor | type == "string" and length > 0) and
+    (.endCursor | type == "string" and length > 0) and
+    .stdoutSha256 == $stdoutSha and .stderrSha256 == $stderrSha
+  ' "$prior_evidence" >/dev/null || {
+    echo 'first source-recovery evidence lacked exact process/log/provenance binding' >&2
+    exit 1
+  }
+
+  retry_shim=$(write_systemd_identity_shim "$fixture_dir")
+  rc=0
+  NOOSPHERE_CONTROLLER_FIXTURE_INVOCATION_ID=fedcba9876543210fedcba9876543210 \
+    run_fixture_controller "$state" "$retry_shim" env \
+      >"$fixture_dir/second.out" 2>"$fixture_dir/second.err" || rc=$?
+  [[ "$rc" == 42 ]] || {
+    echo "source-recovery retry returned $rc instead of 42" >&2
+    exit 1
+  }
+
+  new_evidence=$(jq -er '.sourceRecoveryEvidence.path' "$state")
+  [[ "$new_evidence" != "$prior_evidence" && -f "$new_evidence" ]] || {
+    echo 'source-recovery retry reused the prior unbound evidence path' >&2
+    exit 1
+  }
+  [[ $(sha256sum "$prior_evidence" | awk '{print $1}') == "$evidence_sha" &&
+     $(sha256sum "$prior_stdout" | awk '{print $1}') == "$stdout_sha" &&
+     $(sha256sum "$prior_stderr" | awk '{print $1}') == "$stderr_sha" &&
+     $(stat -c '%i' "$prior_evidence") == "$evidence_inode" &&
+     $(stat -c '%i' "$prior_stdout") == "$stdout_inode" &&
+     $(stat -c '%i' "$prior_stderr") == "$stderr_inode" ]] || {
+    echo 'source-recovery retry overwrote prior truthful evidence or logs' >&2
+    exit 1
+  }
+  new_stdout=$(jq -er '.stdout' "$new_evidence")
+  new_stderr=$(jq -er '.stderr' "$new_evidence")
+  [[ "$new_stdout" != "$prior_stdout" && "$new_stderr" != "$prior_stderr" &&
+     -f "$new_stdout" && -f "$new_stderr" ]] || {
+    echo 'source-recovery retry did not allocate distinct durable logs' >&2
+    exit 1
+  }
+  jq -e --arg evidenceSha "$(sha256sum "$new_evidence" | awk '{print $1}')" \
+    --arg stdoutSha "$expected_stdout_sha" --arg stderrSha "$expected_stderr_sha" '
+    .phase == "incident" and .incidentClass == "pre-journal-source-verification" and
+    .sourceRecoveryEvidence.sha256 == $evidenceSha
+  ' "$state" >/dev/null &&
+  jq -e --arg stdoutSha "$expected_stdout_sha" --arg stderrSha "$expected_stderr_sha" '
+    .phase == "source-recovery-running" and .exitCode == 42 and
+    .invocationId == "fedcba9876543210fedcba9876543210" and
+    .bootId == "fixture-boot" and
+    (.controllerMainPid | type == "number" and . > 0) and
+    (.childPid | type == "number" and . > 0) and
+    .controllerMainPid != .childPid and
+    (.startCursor | type == "string" and length > 0) and
+    (.endCursor | type == "string" and length > 0) and
+    .stdoutSha256 == $stdoutSha and .stderrSha256 == $stderrSha
+  ' "$new_evidence" >/dev/null || {
+    echo 'source-recovery retry did not bind complete new evidence/log/provenance state' >&2
+    exit 1
+  }
+)
+
+test_phase_owned_invariants_reject_unproved_states() (
+  local fixture_dir='' manifest state mutated case_name guard_mode verifier_mode target_phase
+  local target_incident_class proof_key diagnostic_pattern shim rc
+  local -a run_env=()
+  local -a failures=()
+  trap '[[ -z ${fixture_dir:-} ]] || rm -rf "$fixture_dir"' EXIT
+
+  for case_name in \
+    authorization-without-guard \
+    activation-without-guard \
+    closure-without-guard \
+    stop-pending-without-authorization \
+    evidence-pending-without-stop-proof \
+    source-incident-without-source-evidence \
+    closure-incident-without-stop-proof; do
+    guard_mode=complete
+    verifier_mode=success
+    target_incident_class=''
+    run_env=()
+    case "$case_name" in
+      authorization-without-guard)
+        target_phase=authorization-running
+        proof_key=guardEvidence
+        diagnostic_pattern='guard.*evidence.*required|required.*guard.*evidence'
+        ;;
+      activation-without-guard)
+        target_phase=activation-running
+        proof_key=guardEvidence
+        diagnostic_pattern='guard.*evidence.*required|required.*guard.*evidence'
+        ;;
+      closure-without-guard)
+        target_phase=closure-running
+        proof_key=guardEvidence
+        diagnostic_pattern='guard.*evidence.*required|required.*guard.*evidence'
+        ;;
+      stop-pending-without-authorization)
+        verifier_mode=fail
+        target_phase=closure-stop-pending
+        proof_key=authorizationEvidence
+        diagnostic_pattern='authorization.*evidence.*required|required.*authorization.*evidence'
+        ;;
+      evidence-pending-without-stop-proof)
+        verifier_mode=fail
+        target_phase=closure-evidence-pending
+        proof_key=writerStopEvidence
+        diagnostic_pattern='writer.*stop.*evidence.*required|required.*writer.*stop.*evidence'
+        run_env=(NOOSPHERE_CONTROLLER_TEST_FAIL_EVIDENCE=closure-running)
+        ;;
+      source-incident-without-source-evidence)
+        guard_mode=prejournal-fail
+        verifier_mode=source-fail
+        target_phase=incident
+        target_incident_class=pre-journal-source-verification
+        proof_key=sourceRecoveryEvidence
+        diagnostic_pattern='source.*recovery.*evidence.*required|required.*source.*recovery.*evidence'
+        ;;
+      closure-incident-without-stop-proof)
+        verifier_mode=fail
+        target_phase=incident
+        target_incident_class=closure-verification
+        proof_key=writerStopEvidence
+        diagnostic_pattern='writer.*stop.*evidence.*required|required.*writer.*stop.*evidence'
+        ;;
+    esac
+
+    fixture_dir=$(mktemp -d)
+    manifest="$fixture_dir/manifest.json"
+    state="$fixture_dir/controller.json"
+    mutated="$fixture_dir/mutated-controller.json"
+    write_execution_fixture "$fixture_dir" "$manifest" "$guard_mode" "$verifier_mode"
+    export XDG_RUNTIME_DIR="$fixture_dir/locks"
+    shim=$(write_phase_snapshot_shim "$fixture_dir")
+    "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
+
+    rc=0
+    run_fixture_controller "$state" "$shim" env \
+      "${run_env[@]}" \
+      "NOOSPHERE_CONTROLLER_TEST_CAPTURE_PHASE=$target_phase" \
+      "NOOSPHERE_CONTROLLER_TEST_CAPTURE_INCIDENT_CLASS=$target_incident_class" \
+      >"$fixture_dir/controller.out" 2>"$fixture_dir/controller.err" || rc=$?
+    if [[ "$rc" != 86 || ! -e "$fixture_dir/controller-phase-snapshot-captured" ]]; then
+      failures+=("controller did not produce the $case_name baseline at $target_phase")
+      rm -rf "$fixture_dir"
+      fixture_dir=''
+      continue
+    fi
+    if ! /bin/bash -c 'source "$1"; validate_controller_state "$2"' \
+      _ "$CONTROLLER" "$state" >"$fixture_dir/baseline.out" 2>"$fixture_dir/baseline.err"; then
+      failures+=("controller rejected its own valid $case_name baseline")
+      rm -rf "$fixture_dir"
+      fixture_dir=''
+      continue
+    fi
+    if ! jq -e --arg key "$proof_key" 'has($key)' "$state" >/dev/null; then
+      failures+=("controller-produced $case_name baseline lacked owned proof $proof_key")
+      rm -rf "$fixture_dir"
+      fixture_dir=''
+      continue
+    fi
+
+    jq --arg key "$proof_key" 'del(.[$key])' "$state" > "$mutated"
+    chmod 0600 "$mutated"
+    if /bin/bash -c 'source "$1"; validate_controller_state "$2"' \
+      _ "$CONTROLLER" "$mutated" >"$fixture_dir/mutated.out" 2>"$fixture_dir/mutated.err"; then
+      failures+=("controller accepted unproved phase ownership: $case_name")
+    elif ! rg -qi "$diagnostic_pattern" "$fixture_dir/mutated.err"; then
+      failures+=("controller rejected $case_name without a $proof_key-specific diagnostic")
+    fi
+
+    rm -rf "$fixture_dir"
+    fixture_dir=''
+  done
+
+  ((${#failures[@]} == 0)) || {
+    printf '%s\n' "${failures[@]}" >&2
+    exit 1
+  }
+)
+
+test_disposable_rehearsals_clean_and_assert_state_authority() (
+  local fixture_dir manifest state runtime_root lock_key authority rc=0
+  local -a failures=()
+
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf "$fixture_dir"' EXIT
+  manifest="$fixture_dir/manifest.json"
+  state="$fixture_dir/controller.json"
+  runtime_root="$fixture_dir/locks"
+  mkdir -m 700 "$runtime_root"
+
+  # Real prepared tuple: the controller's own claim_authoritative_state_path
+  # creates the authority record.  No fabricated lock_key or special probe.
+  write_execution_fixture "$fixture_dir" "$manifest"
+  export XDG_RUNTIME_DIR="$runtime_root"
+  "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
+
+  lock_key=$(printf '%s\0%s' fixture-engine fixture-volume | sha256sum | awk '{print $1}')
+  authority="$runtime_root/noosphere-pgvector-state-$lock_key.json"
+  [[ -f "$authority" && ! -L "$authority" ]] ||
+    failures+=("real prepare did not create the authority record")
+
+  if ((${#failures[@]} == 0)); then
+    # Success cleanup removes the exact authority record.
+    cleanup_state_authority_record "$runtime_root" "$authority"
+    [[ ! -e "$authority" ]] ||
+      failures+=("real success cleanup left the authority record")
+  fi
+
+  if ((${#failures[@]} == 0)); then
+    # Failure cleanup propagates when the authority record is unsafe (symlink).
+    ln -s /dev/null "$authority"
+    rc=0
+    cleanup_state_authority_record "$runtime_root" "$authority" 2>/dev/null || rc=$?
+    ((rc != 0)) ||
+      failures+=("unsafe authority record was silently accepted by cleanup")
+    rm -f "$authority"
+  fi
+
+  ((${#failures[@]} == 0)) || {
+    printf '%s\n' "${failures[@]}" >&2
+    exit 1
+  }
+)
+
+test_transient_systemd_fixture_independently_proves_identity_and_cursors() (
+  timeout 180s "$SYSTEMD_FIXTURE"
+)
+
+if [[ ${BASH_SOURCE[0]} == "$0" ]]; then
+  test_atomic_controller_state
+  test_source_restore_without_guard_journal
+  test_execution_environment_is_hermetic
+  test_closure_failure_classification
+  test_signal_handler_is_idempotent
+  test_reboot_recovers_prejournal_candidate_publication
+  test_valid_guard_journal_suppresses_outer_restore
+  test_shared_lock_is_inherited
+  test_candidate_publication_intent_is_recoverable
+  test_systemd_contract_has_no_automatic_kill
+  test_process_evidence_is_bounded_and_hashed
+  test_closure_outcome_never_false_completes
+  test_complete_entrypoint_with_disposable_commands
+  test_manifest_mutation_fails_before_publication
+  test_execution_requires_systemd_identity
+  test_guard_failure_before_journal_restores_source
+  test_guard_journal_prevents_outer_restore
+  test_verifier_failure_commits_incident_and_stops_app
+  test_evidence_failure_cannot_complete
+  test_term_during_guard_records_and_recovers
+  test_terminal_states_never_delegate_to_a_stale_guard_journal
+  test_systemd_identity_is_queried_not_asserted
+  test_prepare_refuses_to_overwrite_active_or_terminal_state
+  test_engine_identity_is_rebound_to_the_live_daemon
+  test_lock_root_must_match_the_guard_lock_contract
+  test_child_process_environment_and_docker_resolution_are_hermetic
+  test_latched_signal_before_guard_cannot_be_ignored
+  test_verifier_evidence_failure_stops_writer_before_storage
+  test_process_logs_are_fsynced_before_evidence_binding
+  test_complete_state_binds_guard_and_closure_evidence
+  test_systemd_safety_properties_and_linger_are_queried
+  test_signals_cannot_cross_spawn_or_complete_boundaries
+  test_source_recovery_verifier_is_hermetic_and_target_bound
+  test_complete_state_binds_immutable_guard_journal
+  test_process_evidence_separates_controller_and_child_identity
+  test_guard_arguments_are_semantically_bound_to_manifest
+  test_compose_plugin_and_docker_config_identity_are_bound
+  test_failed_prejournal_recovery_commits_durable_incident
+  test_process_evidence_rejects_impossible_chronology
+  test_source_snapshot_is_revalidated_before_publication
+  test_guard_journal_path_is_canonically_bound
+  test_fixed_path_toolchain_is_immutable_and_bound
+  test_controller_state_cannot_collide_with_guard_journal
+  test_ambient_test_overrides_cannot_falsify_production_evidence
+  test_docker_rehearsal_proves_cleanup_before_success
+  test_process_evidence_rejects_fractional_numbers
+  test_real_systemd_fixture_exercises_signal_delivery
+  test_production_execution_succeeds_without_ambient_fault_hooks
+  test_production_execution_succeeds_without_ambient_signal_hooks
+  test_derived_evidence_paths_cannot_collide_with_bound_inputs
+  test_guard_signal_persists_child_evidence_before_return
+  test_verifier_signal_persists_child_evidence_before_return
+  test_terminal_state_requires_phase_specific_invariants
+  test_preparation_resolves_docker_only_after_hermetic_sanitization
+  test_controller_executable_is_bound_after_preparation
+  test_guard_signal_waits_until_child_is_reaped
+  test_closure_verifier_signal_waits_until_child_is_reaped
+  test_source_verifier_signal_waits_until_child_is_reaped
+  test_bootstrap_ignores_ambient_path
+  test_docker_config_namespace_rejects_descendants
+  test_complete_state_revalidates_durable_evidence
+  test_recovery_preserves_prior_process_evidence
+  test_closure_incident_remains_resumable_until_writer_is_stopped
+  test_bootstrap_blocks_bash_env_and_exported_functions
+  test_fixed_path_is_validated_before_installation
+  test_signal_waits_for_guard_descendant_group
+  test_concurrent_reprepare_cannot_replace_live_prepared_state
+  test_guard_requires_deferred_writer_restart
+  test_verified_guard_bytes_cannot_be_replaced_before_use
+  test_concurrent_first_preparation_is_no_replace
+  test_fixed_path_rejects_mutable_symlink_aliases
+  test_verifier_evidence_failure_remains_resumable
+  test_operation_lock_open_does_not_follow_symlinks
+  test_execution_bundle_accepts_trusted_root_owned_executables
+  test_bootstrap_utility_resolution_is_trusted_before_use
+  test_systemd_context_requires_transient_unit_provenance
+  test_writer_activation_lifecycle_is_ordered_and_evidence_bound
+  test_authorization_evidence_is_durable_before_activation
+  test_app_activation_failure_is_fail_closed_before_final_verification
+  test_term_after_activation_stops_writer_before_return
+  test_closure_evidence_pending_resume_never_reactivates_writer
+  test_missing_live_compose_commits_prejournal_restoration_incident
+  test_post_activation_artifact_setup_failure_stops_writer_durably
+  test_closure_evidence_pending_requires_verified_stop_before_persistence
+  test_same_name_volume_replacement_is_rejected_after_preparation
+  test_live_identity_checks_wait_for_the_shared_operation_lock
+  test_successful_verifier_postprocessing_failure_stops_writer
+  test_post_activation_signal_with_zero_exit_verifier_stops_writer
+  test_source_recovery_signal_persists_process_evidence
+  test_prejournal_recovery_refuses_unexpected_live_compose
+  test_complete_write_cannot_race_final_guard_journal_validation
+  test_engine_volume_identity_has_one_authoritative_state_path
+  test_production_rejects_ambient_test_hook_contamination
+  test_state_authority_survives_runtime_loss_and_is_revalidated_at_execute
+  test_post_authorization_pre_activation_failures_commit_fresh_stop_evidence
+  test_source_recovery_artifacts_cannot_collide_with_bound_inputs
+  test_source_recovery_retry_preserves_prior_unbound_evidence
+  test_phase_owned_invariants_reject_unproved_states
+  test_disposable_rehearsals_clean_and_assert_state_authority
+  test_transient_systemd_fixture_independently_proves_identity_and_cursors
+
+  echo 'PostgreSQL transition controller focused fixtures passed.'
+fi


### PR DESCRIPTION
## Summary

Six native-only regression tests (RED owners turned GREEN) for the execution-controller failure classes identified in the PR #298 post-merge review, plus the controller fixes that satisfy each owner. The most recent commit (15889f4) adds the F1-F8 review-1 corrections and the F8 terminal-phase fixture assertion.

## Commit-by-commit

- 951f530 — feat(controller): add execution controller and supporting fixtures
- bdfdb40 — fix(fixture): rewrite collision matrix to use controller's actual code path
- d4f5fdd — fix(controller): implement six Review-1 owners and round-2 re-review corrections
- 15889f4 — fix(controller): F1-F8 review-1 corrections + F8 fixture assertion (this commit)

## RED owners (all fixture-derived, now controller-corrected)

1. **`test_source_recovery_artifacts_cannot_collide_with_bound_inputs`** (line 4061) — was RED (24 of 27 cases); now GREEN
2. **`test_production_rejects_ambient_test_hook_contamination`** (line 3735) — was RED (6 intended diagnostics); now GREEN
3. **`test_state_authority_survives_runtime_loss_and_is_revalidated_at_execute`** (line 3867) — was RED; now GREEN
4. **`test_post_authorization_pre_activation_failures_commit_fresh_stop_evidence`** (line 3997) — was RED (4 cases); now GREEN
5. **`test_source_recovery_retry_preserves_prior_unbound_evidence`** (line 4137) — was RED; now GREEN
6. **`test_phase_owned_invariants_reject_unproved_states`** (line 4250) — was RED; now GREEN

## F1-F8 review-1 corrections (commit 15889f4)

- **F1 BLOCKER**: durable authority root XDG_STATE_HOME captured inline at claim time (single source of truth); revalidate-mode check fires before root creation so cross-root execute cannot silently populate the wrong namespace.
- **F2 HIGH**: `select_process_artifact_base` failures routed through `begin_closure_incident` artifact-storage.
- **F3 HIGH**: reactivation-forbidden defense for closure-stop-pending write failures (code review at L364/L373).
- **F4 HIGH**: phase-owned evidence validation for the pre-journal-source-* incident classes.
- **F5 MEDIUM**: malformed state reclaim semantics — empty Phase in a non-terminal durable record is rejected.
- **F6 HIGH**: lockRoot validation at revalidate against current XDG_STATE_HOME; cross-root execute rejected.
- **F7 MEDIUM**: parent fsync chain on root creation (root, parent, state_base).
- **F8 LOW**: terminal-phase jq assertion in `test_authorization_evidence_is_durable_before_activation` (fixture-only, +27 lines + 5-line Reviewer-2 clarification comment).

## Reviewer evidence

- Reviewer 1 (cybera, retry): GREEN with full regression probe. Corrupting controller L347 to "WRONG_DIAG" caused exact suite failure: "fresh execution refused for a reason other than terminal-incident classification". Controller md5 a01cc31fe9f9408f57f6989ba86e20de matches pre-probe.
- Reviewer 2 (descartes): NOT GREEN on observation that L332 (closure-stop-pending resume) also matches the terminal-incident diagnostic. Addressed with 5-line comment in fixture documenting the L332/L347 intentional pairing (both terminal-incident resume paths emit the canonical diagnostic by design).

## Verification

- Suite rc=0 (105 tests).
- bash -n clean on both scripts.
- Privacy scan: 0 matches for /home/niya, IPs, tokens, secrets, machine names, personal data.
- Controller SHA: 3e1640eecd9a4c9e96a46b328d6360fc8da753da34be5ba1e5aba6c18e179829
- Fixture SHA: 0075904bcd8a2d1f5880e0cd641000aacd5d27e273b37d8dd186e17855903b66
- No bot comments on commit 15889f4 yet (20-min CI/bot gate pending).

## Pre-publication guard

- No deployment, production mutation, transition, hybrid activation, or merge.
- Production untouched on postgres@sha256:16bc17c6…
- Switch-pgvector-compose.sh remains the only mutator of database, authorization volume, backup, recovery, and transition journal.
- Sherina's per-item approval for item #3 (DB transition) is required separately before any switch execution.

<!-- kody-pr-summary:start -->
## Summary

Adds regression coverage for execution-controller failure handling and durable state-authority validation.

### Functional changes

- **Expands source-recovery incident validation**
  - Requires durable source-recovery path and SHA-256 evidence for all pre-journal source verification and restoration states, including:
    - `pre-journal-source-restoration`
    - `pre-journal-source-restored`
    - `pre-journal-live-compose-divergence`

- **Uses the current `XDG_STATE_HOME` when claiming authoritative state**
  - Removes the controller-level `controller_durable_state_base` capture.
  - The durable authority root is now resolved directly from `XDG_STATE_HOME` at claim time.
  - In revalidation mode, the controller confirms that an authority record exists under the current root **before** creating that root.
  - This prevents execution from silently creating authority state in the wrong namespace when preparation and execution use different state roots.

- **Strengthens the closure-interruption regression test**
  - Verifies that a fresh execution is refused for the expected terminal-incident reason.
  - Confirms the state remains in `incident` with `closure-interruption`.
  - Confirms durable writer-stop evidence remains valid and the writer lifecycle does not proceed to activation.

- **Adds verifier artifact-collision failure coverage**
  - Simulates collisions in canonical and invocation-suffixed verifier artifacts.
  - Requires the controller to:
    - fail the execution;
    - record `closure-artifact-storage`;
    - stop and inspect-verify the writer before publishing the incident;
    - avoid publishing the incident before stopping the writer.

- **Adds cross-root execution rejection coverage**
  - Verifies preparation under one `XDG_STATE_HOME` followed by execution under another is rejected with an authority-root diagnostic.
  - Confirms the controller does not create an authority record in the execution root.

- **Adds corrupt-phase durability coverage**
  - Verifies that a durable state record containing an unrecognized phase cannot be reclaimed through another state path and silently replace the existing authority record.

### Impact

These changes make the controller’s failure paths and durable state ownership behavior explicit and regression-resistant, especially around terminal incidents, artifact collisions, cross-root execution, and corrupt persisted phases.

---

### Summary

This PR adds RED-owner regression tests for failure classes in the PostgreSQL/pgvector transition controller that previously lacked dedicated coverage, alongside supporting fixes to the controller script and documentation that the new tests rely on.

### Key Changes

**New regression tests in `scripts/test-pgvector-transition-controller.sh`:**
- `test_corrupt_phase_durable_state_rejected` — verifies the controller refuses to reclaim authority when the durable state's `.phase` is an unrecognized value.
- `test_bound_transition_inputs_are_pairwise_distinct` — verifies prepare rejects source snapshots that alias live compose or other recovery dependencies.
- `test_invalid_complete_state_cannot_relinquish_durable_authority` — verifies that a complete state whose evidence fails validation cannot be reclaimed under a different path.
- `test_durable_authority_reclaims_complete_or_missing_state` — verifies the positive reclaim path for both terminal and missing predecessor states.
- `test_cli_rejects_duplicate_or_mixed_modes` — verifies `--prepare`/`--execute` flags cannot be combined or duplicated.
- `test_execution_environment_removes_all_ambient_docker_compose_behavior` — verifies hermetic sanitization strips arbitrary `DOCKER_*`/`COMPOSE_*` env vars.
- `test_durable_authority_rejects_runtime_backed_state_home` — verifies the durable authority root cannot live under the reboot-volatile runtime root.
- `test_bound_inputs_and_publication_reject_unsafe_write_modes` — verifies group/world-writable bound inputs and parents are rejected at publication.
- `test_incident_classes_and_stop_proofs_are_closed_world` — verifies unrecognized incident classes without stop proof are rejected.
- `test_real_docker_rehearsal_declares_interruption_resume_coverage` — meta-coverage test ensuring the real-Docker fixture covers interrupt→recovery.

**Controller fixes (`scripts/run-pgvector-transition-controller.sh`) to make the new tests pass:**
- `claim_authoritative_state_path` now requires unrecognized durable phases to fail-closed rather than silently fall through to reclaim.
- Complete states must validate bound evidence, authority root, and identity before relinquishing authority.
- Bound transition inputs are checked for pairwise canonical-path collisions at preparation.
- `validate_controller_state` treats incident phase as a closed-world set including `closure-stop-pending`/`closure-evidence-pending` and the isolated-app-health class.
- `sanitize_execution_environment` strips all `DOCKER_*`/`COMPOSE_*` ambient variables, not just a fixed allowlist.
- `assert_owned_regular_file` and `publish_compose_atomic` reject group/world-writable modes on inputs and parent directories.
- `prepare_execution_state` cleans up its staged temp file on idempotent re-prepare.
- CLI rejects duplicate or mixed `--prepare`/`--execute` flags.

**Real-Docker rehearsal (`scripts/test-pgvector-transition-controller-docker.sh`):**
- Adds an end-to-end interruption rehearsal: stops the guard process group, delivers TERM via systemd, validates `phase=guard-exited` and reaped unit, then a second transient invocation owns recovery, verifies source restoration, and commits a `pre-journal-source-restored` incident.
- Re-prepares the restored source and proves the ordinary transition still completes under a third transient invocation.
- Cleans up any leftover transient systemd units across failure paths.

**Test infrastructure (`scripts/test-pgvector-transition-controller.sh`):**
- Adds `background_fixture_controller` that execs the controller directly (so TERM reaches the controller PID rather than a wrapper subshell), with diagnostic dumps on signal-flake failures and longer bounded waits for slow hosts.
- Adds `_clear_authority_root_for_isolation` to clear the per-suite durable authority namespace between tests, preventing stale records from deleted fixtures from poisoning later tests.
- Sets `umask 0022` for deterministic fixture modes and an ERR trap that surfaces the failing command.

**Documentation (`docs/POSTGRES-PGVECTOR-EXECUTION-CONTROLLER.md`, `docs/superpowers/plans/2026-08-10-item3-execution-controller.md`):**
- Clarifies that complete-state reclaim requires full bound evidence validation and that bound transition inputs must be pairwise distinct.

---

### Pull Request Description

**Title:** test(fixture): RED-owner regression tests for execution-controller failure classes

**Description:**

This PR expands the regression coverage of the execution-controller fixture suite by enforcing closed-world failure classes for the `closure-stop-pending` and `closure-evidence-pending` proof phases, in addition to the `incident` phase already tested.

**Changes:**

1. **`scripts/run-pgvector-transition-controller.sh`**
   - Splits the proof-phase validation dispatch into two `case` blocks so that `closure-stop-pending`, `closure-evidence-pending`, and `incident` phases each independently trigger the incident-class validation path. This ensures all three phases are validated uniformly against the closed-world set of supported `incidentClass` values.

2. **`scripts/test-pgvector-transition-controller.sh`**
   - Extends `test_incident_classes_and_stop_proofs_are_closed_world()` to cover `closure-stop-pending` and `closure-evidence-pending` phases in addition to the existing `incident` baseline.
   - For each additional phase, the test:
     - Builds a fresh execution fixture and runs the controller to produce a valid baseline state for that phase.
     - Confirms the controller accepts its own baseline.
     - Mutates `incidentClass` to an unsupported value (`unclassified-post-authorization`) and asserts the validator rejects it with the expected diagnostic (`incident class is unsupported or unrecognized`).
   - Adds proper per-iteration fixture cleanup and tracks failures across phases so a single regression surfaces all problematic phases in one run.

**Functional Impact:**

These tests act as RED-owner guardrails: any future change that accidentally broadens or misclassifies the closed-world `incidentClass` enumeration for closure-related proof phases will fail the regression, ensuring the controller continues to reject unsupported incident classes consistently across `closure-stop-pending`, `closure-evidence-pending`, and `incident` phases.
<!-- kody-pr-summary:end -->

## Summary by Sourcery

Introduce a fail-closed PostgreSQL transition controller and comprehensive regression coverage for durable state authority, recovery, evidence handling, and execution failure classes.

New Features:
- Add a PostgreSQL/pgvector execution controller with durable phase management, systemd execution boundaries, recovery handling, and evidence-backed writer lifecycle control.

Bug Fixes:
- Prevent ambient test hooks, cross-root state claims, artifact collisions, corrupt phases, unsafe recovery states, and stale or replaced Docker/Compose identities from bypassing controller safeguards.
- Ensure closure, interruption, verifier, authorization, and source-recovery failures stop the application writer and commit classified durable incidents before returning.
- Preserve prior process and source-recovery evidence across retries by allocating invocation-distinct artifacts.

Enhancements:
- Strengthen engine, volume, lock-root, Compose, executable, Docker-config, fixed-PATH, and guard-argument identity validation across preparation and execution.
- Enforce phase-owned evidence proofs, deferred writer restart, serialized preparation, hermetic child environments, and fail-closed resume semantics.

Documentation:
- Document the execution controller safety boundary, durable phases, preparation contract, systemd requirements, recovery behavior, and verification procedures.
- Add a detailed verification plan covering fault injection, systemd execution, disposable Docker rehearsals, recovery, and production safeguards.

Tests:
- Add extensive focused regression fixtures for source-recovery collisions, ambient hook contamination, durable state authority, closure-stop ordering, retry-distinct evidence, phase-owned invariants, and invocation-suffixed artifact collisions.
- Add real transient-systemd coverage for identity binding, signal delivery, process evidence, cursor validation, and cleanup.
- Add a disposable Docker rehearsal covering interruption recovery, pinned-guard execution, successful completion, and zero-residue cleanup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added comprehensive guidance for safely executing and recovering PostgreSQL pgvector transitions.
  - Documented durable phases, locking, recovery, evidence handling, and fail-closed behavior.
  - Added implementation planning details, verification commands, and success criteria.

- **Tests**
  - Added Docker rehearsal coverage for interrupted, recovered, and completed transitions.
  - Added systemd integration coverage for persistence, authorization, cleanup, and signal handling.
  - Added validation for data integrity, health, artifact evidence, and prevention of false success states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->