### PR TITLE
fix(controller): harden issue #303 transition safety

### DIFF
--- a/.github/workflows/postgres-pgvector-rehearsal.yml
+++ b/.github/workflows/postgres-pgvector-rehearsal.yml
@@ -148,6 +148,18 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Set up Node.js
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: 22
+
+      - name: Install pinned Node in controller bootstrap path
+        run: |
+          node_path=$(command -v node)
+          [[ "$node_path" == /* && -f "$node_path" ]]
+          sudo install -o root -g root -m 0755 "$node_path" /usr/bin/node
+          cmp -s "$node_path" /usr/bin/node
+
       - name: Start persistent user manager
         run: |
           runtime_dir="/run/user/$(id -u)"
@@ -183,6 +195,18 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: 22
+
+      - name: Install pinned Node in controller bootstrap path
+        run: |
+          node_path=$(command -v node)
+          [[ "$node_path" == /* && -f "$node_path" ]]
+          sudo install -o root -g root -m 0755 "$node_path" /usr/bin/node
+          cmp -s "$node_path" /usr/bin/node
 
       - name: Start persistent user manager
         run: |

--- a/.github/workflows/postgres-pgvector-rehearsal.yml
+++ b/.github/workflows/postgres-pgvector-rehearsal.yml
@@ -159,6 +159,8 @@ jobs:
           [[ "$node_path" == /* && -f "$node_path" ]]
           sudo install -o root -g root -m 0755 "$node_path" /usr/bin/node
           cmp -s "$node_path" /usr/bin/node
+          sudo chmod 0755 /usr/local/bin
+          [[ $(stat -c '%u:%a' /usr/local/bin) == 0:755 ]]
 
       - name: Start persistent user manager
         run: |
@@ -207,6 +209,8 @@ jobs:
           [[ "$node_path" == /* && -f "$node_path" ]]
           sudo install -o root -g root -m 0755 "$node_path" /usr/bin/node
           cmp -s "$node_path" /usr/bin/node
+          sudo chmod 0755 /usr/local/bin
+          [[ $(stat -c '%u:%a' /usr/local/bin) == 0:755 ]]
 
       - name: Start persistent user manager
         run: |

--- a/.github/workflows/postgres-pgvector-rehearsal.yml
+++ b/.github/workflows/postgres-pgvector-rehearsal.yml
@@ -162,6 +162,12 @@ jobs:
           sudo chmod 0755 /usr/local/bin
           [[ $(stat -c '%u:%a' /usr/local/bin) == 0:755 ]]
 
+      - name: Install focused fixture tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends ripgrep
+          rg --version
+
       - name: Start persistent user manager
         run: |
           runtime_dir="/run/user/$(id -u)"

--- a/.github/workflows/postgres-pgvector-rehearsal.yml
+++ b/.github/workflows/postgres-pgvector-rehearsal.yml
@@ -18,9 +18,13 @@ on:
       - "prisma/schema.prisma"
       - "scripts/rehearse-pgvector-volume-upgrade.sh"
       - "scripts/check-postgres-image-policy.mjs"
+      - "scripts/run-pgvector-transition-controller.sh"
       - "scripts/switch-pgvector-compose.sh"
       - "scripts/test-digest-order-independence.sh"
       - "scripts/test-pgvector-compose-switch.sh"
+      - "scripts/test-pgvector-transition-controller.sh"
+      - "scripts/test-pgvector-transition-controller-systemd.sh"
+      - "scripts/test-pgvector-transition-controller-docker.sh"
       - "scripts/verify-deploy.sh"
   push:
     branches: [main, master]
@@ -39,9 +43,13 @@ on:
       - "prisma/schema.prisma"
       - "scripts/rehearse-pgvector-volume-upgrade.sh"
       - "scripts/check-postgres-image-policy.mjs"
+      - "scripts/run-pgvector-transition-controller.sh"
       - "scripts/switch-pgvector-compose.sh"
       - "scripts/test-digest-order-independence.sh"
       - "scripts/test-pgvector-compose-switch.sh"
+      - "scripts/test-pgvector-transition-controller.sh"
+      - "scripts/test-pgvector-transition-controller-systemd.sh"
+      - "scripts/test-pgvector-transition-controller-docker.sh"
       - "scripts/verify-deploy.sh"
 
 permissions:
@@ -130,3 +138,87 @@ jobs:
           if [[ -x scripts/rehearse-pgvector-volume-upgrade.sh ]]; then
             scripts/rehearse-pgvector-volume-upgrade.sh --cleanup-run "$REHEARSAL_RUN_ID"
           fi
+
+  test-transition-controller:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+
+      - name: Start persistent user manager
+        run: |
+          runtime_dir="/run/user/$(id -u)"
+          sudo loginctl enable-linger "$USER"
+          sudo systemctl start "user@$(id -u).service"
+          for _ in $(seq 1 100); do
+            [[ -S "$runtime_dir/bus" ]] && break
+            sleep 0.1
+          done
+          [[ -S "$runtime_dir/bus" ]]
+          {
+            printf 'XDG_RUNTIME_DIR=%s\n' "$runtime_dir"
+            printf 'DBUS_SESSION_BUS_ADDRESS=unix:path=%s/bus\n' "$runtime_dir"
+          } >> "$GITHUB_ENV"
+          XDG_RUNTIME_DIR="$runtime_dir" \
+            DBUS_SESSION_BUS_ADDRESS="unix:path=$runtime_dir/bus" \
+            systemctl --user show-environment >/dev/null
+          [[ $(loginctl show-user "$(id -u)" -p Linger --value) == yes ]]
+
+      - name: Run focused transition-controller fixture
+        timeout-minutes: 25
+        run: scripts/test-pgvector-transition-controller.sh
+
+      - name: Disable CI user linger
+        if: always()
+        run: sudo loginctl disable-linger "$USER"
+
+  rehearse-transition-controller:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+
+      - name: Start persistent user manager
+        run: |
+          runtime_dir="/run/user/$(id -u)"
+          sudo loginctl enable-linger "$USER"
+          sudo systemctl start "user@$(id -u).service"
+          for _ in $(seq 1 100); do
+            [[ -S "$runtime_dir/bus" ]] && break
+            sleep 0.1
+          done
+          [[ -S "$runtime_dir/bus" ]]
+          {
+            printf 'XDG_RUNTIME_DIR=%s\n' "$runtime_dir"
+            printf 'DBUS_SESSION_BUS_ADDRESS=unix:path=%s/bus\n' "$runtime_dir"
+          } >> "$GITHUB_ENV"
+          XDG_RUNTIME_DIR="$runtime_dir" \
+            DBUS_SESSION_BUS_ADDRESS="unix:path=$runtime_dir/bus" \
+            systemctl --user show-environment >/dev/null
+          [[ $(loginctl show-user "$(id -u)" -p Linger --value) == yes ]]
+
+      - name: Pull pinned controller rehearsal images
+        run: |
+          mapfile -t images < <(
+            sed -nE "s/^(SOURCE_IMAGE|CANDIDATE_IMAGE)='([^']+)'$/\2/p" \
+              scripts/test-pgvector-transition-controller-docker.sh
+          )
+          [[ ${#images[@]} -eq 2 ]]
+          for image in "${images[@]}"; do
+            [[ "$image" =~ ^[^[:space:]]+@sha256:[0-9a-f]{64}$ ]]
+            docker pull --platform linux/amd64 "$image"
+          done
+
+      - name: Run pinned-Docker interruption and recovery rehearsal
+        timeout-minutes: 35
+        run: scripts/test-pgvector-transition-controller-docker.sh linux/amd64
+
+      - name: Disable CI user linger
+        if: always()
+        run: sudo loginctl disable-linger "$USER"

--- a/docs/MEMORY-REVAMP-STATUS.md
+++ b/docs/MEMORY-REVAMP-STATUS.md
@@ -35,9 +35,10 @@ backfill, shadow evaluation, or hybrid serving.
 - The guarded existing-volume transition and its execution controller are
   implemented. Issue #303's production-safety subset is open as PR #305; its
   public-review correction passes the focused and stateful rehearsal gates,
-  and updated CI/review is green on correction head `35df2d0` with zero
-  unresolved threads. It is not merged, and transition execution plus Phase D
-  rollout remain explicit operator actions.
+  and updated CI/review is green with zero unresolved threads. The PR now carries
+  path-filtered focused/systemd and pinned-Docker controller jobs as the Task 7
+  Step 5 pre-rollout gate. It is not merged; Task 7 installer integration,
+  transition execution, and Phase D rollout remain explicit operator actions.
 
 ## Automatic capture and enrichment
 

--- a/docs/MEMORY-REVAMP-STATUS.md
+++ b/docs/MEMORY-REVAMP-STATUS.md
@@ -35,8 +35,9 @@ backfill, shadow evaluation, or hybrid serving.
 - The guarded existing-volume transition and its execution controller are
   implemented. Issue #303's production-safety subset is open as PR #305; its
   public-review correction passes the focused and stateful rehearsal gates,
-  while updated CI/review remains pending. It is not merged, and transition
-  execution plus Phase D rollout remain explicit operator actions.
+  and updated CI/review is green on correction head `35df2d0` with zero
+  unresolved threads. It is not merged, and transition execution plus Phase D
+  rollout remain explicit operator actions.
 
 ## Automatic capture and enrichment
 

--- a/docs/MEMORY-REVAMP-STATUS.md
+++ b/docs/MEMORY-REVAMP-STATUS.md
@@ -33,9 +33,10 @@ backfill, shadow evaluation, or hybrid serving.
   hybrid retrieval remain opt-in; retrieval defaults to
   `NOOSPHERE_HYBRID_RETRIEVAL_ENABLED=false`.
 - The guarded existing-volume transition and its execution controller are
-  implemented. Issue #303's production-safety subset is locally verified but
-  not yet merged; transition execution and Phase D rollout remain explicit
-  operator actions.
+  implemented. Issue #303's production-safety subset is open as PR #305; its
+  public-review correction passes the focused and stateful rehearsal gates,
+  while updated CI/review remains pending. It is not merged, and transition
+  execution plus Phase D rollout remain explicit operator actions.
 
 ## Automatic capture and enrichment
 

--- a/docs/MEMORY-REVAMP-STATUS.md
+++ b/docs/MEMORY-REVAMP-STATUS.md
@@ -1,7 +1,7 @@
 # Memory Capture and Hybrid Retrieval Revamp Status
 
 Status: active implementation status
-Last verified: 2026-08-24 against `master` after PR #300
+Last verified: 2026-08-26 against `master` plus the locally verified issue #303 branch
 
 This document is the authoritative implementation matrix for Noosphere's
 automatic-memory-capture and authorization-safe hybrid-retrieval revamp. It
@@ -33,8 +33,9 @@ backfill, shadow evaluation, or hybrid serving.
   hybrid retrieval remain opt-in; retrieval defaults to
   `NOOSPHERE_HYBRID_RETRIEVAL_ENABLED=false`.
 - The guarded existing-volume transition and its execution controller are
-  implemented, but transition execution and Phase D rollout remain explicit
-  operator actions. Issue #303 holds pre-transition controller hardening.
+  implemented. Issue #303's production-safety subset is locally verified but
+  not yet merged; transition execution and Phase D rollout remain explicit
+  operator actions.
 
 ## Automatic capture and enrichment
 
@@ -61,7 +62,7 @@ The detailed privacy and lifecycle contract remains in
 | A3: optional feature storage | Implemented in PR #287 | Feature schema remains absent until explicit activation | Activate and validate against the target database |
 | B: provider, worker, consent, profile, and backfill tooling | Implemented in PR #288 | No serving profile or worker is required by the keyword-only runtime | Configure an approved provider, activate the worker layer, create a preparing profile, and backfill |
 | C: authorization-safe exact hybrid recall and RRF | Implemented in PR #289, with provider hardening in PR #291 | Disabled by `NOOSPHERE_HYBRID_RETRIEVAL_ENABLED=false`; lexical fallback remains authoritative | Complete Phase D gates before returning hybrid rankings |
-| Existing-volume execution controller | Implemented in PR #300 | Does not run automatically | Resolve the production-safety subset of issue #303, then obtain explicit transition authorization |
+| Existing-volume execution controller | Base controller implemented in PR #300; issue #303 production-safety hardening locally verified and pending PR/CI | Does not run automatically | Merge the focused hardening only after its publication gates, then obtain explicit transition authorization |
 | D: transition, coverage, shadow evaluation, quality acceptance, and serving | Not completed | Keyword-only recall remains the safe default | Transition the target database, activate layers, backfill to the coverage threshold, run opt-in shadow evaluation, and approve serving |
 
 Issue #261 remains open until the operator rollout and Phase D acceptance work is
@@ -81,12 +82,14 @@ own transition, activation, profile, coverage, and serving evidence.
 
 1. Keep this matrix and the linked ADRs synchronized as the source of status
    truth.
-2. Address the three production-safety mechanisms in issue #303 before any
-   existing-volume transition: bound Compose interpolation, durable writer
-   closure after post-authorization failure, and rejection of unsafe root-owned
-   writable Compose parents.
-3. Handle issue #303's remaining harness, documentation, and portability items
-   as a separately bounded follow-up.
+2. Publish and merge issue #303's locally verified production-safety subset:
+   bound Compose interpolation, durable writer closure after post-authorization
+   failure, rejection of writable Compose parents regardless of owner,
+   descriptor/digest-bound publication, fresh-invocation writer closure, and
+   rollback-capable state/evidence publication.
+3. Keep issue #303's remaining status-fidelity, portability, and unrelated
+   hardening observations outside that bounded release floor unless a concrete
+   safety reproducer promotes one.
 4. Obtain explicit operator approval for the PostgreSQL transition, then perform
    feature activation, profile backfill, shadow evaluation, coverage/relevance
    acceptance, and serving activation in that order.

--- a/docs/POSTGRES-PGVECTOR-EXECUTION-CONTROLLER.md
+++ b/docs/POSTGRES-PGVECTOR-EXECUTION-CONTROLLER.md
@@ -44,9 +44,14 @@ mutations remain exclusively inside the pinned guard.
 
 ## Durable phases
 
-`prepared` → `candidate-published` → `guard-exited` →
+The forward path is `prepared` → `candidate-published` → `guard-exited` →
 `authorization-running` → `activation-running` → `closure-running` →
 `complete`.
+
+Recovery can additionally enter `source-recovery-running`,
+`closure-stop-pending`, or `closure-evidence-pending`. Those phases are not
+alternate success paths: they preserve the next required fail-closed action
+across process exit or reboot.
 
 A closure failure first enters resumable `closure-stop-pending`. The controller
 stops the app writer and verifies it is not running before committing terminal
@@ -436,3 +441,49 @@ disposable-Docker suites.
 - **Writer-stop evidence is retry-distinct**: `stop_application_fail_closed` allocates its evidence path through `select_process_artifact_base` (writer-stop role). The first stop owns the canonical `.writer-stop.evidence.json`; a later invocation that finds it allocates an InvocationID-suffixed path, so a crash between evidence publication and phase advance can never overwrite a prior truthful stop record — the same contract the source-recovery role already enforces.
 - **Invocation-suffixed paths join the collision matrix**: whenever an InvocationID is present (always at execute), `assert_controller_artifact_paths_separate` also checks the `.<InvocationID>` suffixed guard/authorization/verify/source-recovery/writer-stop paths against every bound input, matching what a retrying invocation actually writes.
 - **New regression fixtures**: `test_writer_stop_evidence_is_retry_distinct` (canonical-first, InvocationID-distinct retry, prior bytes survive, unsafe InvocationID rejected) and `test_invocation_suffixed_artifacts_cannot_collide_with_bound_inputs` (suffixed writer-stop path rejected as bound input with collision diagnostic; clean control passes).
+
+## Issue #303 transition-safety corrections (Aug 26)
+
+The issue #303 hardening preserves the controller's existing trust boundary and
+adds the following publication, writer-closure, and durability guarantees:
+
+- **Hermetic Compose activation**: application activation runs with only the
+  prepared controller environment. Ambient values cannot override the bound
+  Compose interpolation inputs.
+- **Authorization postprocessing closes the writer**: if evidence publication
+  or binding fails after writer authorization, the controller commits closure
+  intent, stops the application, verifies `State.Running=false`, and records
+  the applicable incident instead of returning through an unclosed writer
+  boundary.
+- **All writable publication parents are rejected**: group/world-writable
+  Compose parents are unsafe regardless of owner. Ownership alone is not a
+  publication authorization.
+- **Descriptor-bound publication identity**: source and target parent device
+  and inode identities are captured before open and compared with the opened
+  directory descriptors. Candidate reads and target writes remain relative to
+  those descriptors, and target attachment is checked around rename. A
+  detached or retargeted parent cannot produce a false successful publication.
+- **Prepared bytes reach the publication boundary**: the exact staged Compose
+  inode is hashed against `candidateComposeSha256` before its descriptor-relative
+  rename. Successful publication therefore binds the reviewed bytes, not merely
+  an earlier pathname lookup.
+- **Fresh writer phases fail closed**: a fresh process that observes
+  `authorization-running` or `activation-running` never replays authorization
+  or activation. It enters interruption closure, performs an inspect-verified
+  stop, and requires operator resolution. If closure-intent persistence and the
+  stop both fail, the unchanged writer phase causes the next invocation to
+  repeat the same stop-only handling.
+- **Post-rename durability failures do not ordinary-fail with advanced state**:
+  atomic state and stop-evidence publication preserves the prior object (or
+  prior absence). If the first parent-directory fsync fails after rename, the
+  controller restores or removes the visible successor and fsyncs that rollback.
+  It returns the original failure only after rollback is durable; rollback-
+  durability failure terminates fail-stopped.
+
+Local verification on the frozen issue #303 bytes completed with five direct
+owners, eleven impacted siblings, the full focused suite (`131/131`), the
+standalone transient-systemd fixture, and the pinned-Docker `linux/amd64`
+interruption/recovery rehearsal all green. Three sequential read-only reviews
+found zero release-floor blockers. These results verify the local implementation
+gate only: merge, deployment, the PostgreSQL transition, feature activation,
+backfill, and hybrid serving remain separately authorized operator actions.

--- a/docs/POSTGRES-PGVECTOR-EXECUTION-CONTROLLER.md
+++ b/docs/POSTGRES-PGVECTOR-EXECUTION-CONTROLLER.md
@@ -469,10 +469,12 @@ adds the following publication, writer-closure, and durability guarantees:
   an earlier pathname lookup.
 - **Fresh writer phases fail closed**: a fresh process that observes
   `authorization-running` or `activation-running` never replays authorization
-  or activation. It enters interruption closure, performs an inspect-verified
-  stop, and requires operator resolution. If closure-intent persistence and the
-  stop both fail, the unchanged writer phase causes the next invocation to
-  repeat the same stop-only handling.
+  or activation. After the immutable execution inputs, Docker binary,
+  engine/volume identity, lock, and authority path are validated, it performs
+  an inspect-verified stop **before** consulting phase-owned proof bytes. Full
+  proof validation then resumes before the interruption incident can advance.
+  If a proof is unavailable, the unresolved running phase retains durable
+  writer-stop evidence and remains stop-only for operator resolution.
 - **Post-rename durability failures do not ordinary-fail with advanced state**:
   atomic state and stop-evidence publication preserves the prior object (or
   prior absence). If the first parent-directory fsync fails after rename, the
@@ -480,10 +482,11 @@ adds the following publication, writer-closure, and durability guarantees:
   It returns the original failure only after rollback is durable; rollback-
   durability failure terminates fail-stopped.
 
-Local verification on the frozen issue #303 bytes completed with five direct
-owners, eleven impacted siblings, the full focused suite (`131/131`), the
-standalone transient-systemd fixture, and the pinned-Docker `linux/amd64`
-interruption/recovery rehearsal all green. Three sequential read-only reviews
-found zero release-floor blockers. These results verify the local implementation
-gate only: merge, deployment, the PostgreSQL transition, feature activation,
-backfill, and hybrid serving remain separately authorized operator actions.
+The current public-review correction passes six direct owners, eleven impacted
+siblings, the full focused suite (`132/132`), the standalone transient-systemd
+fixture, and the pinned-Docker `linux/amd64` interruption/recovery rehearsal,
+with zero owned residue. Three sequential read-only reviews were green on the
+frozen pre-publication bytes; updated public CI/review applies separately to the
+corrected PR head. Merge, deployment, the PostgreSQL transition, feature
+activation, backfill, and hybrid serving remain separately authorized operator
+actions.

--- a/docs/POSTGRES-PGVECTOR-EXECUTION-CONTROLLER.md
+++ b/docs/POSTGRES-PGVECTOR-EXECUTION-CONTROLLER.md
@@ -504,3 +504,12 @@ frozen pre-publication bytes; updated public CI/review applies separately to the
 corrected PR head. Merge, deployment, the PostgreSQL transition, feature
 activation, backfill, and hybrid serving remain separately authorized operator
 actions.
+
+The path-filtered `postgres-pgvector-rehearsal.yml` workflow makes these
+controller gates mandatory evidence on controller, fixture, guard, verifier, or
+workflow changes. One job runs the focused suite, including the real transient
+user-systemd owner. A separate `linux/amd64` job pulls the fixture's two
+digest-pinned images and runs the real-Docker interruption/recovery rehearsal.
+Both jobs use disposable lingering user managers and carry only read-only
+repository permission; they do not authenticate to a registry or touch a
+production Docker endpoint.

--- a/docs/POSTGRES-PGVECTOR-EXECUTION-CONTROLLER.md
+++ b/docs/POSTGRES-PGVECTOR-EXECUTION-CONTROLLER.md
@@ -299,6 +299,10 @@ enters a phase the guard has not authorised.
   activation inspect, and activation Compose calls all use that bundle's
   `HOME`, `DOCKER_CONFIG`, Docker executable, plugin, and fixed child `PATH`;
   the original prepared namespace is not consulted after binding.
+- **One effective Compose project directory**: candidate-model signatures,
+  invocation-bundle revalidation, and activation all resolve relative Compose
+  paths against the live Compose file's parent. Moving the candidate copy into
+  the invocation bundle cannot change bind mounts, build contexts, or includes.
 - **Trusted system-executable ownership**: production Docker and Compose
   executables may be root-owned or deployment-user-owned, but must be regular
   non-symlink files without group/world write permission before they are copied
@@ -492,8 +496,8 @@ adds the following publication, writer-closure, and durability guarantees:
   It returns the original failure only after rollback is durable; rollback-
   durability failure terminates fail-stopped.
 
-The current public-review correction passes eight direct owners, eleven impacted
-siblings, the full focused suite (`134/134`), the standalone transient-systemd
+The current public-review correction passes nine direct owners, eleven impacted
+siblings, the full focused suite (`135/135`), the standalone transient-systemd
 fixture, and the pinned-Docker `linux/amd64` interruption/recovery rehearsal,
 with zero owned residue. Three sequential read-only reviews were green on the
 frozen pre-publication bytes; updated public CI/review applies separately to the

--- a/docs/POSTGRES-PGVECTOR-EXECUTION-CONTROLLER.md
+++ b/docs/POSTGRES-PGVECTOR-EXECUTION-CONTROLLER.md
@@ -295,7 +295,10 @@ enters a phase the guard has not authorised.
   verified guard, verifier, Docker client, Compose plugin, Docker config,
   environment file, source snapshot, and candidate Compose file into a private
   bundle. The copies are re-hashed and their Compose/plugin identity is checked
-  before use, closing hash-then-pathname replacement races.
+  before use, closing hash-then-pathname replacement races. Guard, verifier,
+  activation inspect, and activation Compose calls all use that bundle's
+  `HOME`, `DOCKER_CONFIG`, Docker executable, plugin, and fixed child `PATH`;
+  the original prepared namespace is not consulted after binding.
 - **Trusted system-executable ownership**: production Docker and Compose
   executables may be root-owned or deployment-user-owned, but must be regular
   non-symlink files without group/world write permission before they are copied
@@ -489,8 +492,8 @@ adds the following publication, writer-closure, and durability guarantees:
   It returns the original failure only after rollback is durable; rollback-
   durability failure terminates fail-stopped.
 
-The current public-review correction passes seven direct owners, eleven impacted
-siblings, the full focused suite (`133/133`), the standalone transient-systemd
+The current public-review correction passes eight direct owners, eleven impacted
+siblings, the full focused suite (`134/134`), the standalone transient-systemd
 fixture, and the pinned-Docker `linux/amd64` interruption/recovery rehearsal,
 with zero owned residue. Three sequential read-only reviews were green on the
 frozen pre-publication bytes; updated public CI/review applies separately to the

--- a/docs/POSTGRES-PGVECTOR-EXECUTION-CONTROLLER.md
+++ b/docs/POSTGRES-PGVECTOR-EXECUTION-CONTROLLER.md
@@ -475,6 +475,10 @@ adds the following publication, writer-closure, and durability guarantees:
   proof validation then resumes before the interruption incident can advance.
   If a proof is unavailable, the unresolved running phase retains durable
   writer-stop evidence and remains stop-only for operator resolution.
+  If the stop or stop-evidence step itself fails, the controller durably
+  publishes `closure-stop-pending` through the restricted structural validator
+  before returning nonzero; only a simultaneous intent-publication failure can
+  leave the original writer phase unchanged, and that phase remains stop-only.
 - **Post-rename durability failures do not ordinary-fail with advanced state**:
   atomic state and stop-evidence publication preserves the prior object (or
   prior absence). If the first parent-directory fsync fails after rename, the
@@ -482,8 +486,8 @@ adds the following publication, writer-closure, and durability guarantees:
   It returns the original failure only after rollback is durable; rollback-
   durability failure terminates fail-stopped.
 
-The current public-review correction passes six direct owners, eleven impacted
-siblings, the full focused suite (`132/132`), the standalone transient-systemd
+The current public-review correction passes seven direct owners, eleven impacted
+siblings, the full focused suite (`133/133`), the standalone transient-systemd
 fixture, and the pinned-Docker `linux/amd64` interruption/recovery rehearsal,
 with zero owned residue. Three sequential read-only reviews were green on the
 frozen pre-publication bytes; updated public CI/review applies separately to the

--- a/docs/POSTGRES-PGVECTOR-EXECUTION-CONTROLLER.md
+++ b/docs/POSTGRES-PGVECTOR-EXECUTION-CONTROLLER.md
@@ -477,8 +477,11 @@ adds the following publication, writer-closure, and durability guarantees:
   writer-stop evidence and remains stop-only for operator resolution.
   If the stop or stop-evidence step itself fails, the controller durably
   publishes `closure-stop-pending` through the restricted structural validator
-  before returning nonzero; only a simultaneous intent-publication failure can
-  leave the original writer phase unchanged, and that phase remains stop-only.
+  with a one-phase proof deferral before returning nonzero. Full recovery
+  validates the durable guard proof, retries the stop, consumes the deferral,
+  and commits the terminal incident. Only a simultaneous intent-publication
+  failure can leave the original writer phase unchanged, and that phase remains
+  stop-only.
 - **Post-rename durability failures do not ordinary-fail with advanced state**:
   atomic state and stop-evidence publication preserves the prior object (or
   prior absence). If the first parent-directory fsync fails after rename, the

--- a/docs/superpowers/plans/2026-08-25-issue-303-transition-safety.md
+++ b/docs/superpowers/plans/2026-08-25-issue-303-transition-safety.md
@@ -9,7 +9,7 @@
 **Tech Stack:** Bash 5, jq, Docker Compose, systemd user units, repository shell fixtures.
 
 **Current status (2026-08-26):** PR #305 is open. Its public-review correction
-passes six direct owners, eleven impacted siblings, the focused `132/132` suite,
+passes seven direct owners, eleven impacted siblings, the focused `133/133` suite,
 standalone transient-systemd and pinned-Docker rehearsals, static gates, privacy
 scan, and zero-residue inspection. Updated CI/review and all of Task 7 remain
 separately gated for the corrected head.
@@ -281,9 +281,11 @@ blocked until the corrected bytes are fully re-gated.
 - [x] Make fresh authorization/activation phases stop-only and fail closed.
 - [x] Stop a retained writer before phase-owned proof validation on a fresh
       invocation, then require full proof validation before state advancement.
+- [x] Persist `closure-stop-pending` when the fresh stop/evidence step fails,
+      without consulting unavailable phase-owned proof or replaying a writer.
 - [x] Restore prior bytes or absence after post-rename durability failure and
       terminate fail-stopped if rollback cannot be made durable.
-- [x] Run six direct owners, eleven impacted siblings, and focused `132/132` on
+- [x] Run seven direct owners, eleven impacted siblings, and focused `133/133` on
       the public-review correction with stable hashes.
 - [x] Rerun standalone transient-systemd and pinned-Docker `linux/amd64` against
       the corrected head with zero owned residue.

--- a/docs/superpowers/plans/2026-08-25-issue-303-transition-safety.md
+++ b/docs/superpowers/plans/2026-08-25-issue-303-transition-safety.md
@@ -9,7 +9,7 @@
 **Tech Stack:** Bash 5, jq, Docker Compose, systemd user units, repository shell fixtures.
 
 **Current status (2026-08-26):** PR #305 is open. Its public-review correction
-passes eight direct owners, eleven impacted siblings, the focused `134/134` suite,
+passes nine direct owners, eleven impacted siblings, the focused `135/135` suite,
 standalone transient-systemd and pinned-Docker rehearsals, static gates, privacy
 scan, and zero-residue inspection. Updated CI/review and all of Task 7 remain
 separately gated for the corrected head.
@@ -295,7 +295,7 @@ blocked until the corrected bytes are fully re-gated.
       the next invocation retries the stop without replaying a writer.
 - [x] Restore prior bytes or absence after post-rename durability failure and
       terminate fail-stopped if rollback cannot be made durable.
-- [x] Run eight direct owners, eleven impacted siblings, and focused `134/134` on
+- [x] Run nine direct owners, eleven impacted siblings, and focused `135/135` on
       the public-review correction with stable hashes.
 - [x] Rerun standalone transient-systemd and pinned-Docker `linux/amd64` against
       the corrected head with zero owned residue.
@@ -315,7 +315,10 @@ blocked until the corrected bytes are fully re-gated.
 - [x] Preserve an end-to-end owner that mutates original inputs only after
       `create_execution_bundle`, then requires activation to resolve the copied
       config/plugin and complete without writer replay.
-- [x] Rerun focused `134/134`, standalone transient-systemd, pinned-Docker, static,
+- [x] Bind candidate-model preparation, invocation-bundle revalidation, and
+      activation to the same live Compose project directory; prove relative
+      paths cannot change when the candidate file lives elsewhere.
+- [x] Rerun focused `135/135`, standalone transient-systemd, pinned-Docker, static,
       privacy, and zero-residue gates on the final correction.
 - [ ] Publish the correction and reconcile updated CI/review without merging or
       deploying.

--- a/docs/superpowers/plans/2026-08-25-issue-303-transition-safety.md
+++ b/docs/superpowers/plans/2026-08-25-issue-303-transition-safety.md
@@ -8,11 +8,11 @@
 
 **Tech Stack:** Bash 5, jq, Docker Compose, systemd user units, repository shell fixtures.
 
-**Current status (2026-08-26):** the local implementation gate is verified on
-the frozen issue #303 bytes. Five final direct owners, eleven impacted siblings,
-the focused `131/131` suite, standalone transient-systemd fixture, pinned-Docker
-rehearsal, privacy scan, and three sequential reviews are green. Task 6's
-publication/CI steps and all of Task 7 remain pending and separately gated.
+**Current status (2026-08-26):** PR #305 is open. Its public-review correction
+passes six direct owners, eleven impacted siblings, the focused `132/132` suite,
+standalone transient-systemd and pinned-Docker rehearsals, static gates, privacy
+scan, and zero-residue inspection. Updated CI/review and all of Task 7 remain
+separately gated for the corrected head.
 
 ---
 
@@ -31,7 +31,7 @@ Add `test_authorization_postprocessing_failure_closes_writer_durably`. Inject `N
 
 - [x] **Step 3: Add the root-owned writable-parent owner**
 
-Add `test_root_owned_writable_compose_parent_is_rejected`. Simulate UID 0 for a mode-0777 publication parent, require `publish_compose_atomic` to fail, and prove the live Compose target bytes remain unchanged.
+Add `test_simulated_root_rejects_root_owned_writable_compose_parent`. Simulate UID 0 for a mode-0777 publication parent, require `publish_compose_atomic` to fail, and prove the live Compose target bytes remain unchanged.
 
 - [x] **Step 4: Register all three owners with authority isolation**
 
@@ -57,7 +57,7 @@ timeout 180s bash -c '
 timeout 180s bash -c '
   source scripts/test-pgvector-transition-controller.sh
   _clear_authority_root_for_isolation
-  test_root_owned_writable_compose_parent_is_rejected
+  test_simulated_root_rejects_root_owned_writable_compose_parent
 '
 ```
 
@@ -144,7 +144,7 @@ Remove the current-user-only conditional. Do not weaken the existing owned-file 
 
 - [x] **Step 2: Run the focused owner**
 
-Expected: `test_root_owned_writable_compose_parent_is_rejected` exits 0 and the target retains its original bytes.
+Expected: `test_simulated_root_rejects_root_owned_writable_compose_parent` exits 0 and the target retains its original bytes.
 
 ### Task 5: Verify the corrected controller before review
 
@@ -191,7 +191,7 @@ Require no Graphify artifacts, local paths, machine identifiers, credentials, to
 
 Document that the three production-safety blockers are implemented and verified; keep the transition and hybrid rollout explicitly operator-gated.
 
-- [ ] **Step 2: Commit, push, and open a focused PR**
+- [x] **Step 2: Commit, push, and open a focused PR**
 
 Use the `SweetSophia` GitHub account, verify exact PR scope, and leave the PR open.
 
@@ -279,12 +279,16 @@ blocked until the corrected bytes are fully re-gated.
       directory-fsync failure exposing advanced state/evidence.
 - [x] Bind publication to opened directory identities and exact staged bytes.
 - [x] Make fresh authorization/activation phases stop-only and fail closed.
+- [x] Stop a retained writer before phase-owned proof validation on a fresh
+      invocation, then require full proof validation before state advancement.
 - [x] Restore prior bytes or absence after post-rename durability failure and
       terminate fail-stopped if rollback cannot be made durable.
-- [x] Run five direct owners, eleven impacted siblings, focused `131/131`,
-      standalone transient-systemd, and pinned-Docker `linux/amd64` gates with
-      stable hashes and zero owned residue.
-- [x] Complete three sequential read-only reviews with zero release-floor
-      blockers and a zero-hit privacy scan.
-- [ ] Publish the focused PR, observe CI/review through the mandatory window,
-      and keep merge/deployment/transition separately authorized.
+- [x] Run six direct owners, eleven impacted siblings, and focused `132/132` on
+      the public-review correction with stable hashes.
+- [x] Rerun standalone transient-systemd and pinned-Docker `linux/amd64` against
+      the corrected head with zero owned residue.
+- [x] Complete three sequential read-only reviews on the pre-publication bytes
+      with zero release-floor blockers and a zero-hit privacy scan.
+- [x] Publish focused PR #305 without merging or deploying.
+- [ ] Observe updated CI/review through the mandatory window and keep
+      merge/deployment/transition separately authorized.

--- a/docs/superpowers/plans/2026-08-25-issue-303-transition-safety.md
+++ b/docs/superpowers/plans/2026-08-25-issue-303-transition-safety.md
@@ -11,8 +11,9 @@
 **Current status (2026-08-26):** PR #305 is open. Its public-review correction
 passes nine direct owners, eleven impacted siblings, the focused `135/135` suite,
 standalone transient-systemd and pinned-Docker rehearsals, static gates, privacy
-scan, and zero-residue inspection. Updated CI/review and all of Task 7 remain
-separately gated for the corrected head.
+scan, and zero-residue inspection. Updated CI/review is green on correction head
+`35df2d0fa27f992f270eff56b6ed7b5201d874fc` with zero unresolved threads; all
+of Task 7 remains separately gated.
 
 ---
 
@@ -302,7 +303,7 @@ blocked until the corrected bytes are fully re-gated.
 - [x] Complete three sequential read-only reviews on the pre-publication bytes
       with zero release-floor blockers and a zero-hit privacy scan.
 - [x] Publish focused PR #305 without merging or deploying.
-- [ ] Observe updated CI/review through the mandatory window and keep
+- [x] Observe updated CI/review through the mandatory window and keep
       merge/deployment/transition separately authorized.
 
 ### Consolidated final-review addendum — 2026-08-26
@@ -320,5 +321,5 @@ blocked until the corrected bytes are fully re-gated.
       paths cannot change when the candidate file lives elsewhere.
 - [x] Rerun focused `135/135`, standalone transient-systemd, pinned-Docker, static,
       privacy, and zero-residue gates on the final correction.
-- [ ] Publish the correction and reconcile updated CI/review without merging or
+- [x] Publish the correction and reconcile updated CI/review without merging or
       deploying.

--- a/docs/superpowers/plans/2026-08-25-issue-303-transition-safety.md
+++ b/docs/superpowers/plans/2026-08-25-issue-303-transition-safety.md
@@ -1,0 +1,290 @@
+# Issue #303 Transition-Safety Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Keep the three mechanisms sequential because they share the controller and focused fixture.
+
+**Goal:** Close the three production-safety blockers that must precede Noosphere's existing-volume PostgreSQL-to-pgvector transition.
+
+**Architecture:** Preserve the controller's existing fail-closed state machine and make three surgical changes: run Compose activation with only bound environment values, convert authorization postprocessing failures into durable writer-closure incidents, and reject writable Compose publication parents regardless of owner. Import the preserved RED owners from `fix/item3-controller-hardening-r2` onto current `master`; do not merge or cherry-pick the stale branch wholesale. Keep the current hardening PR bounded, then integrate the reviewed controller into the existing guarded installer so repository users receive the same private artifact staging and one-command upgrade path.
+
+**Tech Stack:** Bash 5, jq, Docker Compose, systemd user units, repository shell fixtures.
+
+**Current status (2026-08-26):** the local implementation gate is verified on
+the frozen issue #303 bytes. Five final direct owners, eleven impacted siblings,
+the focused `131/131` suite, standalone transient-systemd fixture, pinned-Docker
+rehearsal, privacy scan, and three sequential reviews are green. Task 6's
+publication/CI steps and all of Task 7 remain pending and separately gated.
+
+---
+
+### Task 1: Restore the three focused RED owners on current master
+
+**Files:**
+- Modify: `scripts/test-pgvector-transition-controller.sh`
+
+- [x] **Step 1: Add the ambient Compose interpolation owner**
+
+Add `test_activation_uses_only_bound_compose_interpolation_values`. Its fake Docker executable must read `APP_IMAGE` from the bound `--env-file` unless the controller leaks an ambient `APP_IMAGE`; invoke activation with `APP_IMAGE=attacker/image` and require the selected image to remain `expected/image@sha256:bound`.
+
+- [x] **Step 2: Add the authorization-postprocessing closure owner**
+
+Add `test_authorization_postprocessing_failure_closes_writer_durably`. Inject `NOOSPHERE_CONTROLLER_TEST_FAIL_EVIDENCE=authorization-running`, require a non-zero exit before activation, require lifecycle `transition,authorize`, require stop plus `inspect:false`, and require terminal `incident` state with a `closure-*` class and bound `writerStopEvidence`.
+
+- [x] **Step 3: Add the root-owned writable-parent owner**
+
+Add `test_root_owned_writable_compose_parent_is_rejected`. Simulate UID 0 for a mode-0777 publication parent, require `publish_compose_atomic` to fail, and prove the live Compose target bytes remain unchanged.
+
+- [x] **Step 4: Register all three owners with authority isolation**
+
+Append each owner to the focused fixture dispatch, separated by `_clear_authority_root_for_isolation`.
+
+- [x] **Step 5: Prove all three owners are RED for their intended mechanism**
+
+Run each owner independently:
+
+```bash
+timeout 180s bash -c '
+  source scripts/test-pgvector-transition-controller.sh
+  _clear_authority_root_for_isolation
+  test_activation_uses_only_bound_compose_interpolation_values
+'
+
+timeout 180s bash -c '
+  source scripts/test-pgvector-transition-controller.sh
+  _clear_authority_root_for_isolation
+  test_authorization_postprocessing_failure_closes_writer_durably
+'
+
+timeout 180s bash -c '
+  source scripts/test-pgvector-transition-controller.sh
+  _clear_authority_root_for_isolation
+  test_root_owned_writable_compose_parent_is_rejected
+'
+```
+
+Expected: each command exits non-zero with its mechanism-specific diagnostic; no controller, transient-unit, container, volume, network, or runtime-path residue remains.
+
+### Task 2: Bind Compose activation to the prepared environment
+
+**Files:**
+- Modify: `scripts/run-pgvector-transition-controller.sh`
+- Test: `scripts/test-pgvector-transition-controller.sh`
+
+- [x] **Step 1: Run the Compose activation command under an empty environment**
+
+In `activate_application_for_verification`, keep the bound Docker path, candidate Compose path, env file, project directory, and app service. Invoke the Compose command with only the controller's prepared environment:
+
+```bash
+env -i \
+  HOME="$HOME" \
+  DOCKER_CONFIG="$DOCKER_CONFIG" \
+  DOCKER_HOST="$DOCKER_HOST" \
+  COMPOSE_DISABLE_ENV_FILE=1 \
+  PATH="$PATH" \
+  "$docker_path" compose \
+    --project-directory "$project_directory" \
+    --env-file "$execution_env_file" \
+    -f "$execution_candidate_compose" \
+    up -d --no-deps --force-recreate app
+```
+
+Do not add a generic environment abstraction; this is the only Compose activation boundary being corrected.
+
+- [x] **Step 2: Run the focused owner**
+
+Expected: `test_activation_uses_only_bound_compose_interpolation_values` exits 0 and selects `expected/image@sha256:bound`.
+
+### Task 3: Close the writer when authorization evidence postprocessing fails
+
+**Files:**
+- Modify: `scripts/run-pgvector-transition-controller.sh`
+- Test: `scripts/test-pgvector-transition-controller.sh`
+
+- [x] **Step 1: Make authorization postprocessing catchable**
+
+After `--authorize-writer` returns, run the fallible end timestamp, journal cursor, evidence write, and evidence binding inside a subshell so `die` exits the subshell rather than bypassing controller closure:
+
+```bash
+if (
+  ended_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  end_cursor=$(capture_journal_cursor)
+  write_process_evidence_atomic ...
+  bind_process_evidence_to_state ...
+); then
+  :
+else
+  postprocess_exit=$?
+  begin_closure_incident "$state" postprocessing
+  return "$postprocess_exit"
+fi
+```
+
+The guard exit code remains evidence data; a non-zero authorization result still follows the existing `writer-authorization` incident path after evidence is durably bound.
+
+- [x] **Step 2: Run the focused owner**
+
+Expected: `test_authorization_postprocessing_failure_closes_writer_durably` exits 0, never activates the app, and binds inspect-verified writer-stop evidence to a closure incident.
+
+### Task 4: Reject writable Compose publication parents for every owner
+
+**Files:**
+- Modify: `scripts/run-pgvector-transition-controller.sh`
+- Test: `scripts/test-pgvector-transition-controller.sh`
+
+- [x] **Step 1: Enforce parent mode independently of UID**
+
+In `publish_compose_atomic`, retain the real-directory/non-symlink check, then always evaluate the parent's mode:
+
+```bash
+parent_mode=$(stat -c '%a' "$parent")
+(( (8#$parent_mode & 8#022) == 0 )) ||
+  die "Compose publication parent permits group/world writes: $parent"
+```
+
+Remove the current-user-only conditional. Do not weaken the existing owned-file checks or atomic install/fsync/rename sequence.
+
+- [x] **Step 2: Run the focused owner**
+
+Expected: `test_root_owned_writable_compose_parent_is_rejected` exits 0 and the target retains its original bytes.
+
+### Task 5: Verify the corrected controller before review
+
+**Files:**
+- Verify: `scripts/run-pgvector-transition-controller.sh`
+- Verify: `scripts/test-pgvector-transition-controller.sh`
+- Verify: `scripts/test-pgvector-transition-controller-systemd.sh`
+- Verify: `scripts/test-pgvector-transition-controller-docker.sh`
+
+- [x] **Step 1: Run static checks**
+
+```bash
+bash -n scripts/run-pgvector-transition-controller.sh \
+  scripts/test-pgvector-transition-controller.sh \
+  scripts/test-pgvector-transition-controller-systemd.sh \
+  scripts/test-pgvector-transition-controller-docker.sh
+git diff --check
+```
+
+- [x] **Step 2: Run the three corrected owners together and affected siblings**
+
+Include environment-hermeticity, authorization-evidence ordering, activation failure, successful-verifier postprocessing, publication-input permission, and production-hook rejection owners.
+
+- [x] **Step 3: Run the full focused/controller, real transient-systemd, and pinned-Docker gates under bounded supervision**
+
+Require explicit terminal return-code markers, definition/dispatch parity, byte-stable controller hash during each run, and zero owned residue.
+
+- [x] **Step 4: Run three sequential native adversarial reviews**
+
+Review the frozen diff against issue #303's three safety contracts. Reconcile every finding; any byte change returns to Step 1 and the appropriate affected/full gate.
+
+- [x] **Step 5: Privacy and staged-diff scan**
+
+Require no Graphify artifacts, local paths, machine identifiers, credentials, tokens, or unrelated changes.
+
+### Task 6: Publish without touching production
+
+**Files:**
+- Modify as needed: `docs/POSTGRES-PGVECTOR-EXECUTION-CONTROLLER.md`
+- Modify: `docs/MEMORY-REVAMP-STATUS.md`
+- Add: `docs/superpowers/plans/2026-08-25-issue-303-transition-safety.md`
+
+- [x] **Step 1: Update only mechanism-specific operator documentation**
+
+Document that the three production-safety blockers are implemented and verified; keep the transition and hybrid rollout explicitly operator-gated.
+
+- [ ] **Step 2: Commit, push, and open a focused PR**
+
+Use the `SweetSophia` GitHub account, verify exact PR scope, and leave the PR open.
+
+- [ ] **Step 3: Observe CI and review bots for the mandatory window**
+
+Address valid feedback within the approved definition of done. Do not merge, deploy, transition PostgreSQL, activate feature schemas, start the hybrid worker, or mutate the production volume in this implementation stage.
+
+### Task 7: Automate the end-user upgrade in a separate bounded stage
+
+**Files:**
+- Modify: `install-openclaw.sh`
+- Modify: installer regression fixtures selected after inventory
+- Modify: `docs/OPENCLAW-OFFICIAL-PLUGIN-SETUP.md`
+- Modify as needed: `README.md`
+
+- [ ] **Step 1: Stage the reviewed controller and its bound helpers privately**
+
+Extend the installer's existing checksum-pinned `prepare_guard_script` pattern to install the controller, guard, and verifier as owner-only executables. A shared repository checkout and umask `0002` must not make the installed upgrade artifacts group-writable.
+
+- [ ] **Step 2: Route existing-volume upgrades through the controller**
+
+Generate the controller manifest and state paths from installer-managed inputs, then execute prepare and transition through the controller. Preserve the current offline, restore-tested guard and all existing fail-closed recovery behavior.
+
+- [ ] **Step 3: Provide one copy-ready upgrade command**
+
+Keep the checksum-pinned installer invocation as the supported user workflow. The command must upgrade an existing Noosphere installation without requiring users to assemble controller manifests or repair checkout permissions manually.
+
+- [ ] **Step 4: Verify new install, successful upgrade, interrupted upgrade, and rerun recovery**
+
+Require deterministic artifact modes, byte pinning, state/evidence preservation, zero owned residue, and unchanged production opt-in boundaries. Publish this automation only after its own focused fixtures, full installer checks, sequential native reviews, and PR gate are GREEN.
+
+---
+
+## Evidence claim
+
+The hardening stage is complete only when all three defect owners are GREEN, affected siblings and full supervised gates pass with zero residue, sequential native reviews are reconciled, and the published PR is terminally green. The user-facing workflow is complete only after Task 7 proves the checksum-pinned one-command installer upgrade. Database transition authorization remains a separate post-merge go/no-go.
+
+### Review 1 correction addendum — 2026-08-26
+
+The strict sequential review found four additional defects after the earlier
+gates. Complete this addendum before restarting Review 1; Reviews 2 and 3 stay
+blocked until the corrected bytes are fully re-gated.
+
+- [x] Preserve three deterministic RED owners: controller-state fsync failure
+      must not advance phase, writer-stop evidence fsync failure must not bind
+      evidence, and a late authorization-evidence bind failure must remain a
+      valid resumable closure incident.
+- [x] Strengthen the foreign-parent fixture to prove both rejected publication
+      targets retain their original bytes.
+- [x] Make atomic state publication and writer-stop evidence publication return
+      the exact first failure even when their callers use conditional contexts.
+- [x] When authorization evidence binding reports a late durability failure,
+      atomically remove the unusable binding while recording the scoped
+      `authorization-evidence-unavailable` exception.
+- [x] Run the direct owners and affected siblings, then the full focused,
+      transient-systemd, and pinned-Docker gates under durable supervision with
+      stable hashes and zero owned residue before restarting sequential review.
+
+### Fresh Review 1 correction addendum — 2026-08-26 13:30 GMT+2
+
+- [x] Preserve the closure-intent durability failure as an owner that requires
+      exact first-status propagation, inspect-verified writer stop, and refusal
+      to reauthorize a nonterminal state carrying `writerStopEvidence`.
+- [x] Preserve initial activation-inspect failure as an owner that requires a
+      terminal `closure-app-activation` incident and bound writer-stop proof.
+- [x] Preserve ancestor retarget as an owner that substitutes attacker bytes
+      after validation and requires publication to remain anchored to the
+      reviewed source and target directories.
+- [x] Add a simulated-UID-0, root-owned mode-0777 publication-parent owner and
+      prove it detects removal of the parent-mode guard.
+- [x] Apply surgical corrections only: preserve the closure-intent status,
+      block reauthorization after a verified nonterminal stop, return initial
+      inspect failures to the closure caller, and perform publication through
+      verified directory descriptors.
+- [x] Run the four direct owners and affected sibling matrix (`27/27`).
+- [x] Run the full focused suite, transient-systemd fixture, and pinned-Docker
+      rehearsal with stable hashes and zero residue before restarting the three
+      fresh native reviews strictly sequentially.
+
+### Final local gate addendum — 2026-08-26
+
+- [x] Preserve deterministic owners for pre-open parent retarget, candidate-entry
+      swap after digest preparation, closure-intent plus stop dual failure across
+      a fresh invocation, detached target-parent publication, and post-rename
+      directory-fsync failure exposing advanced state/evidence.
+- [x] Bind publication to opened directory identities and exact staged bytes.
+- [x] Make fresh authorization/activation phases stop-only and fail closed.
+- [x] Restore prior bytes or absence after post-rename durability failure and
+      terminate fail-stopped if rollback cannot be made durable.
+- [x] Run five direct owners, eleven impacted siblings, focused `131/131`,
+      standalone transient-systemd, and pinned-Docker `linux/amd64` gates with
+      stable hashes and zero owned residue.
+- [x] Complete three sequential read-only reviews with zero release-floor
+      blockers and a zero-hit privacy scan.
+- [ ] Publish the focused PR, observe CI/review through the mandatory window,
+      and keep merge/deployment/transition separately authorized.

--- a/docs/superpowers/plans/2026-08-25-issue-303-transition-safety.md
+++ b/docs/superpowers/plans/2026-08-25-issue-303-transition-safety.md
@@ -282,7 +282,8 @@ blocked until the corrected bytes are fully re-gated.
 - [x] Stop a retained writer before phase-owned proof validation on a fresh
       invocation, then require full proof validation before state advancement.
 - [x] Persist `closure-stop-pending` when the fresh stop/evidence step fails,
-      without consulting unavailable phase-owned proof or replaying a writer.
+      keep that state full-valid through a one-phase proof deferral, and prove
+      the next invocation retries the stop without replaying a writer.
 - [x] Restore prior bytes or absence after post-rename durability failure and
       terminate fail-stopped if rollback cannot be made durable.
 - [x] Run seven direct owners, eleven impacted siblings, and focused `133/133` on

--- a/docs/superpowers/plans/2026-08-25-issue-303-transition-safety.md
+++ b/docs/superpowers/plans/2026-08-25-issue-303-transition-safety.md
@@ -240,6 +240,13 @@ managers. The PostgreSQL image policy owns the trigger paths, commands, pinned
 image pull, bootstrap Node installation, and user-manager setup/cleanup contract.
 Steps 1–4 remain open and continue to block the one-command installer rollout.
 
+The first hosted runs additionally established and closed three concrete runner
+portability gaps: Node was absent from the controller bootstrap path,
+`/usr/local/bin` was writable on the hosted image, and `ripgrep` was absent.
+The focused source-recovery signal owner also emitted a Bash-version-specific
+job-control line; it now generates one deterministic stderr marker from a
+builtin-only delayed trap while preserving exact process/log SHA binding.
+
 ---
 
 ## Evidence claim

--- a/docs/superpowers/plans/2026-08-25-issue-303-transition-safety.md
+++ b/docs/superpowers/plans/2026-08-25-issue-303-transition-safety.md
@@ -245,7 +245,7 @@ portability gaps: Node was absent from the controller bootstrap path,
 `/usr/local/bin` was writable on the hosted image, and `ripgrep` was absent.
 The focused source-recovery signal owner also emitted a Bash-version-specific
 job-control line; it now generates one deterministic stderr marker from a
-builtin-only delayed trap while preserving exact process/log SHA binding.
+built-in-only delayed trap while preserving exact process/log SHA binding.
 
 ---
 

--- a/docs/superpowers/plans/2026-08-25-issue-303-transition-safety.md
+++ b/docs/superpowers/plans/2026-08-25-issue-303-transition-safety.md
@@ -9,7 +9,7 @@
 **Tech Stack:** Bash 5, jq, Docker Compose, systemd user units, repository shell fixtures.
 
 **Current status (2026-08-26):** PR #305 is open. Its public-review correction
-passes seven direct owners, eleven impacted siblings, the focused `133/133` suite,
+passes eight direct owners, eleven impacted siblings, the focused `134/134` suite,
 standalone transient-systemd and pinned-Docker rehearsals, static gates, privacy
 scan, and zero-residue inspection. Updated CI/review and all of Task 7 remain
 separately gated for the corrected head.
@@ -203,6 +203,7 @@ Address valid feedback within the approved definition of done. Do not merge, dep
 
 **Files:**
 - Modify: `install-openclaw.sh`
+- Modify: `.github/workflows/postgres-pgvector-rehearsal.yml`
 - Modify: installer regression fixtures selected after inventory
 - Modify: `docs/OPENCLAW-OFFICIAL-PLUGIN-SETUP.md`
 - Modify as needed: `README.md`
@@ -222,6 +223,14 @@ Keep the checksum-pinned installer invocation as the supported user workflow. Th
 - [ ] **Step 4: Verify new install, successful upgrade, interrupted upgrade, and rerun recovery**
 
 Require deterministic artifact modes, byte pinning, state/evidence preservation, zero owned residue, and unchanged production opt-in boundaries. Publish this automation only after its own focused fixtures, full installer checks, sequential native reviews, and PR gate are GREEN.
+
+- [ ] **Step 5: Make controller gates rollout-authoritative in CI**
+
+Add the controller and both controller fixture scripts to a path-filtered
+workflow. Require the focused controller suite and pinned-Docker interruption
+rehearsal on controller/test changes before the installer or controller can be
+treated as rollout-authoritative. This is a pre-rollout gate, not evidence
+against the locally executed bytes in PR #305.
 
 ---
 
@@ -286,7 +295,7 @@ blocked until the corrected bytes are fully re-gated.
       the next invocation retries the stop without replaying a writer.
 - [x] Restore prior bytes or absence after post-rename durability failure and
       terminate fail-stopped if rollback cannot be made durable.
-- [x] Run seven direct owners, eleven impacted siblings, and focused `133/133` on
+- [x] Run eight direct owners, eleven impacted siblings, and focused `134/134` on
       the public-review correction with stable hashes.
 - [x] Rerun standalone transient-systemd and pinned-Docker `linux/amd64` against
       the corrected head with zero owned residue.
@@ -295,3 +304,18 @@ blocked until the corrected bytes are fully re-gated.
 - [x] Publish focused PR #305 without merging or deploying.
 - [ ] Observe updated CI/review through the mandatory window and keep
       merge/deployment/transition separately authorized.
+
+### Consolidated final-review addendum — 2026-08-26
+
+- [x] Reproduce activation escaping the invocation-private Docker namespace
+      after the original config/plugin bytes are mutated post-bundle.
+- [x] Bind activation inspect and Compose calls to the copied controller home,
+      Docker config, Docker executable/plugin namespace, fixed child `PATH`,
+      runtime directory, and deterministic locale.
+- [x] Preserve an end-to-end owner that mutates original inputs only after
+      `create_execution_bundle`, then requires activation to resolve the copied
+      config/plugin and complete without writer replay.
+- [x] Rerun focused `134/134`, standalone transient-systemd, pinned-Docker, static,
+      privacy, and zero-residue gates on the final correction.
+- [ ] Publish the correction and reconcile updated CI/review without merging or
+      deploying.

--- a/docs/superpowers/plans/2026-08-25-issue-303-transition-safety.md
+++ b/docs/superpowers/plans/2026-08-25-issue-303-transition-safety.md
@@ -237,8 +237,8 @@ The path-filtered PostgreSQL rehearsal workflow now runs the focused controller
 suite (including its transient-systemd fixture) and the pinned-Docker
 `linux/amd64` interruption/recovery rehearsal under disposable persistent user
 managers. The PostgreSQL image policy owns the trigger paths, commands, pinned
-image pull, and user-manager setup/cleanup contract. Steps 1–4 remain open and
-continue to block the one-command installer rollout.
+image pull, bootstrap Node installation, and user-manager setup/cleanup contract.
+Steps 1–4 remain open and continue to block the one-command installer rollout.
 
 ---
 

--- a/docs/superpowers/plans/2026-08-25-issue-303-transition-safety.md
+++ b/docs/superpowers/plans/2026-08-25-issue-303-transition-safety.md
@@ -13,7 +13,7 @@ passes nine direct owners, eleven impacted siblings, the focused `135/135` suite
 standalone transient-systemd and pinned-Docker rehearsals, static gates, privacy
 scan, and zero-residue inspection. Updated CI/review is green on correction head
 `35df2d0fa27f992f270eff56b6ed7b5201d874fc` with zero unresolved threads; all
-of Task 7 remains separately gated.
+of Task 7 remains separately gated except the Step 5 rollout-authority CI wiring.
 
 ---
 
@@ -225,13 +225,20 @@ Keep the checksum-pinned installer invocation as the supported user workflow. Th
 
 Require deterministic artifact modes, byte pinning, state/evidence preservation, zero owned residue, and unchanged production opt-in boundaries. Publish this automation only after its own focused fixtures, full installer checks, sequential native reviews, and PR gate are GREEN.
 
-- [ ] **Step 5: Make controller gates rollout-authoritative in CI**
+- [x] **Step 5: Make controller gates rollout-authoritative in CI**
 
 Add the controller and both controller fixture scripts to a path-filtered
 workflow. Require the focused controller suite and pinned-Docker interruption
 rehearsal on controller/test changes before the installer or controller can be
 treated as rollout-authoritative. This is a pre-rollout gate, not evidence
 against the locally executed bytes in PR #305.
+
+The path-filtered PostgreSQL rehearsal workflow now runs the focused controller
+suite (including its transient-systemd fixture) and the pinned-Docker
+`linux/amd64` interruption/recovery rehearsal under disposable persistent user
+managers. The PostgreSQL image policy owns the trigger paths, commands, pinned
+image pull, and user-manager setup/cleanup contract. Steps 1–4 remain open and
+continue to block the one-command installer rollout.
 
 ---
 

--- a/scripts/check-postgres-image-policy.mjs
+++ b/scripts/check-postgres-image-policy.mjs
@@ -1076,6 +1076,10 @@ expect(
     ) === 1 &&
     countLiteral(focusedControllerJob, "sudo chmod 0755 /usr/local/bin") === 1 &&
     countLiteral(dockerControllerJob, "sudo chmod 0755 /usr/local/bin") === 1 &&
+    countLiteral(
+      focusedControllerJob,
+      "sudo apt-get install --yes --no-install-recommends ripgrep",
+    ) === 1 &&
     countLiteral(focusedControllerJob, 'sudo loginctl disable-linger "$USER"') === 1 &&
     countLiteral(dockerControllerJob, 'sudo loginctl disable-linger "$USER"') === 1 &&
     countLiteral(

--- a/scripts/check-postgres-image-policy.mjs
+++ b/scripts/check-postgres-image-policy.mjs
@@ -1074,13 +1074,15 @@ expect(
       dockerControllerJob,
       'sudo install -o root -g root -m 0755 "$node_path" /usr/bin/node',
     ) === 1 &&
+    countLiteral(focusedControllerJob, "sudo chmod 0755 /usr/local/bin") === 1 &&
+    countLiteral(dockerControllerJob, "sudo chmod 0755 /usr/local/bin") === 1 &&
     countLiteral(focusedControllerJob, 'sudo loginctl disable-linger "$USER"') === 1 &&
     countLiteral(dockerControllerJob, 'sudo loginctl disable-linger "$USER"') === 1 &&
     countLiteral(
       dockerControllerJob,
       'docker pull --platform linux/amd64 "$image"',
     ) === 1,
-  "the path-filtered PostgreSQL rehearsal workflow must install pinned Node in the controller bootstrap path and run the focused and pinned-Docker interruption gates under disposable persistent user managers",
+  "the path-filtered PostgreSQL rehearsal workflow must install pinned Node, harden the controller bootstrap PATH, and run the focused and pinned-Docker interruption gates under disposable persistent user managers",
 );
 
 const verifyScript = read("scripts/verify-deploy.sh");

--- a/scripts/check-postgres-image-policy.mjs
+++ b/scripts/check-postgres-image-policy.mjs
@@ -1086,7 +1086,7 @@ expect(
       dockerControllerJob,
       'docker pull --platform linux/amd64 "$image"',
     ) === 1,
-  "the path-filtered PostgreSQL rehearsal workflow must install pinned Node, harden the controller bootstrap PATH, and run the focused and pinned-Docker interruption gates under disposable persistent user managers",
+  "the path-filtered PostgreSQL rehearsal workflow must install pinned Node, harden the controller bootstrap PATH, install the focused fixture toolchain, and run the focused and pinned-Docker interruption gates under disposable persistent user managers",
 );
 
 const verifyScript = read("scripts/verify-deploy.sh");

--- a/scripts/check-postgres-image-policy.mjs
+++ b/scripts/check-postgres-image-policy.mjs
@@ -1058,13 +1058,29 @@ expect(
     ) === 1 &&
     countLiteral(focusedControllerJob, 'sudo loginctl enable-linger "$USER"') === 1 &&
     countLiteral(dockerControllerJob, 'sudo loginctl enable-linger "$USER"') === 1 &&
+    countLiteral(
+      focusedControllerJob,
+      "uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6",
+    ) === 1 &&
+    countLiteral(
+      dockerControllerJob,
+      "uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6",
+    ) === 1 &&
+    countLiteral(
+      focusedControllerJob,
+      'sudo install -o root -g root -m 0755 "$node_path" /usr/bin/node',
+    ) === 1 &&
+    countLiteral(
+      dockerControllerJob,
+      'sudo install -o root -g root -m 0755 "$node_path" /usr/bin/node',
+    ) === 1 &&
     countLiteral(focusedControllerJob, 'sudo loginctl disable-linger "$USER"') === 1 &&
     countLiteral(dockerControllerJob, 'sudo loginctl disable-linger "$USER"') === 1 &&
     countLiteral(
       dockerControllerJob,
       'docker pull --platform linux/amd64 "$image"',
     ) === 1,
-  "the path-filtered PostgreSQL rehearsal workflow must run the focused controller and pinned-Docker interruption gates under disposable persistent user managers",
+  "the path-filtered PostgreSQL rehearsal workflow must install pinned Node in the controller bootstrap path and run the focused and pinned-Docker interruption gates under disposable persistent user managers",
 );
 
 const verifyScript = read("scripts/verify-deploy.sh");

--- a/scripts/check-postgres-image-policy.mjs
+++ b/scripts/check-postgres-image-policy.mjs
@@ -844,6 +844,13 @@ const digestTestScript = read("scripts/test-digest-order-independence.sh");
 const postgresRehearsalWorkflow = read(
   ".github/workflows/postgres-pgvector-rehearsal.yml",
 );
+const workflowJob = (source, name) => {
+  const start = source.indexOf(`  ${name}:\n`);
+  if (start < 0) return "";
+  const remainder = source.slice(start + 3);
+  const nextJob = remainder.search(/^  [a-z0-9][a-z0-9-]*:\n/m);
+  return nextJob < 0 ? source.slice(start) : source.slice(start, start + 3 + nextJob);
+};
 const shellFunctionDeclarationPattern = (name) => {
   const escapedName = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   return new RegExp(
@@ -1017,6 +1024,47 @@ expect(
       /- "scripts\/test-digest-order-independence\.sh"/g,
     )?.length === 2,
   "the PostgreSQL rehearsal must run deterministic digest security, coverage, streaming, and failure regressions on both architectures",
+);
+
+const focusedControllerJob = workflowJob(
+  postgresRehearsalWorkflow,
+  "test-transition-controller",
+);
+const dockerControllerJob = workflowJob(
+  postgresRehearsalWorkflow,
+  "rehearse-transition-controller",
+);
+const controllerWorkflowTriggerPaths = [
+  ".github/workflows/postgres-pgvector-rehearsal.yml",
+  "scripts/run-pgvector-transition-controller.sh",
+  "scripts/test-pgvector-transition-controller.sh",
+  "scripts/test-pgvector-transition-controller-systemd.sh",
+  "scripts/test-pgvector-transition-controller-docker.sh",
+  "scripts/switch-pgvector-compose.sh",
+  "scripts/verify-deploy.sh",
+];
+expect(
+  controllerWorkflowTriggerPaths.every(
+    (relativePath) =>
+      countLiteral(postgresRehearsalWorkflow, `- "${relativePath}"`) === 2,
+  ) &&
+    countLiteral(
+      focusedControllerJob,
+      "run: scripts/test-pgvector-transition-controller.sh",
+    ) === 1 &&
+    countLiteral(
+      dockerControllerJob,
+      "run: scripts/test-pgvector-transition-controller-docker.sh linux/amd64",
+    ) === 1 &&
+    countLiteral(focusedControllerJob, 'sudo loginctl enable-linger "$USER"') === 1 &&
+    countLiteral(dockerControllerJob, 'sudo loginctl enable-linger "$USER"') === 1 &&
+    countLiteral(focusedControllerJob, 'sudo loginctl disable-linger "$USER"') === 1 &&
+    countLiteral(dockerControllerJob, 'sudo loginctl disable-linger "$USER"') === 1 &&
+    countLiteral(
+      dockerControllerJob,
+      'docker pull --platform linux/amd64 "$image"',
+    ) === 1,
+  "the path-filtered PostgreSQL rehearsal workflow must run the focused controller and pinned-Docker interruption gates under disposable persistent user managers",
 );
 
 const verifyScript = read("scripts/verify-deploy.sh");

--- a/scripts/run-pgvector-transition-controller.sh
+++ b/scripts/run-pgvector-transition-controller.sh
@@ -361,8 +361,8 @@ validate_evidence_binding() {
 }
 
 update_controller_phase() {
-  local state=$1 phase=$2 incident_class=${3:-} proof_exception=${4:-} temp write_exit=0
-  validate_controller_state "$state"
+  local state=$1 phase=$2 incident_class=${3:-} proof_exception=${4:-} validation_mode=${5:-full} temp write_exit=0
+  validate_controller_state "$state" "$validation_mode"
   case "$phase" in
     prepared|candidate-published|source-recovery-running|guard-exited|authorization-running|activation-running|closure-running|closure-stop-pending|closure-evidence-pending|complete|incident) ;;
     *) die "invalid controller phase: $phase" ;;
@@ -444,7 +444,7 @@ restore_source_compose_snapshot() {
 
 resume_controller_state() {
   local state=$1 phase guard_journal live_compose source_snapshot source_sha candidate_sha live_sha
-  local source_verify_exit=0
+  local source_verify_exit=0 stop_exit=0
   # execute_prepared_state has already revalidated the manifest, pinned Docker
   # binary, engine/volume identity, operation lock, authority path, and every
   # execution input before reaching resume. A fresh process that finds a
@@ -458,7 +458,11 @@ resume_controller_state() {
   phase=$(jq -er '.phase' "$state" 2>/dev/null) || die 'controller state is malformed'
   case "$phase" in
     authorization-running|activation-running)
-      stop_application_fail_closed
+      stop_application_fail_closed return || stop_exit=$?
+      if ((stop_exit != 0)); then
+        update_controller_phase "$state" closure-stop-pending closure-interruption '' writer-stop
+        return "$stop_exit"
+      fi
       ;;
   esac
   validate_controller_state "$state"
@@ -2023,15 +2027,29 @@ assert_source_state_unchanged() {
 }
 
 stop_application_fail_closed() {
-  local docker_path app_container running stop_evidence stop_temp stopped_at stop_phase stop_sha
+  local failure_mode=${1:-die} docker_path app_container running stop_evidence stop_temp stopped_at stop_phase stop_sha
+  local stop_exit=0 inspect_exit=0
+  case "$failure_mode" in
+    die|return) ;;
+    *) die "unsupported application-stop failure mode: $failure_mode" ;;
+  esac
   docker_path=${execution_docker_path:-$(jq -er '.dockerPath' "$controller_state")} || return $?
   app_container=$(jq -er '.appContainer' "$controller_state") || return $?
-  "$docker_path" stop --time 60 "$app_container" >/dev/null 2>&1 ||
+  "$docker_path" stop --time 60 "$app_container" >/dev/null 2>&1 || stop_exit=$?
+  if ((stop_exit != 0)); then
+    [[ "$failure_mode" == return ]] && return "$stop_exit"
     die "failed to stop application container $app_container"
+  fi
   running=$("$docker_path" inspect --format '{{.State.Running}}' "$app_container" 2>/dev/null) ||
+    inspect_exit=$?
+  if ((inspect_exit != 0)); then
+    [[ "$failure_mode" == return ]] && return "$inspect_exit"
     die "could not verify stopped application container $app_container"
-  [[ "$running" == false ]] ||
+  fi
+  if [[ "$running" != false ]]; then
+    [[ "$failure_mode" == return ]] && return 1
     die "application container remains running after stop: $app_container"
+  fi
   # Every inspect-verified stop is durably evidenced and bound to the state so
   # closure-evidence-pending and closure-incident phases carry their owned
   # writer-stop proof. A failure to persist the proof is fatal: the stop itself

--- a/scripts/run-pgvector-transition-controller.sh
+++ b/scripts/run-pgvector-transition-controller.sh
@@ -1827,11 +1827,13 @@ assert_private_docker_config() {
 }
 
 compose_model_signature() {
-  local state=$1 docker_path candidate env_file
+  local state=$1 docker_path candidate env_file project_directory
   docker_path=$(jq -er '.dockerPath' "$state")
   candidate=$(jq -er '.candidateCompose' "$state")
   env_file=$(jq -er '.envFile' "$state")
-  "$docker_path" compose --env-file "$env_file" -f "$candidate" config --no-interpolate |
+  project_directory=$(dirname "$(jq -er '.liveCompose' "$state")")
+  "$docker_path" compose --project-directory "$project_directory" \
+    --env-file "$env_file" -f "$candidate" config --no-interpolate |
     sha256sum | awk '{print $1}'
 }
 
@@ -1898,7 +1900,7 @@ copy_execution_input() {
 }
 
 create_execution_bundle() {
-  local state=$1 base config_source docker_host fixed_path
+  local state=$1 base config_source docker_host fixed_path project_directory
   [[ ${INVOCATION_ID:-} =~ ^[a-fA-F0-9]{32}$ ]] ||
     die 'execution input binding requires a systemd InvocationID'
   base="${state%.json}.inputs.$INVOCATION_ID"
@@ -1940,6 +1942,7 @@ create_execution_bundle() {
 
   docker_host=$(jq -er '.dockerEndpoint' "$state")
   fixed_path=$(jq -er '.fixedPath' "$state")
+  project_directory=$(dirname "$(jq -er '.liveCompose' "$state")")
   [[ $(DOCKER_CONFIG="$execution_controller_home/docker" DOCKER_HOST="$docker_host" \
       "$execution_docker_path" info --format '{{json .ClientInfo.Plugins}}' | \
       jq -er '[.[] | select(.Name == "compose") | .Path] | if length == 1 then .[0] else error("Compose plugin identity is ambiguous") end') == \
@@ -1950,7 +1953,8 @@ create_execution_bundle() {
       "$(jq -er '.dockerComposeVersionSha256' "$state")" ]] ||
     die 'bound Docker Compose version differs from the prepared identity'
   [[ $(DOCKER_CONFIG="$execution_controller_home/docker" DOCKER_HOST="$docker_host" \
-      "$execution_docker_path" compose --env-file "$execution_env_file" \
+      "$execution_docker_path" compose --project-directory "$project_directory" \
+      --env-file "$execution_env_file" \
       -f "$execution_candidate_compose" config --no-interpolate | sha256sum | awk '{print $1}') == \
       "$(jq -er '.effectiveComposeSha256' "$state")" ]] ||
     die 'bound candidate Compose model differs from the prepared model'

--- a/scripts/run-pgvector-transition-controller.sh
+++ b/scripts/run-pgvector-transition-controller.sh
@@ -183,6 +183,13 @@ validate_controller_state() {
       ' "$state" >/dev/null ||
         die 'authorization evidence exception requires an exact closure-authorization-evidence state'
       ;;
+    fresh-writer-proof-deferred)
+      jq -e '
+        .phase == "closure-stop-pending" and
+        .incidentClass == "closure-interruption"
+      ' "$state" >/dev/null ||
+        die 'fresh writer proof deferral requires exact closure-interruption stop-pending state'
+      ;;
     *) die "unsupported controller proof exception: $proof_exception" ;;
   esac
   jq -e --arg validationMode "$validation_mode" '
@@ -212,7 +219,8 @@ validate_controller_state() {
     (.candidateComposeSha256 | type == "string" and test("^[a-f0-9]{64}$")) and
     (.guardJournal | type == "string" and startswith("/")) and
     ((.proofException == null) or
-     .proofException == "authorization-evidence-unavailable") and
+     .proofException == "authorization-evidence-unavailable" or
+     .proofException == "fresh-writer-proof-deferred") and
     if .proofException == "authorization-evidence-unavailable" then
       (.phase == "closure-stop-pending" or .phase == "incident") and
       .incidentClass == "closure-authorization-evidence" and
@@ -256,12 +264,13 @@ validate_controller_state() {
   esac
   case "$proof_phase" in
     closure-stop-pending)
-      if [[ $(jq -er '.proofException // ""' "$state") == authorization-evidence-unavailable ]]; then
-        # Authorization completed, but its evidence could not be persisted.
-        # The earlier guard proof still owns this transition, and the pending
-        # phase must remain valid long enough to durably bind the verified
-        # writer stop. The explicit exception prevents later postprocessing
-        # failures from discarding already-bound authorization evidence.
+      if [[ $(jq -er '.proofException // ""' "$state") == authorization-evidence-unavailable ||
+            $(jq -er '.proofException // ""' "$state") == fresh-writer-proof-deferred ]]; then
+        # The earlier guard proof owns the stop-pending transition while
+        # authorization evidence is unavailable or deliberately deferred until
+        # the writer stop can be retried. The postprocessing exception removes
+        # unavailable evidence; the fresh-writer exception preserves any bound
+        # evidence and is consumed after an inspect-verified stop.
         jq -e '(.guardEvidence.path | type == "string" and startswith("/")) and
                (.guardEvidence.sha256 | type == "string" and test("^[a-f0-9]{64}$"))' \
           "$state" >/dev/null ||
@@ -370,13 +379,17 @@ update_controller_phase() {
   [[ "$phase" != incident && "$phase" != closure-stop-pending && "$phase" != closure-evidence-pending || -n "$incident_class" ]] ||
     die 'closure pending and incident phases require a class'
   case "$proof_exception" in
-    ''|authorization-evidence-unavailable) ;;
+    ''|authorization-evidence-unavailable|fresh-writer-proof-deferred) ;;
     *) die "unsupported controller proof exception: $proof_exception" ;;
   esac
   [[ -z "$proof_exception" ||
-     ( ( "$phase" == closure-stop-pending || "$phase" == incident ) &&
-       "$incident_class" == closure-authorization-evidence ) ]] ||
-    die 'authorization evidence exception is valid only for closure-authorization-evidence closure state'
+     ( "$proof_exception" == authorization-evidence-unavailable &&
+       ( "$phase" == closure-stop-pending || "$phase" == incident ) &&
+       "$incident_class" == closure-authorization-evidence ) ||
+     ( "$proof_exception" == fresh-writer-proof-deferred &&
+       "$phase" == closure-stop-pending &&
+       "$incident_class" == closure-interruption ) ]] ||
+    die 'controller proof exception does not match its closure state'
   temp=$(mktemp "$(dirname "$state")/.controller-phase.XXXXXX")
   trap 'rm -f "$temp"' RETURN
   jq --arg phase "$phase" --arg incidentClass "$incident_class" --arg proofException "$proof_exception" '
@@ -385,7 +398,8 @@ update_controller_phase() {
     if ($phase == "closure-stop-pending" or $phase == "closure-evidence-pending" or $phase == "incident") then .incidentClass = $incidentClass
     else del(.incidentClass) end |
     if (($phase == "closure-stop-pending" or $phase == "incident") and $proofException != "") then
-      .proofException = $proofException | del(.authorizationEvidence)
+      .proofException = $proofException |
+      if $proofException == "authorization-evidence-unavailable" then del(.authorizationEvidence) else . end
     else del(.proofException) end
   ' "$state" > "$temp"
   write_controller_state_atomic "$state" "$temp" || write_exit=$?
@@ -460,7 +474,7 @@ resume_controller_state() {
     authorization-running|activation-running)
       stop_application_fail_closed return || stop_exit=$?
       if ((stop_exit != 0)); then
-        update_controller_phase "$state" closure-stop-pending closure-interruption '' writer-stop
+        update_controller_phase "$state" closure-stop-pending closure-interruption fresh-writer-proof-deferred writer-stop
         return "$stop_exit"
       fi
       ;;
@@ -1506,6 +1520,7 @@ complete_closure_stop_pending() {
   if ! stop_application_fail_closed; then
     return 1
   fi
+  [[ "$proof_exception" != fresh-writer-proof-deferred ]] || proof_exception=''
   update_controller_phase "$state" incident "$incident_class" "$proof_exception"
 }
 

--- a/scripts/run-pgvector-transition-controller.sh
+++ b/scripts/run-pgvector-transition-controller.sh
@@ -73,27 +73,84 @@ fsync_path() {
 }
 
 write_controller_state_atomic() {
-  local target=$1 source=$2 temp
+  local target=$1 source=$2 temp prior='' target_existed=false write_status rollback_status=0
   controller_state_write_active=true
   assert_owned_regular_file "$source"
+  jq -e 'type == "object" and (.phase | type == "string")' "$source" >/dev/null ||
+    die 'controller state must contain one phased JSON object'
   if path_present "$target"; then
     assert_owned_regular_file "$target"
     [[ $(stat -c '%a' "$target") == 600 ]] || die 'controller state mode must be 0600'
+    target_existed=true
+    prior=$(mktemp "${target}.prior.XXXXXX") || {
+      write_status=$?
+      controller_state_write_active=false
+      return "$write_status"
+    }
+    install -m 600 "$target" "$prior" || {
+      write_status=$?
+      rm -f "$prior"
+      prior=''
+      controller_state_write_active=false
+      return "$write_status"
+    }
+    fsync_path "$prior" || {
+      write_status=$?
+      rm -f "$prior"
+      prior=''
+      controller_state_write_active=false
+      return "$write_status"
+    }
   fi
-  jq -e 'type == "object" and (.phase | type == "string")' "$source" >/dev/null ||
-    die 'controller state must contain one phased JSON object'
-  temp=$(mktemp "${target}.tmp.XXXXXX")
-  trap 'rm -f "$temp"' RETURN
-  install -m 600 "$source" "$temp"
-  fsync_path "$temp"
-  mv -f "$temp" "$target"
-  fsync_path "$(dirname "$target")"
+  temp=$(mktemp "${target}.tmp.XXXXXX") || {
+    write_status=$?
+    [[ -z "$prior" ]] || rm -f "$prior"
+    prior=''
+    controller_state_write_active=false
+    return "$write_status"
+  }
+  trap 'rm -f "$temp"; [[ -z ${prior:-} ]] || rm -f "$prior"' RETURN
+  install -m 600 "$source" "$temp" || {
+    write_status=$?
+    controller_state_write_active=false
+    return "$write_status"
+  }
+  fsync_path "$temp" || {
+    write_status=$?
+    controller_state_write_active=false
+    return "$write_status"
+  }
+  mv -f "$temp" "$target" || {
+    write_status=$?
+    controller_state_write_active=false
+    return "$write_status"
+  }
+  fsync_path "$(dirname "$target")" || {
+    write_status=$?
+    if [[ "$target_existed" == true ]]; then
+      mv -f "$prior" "$target" || rollback_status=$?
+      if ((rollback_status == 0)); then
+        fsync_path "$(dirname "$target")" || rollback_status=$?
+      fi
+      prior=''
+    else
+      rm -f "$target" || rollback_status=$?
+      if ((rollback_status == 0)); then
+        fsync_path "$(dirname "$target")" || rollback_status=$?
+      fi
+    fi
+    controller_state_write_active=false
+    ((rollback_status == 0)) || die 'atomic state publication failed after rename and rollback could not be made durable'
+    return "$write_status"
+  }
+  [[ -z "$prior" ]] || rm -f "$prior"
+  prior=''
   trap - RETURN
   controller_state_write_active=false
   if [[ ${controller_interruption_pending:-false} == true &&
         -n ${controller_state:-} && "$target" == "$controller_state" ]]; then
     controller_interruption_pending=false
-    record_controller_interruption "$controller_signal"
+    record_controller_interruption "$controller_signal" || return $?
   fi
 }
 
@@ -102,9 +159,23 @@ sha256_file() {
 }
 
 validate_controller_state() {
-  local state=$1 proof_phase proof_class
+  local state=$1 proof_phase proof_class proof_exception
   assert_owned_regular_file "$state"
   [[ $(stat -c '%a' "$state") == 600 ]] || die 'controller state mode must be 0600'
+  proof_exception=$(jq -er '.proofException // ""' "$state" 2>/dev/null) ||
+    die 'controller state is malformed'
+  case "$proof_exception" in
+    '') ;;
+    authorization-evidence-unavailable)
+      jq -e '
+        (.phase == "closure-stop-pending" or .phase == "incident") and
+        .incidentClass == "closure-authorization-evidence" and
+        (has("authorizationEvidence") | not)
+      ' "$state" >/dev/null ||
+        die 'authorization evidence exception requires an exact closure-authorization-evidence state'
+      ;;
+    *) die "unsupported controller proof exception: $proof_exception" ;;
+  esac
   jq -e '
     type == "object" and
     .version == 1 and
@@ -131,6 +202,15 @@ validate_controller_state() {
     (.sourceSnapshotSha256 | type == "string" and test("^[a-f0-9]{64}$")) and
     (.candidateComposeSha256 | type == "string" and test("^[a-f0-9]{64}$")) and
     (.guardJournal | type == "string" and startswith("/")) and
+    ((.proofException == null) or
+     .proofException == "authorization-evidence-unavailable") and
+    if .proofException == "authorization-evidence-unavailable" then
+      (.phase == "closure-stop-pending" or .phase == "incident") and
+      .incidentClass == "closure-authorization-evidence" and
+      (has("authorizationEvidence") | not)
+    else
+      true
+    end and
     if .phase == "complete" then
       (.guardEvidence.path | type == "string" and startswith("/")) and
       (.guardEvidence.sha256 | type == "string" and test("^[a-f0-9]{64}$")) and
@@ -166,11 +246,24 @@ validate_controller_state() {
   esac
   case "$proof_phase" in
     closure-stop-pending)
-      jq -e '(.authorizationEvidence.path | type == "string" and startswith("/")) and
-             (.authorizationEvidence.sha256 | type == "string" and test("^[a-f0-9]{64}$"))' \
-        "$state" >/dev/null ||
-        die "authorizationEvidence is required for phase $proof_phase but missing or malformed"
-      validate_evidence_binding "$state" authorizationEvidence process
+      if [[ $(jq -er '.proofException // ""' "$state") == authorization-evidence-unavailable ]]; then
+        # Authorization completed, but its evidence could not be persisted.
+        # The earlier guard proof still owns this transition, and the pending
+        # phase must remain valid long enough to durably bind the verified
+        # writer stop. The explicit exception prevents later postprocessing
+        # failures from discarding already-bound authorization evidence.
+        jq -e '(.guardEvidence.path | type == "string" and startswith("/")) and
+               (.guardEvidence.sha256 | type == "string" and test("^[a-f0-9]{64}$"))' \
+          "$state" >/dev/null ||
+          die "guardEvidence is required for closure-authorization-evidence but missing or malformed"
+        validate_evidence_binding "$state" guardEvidence process
+      else
+        jq -e '(.authorizationEvidence.path | type == "string" and startswith("/")) and
+               (.authorizationEvidence.sha256 | type == "string" and test("^[a-f0-9]{64}$"))' \
+          "$state" >/dev/null ||
+          die "authorizationEvidence is required for phase $proof_phase but missing or malformed"
+        validate_evidence_binding "$state" authorizationEvidence process
+      fi
       ;;
     closure-evidence-pending)
       jq -e '(.writerStopEvidence.path | type == "string" and startswith("/")) and
@@ -184,7 +277,7 @@ validate_controller_state() {
     closure-stop-pending|closure-evidence-pending|incident)
       proof_class=$(jq -er '.incidentClass // ""' "$state")
       case "$proof_class" in
-        pre-journal-source-verification|pre-journal-source-restoration|pre-journal-source-restored|pre-journal-live-compose-divergence|closure-artifact-storage|closure-interruption|closure-writer-authorization|closure-app-activation|closure-postprocessing|closure-verification|closure-identity|closure-extension|closure-counts|closure-infrastructure|closure-app-health|isolated-app-health-requires-guard-revalidation) ;;
+        pre-journal-source-verification|pre-journal-source-restoration|pre-journal-source-restored|pre-journal-live-compose-divergence|closure-artifact-storage|closure-interruption|closure-writer-authorization|closure-app-activation|closure-authorization-evidence|closure-postprocessing|closure-verification|closure-identity|closure-extension|closure-counts|closure-infrastructure|closure-app-health|isolated-app-health-requires-guard-revalidation) ;;
         *) die "incident class is unsupported or unrecognized: ${proof_class:-empty}" ;;
       esac
       ;;
@@ -258,7 +351,7 @@ validate_evidence_binding() {
 }
 
 update_controller_phase() {
-  local state=$1 phase=$2 incident_class=${3:-} temp write_exit=0
+  local state=$1 phase=$2 incident_class=${3:-} proof_exception=${4:-} temp write_exit=0
   validate_controller_state "$state"
   case "$phase" in
     prepared|candidate-published|source-recovery-running|guard-exited|authorization-running|activation-running|closure-running|closure-stop-pending|closure-evidence-pending|complete|incident) ;;
@@ -266,13 +359,24 @@ update_controller_phase() {
   esac
   [[ "$phase" != incident && "$phase" != closure-stop-pending && "$phase" != closure-evidence-pending || -n "$incident_class" ]] ||
     die 'closure pending and incident phases require a class'
+  case "$proof_exception" in
+    ''|authorization-evidence-unavailable) ;;
+    *) die "unsupported controller proof exception: $proof_exception" ;;
+  esac
+  [[ -z "$proof_exception" ||
+     ( ( "$phase" == closure-stop-pending || "$phase" == incident ) &&
+       "$incident_class" == closure-authorization-evidence ) ]] ||
+    die 'authorization evidence exception is valid only for closure-authorization-evidence closure state'
   temp=$(mktemp "$(dirname "$state")/.controller-phase.XXXXXX")
   trap 'rm -f "$temp"' RETURN
-  jq --arg phase "$phase" --arg incidentClass "$incident_class" '
+  jq --arg phase "$phase" --arg incidentClass "$incident_class" --arg proofException "$proof_exception" '
     .phase = $phase |
     .updatedAt = (now | todateiso8601) |
     if ($phase == "closure-stop-pending" or $phase == "closure-evidence-pending" or $phase == "incident") then .incidentClass = $incidentClass
-    else del(.incidentClass) end
+    else del(.incidentClass) end |
+    if (($phase == "closure-stop-pending" or $phase == "incident") and $proofException != "") then
+      .proofException = $proofException | del(.authorizationEvidence)
+    else del(.proofException) end
   ' "$state" > "$temp"
   write_controller_state_atomic "$state" "$temp" || write_exit=$?
   trap - RETURN
@@ -363,22 +467,25 @@ resume_controller_state() {
       ;;
   esac
 
-  # Once the initial guard and completed journal are durably bound, resume the
-  # controller-owned writer lifecycle instead of delegating back to switch
-  # mode. Authorization is idempotent and activation is verified separately.
+  # A fresh controller invocation must never cross a writer boundary left by a
+  # prior process. The prior invocation may have failed while persisting its
+  # closure intent, so absence of writer-stop evidence is not proof that no
+  # writer exists. Stop and commit an interruption incident before returning.
   case "$phase" in
     authorization-running)
+      jq -e 'has("writerStopEvidence")' "$state" >/dev/null &&
+        die 'state records a verified writer stop without a terminal incident; reauthorization is forbidden and requires operator resolution'
       assert_bound_guard_journal_unchanged "$state"
-      resume_action=run-authorization
-      return
+      begin_closure_incident "$state" interruption
+      die 'fresh invocation stopped an interrupted authorization phase; operator resolution is required'
       ;;
     activation-running)
       jq -e 'has("writerStopEvidence")' "$state" >/dev/null &&
         die 'state records a verified writer stop without a terminal incident; reactivation is forbidden and requires operator resolution'
       validate_bound_process_evidence "$state" authorizationEvidence authorization-running
       assert_bound_guard_journal_unchanged "$state"
-      resume_action=run-activation
-      return
+      begin_closure_incident "$state" interruption
+      die 'fresh invocation stopped an interrupted activation phase; operator resolution is required'
       ;;
     closure-running)
       jq -e 'has("writerStopEvidence")' "$state" >/dev/null &&
@@ -792,25 +899,97 @@ assert_operation_lock_held() {
 }
 
 publish_compose_atomic() {
-  local source=$1 target=$2 staged parent parent_mode
-  assert_owned_regular_file "$source"
-  assert_owned_regular_file "$target"
-  for parent in "$(dirname "$source")" "$(dirname "$target")"; do
+  local source=$1 target=$2 expected_sha=${3:-} staged parent parent_mode current_uid resolved normalized
+  local source_parent target_parent source_name target_name source_via_fd target_via_fd
+  local source_parent_fd target_parent_fd source_parent_identity target_parent_identity opened_identity
+  source_parent=$(dirname "$source")
+  target_parent=$(dirname "$target")
+  source_name=$(basename "$source")
+  target_name=$(basename "$target")
+  current_uid=$(id -u)
+  for parent in "$source_parent" "$target_parent"; do
     [[ -d "$parent" && ! -L "$parent" ]] ||
       die "Compose publication parent is missing or unsafe: $parent"
-    if [[ $(stat -c '%u' "$parent") == "$(id -u)" ]]; then
-      parent_mode=$(stat -c '%a' "$parent")
-      (( (8#$parent_mode & 8#022) == 0 )) ||
-        die "Compose publication parent permits group/world writes: $parent"
+    resolved=$(realpath -e "$parent") ||
+      die "Compose publication parent cannot be resolved safely: $parent"
+    normalized=$(realpath -m "$parent")
+    [[ "$resolved" == "$normalized" ]] ||
+      die "Compose publication parent contains a symlink ancestor: $parent"
+    [[ $(stat -c '%u' "$resolved") == "$current_uid" ]] ||
+      die "Compose publication parent is not owned by the current user: $parent"
+    # Current ownership does not make a writable directory safe, so enforce
+    # the mode boundary independently for every publication parent.
+    parent_mode=$(stat -c '%a' "$resolved")
+    (( (8#$parent_mode & 8#022) == 0 )) ||
+      die "Compose publication parent permits group/world writes: $parent"
+    if [[ "$parent" == "$source_parent" ]]; then
+      source_parent_identity=$(stat -Lc '%d:%i' "$resolved")
+    fi
+    if [[ "$parent" == "$target_parent" ]]; then
+      target_parent_identity=$(stat -Lc '%d:%i' "$resolved")
     fi
   done
-  staged=$(mktemp "${target}.item3-publish.XXXXXX")
+
+  # Hold both accepted directories open and compare the descriptor identities
+  # with the pre-open identities. Re-resolving a pathname after open would only
+  # validate an attacker's replacement against itself.
+  exec {source_parent_fd}<"$source_parent" ||
+    die "could not anchor Compose source publication parent: $source_parent"
+  opened_identity=$(stat -Lc '%d:%i' "/proc/$BASHPID/fd/$source_parent_fd" 2>/dev/null || true)
+  if [[ -z "$opened_identity" || "$opened_identity" != "$source_parent_identity" ]]; then
+    printf 'Compose source publication parent changed while it was opened: %s\n' "$source_parent" >&2
+    exec {source_parent_fd}<&-
+    return 1
+  fi
+  exec {target_parent_fd}<"$target_parent" ||
+    die "could not anchor Compose target publication parent: $target_parent"
+  opened_identity=$(stat -Lc '%d:%i' "/proc/$BASHPID/fd/$target_parent_fd" 2>/dev/null || true)
+  if [[ -z "$opened_identity" || "$opened_identity" != "$target_parent_identity" ]]; then
+    printf 'Compose target publication parent changed while it was opened: %s\n' "$target_parent" >&2
+    exec {source_parent_fd}<&-
+    exec {target_parent_fd}<&-
+    return 1
+  fi
+  source_via_fd="/proc/$BASHPID/fd/$source_parent_fd/$source_name"
+  target_via_fd="/proc/$BASHPID/fd/$target_parent_fd/$target_name"
+  assert_owned_regular_file "$source_via_fd"
+  assert_owned_regular_file "$target_via_fd"
+
+  staged=$(mktemp "${target_via_fd}.item3-publish.XXXXXX")
   trap 'rm -f "$staged"' RETURN
-  install -m 600 "$source" "$staged"
+  install -m 600 "$source_via_fd" "$staged"
   fsync_path "$staged"
-  mv -f "$staged" "$target"
-  fsync_path "$(dirname "$target")"
+  if [[ -n "$expected_sha" ]]; then
+    [[ "$expected_sha" =~ ^[a-f0-9]{64}$ ]] || die 'expected Compose publication digest is malformed'
+    if [[ $(sha256_file "$staged") != "$expected_sha" ]]; then
+      printf 'staged Compose publication bytes do not match the prepared candidate digest\n' >&2
+      rm -f "$staged"
+      trap - RETURN
+      exec {source_parent_fd}<&-
+      exec {target_parent_fd}<&-
+      return 1
+    fi
+  fi
+  if [[ $(stat -Lc '%d:%i' "$target_parent" 2>/dev/null || true) != "$target_parent_identity" ]]; then
+    printf 'Compose target publication parent detached before rename: %s\n' "$target_parent" >&2
+    rm -f "$staged"
+    trap - RETURN
+    exec {source_parent_fd}<&-
+    exec {target_parent_fd}<&-
+    return 1
+  fi
+  mv -f "$staged" "$target_via_fd"
+  fsync_path "/proc/$BASHPID/fd/$target_parent_fd"
+  if [[ $(stat -Lc '%d:%i' "$target_parent" 2>/dev/null || true) != "$target_parent_identity" ]]; then
+    printf 'Compose target publication parent detached after rename: %s\n' "$target_parent" >&2
+    trap - RETURN
+    exec {source_parent_fd}<&-
+    exec {target_parent_fd}<&-
+    return 1
+  fi
   trap - RETURN
+  exec {source_parent_fd}<&-
+  exec {target_parent_fd}<&-
 }
 
 publish_candidate_under_lock() {
@@ -840,7 +1019,7 @@ publish_candidate_under_lock() {
   if [[ ${NOOSPHERE_CONTROLLER_TEST_INTERRUPT_AFTER_INTENT:-0} == 1 ]]; then
     die 'test interruption after candidate publication intent'
   fi
-  publish_compose_atomic "$candidate_compose" "$live_compose"
+  publish_compose_atomic "$candidate_compose" "$live_compose" "$candidate_sha"
 }
 
 child_path_for_state() {
@@ -1257,12 +1436,16 @@ assert_bound_guard_journal_unchanged() {
 }
 
 begin_closure_incident() {
-  local state=$1 failure_class=$2
-  if ! update_controller_phase "$state" closure-stop-pending "closure-$failure_class"; then
+  local state=$1 failure_class=$2 proof_exception=${3:-} intent_exit=0
+  update_controller_phase "$state" closure-stop-pending "closure-$failure_class" "$proof_exception" ||
+    intent_exit=$?
+  if ((intent_exit != 0)); then
     # Even if the durable intent write fails, attempt to remove the writer
-    # before returning the storage failure to the operator.
+    # before returning the exact first storage failure to the operator. The
+    # stop proof may bind to the unchanged pre-intent phase; resume rejects
+    # that nonterminal proof instead of reauthorizing the writer.
     stop_application_fail_closed || true
-    die 'could not persist closure incident; application stop was attempted'
+    return "$intent_exit"
   fi
   complete_closure_stop_pending "$state"
 }
@@ -1289,14 +1472,15 @@ complete_closure_evidence_pending() {
 }
 
 complete_closure_stop_pending() {
-  local state=$1 incident_class
+  local state=$1 incident_class proof_exception
   incident_class=$(jq -er '.incidentClass' "$state")
+  proof_exception=$(jq -er '.proofException // ""' "$state")
   # Do not depend on errexit here: callers intentionally invoke recovery from
   # conditional contexts where Bash suppresses it for the entire call stack.
   if ! stop_application_fail_closed; then
     return 1
   fi
-  update_controller_phase "$state" incident "$incident_class"
+  update_controller_phase "$state" incident "$incident_class" "$proof_exception"
 }
 
 commit_closure_outcome() {
@@ -1817,9 +2001,9 @@ assert_source_state_unchanged() {
 }
 
 stop_application_fail_closed() {
-  local docker_path app_container running stop_evidence stop_temp stopped_at
-  docker_path=${execution_docker_path:-$(jq -er '.dockerPath' "$controller_state")}
-  app_container=$(jq -er '.appContainer' "$controller_state")
+  local docker_path app_container running stop_evidence stop_temp stopped_at stop_phase stop_sha
+  docker_path=${execution_docker_path:-$(jq -er '.dockerPath' "$controller_state")} || return $?
+  app_container=$(jq -er '.appContainer' "$controller_state") || return $?
   "$docker_path" stop --time 60 "$app_container" >/dev/null 2>&1 ||
     die "failed to stop application container $app_container"
   running=$("$docker_path" inspect --format '{{.State.Running}}' "$app_container" 2>/dev/null) ||
@@ -1830,15 +2014,16 @@ stop_application_fail_closed() {
   # closure-evidence-pending and closure-incident phases carry their owned
   # writer-stop proof. A failure to persist the proof is fatal: the stop itself
   # succeeded, but the state must not advance without its owned evidence.
-  stopped_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  stopped_at=$(date -u +%Y-%m-%dT%H:%M:%SZ) || return $?
   # Retry-distinct allocation: the first stop owns the canonical evidence
   # path; a later invocation that finds it allocates InvocationID-suffixed
   # paths so a prior truthful stop record is never overwritten.
-  stop_evidence="$(select_process_artifact_base "${controller_state%.json}" writer-stop).writer-stop.evidence.json"
-  stop_temp=$(mktemp "$(dirname "$controller_state")/.writer-stop-evidence.XXXXXX")
+  stop_evidence="$(select_process_artifact_base "${controller_state%.json}" writer-stop).writer-stop.evidence.json" || return $?
+  stop_temp=$(mktemp "$(dirname "$controller_state")/.writer-stop-evidence.XXXXXX") || return $?
   trap 'rm -f "$stop_temp"' RETURN
+  stop_phase=$(jq -er '.phase // ""' "$controller_state") || return $?
   jq -n \
-    --arg phase "$(jq -er '.phase // ""' "$controller_state")" \
+    --arg phase "$stop_phase" \
     --arg container "$app_container" \
     --arg stoppedAt "$stopped_at" \
     --arg invocationId "${INVOCATION_ID:-}" \
@@ -1847,33 +2032,48 @@ stop_application_fail_closed() {
       {version:1,phase:$phase,container:$container,stopExitCode:0,
        inspectRunning:false,stoppedAt:$stoppedAt,invocationId:$invocationId,
        bootId:$bootId,controllerMainPid:$controllerMainPid}
-    ' > "$stop_temp"
-  chmod 0600 "$stop_temp"
-  fsync_path "$stop_temp"
-  mv -f "$stop_temp" "$stop_evidence"
-  fsync_path "$(dirname "$stop_evidence")"
+    ' > "$stop_temp" || return $?
+  chmod 0600 "$stop_temp" || return $?
+  fsync_path "$stop_temp" || return $?
+  write_controller_state_atomic "$stop_evidence" "$stop_temp" || return $?
+  rm -f "$stop_temp" || return $?
   trap - RETURN
-  stop_temp=$(mktemp "$(dirname "$controller_state")/.controller-evidence.XXXXXX")
+  stop_temp=$(mktemp "$(dirname "$controller_state")/.controller-evidence.XXXXXX") || return $?
   trap 'rm -f "$stop_temp"' RETURN
-  jq --arg path "$stop_evidence" --arg sha256 "$(sha256_file "$stop_evidence")" '
+  stop_sha=$(sha256_file "$stop_evidence") || return $?
+  jq --arg path "$stop_evidence" --arg sha256 "$stop_sha" '
     .writerStopEvidence = {path:$path, sha256:$sha256}
-  ' "$controller_state" > "$stop_temp"
-  write_controller_state_atomic "$controller_state" "$stop_temp"
+  ' "$controller_state" > "$stop_temp" || return $?
+  write_controller_state_atomic "$controller_state" "$stop_temp" || return $?
   trap - RETURN
 }
 
 activate_application_for_verification() {
-  local state=$1 docker_path app_container running project_directory
+  local state=$1 docker_path app_container running project_directory inspect_exit=0
   docker_path=${execution_docker_path:-$(jq -er '.dockerPath' "$state")}
   app_container=$(jq -er '.appContainer' "$state")
   running=$("$docker_path" inspect --format '{{.State.Running}}' "$app_container" 2>/dev/null) ||
-    die "could not inspect application container before activation: $app_container"
-  [[ "$running" == true || "$running" == false ]] ||
-    die "application container has an invalid running state: $app_container"
+    inspect_exit=$?
+  if ((inspect_exit != 0)); then
+    printf 'PostgreSQL transition controller: could not inspect application container before activation: %s\n' \
+      "$app_container" >&2
+    return "$inspect_exit"
+  fi
+  if [[ "$running" != true && "$running" != false ]]; then
+    printf 'PostgreSQL transition controller: application container has an invalid running state: %s\n' \
+      "$app_container" >&2
+    return 1
+  fi
   [[ "$running" == false ]] || return 0
 
   project_directory=$(dirname "$(jq -er '.liveCompose' "$state")")
-  "$docker_path" compose \
+  env -i \
+    HOME="$HOME" \
+    DOCKER_CONFIG="$DOCKER_CONFIG" \
+    DOCKER_HOST="$DOCKER_HOST" \
+    COMPOSE_DISABLE_ENV_FILE=1 \
+    PATH="$PATH" \
+    "$docker_path" compose \
     --project-directory "$project_directory" \
     --env-file "$execution_env_file" \
     -f "$execution_candidate_compose" \
@@ -2096,13 +2296,28 @@ execute_prepared_state() {
     run_guard_with_inherited_lock "$state" "$engine_id" "$volume" "$lock_root" \
       "$guard" "${authorization_args[@]}" >"$authorization_stdout" 2>"$authorization_stderr" ||
       authorization_exit=$?
-    ended_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-    end_cursor=$(capture_journal_cursor)
-    write_process_evidence_atomic "$authorization_evidence" authorization-running "$authorization_exit" \
-      "$authorization_stdout" "$authorization_stderr" "$INVOCATION_ID" "$boot_id" \
-      "$systemd_controller_main_pid" "$last_guard_pid" "$started_at" "$ended_at" "$start_cursor" "$end_cursor"
-    bind_process_evidence_to_state "$state" authorizationEvidence "$authorization_evidence" \
-      "$INVOCATION_ID" "$boot_id" "$systemd_controller_main_pid" "$last_guard_pid"
+    # This subprocess must be an unconditional simple command. Bash disables
+    # errexit throughout functions and subshells evaluated as an `if`/`||`
+    # condition, which can turn an ordinary durability failure into success
+    # when a later command returns zero. Disable only the parent's errexit long
+    # enough to capture the strict subprocess status after it has terminated.
+    set +e
+    (
+      set -Eeuo pipefail
+      ended_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+      end_cursor=$(capture_journal_cursor)
+      write_process_evidence_atomic "$authorization_evidence" authorization-running "$authorization_exit" \
+        "$authorization_stdout" "$authorization_stderr" "$INVOCATION_ID" "$boot_id" \
+        "$systemd_controller_main_pid" "$last_guard_pid" "$started_at" "$ended_at" "$start_cursor" "$end_cursor"
+      bind_process_evidence_to_state "$state" authorizationEvidence "$authorization_evidence" \
+        "$INVOCATION_ID" "$boot_id" "$systemd_controller_main_pid" "$last_guard_pid"
+    )
+    postprocess_exit=$?
+    set -e
+    if ((postprocess_exit != 0)); then
+      begin_closure_incident "$state" authorization-evidence authorization-evidence-unavailable
+      return "$postprocess_exit"
+    fi
     if [[ -n ${controller_signal:-} ]]; then
       if ! abort_if_interrupted; then
         # A latched signal after successful writer authorization must not

--- a/scripts/run-pgvector-transition-controller.sh
+++ b/scripts/run-pgvector-transition-controller.sh
@@ -159,9 +159,18 @@ sha256_file() {
 }
 
 validate_controller_state() {
-  local state=$1 proof_phase proof_class proof_exception
+  local state=$1 validation_mode=${2:-full} proof_phase proof_class proof_exception
   assert_owned_regular_file "$state"
   [[ $(stat -c '%a' "$state") == 600 ]] || die 'controller state mode must be 0600'
+  case "$validation_mode" in
+    full) ;;
+    writer-stop)
+      jq -e '.phase == "authorization-running" or .phase == "activation-running"' \
+        "$state" >/dev/null 2>&1 ||
+        die 'writer-stop validation is valid only for a writer-capable running phase'
+      ;;
+    *) die "unsupported controller validation mode: $validation_mode" ;;
+  esac
   proof_exception=$(jq -er '.proofException // ""' "$state" 2>/dev/null) ||
     die 'controller state is malformed'
   case "$proof_exception" in
@@ -176,7 +185,7 @@ validate_controller_state() {
       ;;
     *) die "unsupported controller proof exception: $proof_exception" ;;
   esac
-  jq -e '
+  jq -e --arg validationMode "$validation_mode" '
     type == "object" and
     .version == 1 and
     (.phase == "prepared" or
@@ -211,7 +220,7 @@ validate_controller_state() {
     else
       true
     end and
-    if .phase == "complete" then
+    if $validationMode == "full" and .phase == "complete" then
       (.guardEvidence.path | type == "string" and startswith("/")) and
       (.guardEvidence.sha256 | type == "string" and test("^[a-f0-9]{64}$")) and
       (.authorizationEvidence.path | type == "string" and startswith("/")) and
@@ -221,15 +230,16 @@ validate_controller_state() {
       (.guardJournalEvidence.path | type == "string" and startswith("/")) and
       (.guardJournalEvidence.sha256 | type == "string" and test("^[a-f0-9]{64}$")) and
       .guardJournalEvidence.phase == "complete"
-    elif (.phase == "activation-running" or .phase == "closure-running") then
+    elif $validationMode == "full" and (.phase == "activation-running" or .phase == "closure-running") then
       (.authorizationEvidence.path | type == "string" and startswith("/")) and
       (.authorizationEvidence.sha256 | type == "string" and test("^[a-f0-9]{64}$"))
-    elif (.phase == "closure-stop-pending" or .phase == "closure-evidence-pending" or .phase == "incident") then
+    elif $validationMode == "full" and (.phase == "closure-stop-pending" or .phase == "closure-evidence-pending" or .phase == "incident") then
       (.incidentClass | type == "string" and length > 0)
     else
       true
     end
   ' "$state" >/dev/null || die 'controller state is malformed'
+  [[ "$validation_mode" == full ]] || return 0
   # Phase-owned proofs: every non-trivial phase carries evidence that its own
   # mechanism actually ran. Each requirement rejects with a key-specific
   # diagnostic so a mutation that strips one owned proof cannot pass silently.
@@ -435,6 +445,22 @@ restore_source_compose_snapshot() {
 resume_controller_state() {
   local state=$1 phase guard_journal live_compose source_snapshot source_sha candidate_sha live_sha
   local source_verify_exit=0
+  # execute_prepared_state has already revalidated the manifest, pinned Docker
+  # binary, engine/volume identity, operation lock, authority path, and every
+  # execution input before reaching resume. A fresh process that finds a
+  # writer-capable running phase must therefore inspect-stop that pinned app
+  # before phase-owned proof bytes are consulted: those bytes may be the
+  # unavailable/corrupt component that interrupted the prior process after
+  # activation. The full proof validator still runs immediately after the
+  # stop, before any state advancement or writer-capable work.
+  assert_owned_regular_file "$state"
+  [[ $(stat -c '%a' "$state") == 600 ]] || die 'controller state mode must be 0600'
+  phase=$(jq -er '.phase' "$state" 2>/dev/null) || die 'controller state is malformed'
+  case "$phase" in
+    authorization-running|activation-running)
+      stop_application_fail_closed
+      ;;
+  esac
   validate_controller_state "$state"
   phase=$(jq -er '.phase' "$state")
   guard_journal=$(jq -er '.guardJournal' "$state")
@@ -473,18 +499,14 @@ resume_controller_state() {
   # writer exists. Stop and commit an interruption incident before returning.
   case "$phase" in
     authorization-running)
-      jq -e 'has("writerStopEvidence")' "$state" >/dev/null &&
-        die 'state records a verified writer stop without a terminal incident; reauthorization is forbidden and requires operator resolution'
       assert_bound_guard_journal_unchanged "$state"
-      begin_closure_incident "$state" interruption
+      update_controller_phase "$state" incident closure-interruption
       die 'fresh invocation stopped an interrupted authorization phase; operator resolution is required'
       ;;
     activation-running)
-      jq -e 'has("writerStopEvidence")' "$state" >/dev/null &&
-        die 'state records a verified writer stop without a terminal incident; reactivation is forbidden and requires operator resolution'
       validate_bound_process_evidence "$state" authorizationEvidence authorization-running
       assert_bound_guard_journal_unchanged "$state"
-      begin_closure_incident "$state" interruption
+      update_controller_phase "$state" incident closure-interruption
       die 'fresh invocation stopped an interrupted activation phase; operator resolution is required'
       ;;
     closure-running)
@@ -1677,8 +1699,8 @@ assert_guard_journal_path() {
 }
 
 validate_execution_manifest() {
-  local state=$1
-  validate_controller_state "$state"
+  local state=$1 validation_mode=${2:-full}
+  validate_controller_state "$state" "$validation_mode"
   jq -e '
     (.guard | type == "string" and startswith("/")) and
     (.guardSha256 | type == "string" and test("^[a-f0-9]{64}$")) and
@@ -1795,8 +1817,8 @@ compose_model_signature() {
 }
 
 verify_execution_inputs() {
-  local state=$1 field path_field digest_field path expected docker_path plugin_path config_path
-  validate_execution_manifest "$state"
+  local state=$1 validation_mode=${2:-full} field path_field digest_field path expected docker_path plugin_path config_path
+  validate_execution_manifest "$state" "$validation_mode"
   assert_controller_execution_identity "$state"
   assert_owned_private_directory "$(dirname "$state")"
   assert_owned_private_directory "$(jq -er '.backupDir' "$state")"
@@ -2152,7 +2174,7 @@ execute_prepared_state() {
   local verify_stdout verify_stderr verify_evidence start_cursor end_cursor started_at ended_at
   local guard_exit=0 authorization_exit=0 verify_exit=0 postprocess_exit=0 boot_id phase guard_artifact_base verify_artifact_base
   local run_initial_guard=true run_authorization=true run_activation=true
-  local resume_closure_evidence=false
+  local resume_closure_evidence=false validation_mode=full
   local -a guard_args authorization_args
   local ambient_test_hook
   controller_state=$state
@@ -2171,7 +2193,13 @@ execute_prepared_state() {
         die "production execution rejected ambient test hook contamination: $ambient_test_hook is set; unset NOOSPHERE_CONTROLLER_TEST_* outside fixture mode"
     done
   fi
-  validate_execution_manifest "$state"
+  assert_owned_regular_file "$state"
+  [[ $(stat -c '%a' "$state") == 600 ]] || die 'controller state mode must be 0600'
+  phase=$(jq -er '.phase' "$state" 2>/dev/null) || die 'controller state is malformed'
+  case "$phase" in
+    authorization-running|activation-running) validation_mode=writer-stop ;;
+  esac
+  validate_execution_manifest "$state" "$validation_mode"
   docker_host=$(jq -er '.dockerEndpoint' "$state")
   fixed_path=$(jq -er '.fixedPath' "$state")
   controller_home=$(jq -er '.controllerHome' "$state")
@@ -2192,7 +2220,7 @@ execute_prepared_state() {
   [[ $(jq -er '.authorityRoot // empty' "$state") == "$authority_root" ]] ||
     die 'controller state was prepared under a different durable authority root; refusing execution'
   assert_live_engine_binding "$state" "$(jq -er '.dockerPath' "$state")"
-  verify_execution_inputs "$state"
+  verify_execution_inputs "$state" "$validation_mode"
   assert_postgres_volume_binding "$state" "$(jq -er '.dockerPath' "$state")"
   create_execution_bundle "$state"
   boot_id=$(< /proc/sys/kernel/random/boot_id)

--- a/scripts/run-pgvector-transition-controller.sh
+++ b/scripts/run-pgvector-transition-controller.sh
@@ -2105,9 +2105,27 @@ stop_application_fail_closed() {
 
 activate_application_for_verification() {
   local state=$1 docker_path app_container running project_directory inspect_exit=0
+  local controller_home docker_config docker_host lock_root child_path
+  local -a docker_env
   docker_path=${execution_docker_path:-$(jq -er '.dockerPath' "$state")}
+  controller_home=${execution_controller_home:-$(jq -er '.controllerHome' "$state")}
+  docker_config="$controller_home/docker"
+  docker_host=$(jq -er '.dockerEndpoint' "$state")
+  lock_root=$(jq -er '.lockRoot' "$state")
+  child_path=$(child_path_for_state "$state")
+  docker_env=(
+    "HOME=$controller_home"
+    "DOCKER_CONFIG=$docker_config"
+    "DOCKER_HOST=$docker_host"
+    COMPOSE_DISABLE_ENV_FILE=1
+    "XDG_RUNTIME_DIR=$lock_root"
+    LANG=C.UTF-8
+    LC_ALL=C.UTF-8
+    "PATH=$child_path"
+  )
   app_container=$(jq -er '.appContainer' "$state")
-  running=$("$docker_path" inspect --format '{{.State.Running}}' "$app_container" 2>/dev/null) ||
+  running=$(env -i "${docker_env[@]}" \
+    "$docker_path" inspect --format '{{.State.Running}}' "$app_container" 2>/dev/null) ||
     inspect_exit=$?
   if ((inspect_exit != 0)); then
     printf 'PostgreSQL transition controller: could not inspect application container before activation: %s\n' \
@@ -2122,19 +2140,15 @@ activate_application_for_verification() {
   [[ "$running" == false ]] || return 0
 
   project_directory=$(dirname "$(jq -er '.liveCompose' "$state")")
-  env -i \
-    HOME="$HOME" \
-    DOCKER_CONFIG="$DOCKER_CONFIG" \
-    DOCKER_HOST="$DOCKER_HOST" \
-    COMPOSE_DISABLE_ENV_FILE=1 \
-    PATH="$PATH" \
+  env -i "${docker_env[@]}" \
     "$docker_path" compose \
     --project-directory "$project_directory" \
     --env-file "$execution_env_file" \
     -f "$execution_candidate_compose" \
     up -d --no-deps --force-recreate app >/dev/null ||
     return 1
-  running=$("$docker_path" inspect --format '{{.State.Running}}' "$app_container" 2>/dev/null) ||
+  running=$(env -i "${docker_env[@]}" \
+    "$docker_path" inspect --format '{{.State.Running}}' "$app_container" 2>/dev/null) ||
     return 1
   [[ "$running" == true ]]
 }

--- a/scripts/test-pgvector-transition-controller-docker.sh
+++ b/scripts/test-pgvector-transition-controller-docker.sh
@@ -461,7 +461,8 @@ SQL
 
 guard_journal="$backup_dir/$volume.phase-a2b.json"
 docker_compose_version_sha=$(docker compose version --short | sha256sum | awk '{print $1}')
-effective_compose_sha=$(docker compose --env-file "$env_file" -f "$candidate_compose" config --no-interpolate | sha256sum | awk '{print $1}')
+effective_compose_sha=$(docker compose --project-directory "$(dirname "$live_compose")" \
+  --env-file "$env_file" -f "$candidate_compose" config --no-interpolate | sha256sum | awk '{print $1}')
 
 jq -n \
   --arg engineId "$engine_id" \

--- a/scripts/test-pgvector-transition-controller-docker.sh
+++ b/scripts/test-pgvector-transition-controller-docker.sh
@@ -2,9 +2,9 @@
 set -Eeuo pipefail
 
 ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
-CONTROLLER="$ROOT_DIR/scripts/run-pgvector-transition-controller.sh"
-GUARD="$ROOT_DIR/scripts/switch-pgvector-compose.sh"
-VERIFIER="$ROOT_DIR/scripts/verify-deploy.sh"
+CONTROLLER_SOURCE="$ROOT_DIR/scripts/run-pgvector-transition-controller.sh"
+GUARD_SOURCE="$ROOT_DIR/scripts/switch-pgvector-compose.sh"
+VERIFIER_SOURCE="$ROOT_DIR/scripts/verify-deploy.sh"
 
 cleanup_state_authority_record() {
   local runtime_root=$1 authority=$2
@@ -33,7 +33,7 @@ CANDIDATE_IMAGE='ghcr.io/sweetsophia/noosphere-postgres-pgvector@sha256:12bc9b34
   echo 'The controller Docker rehearsal currently supports linux/amd64 only.' >&2
   exit 1
 }
-for path in "$CONTROLLER" "$GUARD" "$VERIFIER"; do
+for path in "$CONTROLLER_SOURCE" "$GUARD_SOURCE" "$VERIFIER_SOURCE"; do
   [[ -x "$path" && -f "$path" && ! -L "$path" ]] || {
     echo "Required executable is missing or unsafe: $path" >&2
     exit 1
@@ -237,6 +237,40 @@ trap cleanup EXIT INT TERM
   echo "Transient rehearsal unit already exists: $unit" >&2
   exit 1
 }
+
+# Model the intended installed-artifact execution boundary instead of binding
+# mutable checkout artifacts directly. Shared Git repositories commonly create
+# executable files as 0775 under umask 0002. The current public installer stages
+# the guard and verifier, while controller integration remains downstream Task 7;
+# this rehearsal pre-stages all three verified bytes with private modes so the
+# controller boundary itself is deterministic without claiming installer coverage.
+execution_artifact_dir="$tmp_dir/execution-artifacts"
+install -d -m 700 "$execution_artifact_dir"
+CONTROLLER="$execution_artifact_dir/run-pgvector-transition-controller.sh"
+GUARD="$execution_artifact_dir/switch-pgvector-compose.sh"
+VERIFIER="$execution_artifact_dir/verify-deploy.sh"
+install -m 700 "$CONTROLLER_SOURCE" "$CONTROLLER"
+install -m 700 "$GUARD_SOURCE" "$GUARD"
+install -m 700 "$VERIFIER_SOURCE" "$VERIFIER"
+
+for path in "$CONTROLLER" "$GUARD" "$VERIFIER"; do
+  mode=$(stat -c '%a' "$path")
+  [[ -x "$path" && -f "$path" && ! -L "$path" ]] || {
+    echo "Installed execution artifact is missing or unsafe: $path" >&2
+    exit 1
+  }
+  [[ $(stat -c '%u' "$path") == "$(id -u)" ]] || {
+    echo "Installed execution artifact has the wrong owner: $path" >&2
+    exit 1
+  }
+  (( (8#$mode & 8#022) == 0 )) || {
+    echo "Installed execution artifact permits group/world writes: $path" >&2
+    exit 1
+  }
+done
+cmp -s "$CONTROLLER_SOURCE" "$CONTROLLER"
+cmp -s "$GUARD_SOURCE" "$GUARD"
+cmp -s "$VERIFIER_SOURCE" "$VERIFIER"
 
 cat > "$live_compose" <<YAML
 name: $project

--- a/scripts/test-pgvector-transition-controller.sh
+++ b/scripts/test-pgvector-transition-controller.sh
@@ -5856,8 +5856,15 @@ test_closure_intent_failure_preserves_status_and_blocks_reauthorization() (
       >"$fixture_dir/retry.out" 2>"$fixture_dir/retry.err" || retry_rc=$?
   ((retry_rc != 0)) ||
     failures+=('closure-intent failure remained resumable through writer reauthorization')
-  rg -Fq 'verified writer stop without a terminal incident' "$fixture_dir/retry.err" ||
-    failures+=('closure-intent retry lacked the nonterminal writer-stop refusal diagnostic')
+  rg -Fq 'fresh invocation stopped an interrupted authorization phase; operator resolution is required' \
+    "$fixture_dir/retry.err" ||
+    failures+=('closure-intent retry lacked the fresh inspect-stop operator-resolution diagnostic')
+  jq -e '
+    .phase == "incident" and
+    .incidentClass == "closure-interruption" and
+    (.writerStopEvidence.sha256 | type == "string" and test("^[a-f0-9]{64}$"))
+  ' "$state" >/dev/null ||
+    failures+=('closure-intent retry did not promote its fresh stop to a terminal interruption incident')
   lifecycle=$(paste -sd, "$fixture_dir/lifecycle.log" 2>/dev/null || true)
   [[ "$lifecycle" == transition,authorize ]] ||
     failures+=("closure-intent retry crossed reauthorization/activation boundary: $lifecycle")
@@ -6204,7 +6211,7 @@ test_candidate_entry_swap_cannot_escape_prepared_digest() (
 )
 
 test_closure_intent_and_stop_failure_cannot_cross_writer_boundary() (
-  local fixture_dir manifest state shim initial_rc=0 retry_rc=0 lifecycle phase
+  local fixture_dir manifest state shim initial_rc=0 retry_rc=0 lifecycle phase control_tail
   fixture_dir=$(mktemp -d)
   trap 'rm -rf -- "$fixture_dir"' EXIT
   manifest="$fixture_dir/manifest.json"
@@ -6246,6 +6253,76 @@ test_closure_intent_and_stop_failure_cannot_cross_writer_boundary() (
       "$retry_rc" "$lifecycle" >&2
     exit 1
   fi
+  control_tail=$(tail -n 2 "$fixture_dir/app-control.log" 2>/dev/null | paste -sd, -)
+  [[ "$control_tail" == stop,inspect:false ]] || {
+    printf 'dual closure failure retry did not inspect-stop the retained writer before proof validation: %s\n' \
+      "$control_tail" >&2
+    exit 1
+  }
+  jq -e '
+    (.writerStopEvidence.path | type == "string" and startswith("/")) and
+    (.writerStopEvidence.sha256 | type == "string" and test("^[a-f0-9]{64}$"))
+  ' "$state" >/dev/null || {
+    echo 'dual closure failure retry did not durably bind its fresh writer stop' >&2
+    exit 1
+  }
+)
+
+test_fresh_activation_recovery_stops_before_phase_owned_proof_validation() (
+  local fixture_dir manifest state shim authorization_evidence initial_rc=0 retry_rc=0 control_tail
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf -- "$fixture_dir"' EXIT
+  manifest="$fixture_dir/manifest.json"
+  state="$fixture_dir/controller.json"
+  write_execution_fixture "$fixture_dir" "$manifest"
+  export XDG_RUNTIME_DIR="$fixture_dir/locks"
+  shim=$(write_phase_snapshot_shim "$fixture_dir")
+  "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
+
+  NOOSPHERE_CONTROLLER_TEST_CAPTURE_PHASE=activation-running \
+    run_fixture_controller "$state" "$shim" env \
+      >"$fixture_dir/initial.out" 2>"$fixture_dir/initial.err" || initial_rc=$?
+  [[ "$initial_rc" == 86 && -e "$fixture_dir/controller-phase-snapshot-captured" ]] || {
+    printf 'fresh activation owner did not capture activation-running: rc=%s\n' "$initial_rc" >&2
+    exit 1
+  }
+  [[ $(jq -er '.phase' "$state") == activation-running ]] || {
+    echo 'fresh activation owner did not retain activation-running state' >&2
+    exit 1
+  }
+
+  # Exact crash image: Compose has started the app, but the controller has not
+  # yet advanced from activation-running. The bound proof then becomes
+  # unavailable before a fresh invocation can recover.
+  : > "$fixture_dir/app-started"
+  authorization_evidence=$(jq -er '.authorizationEvidence.path' "$state")
+  rm -f -- "$authorization_evidence"
+
+  NOOSPHERE_CONTROLLER_FIXTURE_INVOCATION_ID=fedcba9876543210fedcba9876543210 \
+    run_fixture_controller "$state" "$shim" \
+      >"$fixture_dir/retry.out" 2>"$fixture_dir/retry.err" || retry_rc=$?
+  ((retry_rc != 0)) || {
+    echo 'fresh activation recovery unexpectedly reported success' >&2
+    exit 1
+  }
+  if [[ -f "$fixture_dir/app-control.log" ]]; then
+    control_tail=$(tail -n 2 "$fixture_dir/app-control.log" | paste -sd, -)
+  else
+    control_tail=''
+  fi
+  [[ "$control_tail" == stop,inspect:false ]] || {
+    printf 'fresh activation recovery left the writer running before proof validation: %s\n' \
+      "$control_tail" >&2
+    exit 1
+  }
+  jq -e '
+    .phase == "activation-running" and
+    (.writerStopEvidence.path | type == "string" and startswith("/")) and
+    (.writerStopEvidence.sha256 | type == "string" and test("^[a-f0-9]{64}$"))
+  ' "$state" >/dev/null || {
+    echo 'fresh activation recovery did not bind stop evidence before proof validation failed' >&2
+    exit 1
+  }
 )
 
 test_detached_target_parent_cannot_false_complete_publication() (
@@ -6636,6 +6713,8 @@ if [[ ${BASH_SOURCE[0]} == "$0" ]]; then
   test_candidate_entry_swap_cannot_escape_prepared_digest
   _clear_authority_root_for_isolation
   test_closure_intent_and_stop_failure_cannot_cross_writer_boundary
+  _clear_authority_root_for_isolation
+  test_fresh_activation_recovery_stops_before_phase_owned_proof_validation
   _clear_authority_root_for_isolation
   test_detached_target_parent_cannot_false_complete_publication
   _clear_authority_root_for_isolation

--- a/scripts/test-pgvector-transition-controller.sh
+++ b/scripts/test-pgvector-transition-controller.sh
@@ -821,10 +821,10 @@ VERIFIER
 set -euo pipefail
 mode=${NOOSPHERE_EXPECTED_POSTGRES_IMAGE_MODE:-missing}
 root=${NOOSPHERE_CONTROLLER_FIXTURE_ROOT:-$fixture_root}
-trap 'printf "1\n" > "$root/'"$mode"'-verifier-term-count"; sleep 1; : > "$root/'"$mode"'-verifier-delay-complete"; exit 143' TERM INT HUP
+trap 'printf "1\n" > "$root/'"$mode"'-verifier-term-count"; printf "source verifier interrupted\n" >&2; deadline=$((SECONDS + 1)); while ((SECONDS < deadline)); do :; done; : > "$root/'"$mode"'-verifier-delay-complete"; exit 143' TERM INT HUP
 printf '%s\n' "$$" > "$root/$mode-verifier-pid"
 : > "$root/$mode-verifier-running"
-while :; do sleep 0.1; done
+while :; do :; done
 VERIFIER
     } > "$verifier"
   elif [[ "$verifier_mode" == signal-zero ]]; then
@@ -3977,7 +3977,7 @@ test_source_recovery_signal_persists_process_evidence() (
       if [[ "$case_name" == ordinary ]]; then
         expected_stderr_sha=$(printf 'source verification failed\n' | sha256sum | awk '{print $1}')
       else
-        expected_stderr_sha=$(printf 'Terminated%17ssleep 0.1\n' '' | sha256sum | awk '{print $1}')
+        expected_stderr_sha=$(printf 'source verifier interrupted\n' | sha256sum | awk '{print $1}')
       fi
       [[ "$stdout_sha" == "$expected_stdout_sha" && "$stderr_sha" == "$expected_stderr_sha" ]] ||
         failures+=("source recovery $case_name logs do not match the independently expected bytes")

--- a/scripts/test-pgvector-transition-controller.sh
+++ b/scripts/test-pgvector-transition-controller.sh
@@ -586,10 +586,23 @@ elif [[ ${1:-} == stop ]]; then
     kill -KILL "$PPID"
     exit 137
   fi
+  if [[ -e "$root/fail-closure-stop-once" &&
+        ! -e "$root/closure-stop-failure-consumed" ]]; then
+    : > "$root/closure-stop-failure-consumed"
+    exit 76
+  fi
   printf 'stop\n' >> "$root/app-control.log"
   : > "$root/app-stopped"
   exit 0
 elif [[ ${1:-} == inspect ]]; then
+  if [[ -e "$root/fail-initial-activation-inspect" &&
+        -e "$root/writer-authorized" &&
+        ${@: -1} == fixture-app &&
+        ! -e "$root/initial-activation-inspect-failure-consumed" &&
+        ! -e "$root/app-started" ]]; then
+    : > "$root/initial-activation-inspect-failure-consumed"
+    exit 75
+  fi
   if [[ -e "$root/app-stopped" ]]; then
     printf 'inspect:false\n' >> "$root/app-control.log"
     printf 'false\n'
@@ -1127,6 +1140,116 @@ write_process_evidence_atomic() {
     : > "$controller_fixture_root/source-evidence-publication-crash-consumed"
     exit 86
   fi
+}
+main "$@"
+SHIM
+  chmod 0700 "$shim"
+  printf '%s\n' "$shim"
+}
+
+write_authorization_postprocessing_non_die_failure_shim() {
+  local fixture_dir=$1 shim
+  shim=$(write_systemd_identity_shim "$fixture_dir")
+  sed -i '$d' "$shim"
+  cat >> "$shim" <<'SHIM'
+eval "$(declare -f fsync_path | sed '1s/fsync_path/original_fsync_path/')"
+fsync_path() {
+  if [[ ${controller_test_hooks_enabled:-false} == true &&
+        -e "$controller_fixture_root/fail-authorization-postprocessing-fsync" &&
+        ! -e "$controller_fixture_root/authorization-postprocessing-fsync-failure-consumed" &&
+        -f "$controller_fixture_root/lifecycle.log" &&
+        $(tail -n 1 "$controller_fixture_root/lifecycle.log") == authorize ]]; then
+    : > "$controller_fixture_root/authorization-postprocessing-fsync-failure-consumed"
+    return 74
+  fi
+  original_fsync_path "$@"
+}
+main "$@"
+SHIM
+  chmod 0700 "$shim"
+  printf '%s\n' "$shim"
+}
+
+write_writer_stop_evidence_fsync_failure_shim() {
+  local fixture_dir=$1 shim
+  shim=$(write_systemd_identity_shim "$fixture_dir")
+  sed -i '$d' "$shim"
+  cat >> "$shim" <<'SHIM'
+eval "$(declare -f fsync_path | sed '1s/fsync_path/original_fsync_path/')"
+fsync_path() {
+  if [[ ${controller_test_hooks_enabled:-false} == true &&
+        "$1" == */.writer-stop-evidence.* &&
+        ! -e "$controller_fixture_root/writer-stop-evidence-fsync-failure-consumed" ]]; then
+    : > "$controller_fixture_root/writer-stop-evidence-fsync-failure-consumed"
+    return 74
+  fi
+  original_fsync_path "$@"
+}
+main "$@"
+SHIM
+  chmod 0700 "$shim"
+  printf '%s\n' "$shim"
+}
+
+write_writer_stop_postrename_fsync_failure_shim() {
+  local fixture_dir=$1 shim
+  shim=$(write_systemd_identity_shim "$fixture_dir")
+  sed -i '$d' "$shim"
+  cat >> "$shim" <<'SHIM'
+eval "$(declare -f fsync_path | sed '1s/fsync_path/original_fsync_path/')"
+fsync_path() {
+  if [[ ${controller_test_hooks_enabled:-false} == true &&
+        "$1" == "$controller_fixture_root" &&
+        ! -e "$controller_fixture_root/writer-stop-postrename-fsync-failure-consumed" ]] &&
+     compgen -G "${controller_state%.json}.writer-stop*.evidence.json" >/dev/null; then
+    : > "$controller_fixture_root/writer-stop-postrename-fsync-failure-consumed"
+    return 74
+  fi
+  original_fsync_path "$@"
+}
+main "$@"
+SHIM
+  chmod 0700 "$shim"
+  printf '%s\n' "$shim"
+}
+
+write_authorization_evidence_late_failure_shim() {
+  local fixture_dir=$1 shim
+  shim=$(write_systemd_identity_shim "$fixture_dir")
+  sed -i '$d' "$shim"
+  cat >> "$shim" <<'SHIM'
+eval "$(declare -f bind_process_evidence_to_state | sed '1s/bind_process_evidence_to_state/original_bind_process_evidence_to_state/')"
+bind_process_evidence_to_state() {
+  local key=$2
+  original_bind_process_evidence_to_state "$@"
+  if [[ ${controller_test_hooks_enabled:-false} == true &&
+        "$key" == authorizationEvidence &&
+        ! -e "$controller_fixture_root/authorization-evidence-late-failure-consumed" ]]; then
+    : > "$controller_fixture_root/authorization-evidence-late-failure-consumed"
+    return 74
+  fi
+}
+main "$@"
+SHIM
+  chmod 0700 "$shim"
+  printf '%s\n' "$shim"
+}
+
+write_closure_intent_fsync_failure_shim() {
+  local fixture_dir=$1 shim
+  shim=$(write_systemd_identity_shim "$fixture_dir")
+  sed -i '$d' "$shim"
+  cat >> "$shim" <<'SHIM'
+eval "$(declare -f write_controller_state_atomic | sed '1s/write_controller_state_atomic/original_write_controller_state_atomic/')"
+write_controller_state_atomic() {
+  local source=$2
+  if [[ ${controller_test_hooks_enabled:-false} == true &&
+        $(jq -r '.phase // empty' "$source") == closure-stop-pending &&
+        ! -e "$controller_fixture_root/closure-intent-fsync-failure-consumed" ]]; then
+    : > "$controller_fixture_root/closure-intent-fsync-failure-consumed"
+    return 73
+  fi
+  original_write_controller_state_atomic "$@"
 }
 main "$@"
 SHIM
@@ -5315,6 +5438,934 @@ test_real_docker_rehearsal_declares_interruption_resume_coverage() (
   }
 )
 
