### PR TITLE
docs: align memory revamp status with implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ sync workflow through a versioned frontmatter codec. The sync design lives in
 | **Auto-Capture** | ⚠️ Disabled-by-default private capture API, principal/lineage storage, and cleanup foundation; OpenClaw turn hook/extraction planned | ✅ Every turn | ❌ Manual indexing | ✅ Continuous learning | ✅ `memory.add()` | ✅ Smart extraction |
 | **Auto-Recall** | ✅ Capture guidance on clean misses + recall results when available; provider errors fail open | ✅ Before each turn | ✅ Keyword search only | ✅ Proactive context loading | ✅ `memory.search()` | ✅ Before prompt build |
 | **Manual Recall** | ✅ REST API + tools | ✅ MCP tools | ✅ CLI / tool query | ✅ REST API | ✅ SDK + REST | ✅ CLI + MCP tools |
-| **Semantic Search** | ✅ PostgreSQL FTS (live) + vector (planned) | ✅ Vector + biomimetic | ⚠️ Keyword + pending vector | ✅ pgvector | ✅ Semantic + BM25 + entity fusion | ✅ Vector + BM25 hybrid |
+| **Semantic Search** | ✅ PostgreSQL FTS (default) + implemented opt-in pgvector/RRF; rollout pending | ✅ Vector + biomimetic | ⚠️ Keyword + pending vector | ✅ pgvector | ✅ Semantic + BM25 + entity fusion | ✅ Vector + BM25 hybrid |
 | **Keyword Search** | ✅ PostgreSQL full-text | ✅ | ✅ Primary mode | ✅ | ✅ BM25 | ✅ BM25 |
 | **Cross-Encoder Rerank** | ❌ (planned) | ❌ | ❌ | ❌ | ❌ | ✅ Cross-encoder |
 | **Memory Types** | Articles (wiki) | world / experience / observation | Markdown files | Categories / Items / Resources | Facts (ADD-only v3) | 6-category classification |
@@ -346,6 +346,7 @@ Keep detailed recovery work in deployment/runbook docs rather than this README.
 | Document | Use it for |
 | --- | --- |
 | [README-legacy.md](README-legacy.md) | Previous full README content kept for reference during the docs split |
+| [docs/MEMORY-REVAMP-STATUS.md](docs/MEMORY-REVAMP-STATUS.md) | Authoritative implementation and rollout matrix for automatic capture and hybrid retrieval |
 | [docs/OPENCLAW-OFFICIAL-PLUGIN-SETUP.md](docs/OPENCLAW-OFFICIAL-PLUGIN-SETUP.md) | OpenClaw install, operations, upgrade, troubleshooting, and uninstall |
 | [docs/POSTGRES-PGVECTOR-COMPOSE-UPGRADE.md](docs/POSTGRES-PGVECTOR-COMPOSE-UPGRADE.md) | Guarded PostgreSQL image transition, proof, rollback, and recovery |
 | [docs/NOOSPHERE-MEMORY-ARCHITECTURE.md](docs/NOOSPHERE-MEMORY-ARCHITECTURE.md) | Provider abstraction, recall orchestration, ranking, budgeting, and scheduler |

--- a/docs/AUTOMATIC-MEMORY-CAPTURE-AND-ENRICHMENT-ADR.md
+++ b/docs/AUTOMATIC-MEMORY-CAPTURE-AND-ENRICHMENT-ADR.md
@@ -1,8 +1,14 @@
 # Automatic Memory Capture and Recall Enrichment ADR
 
-**Status:** Proposed
+**Status:** Accepted — Phase 0 and Phase A implemented; Phases B through E pending
 **Date:** 2026-07-14
+**Last status review:** 2026-08-24
 **Scope:** Noosphere server, OpenClaw memory plugin, recall providers, and curation lifecycle
+
+Implementation and rollout status is tracked in the
+[memory revamp status matrix](MEMORY-REVAMP-STATUS.md). The decision sections
+retain prospective wording for phases that have not landed. Acceptance does not
+enable automatic ingestion or make proposed Phase C configuration keys live.
 
 Current implemented OpenClaw settings are documented in the
 [official plugin setup guide](OPENCLAW-OFFICIAL-PLUGIN-SETUP.md). Configuration
@@ -14,7 +20,8 @@ Noosphere should add two connected but independently deployable capabilities:
 
 1. **Recall enrichment:** generate a short factual recall summary plus separate
    search terms for each article. Lexical search indexes both fields, while the
