### PR TITLE
fix(ci): verify Hermes checksum from dist

### DIFF
--- a/.github/workflows/hermes-release.yml
+++ b/.github/workflows/hermes-release.yml
@@ -41,7 +41,7 @@ jobs:
           scripts/package-hermes-plugin.sh dist
           version=$(cat VERSION)
           archive="dist/hermes-noosphere-memory-${version}.tar.gz"
-          sha256sum --check "${archive}.sha256"
+          (cd dist && sha256sum --check "hermes-noosphere-memory-${version}.tar.gz.sha256")
           tar -tzf "$archive" >/dev/null
 
       - name: Verify release bundle installation

--- a/scripts/check-package-policies.mjs
+++ b/scripts/check-package-policies.mjs
@@ -355,9 +355,13 @@ expect(
     hermesReleaseWorkflowLines.includes("persist-credentials: false") &&
     hermesReleaseWorkflow.includes("actions/upload-artifact@") &&
     hermesReleaseWorkflow.includes("Verify release bundle installation") &&
+    hermesReleaseWorkflow.includes(
+      '(cd dist && sha256sum --check "hermes-noosphere-memory-${version}.tar.gz.sha256")',
+    ) &&
+    !hermesReleaseWorkflow.includes('sha256sum --check "${archive}.sha256"') &&
     !hermesReleaseWorkflow.includes("GH_TOKEN") &&
     !hermesReleaseWorkflow.includes("gh release upload"),
-  "The Hermes tag workflow must be secret-free, install-test its bundle, and publish only a read-only Actions artifact.",
+  "The Hermes tag workflow must verify checksums from dist, remain secret-free, install-test its bundle, and publish only a read-only Actions artifact.",
 );
 
 if (failures.length > 0) {


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary

Fixes a failure in the Hermes release workflow where the generated archive checksum was being verified from the wrong directory, causing artifact upload to fail despite a valid bundle.

## The Bug

The `v-hermes-1.12.0` workflow produced the deterministic archive and its `.sha256` sidecar successfully, but the subsequent verification step ran:

```bash
sha256sum --check "${archive}.sha256"
```

Where `${archive}` resolved to `dist/hermes-noosphere-memory-<version>.tar.gz`. `sha256sum --check` interprets the path inside the checksum file relative to the **current working directory** (the repo root), not the file's actual location. Since the archive lives in `dist/`, the check failed and the artifact upload step never ran — even though the bundle itself was correct.

## What This PR Changes

**`.github/workflows/hermes-release.yml`**
The checksum verification now `cd`s into `dist/` first and checks against the local basename:

```bash
(cd dist && sha256sum --check "hermes-noosphere-memory-${version}.tar.gz.sha256")
```

This matches where the checksum file actually lives and makes the basename resolve correctly.

**`scripts/check-package-policies.mjs`**
The package-policy gate is tightened so the corrected command is required and the broken form is explicitly rejected:

- **Positive assertion:** the workflow must contain the new `(cd dist && sha256sum --check "hermes-noosphere-memory-${version}.tar.gz.sha256")` line.
- **Negative assertion:** the workflow must *not* contain the old root-relative `sha256sum --check "${archive}.sha256"` invocation.
- **Updated failure message** to mention the new checksum-location requirement alongside the existing secret-free, install-test, and read-only-artifact expectations.

## Why Both Changes Together

The policy check ensures that any future regression to the original broken invocation is caught locally by `node scripts/check-package-policies.mjs`, rather than surfacing only as a failed release run. The negative-control verification described in the PR description confirms that stashing only the workflow fix while keeping the policy change makes the policy test fail — proving the two pieces work together as a guardrail.

## Scope

This PR does **not**:
- Move, rewrite, or republish the `1.12.0` tag or any published artifact.
- Touch the actual packaging logic in `scripts/package-hermes-plugin.sh`.
- Change the install-test, secret-free, or artifact-publish requirements.

It only repairs the verification step that runs after packaging and locks that fix in via the policy gate.
<!-- kody-pr-summary:end -->