+test_activation_uses_only_bound_compose_interpolation_values() (
+  local fixture_dir fake_docker state env_file candidate live selected
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf -- "$fixture_dir"' EXIT
+  fake_docker="$fixture_dir/docker"
+  state="$fixture_dir/controller.json"
+  env_file="$fixture_dir/runtime.env"
+  candidate="$fixture_dir/candidate-compose.yml"
+  live="$fixture_dir/docker-compose.yml"
+
+  cat > "$fake_docker" <<'DOCKER'
+#!/bin/bash -p
+set -Eeuo pipefail
+root=$(/usr/bin/dirname "$0")
+case ${1:-} in
+  inspect)
+    if [[ -e "$root/app-running" ]]; then
+      printf 'true\n'
+    else
+      printf 'false\n'
+    fi
+    ;;
+  compose)
+    env_file=''
+    while (($# > 0)); do
+      if [[ $1 == --env-file ]]; then
+        shift
+        env_file=$1
+        break
+      fi
+      shift
+    done
+    [[ -n "$env_file" ]]
+    bound_image=$(/usr/bin/sed -n 's/^APP_IMAGE=//p' "$env_file" | /usr/bin/tail -1)
+    selected_image=${APP_IMAGE:-$bound_image}
+    printf '%s\n' "$selected_image" > "$root/selected-image"
+    : > "$root/app-running"
+    ;;
+  *) exit 64 ;;
+esac
+DOCKER
+  chmod 0700 "$fake_docker"
+  printf 'APP_IMAGE=expected/image@sha256:bound\n' > "$env_file"
+  printf 'services:\n  app:\n    image: ${APP_IMAGE}\n' > "$candidate"
+  printf 'source-model\n' > "$live"
+  chmod 0600 "$env_file" "$candidate" "$live"
+  jq -n \
+    --arg dockerPath "$fake_docker" \
+    --arg appContainer fixture-app \
+    --arg liveCompose "$live" \
+    '{dockerPath:$dockerPath,appContainer:$appContainer,liveCompose:$liveCompose}' > "$state"
+  chmod 0600 "$state"
+
+  eval "$(extract_function activate_application_for_verification)"
+  die() {
+    printf 'fixture: %s\n' "$*" >&2
+    exit 1
+  }
+  execution_docker_path=$fake_docker
+  execution_env_file=$env_file
+  execution_candidate_compose=$candidate
+  HOME="$fixture_dir/home"
+  DOCKER_CONFIG="$HOME/docker"
+  DOCKER_HOST='unix:///fixture/docker.sock'
+  PATH='/usr/sbin:/usr/bin:/sbin:/bin'
+  export HOME DOCKER_CONFIG DOCKER_HOST PATH
+
+  APP_IMAGE=attacker/image \
+    activate_application_for_verification "$state" || {
+      echo 'activation fixture failed before observing Compose interpolation' >&2
+      exit 1
+    }
+  selected=$(<"$fixture_dir/selected-image")
+  [[ "$selected" == expected/image@sha256:bound ]] || {
+    printf 'ambient APP_IMAGE overrode the bound Compose env file during activation: %s\n' \
+      "$selected" >&2
+    exit 1
+  }
+)
+
+test_authorization_postprocessing_failure_closes_writer_durably() (
+  local fixture_dir manifest state shim rc=0 lifecycle control_tail
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf -- "$fixture_dir"' EXIT
+  manifest="$fixture_dir/manifest.json"
+  state="$fixture_dir/controller.json"
+  write_execution_fixture "$fixture_dir" "$manifest"
+  export XDG_RUNTIME_DIR="$fixture_dir/locks"
+  shim=$(write_systemd_identity_shim "$fixture_dir")
+  "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
+
+  run_fixture_controller "$state" "$shim" env \
+    NOOSPHERE_CONTROLLER_TEST_FAIL_EVIDENCE=authorization-running \
+    >"$fixture_dir/controller.out" 2>"$fixture_dir/controller.err" || rc=$?
+
+  ((rc != 0)) || {
+    echo 'authorization evidence postprocessing failure unexpectedly reported success' >&2
+    exit 1
+  }
+  rg -Fq 'test evidence failure at phase authorization-running' \
+    "$fixture_dir/controller.err" || {
+      echo 'authorization postprocessing owner missed its injected evidence failure' >&2
+      exit 1
+    }
+  lifecycle=$(paste -sd, "$fixture_dir/lifecycle.log" 2>/dev/null || true)
+  [[ "$lifecycle" == transition,authorize ]] || {
+    printf 'authorization postprocessing failure crossed the activation boundary: %s\n' \
+      "$lifecycle" >&2
+    exit 1
+  }
+  [[ ! -e "$fixture_dir/app-started" ]] || {
+    echo 'authorization postprocessing failure activated the application writer' >&2
+    exit 1
+  }
+  if [[ -f "$fixture_dir/app-control.log" ]]; then
+    control_tail=$(tail -n 2 "$fixture_dir/app-control.log" | paste -sd, -)
+  else
+    control_tail=''
+  fi
+  [[ "$control_tail" == stop,inspect:false ]] || {
+    echo 'authorization postprocessing failure did not inspect-verify writer closure' >&2
+    exit 1
+  }
+  jq -e '
+    .phase == "incident" and
+    .incidentClass == "closure-authorization-evidence" and
+    .proofException == "authorization-evidence-unavailable" and
+    (.writerStopEvidence.path | type == "string" and startswith("/")) and
+    (.writerStopEvidence.sha256 | type == "string" and test("^[a-f0-9]{64}$"))
+  ' "$state" >/dev/null || {
+    echo 'authorization postprocessing failure lacks a durable closure incident and writer-stop proof' >&2
+    exit 1
+  }
+)
+
+test_authorization_postprocessing_ordinary_failure_is_fail_closed() (
+  local fixture_dir manifest state shim rc=0 lifecycle control_tail
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf -- "$fixture_dir"' EXIT
+  manifest="$fixture_dir/manifest.json"
+  state="$fixture_dir/controller.json"
+  write_execution_fixture "$fixture_dir" "$manifest"
+  : > "$fixture_dir/fail-authorization-postprocessing-fsync"
+  export XDG_RUNTIME_DIR="$fixture_dir/locks"
+  shim=$(write_authorization_postprocessing_non_die_failure_shim "$fixture_dir")
+  "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
+
+  run_fixture_controller "$state" "$shim" \
+    >"$fixture_dir/controller.out" 2>"$fixture_dir/controller.err" || rc=$?
+
+  [[ -e "$fixture_dir/authorization-postprocessing-fsync-failure-consumed" ]] || {
+    echo 'authorization postprocessing owner missed its ordinary fsync failure' >&2
+    exit 1
+  }
+  ((rc != 0)) || {
+    echo 'ordinary authorization postprocessing failure was ignored under conditional errexit' >&2
+    exit 1
+  }
+  lifecycle=$(paste -sd, "$fixture_dir/lifecycle.log" 2>/dev/null || true)
+  [[ "$lifecycle" == transition,authorize ]] || {
+    printf 'ordinary authorization postprocessing failure crossed the activation boundary: %s\n' \
+      "$lifecycle" >&2
+    exit 1
+  }
+  [[ ! -e "$fixture_dir/app-started" ]] || {
+    echo 'ordinary authorization postprocessing failure activated the application writer' >&2
+    exit 1
+  }
+  if [[ -f "$fixture_dir/app-control.log" ]]; then
+    control_tail=$(tail -n 2 "$fixture_dir/app-control.log" | paste -sd, -)
+  else
+    control_tail=''
+  fi
+  [[ "$control_tail" == stop,inspect:false ]] || {
+    echo 'ordinary authorization postprocessing failure did not inspect-verify writer closure' >&2
+    exit 1
+  }
+  jq -e '
+    .phase == "incident" and
+    .incidentClass == "closure-authorization-evidence" and
+    .proofException == "authorization-evidence-unavailable" and
+    (.writerStopEvidence.path | type == "string" and startswith("/")) and
+    (.writerStopEvidence.sha256 | type == "string" and test("^[a-f0-9]{64}$"))
+  ' "$state" >/dev/null || {
+    echo 'ordinary authorization postprocessing failure lacks its exact durable closure proof' >&2
+    exit 1
+  }
+)
+
+test_closure_postprocessing_proof_exception_is_scoped() (
+  local fixture_dir manifest state mutated shim rc=0
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf -- "$fixture_dir"' EXIT
+  manifest="$fixture_dir/manifest.json"
+  state="$fixture_dir/controller.json"
+  mutated="$fixture_dir/missing-authorization-evidence.json"
+  write_execution_fixture "$fixture_dir" "$manifest" complete success
+  export XDG_RUNTIME_DIR="$fixture_dir/locks"
+  shim=$(write_phase_snapshot_shim "$fixture_dir")
+  "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
+
+  run_fixture_controller "$state" "$shim" env \
+    NOOSPHERE_CONTROLLER_TEST_FAIL_EVIDENCE=closure-running \
+    NOOSPHERE_CONTROLLER_TEST_CAPTURE_PHASE=closure-stop-pending \
+    NOOSPHERE_CONTROLLER_TEST_CAPTURE_INCIDENT_CLASS=closure-postprocessing \
+    >"$fixture_dir/controller.out" 2>"$fixture_dir/controller.err" || rc=$?
+
+  [[ "$rc" == 86 && -e "$fixture_dir/controller-phase-snapshot-captured" ]] || {
+    echo 'controller did not capture the later closure-postprocessing baseline' >&2
+    exit 1
+  }
+  /bin/bash -c 'source "$1"; validate_controller_state "$2"' \
+    _ "$CONTROLLER" "$state"
+
+  jq '.proofException = "authorization-evidence-unavailable" | del(.authorizationEvidence)' \
+    "$state" > "$mutated"
+  chmod 0600 "$mutated"
+  if /bin/bash -c 'source "$1"; validate_controller_state "$2"' \
+    _ "$CONTROLLER" "$mutated" \
+      >"$fixture_dir/validate.out" 2>"$fixture_dir/validate.err"; then
+    echo 'later closure-postprocessing accepted missing authorization evidence' >&2
+    exit 1
+  fi
+  rg -qi 'authorization.*evidence.*(required|exception)|(required|exception).*authorization.*evidence' \
+    "$fixture_dir/validate.err" || {
+      echo 'missing authorization-evidence rejection lacked its proof diagnostic' >&2
+      exit 1
+  }
+)
+
+test_phase_state_fsync_failure_does_not_advance() (
+  local fixture_dir state rc=0
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf -- "$fixture_dir"' EXIT
+  state="$fixture_dir/controller.json"
+  printf '{"phase":"prepared"}\n' > "$state"
+  chmod 0600 "$state"
+
+  eval "$(extract_function path_present)"
+  eval "$(extract_function assert_owned_regular_file)"
+  eval "$(extract_function write_controller_state_atomic)"
+  eval "$(extract_function update_controller_phase)"
+  validate_controller_state() { :; }
+  record_controller_interruption() { :; }
+  die() {
+    printf 'fixture: %s\n' "$*" >&2
+    exit 1
+  }
+  fsync_path() {
+    if [[ "$1" == "$state.tmp."* &&
+          ! -e "$fixture_dir/state-fsync-failure-consumed" ]]; then
+      : > "$fixture_dir/state-fsync-failure-consumed"
+      return 74
+    fi
+    :
+  }
+
+  set +e
+  update_controller_phase "$state" candidate-published \
+    >"$fixture_dir/update.out" 2>"$fixture_dir/update.err"
+  rc=$?
+  set -e
+
+  [[ -e "$fixture_dir/state-fsync-failure-consumed" ]] || {
+    echo 'phase-state owner missed its injected fsync failure' >&2
+    exit 1
+  }
+  ((rc != 0)) || {
+    echo 'phase-state fsync failure was swallowed as success' >&2
+    exit 1
+  }
+  [[ $(jq -er '.phase' "$state") == prepared ]] || {
+    echo 'phase-state fsync failure still advanced the controller phase' >&2
+    exit 1
+  }
+)
+
+test_writer_stop_evidence_fsync_failure_is_not_bound() (
+  local fixture_dir manifest state shim rc=0 control_tail
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf -- "$fixture_dir"' EXIT
+  manifest="$fixture_dir/manifest.json"
+  state="$fixture_dir/controller.json"
+  write_execution_fixture "$fixture_dir" "$manifest" complete fail
+  export XDG_RUNTIME_DIR="$fixture_dir/locks"
+  shim=$(write_writer_stop_evidence_fsync_failure_shim "$fixture_dir")
+  "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
+
+  run_fixture_controller "$state" "$shim" \
+    >"$fixture_dir/controller.out" 2>"$fixture_dir/controller.err" || rc=$?
+
+  [[ -e "$fixture_dir/writer-stop-evidence-fsync-failure-consumed" ]] || {
+    echo 'writer-stop owner missed its injected evidence fsync failure' >&2
+    exit 1
+  }
+  ((rc != 0)) || {
+    echo 'writer-stop evidence fsync failure unexpectedly reported success' >&2
+    exit 1
+  }
+  if [[ -f "$fixture_dir/app-control.log" ]]; then
+    control_tail=$(tail -n 2 "$fixture_dir/app-control.log" | paste -sd, -)
+  else
+    control_tail=''
+  fi
+  [[ "$control_tail" == stop,inspect:false ]] || {
+    echo 'writer-stop evidence failure did not inspect-verify the application stop' >&2
+    exit 1
+  }
+  jq -e '
+    .phase == "closure-stop-pending" and
+    .incidentClass == "closure-verification" and
+    (has("writerStopEvidence") | not)
+  ' "$state" >/dev/null || {
+    echo 'writer-stop evidence fsync failure advanced or bound non-durable evidence' >&2
+    exit 1
+  }
+  [[ ! -e "${state%.json}.writer-stop.evidence.json" ]] || {
+    echo 'writer-stop evidence fsync failure published a non-durable evidence file' >&2
+    exit 1
+  }
+)
+
+test_late_authorization_evidence_failure_remains_resumable() (
+  local fixture_dir manifest state shim rc=0 retry_rc=0 control_tail
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf -- "$fixture_dir"' EXIT
+  manifest="$fixture_dir/manifest.json"
+  state="$fixture_dir/controller.json"
+  write_execution_fixture "$fixture_dir" "$manifest"
+  export XDG_RUNTIME_DIR="$fixture_dir/locks"
+  shim=$(write_authorization_evidence_late_failure_shim "$fixture_dir")
+  "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
+
+  run_fixture_controller "$state" "$shim" \
+    >"$fixture_dir/controller.out" 2>"$fixture_dir/controller.err" || rc=$?
+
+  [[ -e "$fixture_dir/authorization-evidence-late-failure-consumed" ]] || {
+    echo 'late authorization-evidence owner missed its injected bind failure' >&2
+    exit 1
+  }
+  ((rc != 0)) || {
+    echo 'late authorization-evidence failure unexpectedly reported success' >&2
+    exit 1
+  }
+  control_tail=$(tail -n 2 "$fixture_dir/app-control.log" 2>/dev/null | paste -sd, -)
+  [[ "$control_tail" == stop,inspect:false ]] || {
+    echo 'late authorization-evidence failure did not inspect-verify writer closure' >&2
+    exit 1
+  }
+  jq -e '
+    .phase == "incident" and
+    .incidentClass == "closure-authorization-evidence" and
+    .proofException == "authorization-evidence-unavailable" and
+    (has("authorizationEvidence") | not) and
+    (.writerStopEvidence.path | type == "string" and startswith("/"))
+  ' "$state" >/dev/null || {
+    echo 'late authorization-evidence failure stranded an invalid closure state' >&2
+    exit 1
+  }
+  /bin/bash -c 'source "$1"; validate_controller_state "$2"' \
+    _ "$CONTROLLER" "$state" || {
+      echo 'late authorization-evidence incident is not independently resumable' >&2
+      exit 1
+    }
+
+  NOOSPHERE_CONTROLLER_FIXTURE_INVOCATION_ID=fedcba9876543210fedcba9876543210 \
+    run_fixture_controller "$state" "$shim" \
+      >"$fixture_dir/retry.out" 2>"$fixture_dir/retry.err" || retry_rc=$?
+  ((retry_rc != 0)) || {
+    echo 'terminal authorization-evidence incident unexpectedly resumed execution' >&2
+    exit 1
+  }
+  jq -e '
+    .phase == "incident" and
+    .incidentClass == "closure-authorization-evidence" and
+    .proofException == "authorization-evidence-unavailable" and
+    (has("authorizationEvidence") | not)
+  ' "$state" >/dev/null || {
+    echo 'terminal authorization-evidence retry changed the durable incident' >&2
+    exit 1
+  }
+)
+
+test_closure_intent_failure_preserves_status_and_blocks_reauthorization() (
+  local fixture_dir manifest state shim rc=0 retry_rc=0 lifecycle control_tail
+  local -a failures=()
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf -- "$fixture_dir"' EXIT
+  manifest="$fixture_dir/manifest.json"
+  state="$fixture_dir/controller.json"
+  write_execution_fixture "$fixture_dir" "$manifest"
+  export XDG_RUNTIME_DIR="$fixture_dir/locks"
+  shim=$(write_closure_intent_fsync_failure_shim "$fixture_dir")
+  "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
+
+  run_fixture_controller "$state" "$shim" env \
+    NOOSPHERE_CONTROLLER_TEST_FAIL_EVIDENCE=authorization-running \
+    >"$fixture_dir/controller.out" 2>"$fixture_dir/controller.err" || rc=$?
+
+  [[ -e "$fixture_dir/closure-intent-fsync-failure-consumed" ]] ||
+    failures+=('closure-intent owner missed its injected state-publication failure')
+  [[ "$rc" == 73 ]] ||
+    failures+=("closure-intent failure returned $rc instead of preserving status 73")
+  control_tail=$(tail -n 2 "$fixture_dir/app-control.log" 2>/dev/null | paste -sd, -)
+  [[ "$control_tail" == stop,inspect:false ]] ||
+    failures+=("closure-intent failure lacked an inspect-verified stop (control_tail=$control_tail)")
+  jq -e '
+    .phase == "authorization-running" and
+    (.writerStopEvidence.path | type == "string" and startswith("/")) and
+    (.writerStopEvidence.sha256 | type == "string" and test("^[a-f0-9]{64}$"))
+  ' "$state" >/dev/null ||
+    failures+=('closure-intent failure did not preserve its truthful pre-intent phase and writer-stop proof')
+
+  NOOSPHERE_CONTROLLER_FIXTURE_INVOCATION_ID=fedcba9876543210fedcba9876543210 \
+    run_fixture_controller "$state" "$shim" \
+      >"$fixture_dir/retry.out" 2>"$fixture_dir/retry.err" || retry_rc=$?
+  ((retry_rc != 0)) ||
+    failures+=('closure-intent failure remained resumable through writer reauthorization')
+  rg -Fq 'verified writer stop without a terminal incident' "$fixture_dir/retry.err" ||
+    failures+=('closure-intent retry lacked the nonterminal writer-stop refusal diagnostic')
+  lifecycle=$(paste -sd, "$fixture_dir/lifecycle.log" 2>/dev/null || true)
+  [[ "$lifecycle" == transition,authorize ]] ||
+    failures+=("closure-intent retry crossed reauthorization/activation boundary: $lifecycle")
+
+  ((${#failures[@]} == 0)) || {
+    printf '%s\n' "${failures[@]}" >&2
+    exit 1
+  }
+)
+
+test_initial_activation_inspect_failure_commits_durable_closure() (
+  local fixture_dir manifest state shim rc=0 retry_rc=0 lifecycle control_tail
+  local -a failures=()
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf -- "$fixture_dir"' EXIT
+  manifest="$fixture_dir/manifest.json"
+  state="$fixture_dir/controller.json"
+  write_execution_fixture "$fixture_dir" "$manifest"
+  : > "$fixture_dir/fail-initial-activation-inspect"
+  export XDG_RUNTIME_DIR="$fixture_dir/locks"
+  shim=$(write_systemd_identity_shim "$fixture_dir")
+  "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
+
+  run_fixture_controller "$state" "$shim" \
+    >"$fixture_dir/controller.out" 2>"$fixture_dir/controller.err" || rc=$?
+  [[ -e "$fixture_dir/initial-activation-inspect-failure-consumed" ]] ||
+    failures+=('activation-inspect owner missed the initial inspect boundary')
+  ((rc != 0)) || failures+=('initial activation inspect failure unexpectedly reported success')
+  lifecycle=$(paste -sd, "$fixture_dir/lifecycle.log" 2>/dev/null || true)
+  [[ "$lifecycle" == transition,authorize ]] ||
+    failures+=("initial activation inspect failure crossed activation: $lifecycle")
+  if [[ -f "$fixture_dir/app-control.log" ]]; then
+    control_tail=$(tail -n 2 "$fixture_dir/app-control.log" | paste -sd, -)
+  else
+    control_tail=''
+  fi
+  [[ "$control_tail" == stop,inspect:false ]] ||
+    failures+=("initial activation inspect failure lacked a fresh stop proof (control_tail=$control_tail)")
+  jq -e '
+    .phase == "incident" and
+    .incidentClass == "closure-app-activation" and
+    (.authorizationEvidence.sha256 | test("^[a-f0-9]{64}$")) and
+    (.writerStopEvidence.sha256 | test("^[a-f0-9]{64}$"))
+  ' "$state" >/dev/null ||
+    failures+=('initial activation inspect failure bypassed durable app-activation closure')
+
+  NOOSPHERE_CONTROLLER_FIXTURE_INVOCATION_ID=fedcba9876543210fedcba9876543210 \
+    run_fixture_controller "$state" "$shim" \
+      >"$fixture_dir/retry.out" 2>"$fixture_dir/retry.err" || retry_rc=$?
+  ((retry_rc != 0)) || failures+=('activation-inspect incident was resumable')
+  [[ $(paste -sd, "$fixture_dir/lifecycle.log" 2>/dev/null || true) == transition,authorize ]] ||
+    failures+=('activation-inspect incident retry reauthorized or activated the writer')
+
+  ((${#failures[@]} == 0)) || {
+    printf '%s\n' "${failures[@]}" >&2
+    exit 1
+  }
+)
+
+test_compose_publication_is_anchored_against_ancestor_retarget() (
+  local fixture_dir source_root original_root attacker_root target_root source target
+  local -a failures=()
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf -- "$fixture_dir"' EXIT
+  source_root="$fixture_dir/source-root"
+  original_root="$fixture_dir/source-root-original"
+  attacker_root="$fixture_dir/attacker-root"
+  target_root="$fixture_dir/target-root"
+  install -d -m 700 "$source_root/parent" "$attacker_root/parent" "$target_root"
+  source="$source_root/parent/candidate.yml"
+  target="$target_root/live-compose.yml"
+  printf 'reviewed-candidate\n' > "$source"
+  printf 'attacker-candidate\n' > "$attacker_root/parent/candidate.yml"
+  printf 'source-model\n' > "$target"
+  chmod 0600 "$source" "$attacker_root/parent/candidate.yml" "$target"
+
+  eval "$(extract_function assert_owned_regular_file)"
+  eval "$(extract_function publish_compose_atomic)"
+  die() { printf 'fixture: %s\n' "$*" >&2; exit 1; }
+  fsync_path() { :; }
+  mktemp() {
+    if [[ $1 == *.item3-publish.* &&
+          ! -e "$fixture_dir/ancestor-retarget-consumed" ]]; then
+      command mv "$source_root" "$original_root"
+      command ln -s "$attacker_root" "$source_root"
+      : > "$fixture_dir/ancestor-retarget-consumed"
+    fi
+    command mktemp "$@"
+  }
+
+  if ! publish_compose_atomic "$source" "$target"; then
+    failures+=('anchored publication rejected a path that was safe when opened')
+  fi
+  [[ -e "$fixture_dir/ancestor-retarget-consumed" ]] ||
+    failures+=('publication owner missed its deterministic ancestor retarget')
+  [[ $(<"$target") == reviewed-candidate ]] ||
+    failures+=("ancestor retarget substituted publication bytes: $(<"$target")")
+
+  ((${#failures[@]} == 0)) || {
+    printf '%s\n' "${failures[@]}" >&2
+    exit 1
+  }
+)
+
+test_simulated_root_rejects_root_owned_writable_compose_parent() (
+  local fixture_dir unsafe_dir safe_dir source target definition mutant
+  local -a failures=()
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf -- "$fixture_dir"' EXIT
+  unsafe_dir="$fixture_dir/root-owned-writable"
+  safe_dir="$fixture_dir/safe"
+  install -d -m 777 "$unsafe_dir"
+  install -d -m 700 "$safe_dir"
+  source="$unsafe_dir/candidate.yml"
+  target="$safe_dir/live-compose.yml"
+  printf 'candidate-model\n' > "$source"
+  printf 'source-model\n' > "$target"
+  chmod 0600 "$source" "$target"
+
+  eval "$(extract_function assert_owned_regular_file)"
+  definition=$(extract_function publish_compose_atomic)
+  eval "$definition"
+  die() { printf 'fixture: %s\n' "$*" >&2; exit 1; }
+  fsync_path() { :; }
+  id() {
+    [[ ${1:-} == -u ]] && { printf '0\n'; return; }
+    command id "$@"
+  }
+  stat() {
+    if [[ $1 == -c && $2 == %u &&
+          ( $3 == "$fixture_dir"/* || $3 == /proc/*/fd/* ) ]]; then
+      printf '0\n'
+      return
+    fi
+    command stat "$@"
+  }
+
+  if (publish_compose_atomic "$source" "$target"); then
+    failures+=('simulated root accepted a root-owned mode-0777 publication parent')
+  fi
+  [[ $(<"$target") == source-model ]] ||
+    failures+=('simulated-root writable-parent rejection changed target bytes')
+
+  # Mutation proof: delete only the parent-mode guard from an extracted copy.
+  # The same owner must then expose the unsafe publication by observing the
+  # target overwrite; this keeps the fixture meaningful under a root runner.
+  mutant=$(printf '%s\n' "$definition" | awk '
+    /^publish_compose_atomic\(\) \{/ { sub(/publish_compose_atomic/, "publish_compose_atomic_without_parent_mode") }
+    /^[[:space:]]*parent_mode=\$\(stat -c/ { skip = 2; next }
+    skip > 0 { skip--; next }
+    { print }
+  ')
+  eval "$mutant"
+  printf 'source-model\n' > "$target"
+  if ! publish_compose_atomic_without_parent_mode "$source" "$target"; then
+    failures+=('simulated-root owner could not exercise its parent-mode mutation')
+  elif [[ $(<"$target") != candidate-model ]]; then
+    failures+=('simulated-root owner did not detect the removed parent-mode guard')
+  fi
+
+  ((${#failures[@]} == 0)) || {
+    printf '%s\n' "${failures[@]}" >&2
+    exit 1
+  }
+)
+
+test_foreign_owned_compose_parents_are_rejected() (
+  local fixture_dir safe_source_dir safe_target_dir foreign_source_dir foreign_target_dir
+  local source target simulated_current_uid=0 foreign_uid
+  local -a failures=()
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf -- "$fixture_dir"' EXIT
+  safe_source_dir="$fixture_dir/safe-source"
+  safe_target_dir="$fixture_dir/safe-target"
+  foreign_source_dir="$fixture_dir/foreign-source"
+  foreign_target_dir="$fixture_dir/foreign-target"
+  install -d -m 700 \
+    "$safe_source_dir" "$safe_target_dir" "$foreign_source_dir" "$foreign_target_dir"
+  foreign_uid=$(( simulated_current_uid == 0 ? 1 : 0 ))
+
+  eval "$(extract_function assert_owned_regular_file)"
+  eval "$(extract_function publish_compose_atomic)"
+  die() {
+    printf 'fixture: %s\n' "$*" >&2
+    exit 1
+  }
+  fsync_path() { :; }
+  id() {
+    if [[ ${1:-} == -u ]]; then
+      printf '%s\n' "$simulated_current_uid"
+      return 0
+    fi
+    command id "$@"
+  }
+  stat() {
+    if [[ $1 == -c && $2 == %u ]]; then
+      if [[ $3 == "$foreign_source_dir" || $3 == "$foreign_target_dir" ]]; then
+        printf '%s\n' "$foreign_uid"
+        return 0
+      fi
+      if [[ $3 == "$fixture_dir"/* ]]; then
+        printf '%s\n' "$simulated_current_uid"
+        return 0
+      fi
+    fi
+    command stat "$@"
+  }
+
+  source="$foreign_source_dir/candidate.yml"
+  target="$safe_target_dir/live-compose.yml"
+  printf 'candidate-from-foreign-parent\n' > "$source"
+  printf 'source-model\n' > "$target"
+  chmod 0600 "$source" "$target"
+  if (publish_compose_atomic "$source" "$target"); then
+    failures+=('publication accepted a foreign-owned source parent')
+  fi
+  [[ $(<"$target") == source-model ]] ||
+    failures+=('foreign-owned source parent rejection overwrote the live Compose target')
+
+  source="$safe_source_dir/candidate.yml"
+  target="$foreign_target_dir/live-compose.yml"
+  printf 'candidate-to-foreign-parent\n' > "$source"
+  printf 'source-model\n' > "$target"
+  chmod 0600 "$source" "$target"
+  if (publish_compose_atomic "$source" "$target"); then
+    failures+=('publication accepted a foreign-owned target parent')
+  fi
+  [[ $(<"$target") == source-model ]] ||
+    failures+=('foreign-owned target parent rejection overwrote the live Compose target')
+
+  ((${#failures[@]} == 0)) || {
+    printf '%s\n' "${failures[@]}" >&2
+    exit 1
+  }
+)
+
+test_preopen_parent_retarget_cannot_substitute_publication_identity() (
+  local fixture_dir source_parent original_parent attacker_parent target_parent source target rc=0
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf -- "$fixture_dir"' EXIT
+  source_parent="$fixture_dir/source-parent"
+  original_parent="$fixture_dir/source-parent-original"
+  attacker_parent="$fixture_dir/attacker-parent"
+  target_parent="$fixture_dir/target-parent"
+  install -d -m 700 "$source_parent" "$attacker_parent" "$target_parent"
+  source="$source_parent/candidate.yml"
+  target="$target_parent/live-compose.yml"
+  printf 'reviewed-candidate\n' > "$source"
+  printf 'attacker-candidate\n' > "$attacker_parent/candidate.yml"
+  printf 'source-model\n' > "$target"
+  chmod 0600 "$source" "$attacker_parent/candidate.yml" "$target"
+
+  eval "$(extract_function assert_owned_regular_file)"
+  eval "$(extract_function publish_compose_atomic)"
+  die() { printf 'fixture: %s\n' "$*" >&2; exit 1; }
+  fsync_path() { :; }
+  stat() {
+    local result
+    if [[ $1 == -c && $2 == %a && $3 == "$target_parent" &&
+          ! -e "$fixture_dir/preopen-parent-retarget-consumed" ]]; then
+      result=$(command stat "$@")
+      printf '%s\n' "$result"
+      command mv "$source_parent" "$original_parent"
+      command ln -s "$attacker_parent" "$source_parent"
+      : > "$fixture_dir/preopen-parent-retarget-consumed"
+      return 0
+    fi
+    command stat "$@"
+  }
+
+  publish_compose_atomic "$source" "$target" || rc=$?
+  [[ -e "$fixture_dir/preopen-parent-retarget-consumed" ]] || {
+    echo 'pre-open parent-retarget owner missed the final validation boundary' >&2
+    exit 1
+  }
+  if ((rc == 0)) && [[ $(<"$target") != reviewed-candidate ]]; then
+    printf 'pre-open parent retarget substituted publication bytes: %s\n' \
+      "$(<"$target")" >&2
+    exit 1
+  fi
+  ((rc != 0)) || [[ $(<"$target") == reviewed-candidate ]]
+)
+
+test_candidate_entry_swap_cannot_escape_prepared_digest() (
+  local fixture_dir candidate_parent target_parent candidate live source_snapshot state
+  local expected_candidate_sha source_sha rc=0
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf -- "$fixture_dir"' EXIT
+  candidate_parent="$fixture_dir/candidate-parent"
+  target_parent="$fixture_dir/target-parent"
+  install -d -m 700 "$candidate_parent" "$target_parent"
+  candidate="$candidate_parent/candidate.yml"
+  live="$target_parent/live-compose.yml"
+  source_snapshot="$fixture_dir/source-compose.yml"
+  state="$fixture_dir/controller.json"
+  printf 'reviewed-candidate\n' > "$candidate"
+  printf 'source-model\n' > "$live"
+  printf 'source-model\n' > "$source_snapshot"
+  chmod 0600 "$candidate" "$live" "$source_snapshot"
+  expected_candidate_sha=$(sha256sum "$candidate" | awk '{print $1}')
+  source_sha=$(sha256sum "$source_snapshot" | awk '{print $1}')
+  jq -n \
+    --arg liveCompose "$live" \
+    --arg sourceSnapshot "$source_snapshot" \
+    --arg sourceSha "$source_sha" \
+    --arg candidateSha "$expected_candidate_sha" \
+    '{phase:"prepared",engineId:"fixture-engine",volume:"fixture-volume",
+      liveCompose:$liveCompose,sourceSnapshot:$sourceSnapshot,
+      sourceSnapshotSha256:$sourceSha,candidateComposeSha256:$candidateSha}' > "$state"
+  chmod 0600 "$state"
+
+  eval "$(extract_function path_present)"
+  eval "$(extract_function assert_owned_regular_file)"
+  eval "$(extract_function sha256_file)"
+  eval "$(extract_function publish_compose_atomic)"
+  eval "$(extract_function publish_candidate_under_lock)"
+  die() { printf 'fixture: %s\n' "$*" >&2; exit 1; }
+  fsync_path() { :; }
+  validate_controller_state() { :; }
+  assert_operation_lock_held() { :; }
+  update_controller_phase() {
+    local next_phase=$2 replacement
+    if [[ "$next_phase" == candidate-published &&
+          ! -e "$fixture_dir/candidate-entry-swap-consumed" ]]; then
+      replacement="$candidate_parent/candidate.replacement"
+      printf 'attacker-candidate\n' > "$replacement"
+      chmod 0600 "$replacement"
+      command mv -f "$replacement" "$candidate"
+      : > "$fixture_dir/candidate-entry-swap-consumed"
+    fi
+  }
+
+  publish_candidate_under_lock "$state" "$candidate" "$fixture_dir/locks" || rc=$?
+  [[ -e "$fixture_dir/candidate-entry-swap-consumed" ]] || {
+    echo 'candidate-entry owner missed the post-digest publication-intent boundary' >&2
+    exit 1
+  }
+  if ((rc == 0)) && [[ $(sha256sum "$live" | awk '{print $1}') != "$expected_candidate_sha" ]]; then
+    printf 'candidate entry swap published bytes outside the prepared digest: %s\n' \
+      "$(<"$live")" >&2
+    exit 1
+  fi
+  ((rc != 0)) || [[ $(sha256sum "$live" | awk '{print $1}') == "$expected_candidate_sha" ]]
+)
+
+test_closure_intent_and_stop_failure_cannot_cross_writer_boundary() (
+  local fixture_dir manifest state shim initial_rc=0 retry_rc=0 lifecycle phase
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf -- "$fixture_dir"' EXIT
+  manifest="$fixture_dir/manifest.json"
+  state="$fixture_dir/controller.json"
+  write_execution_fixture "$fixture_dir" "$manifest"
+  : > "$fixture_dir/fail-closure-stop-once"
+  export XDG_RUNTIME_DIR="$fixture_dir/locks"
+  shim=$(write_closure_intent_fsync_failure_shim "$fixture_dir")
+  "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
+
+  run_fixture_controller "$state" "$shim" env \
+    NOOSPHERE_CONTROLLER_TEST_FAIL_EVIDENCE=authorization-running \
+    >"$fixture_dir/controller.out" 2>"$fixture_dir/controller.err" || initial_rc=$?
+  ((initial_rc != 0)) || {
+    echo 'dual closure failure unexpectedly reported initial success' >&2
+    exit 1
+  }
+  [[ -e "$fixture_dir/closure-intent-fsync-failure-consumed" &&
+     -e "$fixture_dir/closure-stop-failure-consumed" ]] || {
+    echo 'dual closure owner missed its intent-write or fixture-Docker stop failure' >&2
+    exit 1
+  }
+  phase=$(jq -r '.phase // empty' "$state")
+  [[ "$phase" == authorization-running || "$phase" == activation-running ]] || {
+    printf 'dual closure owner did not retain a resumable writer phase: %s\n' "$phase" >&2
+    exit 1
+  }
+  jq -e 'has("writerStopEvidence") | not' "$state" >/dev/null || {
+    echo 'dual closure owner unexpectedly bound writer-stop evidence' >&2
+    exit 1
+  }
+
+  NOOSPHERE_CONTROLLER_FIXTURE_INVOCATION_ID=fedcba9876543210fedcba9876543210 \
+    run_fixture_controller "$state" "$shim" \
+      >"$fixture_dir/retry.out" 2>"$fixture_dir/retry.err" || retry_rc=$?
+  lifecycle=$(paste -sd, "$fixture_dir/lifecycle.log" 2>/dev/null || true)
+  if [[ "$lifecycle" == *,authorize,authorize* || "$lifecycle" == *,activate* || "$retry_rc" == 0 ]]; then
+    printf 'dual closure failure retry crossed writer reauthorization/reactivation: rc=%s lifecycle=%s\n' \
+      "$retry_rc" "$lifecycle" >&2
+    exit 1
+  fi
+)
+
+test_detached_target_parent_cannot_false_complete_publication() (
+  local fixture_dir source_parent target_parent detached_parent source target rc=0
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf -- "$fixture_dir"' EXIT
+  source_parent="$fixture_dir/source-parent"
+  target_parent="$fixture_dir/target-parent"
+  detached_parent="$fixture_dir/target-parent-detached"
+  install -d -m 700 "$source_parent" "$target_parent"
+  source="$source_parent/candidate.yml"
+  target="$target_parent/live-compose.yml"
+  printf 'reviewed-candidate\n' > "$source"
+  printf 'source-model\n' > "$target"
+  chmod 0600 "$source" "$target"
+
+  eval "$(extract_function assert_owned_regular_file)"
+  eval "$(extract_function publish_compose_atomic)"
+  die() { printf 'fixture: %s\n' "$*" >&2; exit 1; }
+  fsync_path() { :; }
+  mktemp() {
+    if [[ $1 == *.item3-publish.* &&
+          ! -e "$fixture_dir/detached-target-parent-consumed" ]]; then
+      command mv "$target_parent" "$detached_parent"
+      command install -d -m 700 "$target_parent"
+      printf 'source-model\n' > "$target"
+      chmod 0600 "$target"
+      : > "$fixture_dir/detached-target-parent-consumed"
+    fi
+    command mktemp "$@"
+  }
+
+  publish_compose_atomic "$source" "$target" || rc=$?
+  [[ -e "$fixture_dir/detached-target-parent-consumed" ]] || {
+    echo 'detached-target owner missed the post-descriptor publication boundary' >&2
+    exit 1
+  }
+  if ((rc == 0)) && [[ $(<"$target") != reviewed-candidate ]]; then
+    printf 'detached target parent falsely reported publication success: live=%s detached=%s\n' \
+      "$(<"$target")" "$(<"$detached_parent/live-compose.yml")" >&2
+    exit 1
+  fi
+  ((rc != 0)) || [[ $(<"$target") == reviewed-candidate ]]
+)
+
+test_postrename_fsync_failure_cannot_expose_advanced_publications() (
+  local state_case_rc=0 writer_case_rc=0
+
+  (
+    local fixture_dir state rc=0 phase
+    fixture_dir=$(mktemp -d)
+    trap 'rm -rf -- "$fixture_dir"' EXIT
+    state="$fixture_dir/controller.json"
+    printf '{"phase":"prepared"}\n' > "$state"
+    chmod 0600 "$state"
+    eval "$(extract_function path_present)"
+    eval "$(extract_function assert_owned_regular_file)"
+    eval "$(extract_function write_controller_state_atomic)"
+    eval "$(extract_function update_controller_phase)"
+    validate_controller_state() { :; }
+    record_controller_interruption() { :; }
+    die() { printf 'fixture: %s\n' "$*" >&2; exit 1; }
+    fsync_path() {
+      if [[ "$1" == "$fixture_dir" &&
+            ! -e "$fixture_dir/state-postrename-fsync-failure-consumed" ]]; then
+        : > "$fixture_dir/state-postrename-fsync-failure-consumed"
+        return 74
+      fi
+      :
+    }
+    set +e
+    update_controller_phase "$state" candidate-published
+    rc=$?
+    set -e
+    [[ -e "$fixture_dir/state-postrename-fsync-failure-consumed" ]] || {
+      echo 'post-rename state owner missed the parent-directory fsync boundary' >&2
+      exit 1
+    }
+    ((rc != 0)) || {
+      echo 'post-rename state parent-fsync failure unexpectedly reported success' >&2
+      exit 1
+    }
+    phase=$(jq -r '.phase // empty' "$state")
+    [[ "$phase" == prepared ]] || {
+      printf 'post-rename state fsync failure exposed advanced phase: %s\n' "$phase" >&2
+      exit 1
+    }
+  ) || state_case_rc=$?
+
+  (
+    local fixture_dir manifest state shim rc=0 evidence_count
+    fixture_dir=$(mktemp -d)
+    trap 'rm -rf -- "$fixture_dir"' EXIT
+    manifest="$fixture_dir/manifest.json"
+    state="$fixture_dir/controller.json"
+    write_execution_fixture "$fixture_dir" "$manifest" complete fail
+    export XDG_RUNTIME_DIR="$fixture_dir/locks"
+    shim=$(write_writer_stop_postrename_fsync_failure_shim "$fixture_dir")
+    "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
+    run_fixture_controller "$state" "$shim" \
+      >"$fixture_dir/controller.out" 2>"$fixture_dir/controller.err" || rc=$?
+    [[ -e "$fixture_dir/writer-stop-postrename-fsync-failure-consumed" ]] || {
+      echo 'post-rename writer-stop owner missed the evidence parent-directory fsync boundary' >&2
+      exit 1
+    }
+    ((rc != 0)) || {
+      echo 'post-rename writer-stop parent-fsync failure unexpectedly reported success' >&2
+      exit 1
+    }
+    evidence_count=$(compgen -G "${state%.json}.writer-stop*.evidence.json" | wc -l)
+    [[ "$evidence_count" == 0 ]] || {
+      printf 'post-rename writer-stop fsync failure exposed %s advanced evidence object(s)\n' \
+        "$evidence_count" >&2
+      exit 1
+    }
+  ) || writer_case_rc=$?
+
+  ((state_case_rc == 0 && writer_case_rc == 0)) || exit 1
+)
+
 # Per-test isolation helper: clear the durable authority namespace so a
 # prior test's stale record (pointing at an already-rm-rf'd fixture_dir)
 # cannot fire the R3-1 unrecognized-phase arm before the current test
@@ -5555,5 +6606,39 @@ if [[ ${BASH_SOURCE[0]} == "$0" ]]; then
   test_incident_classes_and_stop_proofs_are_closed_world
   _clear_authority_root_for_isolation
   test_real_docker_rehearsal_declares_interruption_resume_coverage
+  _clear_authority_root_for_isolation
+  test_activation_uses_only_bound_compose_interpolation_values
+  _clear_authority_root_for_isolation
+  test_authorization_postprocessing_failure_closes_writer_durably
+  _clear_authority_root_for_isolation
+  test_authorization_postprocessing_ordinary_failure_is_fail_closed
+  _clear_authority_root_for_isolation
+  test_closure_postprocessing_proof_exception_is_scoped
+  _clear_authority_root_for_isolation
+  test_phase_state_fsync_failure_does_not_advance
+  _clear_authority_root_for_isolation
+  test_writer_stop_evidence_fsync_failure_is_not_bound
+  _clear_authority_root_for_isolation
+  test_late_authorization_evidence_failure_remains_resumable
+  _clear_authority_root_for_isolation
+  test_closure_intent_failure_preserves_status_and_blocks_reauthorization
+  _clear_authority_root_for_isolation
+  test_initial_activation_inspect_failure_commits_durable_closure
+  _clear_authority_root_for_isolation
+  test_compose_publication_is_anchored_against_ancestor_retarget
+  _clear_authority_root_for_isolation
+  test_simulated_root_rejects_root_owned_writable_compose_parent
+  _clear_authority_root_for_isolation
+  test_foreign_owned_compose_parents_are_rejected
+  _clear_authority_root_for_isolation
+  test_preopen_parent_retarget_cannot_substitute_publication_identity
+  _clear_authority_root_for_isolation
+  test_candidate_entry_swap_cannot_escape_prepared_digest
+  _clear_authority_root_for_isolation
+  test_closure_intent_and_stop_failure_cannot_cross_writer_boundary
+  _clear_authority_root_for_isolation
+  test_detached_target_parent_cannot_false_complete_publication
+  _clear_authority_root_for_isolation
+  test_postrename_fsync_failure_cannot_expose_advanced_publications
   echo 'PostgreSQL transition controller focused fixtures passed.'
 fi

--- a/scripts/test-pgvector-transition-controller.sh
+++ b/scripts/test-pgvector-transition-controller.sh
@@ -567,6 +567,15 @@ elif [[ ${1:-} == compose ]]; then
     printf 'compose-config:%s\n' "$operation_lock_state" >> "$root/live-identity.log"
     printf 'candidate model\n'
   elif [[ " $* " == *" up "* && " $* " == *" app "* ]]; then
+    if [[ -e "$root/require-bundle-docker-config-on-activation" ]]; then
+      expected_config=$(<"$root/expected-activation-docker-config")
+      selected_plugin="$DOCKER_CONFIG/cli-plugins/docker-compose"
+      printf '%s\n' "$DOCKER_CONFIG" > "$root/activation-docker-config"
+      printf '%s\n' "$selected_plugin" > "$root/activation-compose-plugin"
+      [[ "$DOCKER_CONFIG" == "$expected_config" ]]
+      cmp -s "$DOCKER_CONFIG/config.json" "$root/expected-bundle-docker-config.json"
+      cmp -s "$selected_plugin" "$root/expected-bundle-compose-plugin"
+    fi
     printf 'activate\n' >> "$root/lifecycle.log"
     [[ -e "$root/writer-authorized" ]]
     [[ ! -e "$root/fail-activation" ]] || exit 71
@@ -1039,6 +1048,40 @@ capture_journal_cursor() {
 main "$@"
 SHIM
   } > "$shim"
+  chmod 0700 "$shim"
+  printf '%s\n' "$shim"
+}
+
+write_activation_bundle_namespace_shim() {
+  local fixture_dir=$1 shim
+  shim=$(write_systemd_identity_shim "$fixture_dir")
+  sed -i '$d' "$shim"
+  cat >> "$shim" <<'SHIM'
+eval "$(declare -f create_execution_bundle | sed '1s/create_execution_bundle/original_create_execution_bundle/')"
+create_execution_bundle() {
+  local state=$1 original_home original_plugin
+  original_create_execution_bundle "$@"
+  cp -- "$execution_controller_home/docker/config.json" \
+    "$controller_fixture_root/expected-bundle-docker-config.json"
+  cp -- "$execution_compose_plugin" \
+    "$controller_fixture_root/expected-bundle-compose-plugin"
+  printf '%s\n' "$execution_controller_home/docker" > \
+    "$controller_fixture_root/expected-activation-docker-config"
+
+  original_home=$(jq -er '.controllerHome' "$state")
+  original_plugin=$(jq -er '.composePluginPath' "$state")
+  mkdir -p -- "$original_home/docker/cli-plugins"
+  printf '{"cliPluginsExtraDirs":["/tmp/post-bundle-mutation"]}\n' > \
+    "$original_home/docker/config.json"
+  printf '#!/usr/bin/env bash\nprintf "mutated original plugin\\n"\n' > \
+    "$original_home/docker/cli-plugins/docker-compose"
+  printf '# post-bundle original plugin mutation\n' >> "$original_plugin"
+  chmod 0600 "$original_home/docker/config.json"
+  chmod 0700 "$original_home/docker/cli-plugins/docker-compose" "$original_plugin"
+  : > "$controller_fixture_root/require-bundle-docker-config-on-activation"
+}
+main "$@"
+SHIM
   chmod 0700 "$shim"
   printf '%s\n' "$shim"
 }
@@ -2066,6 +2109,41 @@ test_compose_plugin_and_docker_config_identity_are_bound() (
   }
   [[ $(jq -er '.phase' "$state") == prepared ]]
   [[ $(<"$live") == 'source model' ]]
+)
+
+test_activation_uses_invocation_private_docker_bundle() (
+  local fixture_dir manifest state shim rc=0 expected_config actual_config expected_plugin actual_plugin
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf -- "$fixture_dir"' EXIT
+  manifest="$fixture_dir/manifest.json"
+  state="$fixture_dir/controller.json"
+  write_execution_fixture "$fixture_dir" "$manifest"
+  export XDG_RUNTIME_DIR="$fixture_dir/locks"
+  shim=$(write_activation_bundle_namespace_shim "$fixture_dir")
+  "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
+
+  run_fixture_controller "$state" "$shim" env \
+    >"$fixture_dir/controller.out" 2>"$fixture_dir/controller.err" || rc=$?
+  ((rc == 0)) || {
+    echo 'activation did not retain the invocation-private Docker namespace after original-input mutation' >&2
+    sed 's/^/  controller.err: /' "$fixture_dir/controller.err" >&2 || true
+    exit 1
+  }
+  [[ $(jq -er '.phase' "$state") == complete ]] || {
+    echo 'bundle-bound activation did not complete the controller lifecycle' >&2
+    exit 1
+  }
+  expected_config=$(<"$fixture_dir/expected-activation-docker-config")
+  actual_config=$(<"$fixture_dir/activation-docker-config")
+  expected_plugin="$expected_config/cli-plugins/docker-compose"
+  actual_plugin=$(<"$fixture_dir/activation-compose-plugin")
+  [[ "$actual_config" == "$expected_config" && "$actual_plugin" == "$expected_plugin" ]] || {
+    printf 'activation escaped its invocation bundle: config=%s plugin=%s\n' \
+      "$actual_config" "$actual_plugin" >&2
+    exit 1
+  }
+  cmp -s "$actual_config/config.json" "$fixture_dir/expected-bundle-docker-config.json"
+  cmp -s "$actual_plugin" "$fixture_dir/expected-bundle-compose-plugin"
 )
 
 test_failed_prejournal_recovery_commits_durable_incident() (
@@ -5439,7 +5517,7 @@ test_real_docker_rehearsal_declares_interruption_resume_coverage() (
 )
 
 test_activation_uses_only_bound_compose_interpolation_values() (
-  local fixture_dir fake_docker state env_file candidate live selected
+  local fixture_dir fake_docker state env_file candidate live selected execution_home
   fixture_dir=$(mktemp -d)
   trap 'rm -rf -- "$fixture_dir"' EXIT
   fake_docker="$fixture_dir/docker"
@@ -5447,6 +5525,7 @@ test_activation_uses_only_bound_compose_interpolation_values() (
   env_file="$fixture_dir/runtime.env"
   candidate="$fixture_dir/candidate-compose.yml"
   live="$fixture_dir/docker-compose.yml"
+  execution_home="$fixture_dir/execution-home"
 
   cat > "$fake_docker" <<'DOCKER'
 #!/bin/bash -p
@@ -5484,19 +5563,28 @@ DOCKER
   printf 'services:\n  app:\n    image: ${APP_IMAGE}\n' > "$candidate"
   printf 'source-model\n' > "$live"
   chmod 0600 "$env_file" "$candidate" "$live"
+  mkdir -m 700 -p "$execution_home/docker" "$fixture_dir/locks"
+  printf '{}\n' > "$execution_home/docker/config.json"
+  chmod 0600 "$execution_home/docker/config.json"
   jq -n \
     --arg dockerPath "$fake_docker" \
     --arg appContainer fixture-app \
     --arg liveCompose "$live" \
-    '{dockerPath:$dockerPath,appContainer:$appContainer,liveCompose:$liveCompose}' > "$state"
+    --arg dockerEndpoint 'unix:///fixture/docker.sock' \
+    --arg lockRoot "$fixture_dir/locks" \
+    --arg fixedPath '/usr/sbin:/usr/bin:/sbin:/bin' \
+    '{dockerPath:$dockerPath,appContainer:$appContainer,liveCompose:$liveCompose,
+      dockerEndpoint:$dockerEndpoint,lockRoot:$lockRoot,fixedPath:$fixedPath}' > "$state"
   chmod 0600 "$state"
 
+  eval "$(extract_function child_path_for_state)"
   eval "$(extract_function activate_application_for_verification)"
   die() {
     printf 'fixture: %s\n' "$*" >&2
     exit 1
   }
   execution_docker_path=$fake_docker
+  execution_controller_home=$execution_home
   execution_env_file=$env_file
   execution_candidate_compose=$candidate
   HOME="$fixture_dir/home"
@@ -6598,6 +6686,8 @@ if [[ ${BASH_SOURCE[0]} == "$0" ]]; then
   test_guard_arguments_are_semantically_bound_to_manifest
   _clear_authority_root_for_isolation
   test_compose_plugin_and_docker_config_identity_are_bound
+  _clear_authority_root_for_isolation
+  test_activation_uses_invocation_private_docker_bundle
   _clear_authority_root_for_isolation
   test_failed_prejournal_recovery_commits_durable_incident
   _clear_authority_root_for_isolation

--- a/scripts/test-pgvector-transition-controller.sh
+++ b/scripts/test-pgvector-transition-controller.sh
@@ -563,9 +563,32 @@ elif [[ ${1:-} == compose && ${2:-} == version ]]; then
   printf 'compose-version:%s\n' "$operation_lock_state" >> "$root/live-identity.log"
   printf 'v2.fixture\n'
 elif [[ ${1:-} == compose ]]; then
+  project_directory=''
+  compose_file=''
+  if [[ -e "$root/require-live-project-directory" ]]; then
+    compose_args=("$@")
+    for ((compose_index = 0; compose_index < ${#compose_args[@]}; compose_index++)); do
+      case ${compose_args[$compose_index]} in
+        --project-directory)
+          project_directory=${compose_args[$((compose_index + 1))]}
+          ;;
+        -f)
+          compose_file=${compose_args[$((compose_index + 1))]}
+          ;;
+      esac
+    done
+    if [[ -z "$project_directory" && -n "$compose_file" ]]; then
+      project_directory=$(dirname "$compose_file")
+    fi
+    printf '%s\n' "$project_directory" >> "$root/compose-project-directories.log"
+  fi
   if [[ " $* " == *" config "* ]]; then
     printf 'compose-config:%s\n' "$operation_lock_state" >> "$root/live-identity.log"
-    printf 'candidate model\n'
+    if [[ -e "$root/require-live-project-directory" ]]; then
+      printf 'candidate model:%s\n' "$project_directory"
+    else
+      printf 'candidate model\n'
+    fi
   elif [[ " $* " == *" up "* && " $* " == *" app "* ]]; then
     if [[ -e "$root/require-bundle-docker-config-on-activation" ]]; then
       expected_config=$(<"$root/expected-activation-docker-config")
@@ -893,7 +916,7 @@ VERIFIER
     --arg composePluginPath "$compose_plugin" \
     --arg composePluginSha256 "$(sha256sum "$compose_plugin" | awk '{print $1}')" \
     --arg dockerConfigSha256 "$(sha256sum "$config_file" | awk '{print $1}')" \
-    --arg effectiveComposeSha256 "$("$fake_docker" compose --env-file "$env_file" -f "$candidate" config --no-interpolate | sha256sum | awk '{print $1}')" \
+    --arg effectiveComposeSha256 "$("$fake_docker" compose --project-directory "$(dirname "$live")" --env-file "$env_file" -f "$candidate" config --no-interpolate | sha256sum | awk '{print $1}')" \
     --arg backupDir "$backup" \
     --arg lockRoot "$lock_root" \
     --arg controllerHome "$controller_home" \
@@ -2144,6 +2167,53 @@ test_activation_uses_invocation_private_docker_bundle() (
   }
   cmp -s "$actual_config/config.json" "$fixture_dir/expected-bundle-docker-config.json"
   cmp -s "$actual_plugin" "$fixture_dir/expected-bundle-compose-plugin"
+)
+
+test_candidate_model_uses_activation_project_directory() (
+  local fixture_dir manifest state shim fake_docker env_file candidate live candidate_dir rc=0
+  local effective_sha expected_project unique_projects
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf -- "$fixture_dir"' EXIT
+  manifest="$fixture_dir/manifest.json"
+  state="$fixture_dir/controller.json"
+  write_execution_fixture "$fixture_dir" "$manifest"
+  fake_docker=$(jq -er '.dockerPath' "$manifest")
+  env_file=$(jq -er '.envFile' "$manifest")
+  candidate=$(jq -er '.candidateCompose' "$manifest")
+  live=$(jq -er '.liveCompose' "$manifest")
+  expected_project=$(dirname "$live")
+  candidate_dir="$fixture_dir/candidate-input"
+  mkdir -m 700 "$candidate_dir"
+  mv -- "$candidate" "$candidate_dir/candidate-compose.yml"
+  candidate="$candidate_dir/candidate-compose.yml"
+  : > "$fixture_dir/require-live-project-directory"
+  effective_sha=$("$fake_docker" compose --project-directory "$expected_project" \
+    --env-file "$env_file" -f "$candidate" config --no-interpolate | sha256sum | awk '{print $1}')
+  jq --arg candidate "$candidate" \
+    --arg candidateSha "$(sha256sum "$candidate" | awk '{print $1}')" \
+    --arg effectiveSha "$effective_sha" '
+      .candidateCompose = $candidate |
+      .candidateComposeSha256 = $candidateSha |
+      .effectiveComposeSha256 = $effectiveSha
+    ' "$manifest" > "$manifest.next"
+  install -m 600 "$manifest.next" "$manifest"
+  export XDG_RUNTIME_DIR="$fixture_dir/locks"
+  shim=$(write_systemd_identity_shim "$fixture_dir")
+
+  "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
+  run_fixture_controller "$state" "$shim" env \
+    >"$fixture_dir/controller.out" 2>"$fixture_dir/controller.err" || rc=$?
+  ((rc == 0)) || {
+    echo 'candidate model and activation used different Compose project directories' >&2
+    sed 's/^/  controller.err: /' "$fixture_dir/controller.err" >&2 || true
+    exit 1
+  }
+  [[ $(jq -er '.phase' "$state") == complete ]]
+  unique_projects=$(sort -u "$fixture_dir/compose-project-directories.log")
+  [[ "$unique_projects" == "$expected_project" ]] || {
+    printf 'Compose calls used inconsistent project directories: %s\n' "$unique_projects" >&2
+    exit 1
+  }
 )
 
 test_failed_prejournal_recovery_commits_durable_incident() (
@@ -6688,6 +6758,8 @@ if [[ ${BASH_SOURCE[0]} == "$0" ]]; then
   test_compose_plugin_and_docker_config_identity_are_bound
   _clear_authority_root_for_isolation
   test_activation_uses_invocation_private_docker_bundle
+  _clear_authority_root_for_isolation
+  test_candidate_model_uses_activation_project_directory
   _clear_authority_root_for_isolation
   test_failed_prejournal_recovery_commits_durable_incident
   _clear_authority_root_for_isolation

--- a/scripts/test-pgvector-transition-controller.sh
+++ b/scripts/test-pgvector-transition-controller.sh
@@ -6325,6 +6325,56 @@ test_fresh_activation_recovery_stops_before_phase_owned_proof_validation() (
   }
 )
 
+test_fresh_activation_stop_failure_persists_closure_intent() (
+  local fixture_dir manifest state shim authorization_evidence initial_rc=0 retry_rc=0 lifecycle
+  fixture_dir=$(mktemp -d)
+  trap 'rm -rf -- "$fixture_dir"' EXIT
+  manifest="$fixture_dir/manifest.json"
+  state="$fixture_dir/controller.json"
+  write_execution_fixture "$fixture_dir" "$manifest"
+  export XDG_RUNTIME_DIR="$fixture_dir/locks"
+  shim=$(write_phase_snapshot_shim "$fixture_dir")
+  "$CONTROLLER" --prepare --manifest "$manifest" --state "$state"
+
+  NOOSPHERE_CONTROLLER_TEST_CAPTURE_PHASE=activation-running \
+    run_fixture_controller "$state" "$shim" env \
+      >"$fixture_dir/initial.out" 2>"$fixture_dir/initial.err" || initial_rc=$?
+  [[ "$initial_rc" == 86 && $(jq -er '.phase' "$state") == activation-running ]] || {
+    printf 'fresh stop-failure owner did not capture activation-running: rc=%s\n' "$initial_rc" >&2
+    exit 1
+  }
+
+  : > "$fixture_dir/app-started"
+  : > "$fixture_dir/fail-closure-stop-once"
+  authorization_evidence=$(jq -er '.authorizationEvidence.path' "$state")
+  rm -f -- "$authorization_evidence"
+
+  NOOSPHERE_CONTROLLER_FIXTURE_INVOCATION_ID=fedcba9876543210fedcba9876543210 \
+    run_fixture_controller "$state" "$shim" \
+      >"$fixture_dir/retry.out" 2>"$fixture_dir/retry.err" || retry_rc=$?
+  ((retry_rc != 0)) || {
+    echo 'fresh activation stop failure unexpectedly reported success' >&2
+    exit 1
+  }
+  [[ -e "$fixture_dir/closure-stop-failure-consumed" ]] || {
+    echo 'fresh activation stop-failure owner did not exercise the injected stop failure' >&2
+    exit 1
+  }
+  jq -e '
+    .phase == "closure-stop-pending" and
+    .incidentClass == "closure-interruption" and
+    (has("writerStopEvidence") | not)
+  ' "$state" >/dev/null || {
+    echo 'fresh activation stop failure did not preserve durable closure intent' >&2
+    exit 1
+  }
+  lifecycle=$(paste -sd, "$fixture_dir/lifecycle.log" 2>/dev/null || true)
+  [[ "$lifecycle" == transition,authorize ]] || {
+    printf 'fresh activation stop failure crossed writer replay boundary: %s\n' "$lifecycle" >&2
+    exit 1
+  }
+)
+
 test_detached_target_parent_cannot_false_complete_publication() (
   local fixture_dir source_parent target_parent detached_parent source target rc=0
   fixture_dir=$(mktemp -d)
@@ -6715,6 +6765,8 @@ if [[ ${BASH_SOURCE[0]} == "$0" ]]; then
   test_closure_intent_and_stop_failure_cannot_cross_writer_boundary
   _clear_authority_root_for_isolation
   test_fresh_activation_recovery_stops_before_phase_owned_proof_validation
+  _clear_authority_root_for_isolation
+  test_fresh_activation_stop_failure_persists_closure_intent
   _clear_authority_root_for_isolation
   test_detached_target_parent_cannot_false_complete_publication
   _clear_authority_root_for_isolation

--- a/scripts/test-pgvector-transition-controller.sh
+++ b/scripts/test-pgvector-transition-controller.sh
@@ -6295,6 +6295,7 @@ test_fresh_activation_recovery_stops_before_phase_owned_proof_validation() (
   # yet advanced from activation-running. The bound proof then becomes
   # unavailable before a fresh invocation can recover.
   : > "$fixture_dir/app-started"
+  rm -f -- "$fixture_dir/app-stopped"
   authorization_evidence=$(jq -er '.authorizationEvidence.path' "$state")
   rm -f -- "$authorization_evidence"
 
@@ -6345,6 +6346,7 @@ test_fresh_activation_stop_failure_persists_closure_intent() (
   }
 
   : > "$fixture_dir/app-started"
+  rm -f -- "$fixture_dir/app-stopped"
   : > "$fixture_dir/fail-closure-stop-once"
   authorization_evidence=$(jq -er '.authorizationEvidence.path' "$state")
   rm -f -- "$authorization_evidence"
@@ -6371,6 +6373,26 @@ test_fresh_activation_stop_failure_persists_closure_intent() (
   lifecycle=$(paste -sd, "$fixture_dir/lifecycle.log" 2>/dev/null || true)
   [[ "$lifecycle" == transition,authorize ]] || {
     printf 'fresh activation stop failure crossed writer replay boundary: %s\n' "$lifecycle" >&2
+    exit 1
+  }
+
+  retry_rc=0
+  NOOSPHERE_CONTROLLER_FIXTURE_INVOCATION_ID=11112222333344445555666677778888 \
+    run_fixture_controller "$state" "$shim" \
+      >"$fixture_dir/recovery.out" 2>"$fixture_dir/recovery.err" || retry_rc=$?
+  ((retry_rc != 0)) || {
+    echo 'fresh activation stop-failure recovery unexpectedly reported success' >&2
+    exit 1
+  }
+  jq -e '
+    .phase == "incident" and
+    .incidentClass == "closure-interruption" and
+    (.writerStopEvidence.sha256 | type == "string" and test("^[a-f0-9]{64}$")) and
+    (has("proofException") | not)
+  ' "$state" >/dev/null || {
+    echo 'fresh activation stop-failure state was not resumable to terminal interruption' >&2
+    sed 's/^/  recovery.err: /' "$fixture_dir/recovery.err" >&2 || true
+    jq . "$state" >&2 || true
     exit 1
   }
 )


### PR DESCRIPTION
## What Problem This Solves

Issue #303 tracks the post-PR-#300 hardening required before an existing PostgreSQL volume can be considered for the guarded pgvector transition. The controller needed stronger guarantees at nine concrete failure/race boundaries:

- parent-path retargeting before descriptor acquisition;
- candidate-entry substitution after digest preparation;
- closure-intent plus stop/evidence dual failure across a fresh invocation;
- detached target-parent publication;
- post-rename directory-fsync failure exposing advanced state or evidence.
- fresh `activation-running` recovery blocked by unavailable phase-owned proof
  before the retained writer was stopped.
- fresh stop/evidence failure returning before durable `closure-stop-pending`
  intent was recorded.
- activation using the original prepared Docker config/plugin namespace after
  the invocation-private execution bundle had been verified.
- candidate-model verification and activation resolving relative Compose paths
  against different project directories.

The issue's original production-safety items also require hermetic Compose interpolation, durable writer closure after authorization postprocessing failure, and rejection of writable publication parents regardless of owner.

Refs #303. This PR intentionally does not auto-close the issue; separately bounded portability, harness, publication-window, and installer work remains tracked there.

## Approach

- Bind Compose publication to validated source/target directory descriptors and pre-open device/inode identities.
- Recheck target attachment around descriptor-relative rename.
- Pass `candidateComposeSha256` into publication and hash the exact staged inode before rename.
- Make fresh `authorization-running` and `activation-running` processes stop-only and fail closed instead of replaying writer-capable actions; validate immutable execution identity first, inspect-stop next, and consult phase-owned proof only after the stop.
- Persist `closure-stop-pending` through restricted structural validation when
  that fresh stop/evidence step fails; a one-phase proof deferral keeps the
  pending state full-valid so the next invocation retries the stop, consumes
  the deferral, and commits the terminal incident without replay.
- Bind activation inspect and Compose calls to the invocation-private copied
  controller home, Docker config/client/plugin, fixed `PATH`, runtime directory,
  and deterministic locale.
- Bind candidate-model signatures, invocation-bundle revalidation, and
  activation to the live Compose file's parent as one project directory.
- Make Task 7 Step 5 rollout-authoritative by running the focused controller
  suite and pinned-Docker interruption/recovery rehearsal from the existing
  path-filtered PostgreSQL workflow under disposable persistent user managers.
- Publish controller state and writer-stop evidence through rollback-capable atomic writes that restore prior bytes or prior absence after post-rename fsync failure.
- Keep the first failure authoritative and terminate fail-stopped if rollback cannot be made durable.
- Add deterministic owners for each admitted mechanism and strengthen impacted siblings.
- Synchronize the controller runbook, revamp status matrix, and implementation plan with the verified local gate.

## Evidence

Exact corrected artifact hashes:

- controller: `5dfafa862907dfe021e4c42e9bdb1fb6481e274e6101a4212ad12a5062aacf01`
- focused fixture: `2b99bc4c9ce33387fde698b0f25ade8486e62477da02efbc26a391ab52adf9dd`
- systemd fixture: `51c06461dbd49d9f42328458b69e922d5dc7ad27c6a6b377bd2ff8128f910b9a`
- Docker fixture: `6502adf1b87ba4f143b12b5993a690877eb59b76d2217b0f4c35ef8454b10e03`

Verification completed:

- nine direct deterministic owners: green;
- eleven impacted siblings: green;
- focused controller suite: `135/135`, RC 0;
- standalone transient-systemd fixture: green, RC 0;
- pinned-Docker `linux/amd64` interruption/recovery rehearsal: green;
- owned unit/process/container/volume/network residue: zero;
- `bash -n` on all four shell surfaces: green;
- `git diff --check`: green;
- `npm run lint`: RC 0 (one unrelated pre-existing warning);
- `npm run typecheck`: green;
- `npm run package-policy:check`: green;
- Task 7 workflow policy owner: RED before wiring with the missing-gate finding,
  GREEN after trigger/job/user-manager/pinned-image wiring;
- `npm run postgres-image:check`: green;
- updated PostgreSQL rehearsal workflow: valid YAML with the existing volume
  rehearsal plus focused-controller and pinned-Docker controller jobs;
- hosted runner portability: pinned Node installed into the trusted bootstrap
  path, `/usr/local/bin` tightened to root-owned `0755`, and focused-only
  `ripgrep` installed; all requirements are policy-owned;
- source-recovery signal evidence uses a deterministic built-in-only trap marker
  instead of Bash-version-specific job-control stderr; exact log/evidence SHA
  assertions remain intact;
- exact-head hosted Task 7 workflow
  [`33079477202`](https://github.com/SweetSophia/noosphere/actions/runs/33079477202):
  focused controller `16m6s`, pinned-Docker controller `1m30s`, amd64 volume
  rehearsal `5m23s`, arm64 volume rehearsal `13m0s`; all green;
- relative Markdown link validation: green;
- definition/dispatch parity: `135/135`;
- public-diff privacy scan: 2,573 added lines, zero secret/private-artifact hits;
- three pre-publication sequential read-only reviews: PASS, zero release-floor blockers in each;
- public review: five safety findings reproduced deterministically and fixed, plus one plan-name consistency correction; remaining bot suggestions were adjudicated below the active release floor.

Application-suite state:

- `npm test`: attempted before push; local RC 1 because the repository test environment cannot authenticate the `.env.test` PostgreSQL test user, and the unfiltered environment supplied `NOOSPHERE_API_KEY` to two missing-key tests.
- missing-key test file rerun with the ambient key removed: `66/66` green.
- memory rerun with the ambient key removed: `267` pass, `10` database-authentication failures.
- wiki: `11/11` green; cache: `18/18` green; rate-limit: `42/42` green; security: `34/34` green.
- persistence: `10` pass, `17` database-authentication failures.
- API: non-database tests ran, while `16` DB-backed files failed because that package script does not load `DATABASE_URL`.
- every failing application-test source is byte-identical to `origin/master`; this controller/docs diff touches none of them. CI remains the clean-environment authority for those suites.

## Safety and Rollout Boundaries

This PR does **not** run the controller automatically and does not authorize or perform:

- merge;
- production deployment or PostgreSQL transition;
- schema or production-volume mutation;
- feature activation, backfill, shadow evaluation, or hybrid serving;
- installer rollout.

The accurate current claim is **issue-303 implementation and Task 7 Step 5
rollout-authority CI gates verified on exact PR head**. Merge, installer rollout,
and all operator rollout decisions remain separate approvals.

## Deferred / Out of Scope

- non-gate status-code/diagnostic fidelity;
- unrelated portability and harness hardening without a deterministic safety reproducer;
- checksum-pinned one-command installer integration (separate bounded stage);
- production transition and Phase D rollout.