-   planned pgvector/RRF work remains the primary semantic-retrieval path.
+   merged, default-off pgvector/RRF implementation remains the primary
+   semantic-retrieval path.
 2. **Automatic event capture:** an opt-in OpenClaw `agent_end` hook submits a
    bounded turn envelope to an agent-isolated, private-scope, TTL-bound capture
    inbox. A separate extraction step converts useful events into searchable
@@ -39,7 +46,7 @@ hard-coded synonym groups. This works when the query and article share words,
 but ordinary paraphrases can still miss the correct article and force an agent
 to search manually.
 
-The [proposed hybrid-retrieval ADR](HYBRID-RETRIEVAL-ADR.md) addresses the
+The [accepted hybrid-retrieval ADR](HYBRID-RETRIEVAL-ADR.md) addresses the
 broader semantic problem with embeddings and reciprocal-rank fusion. Recall
 enrichment remains useful because:
 
@@ -54,14 +61,15 @@ enrichment remains useful because:
 
 The OpenClaw plugin currently exposes `noosphere_save` and injects instructions
 that tell an agent when to use it. The agent must still choose to call the tool.
-Before the Phase 0 fix in this change set, those instructions were only injected
-when auto-recall returned non-empty prompt text. A turn containing genuinely new
+Before Phase 0 in PR #281, those instructions were only injected when
+auto-recall returned non-empty prompt text. A turn containing genuinely new
 information could therefore receive no capture reminder at all.
 
-Noosphere also contains pure promotion and synthesis modules, but recall
-statistics, candidates, and synthesis jobs are not persisted or wired into the
-live recall path. The scheduler CLI currently runs only a health job. Existing
-documentation describes the intended abstractions, not a completed automatic
+Phase A persists private captures, candidate state, and durable cleanup jobs,
+and the scheduler CLI runs both health and expiry/privacy maintenance. Durable
+final-selection statistics, candidate synthesis/promotion workers, and their
+live recall-path integration remain unimplemented. Existing promotion and
+synthesis modules therefore describe foundations, not a completed automatic
 promotion service.
 
 ## 3. Goals
@@ -590,9 +598,9 @@ promotion until resolved. A newer statement is not automatically more correct.
 - add provenance-graph deletion, tombstone, and revocation-generation jobs;
 - keep all new ingestion behavior disabled by default.
 
-Phase A implementation status in this change: complete pending PR review. It
-includes principal administration, creation-time key binding, safe credential
-rotation, private capture persistence, content-free recall caches with locked DB
+Phase A merged in PR #282. It includes principal administration,
+creation-time key binding, safe credential rotation, private capture persistence,
+content-free recall caches with locked DB
 rehydration, durable expiry/privacy jobs, and capture/candidate/job/tombstone/
 privacy-review inspection APIs. Exact private-scope arrays are non-null at the
 database boundary; database triggers require canonical raw-capture lineage,

--- a/docs/HYBRID-RETRIEVAL-ADR.md
+++ b/docs/HYBRID-RETRIEVAL-ADR.md
@@ -1,9 +1,16 @@
 # ADR: Authorization-safe hybrid retrieval
 
-- Status: Proposed
+- Status: Accepted — Phases A1 through C implemented; Phase D rollout pending
 - Issue: [#261](https://github.com/SweetSophia/noosphere/issues/261)
 - Date: 2026-07-12
+- Last status review: 2026-08-24
 - Decision owners: Noosphere maintainers
+
+Implementation and rollout status is tracked in the
+[memory revamp status matrix](MEMORY-REVAMP-STATUS.md). The decision sections
+retain their prospective wording where it explains sequencing; accepting this
+ADR and merging its implementation do not activate storage, provider egress,
+backfill, shadow evaluation, or hybrid serving.
 
 Related decision: [Automatic Memory Capture and Recall Enrichment](AUTOMATIC-MEMORY-CAPTURE-AND-ENRICHMENT-ADR.md), which treats enrichment as a
 complementary lexical/document layer and defines how enrichment participates in
@@ -13,9 +20,9 @@ embedding-profile versioning.
 
 Noosphere currently retrieves its own articles with PostgreSQL full-text search. The Noosphere memory provider builds one weighted document from the title, excerpt, content, and tags, applies article and restricted-scope filters, and ranks matches with `ts_rank`. This is precise for shared terms but cannot recover semantically related articles that use different language.
 
-Issue #261 proposes pgvector embeddings and Reciprocal Rank Fusion (RRF). That change crosses database distribution, article persistence, remote data egress, background work, authorization, pagination, caching, and failure handling. It must therefore be delivered as a staged epic rather than as one application patch.
+Issue #261 tracks pgvector embeddings and Reciprocal Rank Fusion (RRF). That change crosses database distribution, article persistence, remote data egress, background work, authorization, pagination, caching, and failure handling. It must therefore be delivered as a staged epic rather than as one application patch.
 
-This ADR fixes the contracts that later implementation PRs must preserve. It does not enable embeddings, install pgvector, or change retrieval behavior.
+This ADR fixes the contracts that implementation and rollout work must preserve. The ADR itself does not enable embeddings, install pgvector, or change retrieval behavior.
 
 ## Decision
 

--- a/docs/MEMORY-REVAMP-STATUS.md
+++ b/docs/MEMORY-REVAMP-STATUS.md
@@ -1,0 +1,110 @@
+# Memory Capture and Hybrid Retrieval Revamp Status
+
+Status: active implementation status
+Last verified: 2026-08-24 against `master` after PR #300
+
+This document is the authoritative implementation matrix for Noosphere's
+automatic-memory-capture and authorization-safe hybrid-retrieval revamp. It
+separates four states that older plans sometimes conflated:
+
+- **Merged capability** — code and its verification have landed on `master`.
+- **Default runtime** — behavior a normal installation receives without an
+  explicit activation decision.
+- **Deployment state** — behavior verified in one named environment at a stated
+  point in time; it is not inferred from repository defaults.
+- **Operator rollout** — deployment-specific transition, backfill, quality, or
+  serving work that must be approved and executed separately.
+
+An implemented capability is not necessarily enabled, deployed, or serving.
+This status document does not authorize a database transition, provider egress,
+backfill, shadow evaluation, or hybrid serving.
+
+## Executive status
+
+- Explicit `noosphere_save` and prompt-time capture guidance are implemented.
+- Automatic-capture Phase A persistence, privacy, lineage, TTL, and inspection
+  foundations are merged but ingestion remains disabled by default.
+- The OpenClaw `agent_end` hook, extraction into candidates, recall enrichment,
+  and automatic promotion are not live.
+- Hybrid-retrieval Phases A1, A2, A2b, A3, B, and C are merged. Storage,
+  provider/worker, backfill, exact retrieval, and activation tooling exist.
+- Current Compose templates use the guarded, digest-pinned pgvector database
+  image. Feature-schema activation, provider/worker operation, backfill, and
+  hybrid retrieval remain opt-in; retrieval defaults to
+  `NOOSPHERE_HYBRID_RETRIEVAL_ENABLED=false`.
+- The guarded existing-volume transition and its execution controller are
+  implemented, but transition execution and Phase D rollout remain explicit
+  operator actions. Issue #303 holds pre-transition controller hardening.
+
+## Automatic capture and enrichment
+
+| Capability | Merged capability | Default runtime | Remaining work |
+| --- | --- | --- | --- |
+| Explicit draft save (`noosphere_save`) | Implemented | Available when the plugin is configured; the agent deliberately invokes it | Continue normal curation and review |
+| Capture guidance on recall hits and misses (Phase 0) | Implemented in PR #281 | Available only after `autoRecall: true`, prompt injection, and session eligibility; the nested guidance switch then defaults on | None for the Phase 0 contract |
+| Capture schema, authenticated endpoint, private scopes, lineage, revocation, TTL jobs, and inspection APIs (Phase A) | Implemented in PR #282 | New ingestion is disabled unless `NOOSPHERE_AUTO_MEMORY_CAPTURE_ENABLED=true`; maintenance is a separate scheduler responsibility | Operate only after keys, private scopes, HMAC rotation, and cleanup are configured |
+| Article recall enrichment (Phase B) | Not implemented | Lexical article documents have no generated recall-summary/search-term layer | Provider contract, consent, backfill, search integration, and measured quality gate |
+| OpenClaw `agent_end` capture and extraction (Phase C) | Not implemented | No automatic turn submission or candidate extraction | Agent/chat allowlists, bounded hook, extraction worker, metrics, and operations runbook |
+| Useful-recall promotion (Phase D) | Foundations only; no live promotion service | No automatic candidate-to-draft promotion | Durable selection statistics, review UI, contradiction/duplicate gates, and draft synthesis worker |
+| Enrichment-aware hybrid convergence (Phase E) | Not implemented | Current hybrid canonical document excludes future enrichment fields | New immutable profile, full backfill, coverage gate, and measured replacement of the prior profile |
+
+The detailed privacy and lifecycle contract remains in
+[Automatic Memory Capture and Recall Enrichment](AUTOMATIC-MEMORY-CAPTURE-AND-ENRICHMENT-ADR.md).
+
+## Hybrid retrieval and pgvector rollout
+
+| Phase or capability | Merged capability | Default runtime | Remaining work |
+| --- | --- | --- | --- |
+| Architecture contract | Introduced in PR #280 and accepted by the current ADR | No behavior change by itself | Keep implementation and rollout aligned with the ADR |
+| A1: owned PostgreSQL + pgvector image | Implemented in PR #284 | Current Compose templates select the digest-pinned image and require authorization markers | Existing source-image volumes still require the guarded transition |
+| A2/A2b: rehearsal and guarded Compose switch | Implemented in PRs #285 and #286; later recovery/digest hardening landed through PR #299 | No unrestricted in-place upgrade; the guard remains mandatory | Execute only with deployment-specific approval and evidence |
+| A3: optional feature storage | Implemented in PR #287 | Feature schema remains absent until explicit activation | Activate and validate against the target database |
+| B: provider, worker, consent, profile, and backfill tooling | Implemented in PR #288 | No serving profile or worker is required by the keyword-only runtime | Configure an approved provider, activate the worker layer, create a preparing profile, and backfill |
+| C: authorization-safe exact hybrid recall and RRF | Implemented in PR #289, with provider hardening in PR #291 | Disabled by `NOOSPHERE_HYBRID_RETRIEVAL_ENABLED=false`; lexical fallback remains authoritative | Complete Phase D gates before returning hybrid rankings |
+| Existing-volume execution controller | Implemented in PR #300 | Does not run automatically | Resolve the production-safety subset of issue #303, then obtain explicit transition authorization |
+| D: transition, coverage, shadow evaluation, quality acceptance, and serving | Not completed | Keyword-only recall remains the safe default | Transition the target database, activate layers, backfill to the coverage threshold, run opt-in shadow evaluation, and approve serving |
+
+Issue #261 remains open until the operator rollout and Phase D acceptance work is
+complete. Merged code alone does not satisfy that epic's serving outcome.
+
+## Reference deployment state
+
+The local reference deployment was checked read-only on 2026-08-24. It still
+uses the source PostgreSQL 16 image digest, retains the populated
+`noosphere_postgres_data` volume, and runs with
+`NOOSPHERE_HYBRID_RETRIEVAL_ENABLED=false`. It has not performed the guarded
+existing-volume transition and is not hybrid-serving.
+
+This is a point-in-time environment observation, not an installation default or
+authorization to change that environment. Other deployments must publish their
+own transition, activation, profile, coverage, and serving evidence.
+
+## Current gated milestones
+
+1. Keep this matrix and the linked ADRs synchronized as the source of status
+   truth.
+2. Address the three production-safety mechanisms in issue #303 before any
+   existing-volume transition: bound Compose interpolation, durable writer
+   closure after post-authorization failure, and rejection of unsafe root-owned
+   writable Compose parents.
+3. Handle issue #303's remaining harness, documentation, and portability items
+   as a separately bounded follow-up.
+4. Obtain explicit operator approval for the PostgreSQL transition, then perform
+   feature activation, profile backfill, shadow evaluation, coverage/relevance
+   acceptance, and serving activation in that order.
+5. Continue automatic-capture Phases B, C, and D. Defer importance decay
+   (issue #262) until capture, promotion, and retrieval metrics are live enough
+   to measure its effects.
+
+## Status maintenance
+
+Update this matrix when any of these events occur:
+
+- a listed phase merges or is materially redesigned;
+- a default flag changes;
+- an operator rollout gate completes;
+- issue #303 changes the transition boundary; or
+- automatic capture begins generating or promoting candidates.
+
+ADRs remain the decision and invariant records. Runbooks remain the operational
+source of truth. This document records implementation and rollout status only.

--- a/docs/MEMORY-REVAMP-STATUS.md
+++ b/docs/MEMORY-REVAMP-STATUS.md
@@ -41,7 +41,7 @@ backfill, shadow evaluation, or hybrid serving.
 | Capability | Merged capability | Default runtime | Remaining work |
 | --- | --- | --- | --- |
 | Explicit draft save (`noosphere_save`) | Implemented | Available when the plugin is configured; the agent deliberately invokes it | Continue normal curation and review |
-| Capture guidance on recall hits and misses (Phase 0) | Implemented in PR #281 | Available only after `autoRecall: true`, prompt injection, and session eligibility; the nested guidance switch then defaults on | None for the Phase 0 contract |
+| Capture guidance on successful recall results and clean misses (Phase 0) | Implemented in PR #281 | Available only after `autoRecall: true`, prompt injection, and session eligibility; successful results and clean misses can inject guidance, while unexpected modes, malformed provider metadata, total provider failure, and empty responses carrying any provider error fail open without guidance | None for the Phase 0 contract |
 | Capture schema, authenticated endpoint, private scopes, lineage, revocation, TTL jobs, and inspection APIs (Phase A) | Implemented in PR #282 | New ingestion is disabled unless `NOOSPHERE_AUTO_MEMORY_CAPTURE_ENABLED=true`; maintenance is a separate scheduler responsibility | Operate only after keys, private scopes, HMAC rotation, and cleanup are configured |
 | Article recall enrichment (Phase B) | Not implemented | Lexical article documents have no generated recall-summary/search-term layer | Provider contract, consent, backfill, search integration, and measured quality gate |
 | OpenClaw `agent_end` capture and extraction (Phase C) | Not implemented | No automatic turn submission or candidate extraction | Agent/chat allowlists, bounded hook, extraction worker, metrics, and operations runbook |
@@ -69,11 +69,9 @@ complete. Merged code alone does not satisfy that epic's serving outcome.
 
 ## Reference deployment state
 
-The local reference deployment was checked read-only on 2026-08-24. It still
-uses the source PostgreSQL 16 image digest, retains the populated
-`noosphere_postgres_data` volume, and runs with
-`NOOSPHERE_HYBRID_RETRIEVAL_ENABLED=false`. It has not performed the guarded
-existing-volume transition and is not hybrid-serving.
+| Environment | Last verified | Database state | Hybrid flag | Rollout state |
+| --- | --- | --- | --- | --- |
+| Local reference deployment | 2026-08-24 (read-only) | Source PostgreSQL 16 image with populated `noosphere_postgres_data` volume | `NOOSPHERE_HYBRID_RETRIEVAL_ENABLED=false` | Guarded existing-volume transition not performed; not hybrid-serving |
 
 This is a point-in-time environment observation, not an installation default or
 authorization to change that environment. Other deployments must publish their
@@ -102,6 +100,7 @@ Update this matrix when any of these events occur:
 
 - a listed phase merges or is materially redesigned;
 - a default flag changes;
+- the reference deployment changes or its observation is re-verified;
 - an operator rollout gate completes;
 - issue #303 changes the transition boundary; or
 - automatic capture begins generating or promoting candidates.

--- a/docs/NOOSPHERE-MEMORY-ARCHITECTURE.md
+++ b/docs/NOOSPHERE-MEMORY-ARCHITECTURE.md
@@ -8,7 +8,14 @@ configuration model used by the memory modules.
 
 Related issue: [#18 — Document architecture and config model](https://github.com/SweetSophia/noosphere/issues/18)
 
-Planned semantic retrieval is specified separately in the [authorization-safe hybrid retrieval ADR](HYBRID-RETRIEVAL-ADR.md) for [issue #261](https://github.com/SweetSophia/noosphere/issues/261). The ADR is proposed and does not describe current runtime behavior.
+Optional semantic retrieval is specified in the accepted
+[authorization-safe hybrid retrieval ADR](HYBRID-RETRIEVAL-ADR.md) for
+[issue #261](https://github.com/SweetSophia/noosphere/issues/261). Phases A1
+through C are implemented. Current Compose templates select the guarded
+pgvector image, while feature-schema activation, provider/worker operation,
+backfill, and hybrid retrieval remain explicit opt-in actions. Deployment and
+serving state are tracked separately in the
+[memory revamp status matrix](MEMORY-REVAMP-STATUS.md).
 
 ---
 

--- a/docs/NOOSPHERE_MEMORY_COMPARISON.md
+++ b/docs/NOOSPHERE_MEMORY_COMPARISON.md
@@ -110,7 +110,7 @@ pending.
 
 | Feature | **Noosphere** | **Hindsight** | **QMD** | **memU** | **mem0** | **LanceDB Pro** |
 |---|---|---|---|---|---|---|
-| **Embedding Provider** | OpenAI-compatible local/remote contract; explicit consent and operator configuration required | Configurable | Built-in / optional | OpenAI / custom | OpenAI / custom | OpenAI / Jina / Ollama / custom |
+| **Embedding Provider** | OpenAI-compatible local/remote contract; provider configuration required, with explicit operator consent for remote content or query egress | Configurable | Built-in / optional | OpenAI / custom | OpenAI / custom | OpenAI / Jina / Ollama / custom |
 | **Vector Store** | PostgreSQL + pgvector capability; explicit storage activation required | Embedded (Rust) | SQLite / QMD sidecar | pgvector | Qdrant / pgvector / Chroma | LanceDB (local) |
 | **External Dependencies** | PostgreSQL | Rust daemon | None | PostgreSQL + pgvector | Varies by backend | None (local) |
 | **CPU Requirement** | Standard | Standard | Standard | Standard | Standard | ⚠️ AVX/AVX2 required |

--- a/docs/NOOSPHERE_MEMORY_COMPARISON.md
+++ b/docs/NOOSPHERE_MEMORY_COMPARISON.md
@@ -22,16 +22,18 @@
 
 ## Core Memory Features
 
-Noosphere rows marked as planned or partial below are staged in the
+Noosphere rows marked as planned or partial below are tracked in the
+[memory revamp status matrix](MEMORY-REVAMP-STATUS.md). The related
 [Automatic Memory Capture and Recall Enrichment ADR](AUTOMATIC-MEMORY-CAPTURE-AND-ENRICHMENT-ADR.md)
-(status: **Proposed**; Phases A–E are pending).
+is accepted: Phase 0 and Phase A are implemented, while Phases B–E remain
+pending.
 
 | Feature | **Noosphere** | **Hindsight** | **QMD** | **memU** | **mem0** | **LanceDB Pro** |
 |---|---|---|---|---|---|---|
-| **Auto-Capture** | ⚠️ Explicit draft save + advisory capture guidance; deterministic turn capture planned | ✅ Every turn | ❌ Manual indexing | ✅ Continuous learning | ✅ `memory.add()` | ✅ Smart extraction |
+| **Auto-Capture** | ⚠️ Explicit draft save + optional advisory guidance + default-off Phase A persistence/privacy foundation; `agent_end` capture and extraction pending | ✅ Every turn | ❌ Manual indexing | ✅ Continuous learning | ✅ `memory.add()` | ✅ Smart extraction |
 | **Auto-Recall** | ✅ Capture guidance on clean misses + recall results when available; provider errors fail open | ✅ Before each turn | ✅ Keyword search only | ✅ Proactive context loading | ✅ `memory.search()` | ✅ Before prompt build |
 | **Manual Recall** | ✅ REST API + tools | ✅ MCP tools | ✅ CLI / tool query | ✅ REST API | ✅ SDK + REST | ✅ CLI + MCP tools |
-| **Semantic Search** | ✅ PostgreSQL FTS (live) + vector (planned) | ✅ Vector + biomimetic | ⚠️ Keyword + pending vector | ✅ pgvector | ✅ Semantic + BM25 + entity fusion | ✅ Vector + BM25 hybrid |
+| **Semantic Search** | ✅ PostgreSQL FTS (default) + implemented opt-in pgvector/RRF; rollout pending | ✅ Vector + biomimetic | ⚠️ Keyword + pending vector | ✅ pgvector | ✅ Semantic + BM25 + entity fusion | ✅ Vector + BM25 hybrid |
 | **Keyword Search** | ✅ PostgreSQL full-text | ✅ | ✅ Primary mode | ✅ | ✅ BM25 | ✅ BM25 |
 | **Cross-Encoder Rerank** | ❌ (planned) | ❌ | ❌ | ❌ | ❌ | ✅ Cross-encoder |
 | **Memory Types** | Articles (wiki) | world / experience / observation | Markdown files | Categories / Items / Resources | Facts (ADD-only v3) | 6-category classification |
@@ -52,7 +54,7 @@ Noosphere rows marked as planned or partial below are staged in the
 | **Token Budget Manager** | ✅ Prompt-safe recall blocks | ✅ `recallMaxTokens` | ❌ | ❌ | ❌ | ❌ |
 | **Promotion (ephemeral → curated)** | ⚠️ Pure threshold/review scaffolding; durable statistics and worker wiring planned | ❌ | ❌ | ❌ | ❌ | ⚠️ Decay model (Weibull) |
 | **Backfill / Synthesis** | ⚠️ Pure job/content helpers; durable execution wiring planned | ✅ Historical backfill CLI | ❌ | ❌ | ❌ | ❌ |
-| **Local Scheduler** | ⚠️ Scheduler framework; only the health job is currently wired | ❌ | ❌ | ✅ Continuous sync loop | ❌ | ❌ |
+| **Local Scheduler** | ⚠️ Health plus durable Phase A expiry/privacy cleanup; extraction and promotion workers pending | ❌ | ❌ | ✅ Continuous sync loop | ❌ | ❌ |
 | **Revision History** | ✅ Per-article | ❌ | ❌ | ❌ | ❌ | ❌ |
 | **Topic Hierarchy** | ✅ Unlimited depth | ❌ | ❌ | ✅ Category hierarchy | ❌ | ❌ |
 | **Tags / Relations** | ✅ Tags + article edges | ❌ | ❌ | ✅ Cross-references | ✅ Entity linking (v3) | ❌ |
@@ -108,8 +110,8 @@ Noosphere rows marked as planned or partial below are staged in the
 
 | Feature | **Noosphere** | **Hindsight** | **QMD** | **memU** | **mem0** | **LanceDB Pro** |
 |---|---|---|---|---|---|---|
-| **Embedding Provider** | TBD (PostgreSQL) | Configurable | Built-in / optional | OpenAI / custom | OpenAI / custom | OpenAI / Jina / Ollama / custom |
-| **Vector Store** | PostgreSQL (planned) | Embedded (Rust) | SQLite / QMD sidecar | pgvector | Qdrant / pgvector / Chroma | LanceDB (local) |
+| **Embedding Provider** | OpenAI-compatible local/remote contract; explicit consent and operator configuration required | Configurable | Built-in / optional | OpenAI / custom | OpenAI / custom | OpenAI / Jina / Ollama / custom |
+| **Vector Store** | PostgreSQL + pgvector capability; explicit storage activation required | Embedded (Rust) | SQLite / QMD sidecar | pgvector | Qdrant / pgvector / Chroma | LanceDB (local) |
 | **External Dependencies** | PostgreSQL | Rust daemon | None | PostgreSQL + pgvector | Varies by backend | None (local) |
 | **CPU Requirement** | Standard | Standard | Standard | Standard | Standard | ⚠️ AVX/AVX2 required |
 | **Benchmarked** | ❌ | ❌ | ❌ | ❌ | ✅ LoCoMo 91.6, LongMemEval 93.4 | ❌ |

--- a/docs/OPENCLAW-NOOSPHERE-BRIDGE-ROADMAP.md
+++ b/docs/OPENCLAW-NOOSPHERE-BRIDGE-ROADMAP.md
@@ -19,7 +19,7 @@ Current boundary:
   capture, extraction, enrichment, and promotion remain pending;
 - hybrid Phases A1 through C and the transition controller are merged; current
   Compose templates select the guarded pgvector image, while storage activation,
-  provider/worker operation, backfill, and retrieval remain opt-in;
+  provider/worker operation, backfill, and hybrid retrieval remain opt-in;
 - issue #303's production-safety subset precedes any existing-volume
   transition; and
 - transition, backfill, shadow evaluation, quality acceptance, and serving all

--- a/docs/OPENCLAW-NOOSPHERE-BRIDGE-ROADMAP.md
+++ b/docs/OPENCLAW-NOOSPHERE-BRIDGE-ROADMAP.md
@@ -1,8 +1,32 @@
 # OpenClaw ↔ Noosphere Memory Bridge Roadmap
 
-Status: implementation complete through PR 7; official plugin productization tracked separately in `OPENCLAW-OFFICIAL-PLUGIN-DEVELOPMENT-PLAN.md`.
+Status: bridge implementation complete through PR 7; memory revamp continues under the linked status matrix.
 Owner: Noosphere/OpenClaw integration workstream
-Last updated: 2026-04-30
+Last updated: 2026-08-24
+
+## Memory revamp continuation
+
+The bridge baseline in this roadmap is complete. Automatic capture and hybrid
+retrieval now span server storage, privacy lifecycle, workers, retrieval, and
+operator rollout, so their current state is maintained in the
+[memory revamp status matrix](MEMORY-REVAMP-STATUS.md) rather than duplicated
+here.
+
+Current boundary:
+
+- explicit save and prompt-time capture guidance are implemented;
+- automatic-capture Phase A is merged but default-off, while `agent_end`
+  capture, extraction, enrichment, and promotion remain pending;
+- hybrid Phases A1 through C and the transition controller are merged; current
+  Compose templates select the guarded pgvector image, while storage activation,
+  provider/worker operation, backfill, and retrieval remain opt-in;
+- issue #303's production-safety subset precedes any existing-volume
+  transition; and
+- transition, backfill, shadow evaluation, quality acceptance, and serving all
+  remain explicit operator actions.
+
+Updating this roadmap or the status matrix never authorizes those rollout
+actions.
 
 ## Goal
 


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary

This pull request introduces a documentation-only status matrix for Noosphere's memory revamp and aligns existing documentation surfaces (ADRs, architecture, comparison, roadmap, README) with the implementation that has actually merged. It distinguishes four states that older plans conflated: merged capability, default runtime, deployment state, and operator rollout.

## What changed

### New authoritative status matrix

- Added `docs/MEMORY-REVAMP-STATUS.md` as the single source of truth for memory revamp status, verified against `master` after PR #300.
- Separates four explicit states: merged capability, default runtime, deployment state, and operator rollout.
- Covers automatic capture (Phases 0 through E) and hybrid retrieval (Phases A1 through D), with per-row indicators for merged capability, default behavior, and remaining work.
- Records a point-in-time read-only reference deployment observation (PostgreSQL 16 source image, populated volume, hybrid retrieval disabled).
- Lists gated milestones tied to issue #303's production-safety subset and Phase D acceptance.
- Specifies maintenance triggers so the matrix stays the source of status truth.

### ADR alignment

- `AUTOMATIC-MEMORY-CAPTURE-AND-ENRICHMENT-ADR.md`: Status moved from "Proposed" to "Accepted — Phase 0 and Phase A implemented; Phases B through E pending." Adds a link to the status matrix and clarifies that acceptance does not enable automatic ingestion or proposed Phase C config keys. Phase A is now attributed to PR #282.
- `HYBRID-RETRIEVAL-ADR.md`: Status moved from "Proposed" to "Accepted — Phases A1 through C implemented; Phase D rollout pending." Notes that merged implementation does not activate storage, provider egress, backfill, shadow evaluation, or hybrid serving.

### README and architecture updates

- README semantic-search row updated from "vector (planned)" to "implemented opt-in pgvector/RRF; rollout pending," and the document index points to the new status matrix.
- `NOOSPHERE-MEMORY-ARCHITECTURE.md` now references the accepted hybrid retrieval ADR and links to the status matrix for deployment/serving state.
- `OPENCLAW-NOOSPHERE-BRIDGE-ROADMAP.md` defers revamp status to the matrix and explicitly records the current boundary (Phase A default-off, hybrid rollout opt-in, issue #303 gates transition, all rollout actions explicit).
- `NOOSPHERE_MEMORY_COMPARISON.md` updates Auto-Capture, Semantic Search, Local Scheduler, Embedding Provider, and Vector Store rows to reflect merged-but-default-off state, removing the "PostgreSQL FTS (live) + vector (planned)" framing.

## Functional impact

- No runtime, database, deployment, or activation changes — defaults remain disabled unless operators explicitly opt in.
- Readers can now determine, for each revamp capability, whether it is merged, what it does by default, and what explicit operator work remains.
- Existing-volume PostgreSQL transition remains gated by issue #303.
- Automatic-capture Phases B-E remain unimplemented; hybrid Phase D rollout remains pending.

---

**Pull Request Description:**

This PR aligns documentation with the actual implementation status of the memory revamp. Key changes include:

### `docs/MEMORY-STATUS.md`
- **Phase 0 guidance capture row:** Clarified that the implementation only injects guidance on successful recall results and clean misses. Explicitly documents the fail-open behavior for edge cases: unexpected modes, malformed provider metadata, total provider failure, and empty responses with provider errors.
- **Reference deployment state:** Replaced the prose paragraph with a comparison table that includes environment, last-verified date, database state, hybrid flag, and rollout state for better clarity.
- **Update triggers:** Added a new trigger to revise the document when the reference deployment changes or its observation is re-verified.

### `docs/NOOSPHERE_MEMORY_COMPARISON.md`
- **Embedding Provider row:** Refined the description to make it clear that provider configuration is required, with explicit operator consent needed only for remote content or query egress (rather than implying consent was required for the local case as well).

### `docs/OPENCLAW-NOOSPHERE-BRIDGE-ROADMAP.md`
- **Phase boundaries:** Corrected "retrieval" to "hybrid retrieval" in the list of opt-in capabilities, more precisely matching the terminology used elsewhere in the revamp (distinguishing hybrid retrieval from other retrieval paths).
<!-- kody-pr-summary:end -->

## Summary by Sourcery

Align memory revamp documentation with the implementation while preserving disabled-by-default behavior and explicit operator rollout requirements.

New Features:
- Add an authoritative status matrix distinguishing merged capabilities, default runtime behavior, deployment state, and operator rollout for the memory revamp.

Enhancements:
- Align memory capture and hybrid retrieval ADRs, architecture documentation, comparison tables, roadmap, and README with the implemented-but-default-off state and remaining rollout gates.

Documentation:
- Document the current automatic-capture and hybrid-retrieval phases, reference deployment observation, production-safety gates, and status maintenance expectations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated memory architecture and comparison guides to reflect implemented Phase 0/A capabilities and pending future phases.
  * Documented opt-in pgvector and hybrid retrieval support while retaining PostgreSQL full-text search as the default.
  * Added a central status matrix covering rollout requirements, safety gates, runtime behavior, and remaining work.
  * Updated roadmap and ADRs with current implementation status, deployment boundaries, and operator-controlled activation requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->