### PR TITLE
docs: work-VM Hermes installer + llama.cpp hybrid runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,7 @@ Keep detailed recovery work in deployment/runbook docs rather than this README.
 | [README-legacy.md](README-legacy.md) | Previous full README content kept for reference during the docs split |
 | [docs/MEMORY-REVAMP-STATUS.md](docs/MEMORY-REVAMP-STATUS.md) | Authoritative implementation and rollout matrix for automatic capture and hybrid retrieval |
 | [docs/INSTALLATION.md](docs/INSTALLATION.md) | Guided installer, auditable download, upgrades, manual Compose, and credential handling |
+| [docs/HERMES-INSTALLER-HYBRID.md](docs/HERMES-INSTALLER-HYBRID.md) | Installer-runtime work-VM hybrid runbook (`~/.noosphere`, sidecar A/B/C, llama.cpp) |
 | [docs/OPENCLAW-OFFICIAL-PLUGIN-SETUP.md](docs/OPENCLAW-OFFICIAL-PLUGIN-SETUP.md) | OpenClaw install, operations, upgrade, troubleshooting, and uninstall |
 | [docs/POSTGRES-PGVECTOR-COMPOSE-UPGRADE.md](docs/POSTGRES-PGVECTOR-COMPOSE-UPGRADE.md) | Guarded PostgreSQL image transition, proof, rollback, and recovery |
 | [docs/NOOSPHERE-MEMORY-ARCHITECTURE.md](docs/NOOSPHERE-MEMORY-ARCHITECTURE.md) | Provider abstraction, recall orchestration, ranking, budgeting, and scheduler |

--- a/README.md
+++ b/README.md
@@ -86,7 +86,10 @@ for the full stateful recovery contract.
 
 Optional pgvector hybrid storage remains a separate activation step. Operator
 how-to (llama.cpp local embeddings, no wiki toggle):
-[docs/HYBRID-RETRIEVAL-ACTIVATION.md](docs/HYBRID-RETRIEVAL-ACTIVATION.md).
+[docs/HYBRID-RETRIEVAL-ACTIVATION.md](docs/HYBRID-RETRIEVAL-ACTIVATION.md)
+for a source Compose checkout, or
+[docs/HERMES-INSTALLER-HYBRID.md](docs/HERMES-INSTALLER-HYBRID.md) for a
+guided-installer runtime plus Hermes.
 SQL/privilege contract:
 [docker/hybrid-storage/README.md](docker/hybrid-storage/README.md).
 

--- a/docs/HERMES-INSTALLER-HYBRID.md
+++ b/docs/HERMES-INSTALLER-HYBRID.md
@@ -54,8 +54,8 @@ commands; Compose stays in `~/.noosphere`.
 ### Prerequisites
 
 Docker Compose v2, Node.js 22+ with `npm`, `git`, `python3`, `pg_restore`,
-`curl`, `jq`, `sha256sum`, and `tar`. Hermes CLI on `PATH`. If Hermes uses a
-named profile:
+`curl`, `jq`, `openssl`, `sha256sum`, and `tar`. Hermes CLI on `PATH`. If Hermes
+uses a named profile:
 
 ```bash
 export HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
@@ -329,7 +329,8 @@ magic — build it from the printed id (empty `apiKey` is valid for local):
 
 ```bash
 profile_id='00000000-0000-4000-8000-000000000000'  # paste the printed id
-test "$profile_id" != '00000000-0000-4000-8000-000000000000'
+uuid_re='^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$'
+[[ "$profile_id" =~ $uuid_re ]] && test "$profile_id" != '00000000-0000-4000-8000-000000000000'
 json=$(python3 -c 'import json,sys; print(json.dumps([{"profileId":sys.argv[1],"locality":"local","endpoint":"http://host.docker.internal:8741/v1/embeddings","apiKey":""}],separators=(",",":")))' "$profile_id")
 b64=$(printf '%s' "$json" | base64 | tr -d '\n')
 test -n "$b64"
@@ -387,7 +388,8 @@ network=$(docker inspect -f '{{range $k, $v := .NetworkSettings.Networks}}{{$k}}
 test -n "$network"
 test -n "${NOOSPHERE_HYBRID_ADMIN_DATABASE_URL:-}"
 profile_id='00000000-0000-4000-8000-000000000000'  # paste the printed id
-test "$profile_id" != '00000000-0000-4000-8000-000000000000'
+uuid_re='^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$'
+[[ "$profile_id" =~ $uuid_re ]] && test "$profile_id" != '00000000-0000-4000-8000-000000000000'
 docker run --rm --network "$network" \
   -v "$HOME/src/noosphere-scripts:/src" -w /src \
   -e NOOSPHERE_HYBRID_ADMIN_DATABASE_URL \
@@ -406,8 +408,14 @@ not a lexical fallback:
 
 ```bash
 # profile_id pasted from step 4.4; mint a 32-byte v1 key, never print it
+uuid_re='^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$'
+test -n "$profile_id" && [[ "$profile_id" =~ $uuid_re ]] && test "$profile_id" != '00000000-0000-4000-8000-000000000000'
 key_b64=$(openssl rand -base64 32)
 hmac_b64=$(printf '{"v1":"%s"}' "$key_b64" | base64 | tr -d '\n')
+Both writers share the same `os.replace` core on purpose: each is self-contained
+and copy-pasteable in isolation — an operator mid-procedure should not need to
+have run (or even read) the other block first.
+
 python3 - "$profile_id" "$hmac_b64" <<'PY'
 import os, sys, tempfile
 env_path = os.path.join(os.environ["NOOSPHERE_HOME"], ".env")
@@ -447,14 +455,18 @@ Then:
 
 `docker compose restart` does **not** reload env. Set
 `NOOSPHERE_HYBRID_RETRIEVAL_ENABLED` to the exact string `true`, recreate
-app again, health-check again. Then verify the gate actually opened:
+app again, health-check again.
+
+The config is parsed per **search request**, not at boot — boot logs stay
+clean until the first recall. After the recreate, run one throwaway recall
+(any Hermes key, `mode: "auto"`), then check for the fail-closed errors:
 
 ```bash
-"${compose[@]}" logs app 2>&1 | grep -E 'HybridCorrectnessError|query_profile_invalid|cache_keyring_invalid' || true
+"${compose[@]}" logs app 2>&1 | grep -E 'HybridCorrectnessError|query_profile_invalid|query_profile_missing|cache_keyring_invalid' || true
 ```
 
-Empty output above = config valid; any hit = fix `.env` before trusting
-Phase 4.6.
+Empty output **after that recall** = config valid; any hit = fix `.env`
+before trusting Phase 4.6. Without the recall, empty output proves nothing.
 
 ### 4.6 Prove hybrid
 

--- a/docs/HERMES-INSTALLER-HYBRID.md
+++ b/docs/HERMES-INSTALLER-HYBRID.md
@@ -50,8 +50,9 @@ commands only; Compose stays in `~/.noosphere`.
 
 ### Prerequisites
 
-Docker Compose v2, Node.js 22+, `curl`, `jq`, `sha256sum`, `tar`. Hermes CLI
-on `PATH`. If Hermes uses a named profile:
+Docker Compose v2, Node.js 22+ with `npm`, `git`, `python3`, `pg_restore`,
+`curl`, `jq`, `sha256sum`, and `tar`. Hermes CLI on `PATH`. If Hermes uses a
+named profile:
 
 ```bash
 export HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
@@ -169,21 +170,21 @@ Host smoke must return `model` = `nomic-embed-text` and 768 finite floats:
 ```bash
 curl -fsS http://172.17.0.1:8741/v1/embeddings \
   -H 'content-type: application/json' \
-  -d '{"model":"nomic-embed-text","input":"ping","encoding_format":"float"}'
+  -d '{"model":"nomic-embed-text","input":"ping","encoding_format":"float"}' |
+  jq -e '.model == "nomic-embed-text" and (.data|length==1) and (.data[0].embedding|length==768)'
 ```
 
-Then from the compose network (app/worker already have
-`extra_hosts: host.docker.internal:host-gateway`):
+Then from the compose network. The published app image is `node:22-alpine`
+(BusyBox `wget`, no `curl`):
 
 ```bash
-docker compose --project-directory "${NOOSPHERE_HOME:-$HOME/.noosphere}" run --rm --no-deps --entrypoint curl app \
-  -fsS http://host.docker.internal:8741/v1/embeddings \
-  -H 'content-type: application/json' \
-  -d '{"model":"nomic-embed-text","input":"ping","encoding_format":"float"}'
+docker compose --project-directory "${NOOSPHERE_HOME:-$HOME/.noosphere}" exec -T app \
+  wget -qO- --header='content-type: application/json' \
+  --post-data='{"model":"nomic-embed-text","input":"ping","encoding_format":"float"}' \
+  http://host.docker.internal:8741/v1/embeddings
 ```
 
-If the image has no `curl`, run the same URL from any throwaway container on
-the project network with `--add-host host.docker.internal:host-gateway`.
+App and worker already have `extra_hosts: host.docker.internal:host-gateway`.
 
 ---
 
@@ -203,18 +204,19 @@ Never `docker compose` from a git clone. Never re-run `init`.
 ```bash
 git clone --branch v1.13.2 --depth 1 https://github.com/SweetSophia/noosphere.git ~/src/noosphere-scripts
 cd ~/src/noosphere-scripts
+test "$(git rev-parse HEAD)" = 11e1be9bb07a60e1df775f33688a7e4dd3dd5645
 npm ci
 ```
 
-Pin the branch to the same release as the installer. `npm ci` is for
-activators only.
+That commit is tag `v1.13.2`. `npm ci` is for activators only. Do not run
+Compose from this clone.
 
 ### 4.2 Snapshot
 
 ```bash
 umask 077
 stamp=$(date +%Y%m%d-%H%M%S)
-dest="$HOME/.noosphere/backups/pre-hybrid-A-${stamp}"
+dest="$NOOSPHERE_HOME/backups/pre-hybrid-A-${stamp}"
 mkdir -p "$dest"
 chmod 700 "$dest"
 cp -a "$NOOSPHERE_HOME/.env" "$dest/.env.bak"
@@ -224,12 +226,17 @@ chmod 600 "$dest/pre-hybrid-A.dump"
 pg_restore -l "$dest/pre-hybrid-A.dump" >/dev/null
 ```
 
-Confirm the writer-authorization marker (must match the digest in
-`docker-compose.noosphere.yml`):
+Confirm the writer-authorization marker matches the digest in the **installer**
+Compose file (`$NOOSPHERE_HOME/docker-compose.yml`), not the source-checkout
+filename `docker-compose.noosphere.yml`:
 
 ```bash
-"${compose[@]}" exec -T db cat /run/noosphere-pgvector/writer-authorized
+marker=$("${compose[@]}" exec -T db cat /run/noosphere-pgvector/writer-authorized)
+grep -F "$marker" "$NOOSPHERE_HOME/docker-compose.yml"
 ```
+
+`grep` must exit 0. A mismatch means the wrong image or an incomplete
+new-install guard — stop.
 
 ### 4.3 Role URLs on the compose network
 
@@ -258,14 +265,26 @@ network=$(docker inspect -f '{{range $k, $v := .NetworkSettings.Networks}}{{$k}}
 
 ### 4.4 A/B/C + profile, from a sidecar
 
-Host `npm run hybrid-*` cannot resolve `db`. Run the clone on that network.
-The sidecar needs Node 22 and `psql` (activators call both). Build the five
-URLs in a wrapper that never prints them, then pass them as `-e`:
+Host `npm run hybrid-*` cannot resolve hostname `db`. Bundled provenance also
+**requires Docker** (`scripts/activate-hybrid-storage.sh` inspects
+`NOOSPHERE_DB_CONTAINER`). A `node:22-bookworm` container has neither the
+Docker CLI nor the daemon socket, so A/B/C exits before SQL unless you mount
+both.
+
+The sidecar therefore needs: Node 22, `psql`, the host Docker CLI, and the
+Docker socket. Mounting the socket gives the sidecar the same Docker rights as
+the operator — treat that as trusted, local, and temporary.
+
+Build the five URLs in a wrapper that never prints them, then:
 
 ```bash
+docker_bin=$(command -v docker)
 docker run --rm --network "$network" \
   --add-host host.docker.internal:host-gateway \
+  -v "$docker_bin":/usr/bin/docker:ro \
+  -v /var/run/docker.sock:/var/run/docker.sock \
   -v "$HOME/src/noosphere-scripts:/src" -w /src \
+  -e NOOSPHERE_DB_CONTAINER=noosphere-openclaw-db \
   -e NOOSPHERE_BOOTSTRAP_DATABASE_URL \
   -e DATABASE_URL \
   -e NOOSPHERE_APP_DATABASE_URL \
@@ -276,20 +295,30 @@ docker run --rm --network "$network" \
     npm run hybrid-storage:activate
     npm run hybrid-worker:activate
     npm run hybrid-retrieval:activate
-    node scripts/hybrid-profile.mjs create \
+    profile_json=$(node scripts/hybrid-profile.mjs create \
       --locality local \
       --endpoint http://host.docker.internal:8741/v1/embeddings \
       --model nomic-embed-text \
       --revision Q8_0-b10783 \
-      --dimensions 768
+      --dimensions 768)
+    profile_id=$(printf "%s" "$profile_json" | node -e "let s=\"\";process.stdin.on(\"data\",d=>s+=d);process.stdin.on(\"end\",()=>console.log(JSON.parse(s).profileId))")
+    printf "profile_id=%s\n" "$profile_id"
+    node scripts/hybrid-profile.mjs prepare --profile "$profile_id"
+    node scripts/hybrid-backfill.mjs --profile "$profile_id" --chunk 100
+    node scripts/hybrid-profile.mjs status --profile "$profile_id"
   '
 ```
 
-Repeat activation is validate-only — do not repair A/B/C by hand.
+Prefer a digest-pinned `node:22-bookworm` if your policy requires it (`docker
+image inspect --format '{{.RepoDigests}}'`). Repeat activation is
+validate-only — do not repair A/B/C by hand.
 
-`hybrid:profile create` prints a `profileId`. Keep it. Prepare and backfill
-with that id (`node scripts/hybrid-profile.mjs prepare|status` and
-`node scripts/hybrid-backfill.mjs`). Coverage must be ≥ 0.95 before serving.
+Keep the printed `profile_id`. Coverage must be ≥ 0.95 before serving. Serve
+from the **same** sidecar (still on the compose network):
+
+```bash
+node scripts/hybrid-profile.mjs serve --profile "$profile_id"
+```
 
 Persist **only** `NOOSPHERE_HYBRID_PROVIDER_CONFIG_B64` in
 `~/.noosphere/.env` (canonical base64 of compact JSON; empty `apiKey` is
@@ -313,9 +342,9 @@ Wait until the worker is **healthy** (compose healthcheck). Any
 `embedding_job` in `failed` fails that check — cancel over-context rows;
 they stay keyword-only.
 
-When coverage ≥ 0.95: `hybrid:profile serve`. Write HMAC keyring +
-`NOOSPHERE_HYBRID_QUERY_PROFILE_ID` into `~/.noosphere/.env` with the flag
-still `false`. Then:
+When coverage ≥ 0.95: serve the profile (sidecar command above). Write HMAC
+keyring + `NOOSPHERE_HYBRID_QUERY_PROFILE_ID` into `$NOOSPHERE_HOME/.env` with
+the flag still `false`. Then:
 
 ```bash
 "${compose[@]}" up -d --no-deps --force-recreate app
@@ -337,6 +366,8 @@ request.
 ## Rollback
 
 ```bash
+export NOOSPHERE_HOME="${NOOSPHERE_HOME:-$HOME/.noosphere}"
+compose=(docker compose --project-directory "$NOOSPHERE_HOME")
 "${compose[@]}" --profile hybrid stop app hybrid-worker
 ```
 
@@ -351,6 +382,9 @@ recreate app with `--no-deps --force-recreate`. llama.cpp can stay installed.
   `--project-directory ~/.noosphere` target a different stack or nothing.
 - **Wrong DB container / port.** Installer db is `noosphere-openclaw-db`.
   There is no host `:5433`.
+- **Sidecar without Docker socket.** Bundled A/B/C inspects
+  `NOOSPHERE_DB_CONTAINER=noosphere-openclaw-db` via `docker inspect`. Omit the
+  socket/CLI mounts and activation exits before SQL.
 - **Re-running `init`.** `up -d` without `--no-deps` on worker/app can
   double-bootstrap.
 - **llama.cpp on `127.0.0.1` only.** Containers use `host.docker.internal` →

--- a/docs/HERMES-INSTALLER-HYBRID.md
+++ b/docs/HERMES-INSTALLER-HYBRID.md
@@ -40,9 +40,12 @@ checkout onto the work VM (it still carries owner-host defaults).
 It will look for `noosphere-db` and `127.0.0.1:5433`. Do not run it against
 an installer install.
 
-The published image does **not** ship the A/B/C activator scripts or
-`docker/hybrid-storage/*.sql`. Keep a shallow scripts checkout for those
-commands only; Compose stays in `~/.noosphere`.
+The published image does **not** ship the A/B/C **activator scripts** (only
+`hybrid-provider.mjs`, `hybrid-worker.mjs`, `check-hybrid-worker-health.mjs`).
+The `docker/hybrid-storage/*.sql` DDL **is** in the image, but the
+authoritative SQL + privilege SSOT stays in `docker/hybrid-storage/README.md`
+in the repo — keep the shallow scripts checkout for that plus the activator
+commands; Compose stays in `~/.noosphere`.
 
 ---
 
@@ -178,7 +181,7 @@ Then from the compose network. The published app image is `node:22-alpine`
 (BusyBox `wget`, no `curl`):
 
 ```bash
-docker compose --project-directory "${NOOSPHERE_HOME:-$HOME/.noosphere}" exec -T app \
+docker compose --project-directory "$NOOSPHERE_HOME" -f "$NOOSPHERE_HOME/docker-compose.yml" exec -T app \
   wget -qO- --header='content-type: application/json' \
   --post-data='{"model":"nomic-embed-text","input":"ping","encoding_format":"float"}' \
   http://host.docker.internal:8741/v1/embeddings
@@ -372,8 +375,23 @@ docker run --rm --network "$network" \
   '
 ```
 
-Write HMAC keyring + `NOOSPHERE_HYBRID_QUERY_PROFILE_ID` into
-`$NOOSPHERE_HOME/.env` with the flag still `false`. Then:
+Write the keyring + profile id into `$NOOSPHERE_HOME/.env` with the flag
+still `false` — without these the flag flip fail-closes with
+`HybridCorrectnessError` (`query_profile_invalid` / `cache_keyring_invalid`),
+not a lexical fallback:
+
+```bash
+# profile_id pasted from step 4.4; mint a 32-byte v1 key, never print it
+key_b64=$(openssl rand -base64 32)
+hmac_b64=$(printf '{"v1":"%s"}' "$key_b64" | base64 | tr -d '\n')
+# atomic write into $NOOSPHERE_HOME/.env:
+#   NOOSPHERE_HYBRID_QUERY_PROFILE_ID=<profile_id>
+#   NOOSPHERE_HYBRID_CACHE_HMAC_ACTIVE_VERSION=v1
+#   NOOSPHERE_HYBRID_CACHE_HMAC_KEYS_B64=$hmac_b64
+#   NOOSPHERE_HYBRID_RETRIEVAL_ENABLED=false
+```
+
+Then:
 
 ```bash
 "${compose[@]}" up -d --no-deps --force-recreate app
@@ -382,7 +400,14 @@ Write HMAC keyring + `NOOSPHERE_HYBRID_QUERY_PROFILE_ID` into
 
 `docker compose restart` does **not** reload env. Set
 `NOOSPHERE_HYBRID_RETRIEVAL_ENABLED` to the exact string `true`, recreate
-app again, health-check again.
+app again, health-check again. Then verify the gate actually opened:
+
+```bash
+"${compose[@]}" logs app 2>&1 | grep -E 'HybridCorrectnessError|query_profile_invalid|cache_keyring_invalid' || true
+```
+
+Empty output above = config valid; any hit = fix `.env` before trusting
+Phase 4.6.
 
 ### 4.6 Prove hybrid
 
@@ -421,8 +446,10 @@ recreate app with `--no-deps --force-recreate`. llama.cpp can stay installed.
 - **llama.cpp on `0.0.0.0`.** Puts embeddings on LAN/Tailscale without a key.
 - **HTTP 400 from llama.cpp.** Terminal for that job. Raise ctx/ubatch; do
   not retry.
-- **Draft-only corpus.** Agent saves are drafts by default. Unscoped recall
-  sees published articles only; admin/`['*']` sees drafts too.
+- **Draft-only corpus.** Agent saves are drafts by default. Recall does **not**
+  default to published articles: `metadata.status` is unset on the recall
+  path, so unscoped recall returns drafts too. If drafts must stay out of
+  agent recall, publish them or scope the API key.
 
 ---
 

--- a/docs/HERMES-INSTALLER-HYBRID.md
+++ b/docs/HERMES-INSTALLER-HYBRID.md
@@ -235,12 +235,13 @@ set -euo pipefail
 marker=$("${compose[@]}" exec -T db cat /run/noosphere-pgvector/writer-authorized)
 marker=$(printf '%s' "$marker" | tr -d '\r\n')
 test -n "$marker"
-grep -Fq -- "$marker" "$NOOSPHERE_HOME/docker-compose.yml"
+db_image=$("${compose[@]}" config --format json | jq -er '.services.db.image')
+test "$marker" = "$db_image"
 ```
 
-All three must succeed. An empty marker makes `grep -F ""` match anything —
-do not skip the `test -n`. A mismatch means the wrong image or an incomplete
-new-install guard — stop.
+Compare against `services.db.image` only. The same digest string also appears in
+the app/worker entrypoint gates; `grep` on the whole file can pass after a db
+image change. An empty marker, a `cat` failure, or a mismatch — stop.
 
 ### 4.3 Role URLs on the compose network
 
@@ -318,14 +319,18 @@ image inspect --format '{{.RepoDigests}}'`). Repeat activation is
 validate-only — do not repair A/B/C by hand.
 
 Copy the printed `profile_id`. Do not expect `$profile_id` to exist in the
-host shell — the sidecar is `--rm`. Persist **only**
-`NOOSPHERE_HYBRID_PROVIDER_CONFIG_B64` in `$NOOSPHERE_HOME/.env` (canonical
-base64 of compact JSON; empty `apiKey` is valid for local). Do not leave
-`NOOSPHERE_HYBRID_PROVIDER_CONFIG_JSON` set at the same time. Encode
-portably:
+host shell — the sidecar is `--rm`. Construct and persist **only**
+`NOOSPHERE_HYBRID_PROVIDER_CONFIG_B64` in `$NOOSPHERE_HOME/.env`. Do not leave
+`NOOSPHERE_HYBRID_PROVIDER_CONFIG_JSON` set at the same time. `$json` is not
+magic — build it from the printed id (empty `apiKey` is valid for local):
 
 ```bash
-printf '%s' "$json" | base64 | tr -d '\n'
+profile_id='00000000-0000-4000-8000-000000000000'  # paste the printed id
+json=$(python3 -c 'import json,sys; print(json.dumps([{"profileId":sys.argv[1],"locality":"local","endpoint":"http://host.docker.internal:8741/v1/embeddings","apiKey":""}],separators=(",",":")))' "$profile_id")
+b64=$(printf '%s' "$json" | base64 | tr -d '\n')
+test -n "$b64"
+# write NOOSPHERE_HYBRID_PROVIDER_CONFIG_B64=$b64 into $NOOSPHERE_HOME/.env
+# (atomic replace; never echo $b64)
 ```
 
 ### 4.5 Worker, then two app recreates
@@ -347,6 +352,12 @@ coverage is still ~0 until the worker runs. When `status` shows coverage
 printed id (host `$profile_id` is unset):
 
 ```bash
+export NOOSPHERE_HOME="${NOOSPHERE_HOME:-$HOME/.noosphere}"
+compose=(docker compose --project-directory "$NOOSPHERE_HOME")
+db_id=$("${compose[@]}" ps -q db)
+network=$(docker inspect -f '{{range $k, $v := .NetworkSettings.Networks}}{{$k}}{{end}}' "$db_id")
+test -n "$network"
+test -n "${NOOSPHERE_HYBRID_ADMIN_DATABASE_URL:-}"
 profile_id='00000000-0000-4000-8000-000000000000'  # paste the printed id
 docker run --rm --network "$network" \
   -v "$HOME/src/noosphere-scripts:/src" -w /src \

--- a/docs/HERMES-INSTALLER-HYBRID.md
+++ b/docs/HERMES-INSTALLER-HYBRID.md
@@ -330,7 +330,8 @@ magic — build it from the printed id (empty `apiKey` is valid for local):
 ```bash
 profile_id='00000000-0000-4000-8000-000000000000'  # paste the printed id
 uuid_re='^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$'
-[[ "$profile_id" =~ $uuid_re ]] && test "$profile_id" != '00000000-0000-4000-8000-000000000000'
+{ [[ "$profile_id" =~ $uuid_re ]] && test "$profile_id" != '00000000-0000-4000-8000-000000000000'; } \
+  || { echo "paste the real printed profile id (got: '${profile_id:-<empty>}')" >&2; exit 1; }
 json=$(python3 -c 'import json,sys; print(json.dumps([{"profileId":sys.argv[1],"locality":"local","endpoint":"http://host.docker.internal:8741/v1/embeddings","apiKey":""}],separators=(",",":")))' "$profile_id")
 b64=$(printf '%s' "$json" | base64 | tr -d '\n')
 test -n "$b64"
@@ -389,7 +390,8 @@ test -n "$network"
 test -n "${NOOSPHERE_HYBRID_ADMIN_DATABASE_URL:-}"
 profile_id='00000000-0000-4000-8000-000000000000'  # paste the printed id
 uuid_re='^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$'
-[[ "$profile_id" =~ $uuid_re ]] && test "$profile_id" != '00000000-0000-4000-8000-000000000000'
+{ [[ "$profile_id" =~ $uuid_re ]] && test "$profile_id" != '00000000-0000-4000-8000-000000000000'; } \
+  || { echo "paste the real printed profile id (got: '${profile_id:-<empty>}')" >&2; exit 1; }
 docker run --rm --network "$network" \
   -v "$HOME/src/noosphere-scripts:/src" -w /src \
   -e NOOSPHERE_HYBRID_ADMIN_DATABASE_URL \
@@ -409,13 +411,13 @@ not a lexical fallback:
 ```bash
 # profile_id pasted from step 4.4; mint a 32-byte v1 key, never print it
 uuid_re='^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$'
-test -n "$profile_id" && [[ "$profile_id" =~ $uuid_re ]] && test "$profile_id" != '00000000-0000-4000-8000-000000000000'
+{ test -n "$profile_id" && [[ "$profile_id" =~ $uuid_re ]] && test "$profile_id" != '00000000-0000-4000-8000-000000000000'; } \
+  || { echo "paste the real printed profile id (got: '${profile_id:-<empty>}')" >&2; exit 1; }
 key_b64=$(openssl rand -base64 32)
 hmac_b64=$(printf '{"v1":"%s"}' "$key_b64" | base64 | tr -d '\n')
-Both writers share the same `os.replace` core on purpose: each is self-contained
-and copy-pasteable in isolation — an operator mid-procedure should not need to
-have run (or even read) the other block first.
-
+# Both writers share the same os.replace core on purpose: each block is
+# self-contained and copy-pasteable in isolation — an operator mid-procedure
+# should not need to have run (or even read) the other block first.
 python3 - "$profile_id" "$hmac_b64" <<'PY'
 import os, sys, tempfile
 env_path = os.path.join(os.environ["NOOSPHERE_HOME"], ".env")

--- a/docs/HERMES-INSTALLER-HYBRID.md
+++ b/docs/HERMES-INSTALLER-HYBRID.md
@@ -472,9 +472,10 @@ before trusting Phase 4.6. Without the recall, empty output proves nothing.
 
 ### 4.6 Prove hybrid
 
-`POST /api/memory/recall` (not `/api/recall`) returns hits, and app logs
+`POST /api/memory/recall` returns hits, and app logs
 contain **zero** `[hybrid-retrieval] lexical fallback` lines for that
-request.
+request. (`/api/recall` is an alias of the same handler; the Hermes plugin
+uses `/api/memory/recall`.)
 
 ---
 

--- a/docs/HERMES-INSTALLER-HYBRID.md
+++ b/docs/HERMES-INSTALLER-HYBRID.md
@@ -1,0 +1,371 @@
+# Work VM: Hermes + installer runtime + llama.cpp hybrid
+
+This is the path for a **fresh machine** (work VM) where Hermes is already
+installed and you want Noosphere memory, then hybrid retrieval, without using
+the source-development Compose file.
+
+It is **not** a second hybrid ADR. Privilege/SQL contracts stay in
+[`docker/hybrid-storage/README.md`](../docker/hybrid-storage/README.md). The
+source-compose how-to (host Postgres on `127.0.0.1:5433`) stays in
+[`HYBRID-RETRIEVAL-ACTIVATION.md`](HYBRID-RETRIEVAL-ACTIVATION.md). This
+document exists because those two do not describe the guided-installer
+runtime.
+
+## What you get, in order
+
+1. Guided installer → app at `http://127.0.0.1:6578`, keyword-only recall,
+   Hermes plugin with **auto-recall**.
+2. Optional: Hermes **turn capture** (drafts), only after a topic exists.
+3. llama.cpp `llama-server` on the Docker bridge.
+4. Hybrid SQL A/B/C, local profile, worker, then the exact flag `true`.
+
+Hybrid serving and turn capture are **not** one `curl | bash`. The installer
+does not enable them.
+
+Do **not** use Ollama. Do **not** clone `docker-compose.yml` from a source
+checkout onto the work VM (it still carries owner-host defaults).
+
+## Two runtimes — never mix them
+
+| | Guided installer | Source compose |
+| --- | --- | --- |
+| Directory | `~/.noosphere` (`$NOOSPHERE_HOME`) | git clone working tree |
+| Compose file | `~/.noosphere/docker-compose.yml` (published template) | `docker-compose.yml` |
+| Project | `docker compose --project-directory ~/.noosphere` | `docker compose` in the clone |
+| App / db containers | `noosphere-openclaw-app` / `noosphere-openclaw-db` | `noosphere-app` / `noosphere-db` |
+| Postgres on the host | **not published** | `127.0.0.1:5433` |
+| DB URL from scripts | `postgresql://…@db:5432/noosphere` on the compose network | `127.0.0.1:5433` |
+
+`scripts/activate-hybrid-retrieval-stack.sh` targets the source-compose column.
+It will look for `noosphere-db` and `127.0.0.1:5433`. Do not run it against
+an installer install.
+
+The published image does **not** ship the A/B/C activator scripts or
+`docker/hybrid-storage/*.sql`. Keep a shallow scripts checkout for those
+commands only; Compose stays in `~/.noosphere`.
+
+---
+
+## Phase 1 — Noosphere + Hermes
+
+### Prerequisites
+
+Docker Compose v2, Node.js 22+, `curl`, `jq`, `sha256sum`, `tar`. Hermes CLI
+on `PATH`. If Hermes uses a named profile:
+
+```bash
+export HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
+```
+
+Defaults bind `127.0.0.1:6578`. Override with `BIND_ADDRESS`, `NOOSPHERE_PORT`,
+and `APP_URL` **before** the installer if the wiki must be non-loopback. Do
+not copy another host's Tailscale URL.
+
+### Interactive (TTY)
+
+Checksum the launcher, then run it with no flags. It prompts for each agent
+CLI it finds (`[Y/n]`, empty enter = Yes):
+
+```bash
+(
+  set -e
+  installer="$(mktemp)"
+  trap 'rm -f "$installer"' EXIT
+  curl -fsSL https://raw.githubusercontent.com/SweetSophia/noosphere/5c84a170a5b48754791e57b7e98191df5fbed5b8/install.sh -o "$installer"
+  printf '%s  %s\n' '1b98ea75fbcc15d224d4ab188d6f6958380321d98dc412816e3780937473e951' "$installer" | sha256sum -c -
+  bash "$installer"
+)
+```
+
+Say Yes to Hermes. Say No to any other detected CLI you do not want mutated.
+
+### Non-interactive
+
+Same checksum block, last line:
+
+```bash
+bash "$installer" --non-interactive --with hermes
+```
+
+`--non-interactive` without `--with` or `--core-only` exits 2. No TTY and no
+`--with`/`--core-only` also exits 2.
+
+### What the installer did
+
+- Runtime and mode-0600 `.env` in `~/.noosphere`
+- Guarded new-install: prepare → db/redis → `init` **once** → record → app
+- pgvector image + writer-authorization marker (no existing-volume transition)
+- `NOOSPHERE_HYBRID_RETRIEVAL_ENABLED=false`
+- Distinct `POSTGRES_*` and `POSTGRES_HYBRID_*` passwords (never printed)
+- Admin credentials in `~/.noosphere/credentials.json` (dir 0700, file 0600)
+- Scoped Hermes WRITE key in `$HERMES_HOME/.env` as `HERMES_NOOSPHERE_API_KEY`
+- Plugin + setup skill under `$HERMES_HOME`; `hermes config set memory.provider noosphere`
+- `$HERMES_HOME/noosphere.json` with `auto_recall: true`, `auto_capture: false`
+
+Bootstrap ADMIN key is not written into Hermes config.
+
+### Prove Phase 1
+
+```bash
+curl -fsS http://127.0.0.1:6578/api/health
+hermes memory status
+```
+
+Wiki: `http://127.0.0.1:6578/wiki` — password from `credentials.json`, not from
+the installer transcript. Keyword recall is live.
+
+---
+
+## Phase 2 — Capture layers (do not mix)
+
+**Auto-recall** (already on): prompt-time `POST /api/memory/recall`. This is
+“Hermes remembers.” Leave it on.
+
+**Hermes turn capture** (`sync_turn`): writes substantial turns as **draft**
+articles. Off by design. It is a no-op unless **both** are set:
+
+- `auto_capture: true`
+- a real `topic_id` (create the topic in the wiki first)
+
+Then restart the Hermes session so it reloads `$HERMES_HOME/noosphere.json`.
+
+**Server `NOOSPHERE_AUTO_MEMORY_CAPTURE_ENABLED`**: a different API (HMAC
+keyring, capture endpoint, scheduler). The OpenClaw `agent_end` pipeline is
+not implemented. Leave this **false** on a Hermes-only VM.
+
+Day-one recipe: auto-recall on, turn capture off, server capture off. Use
+`noosphere_save` for curated knowledge.
+
+---
+
+## Phase 3 — llama.cpp embeddings
+
+Hybrid needs `POST /v1/embeddings` where **containers** can reach it. Bind the
+Docker bridge, not loopback-only, not LAN.
+
+Do **not** use Ollama.
+
+Verified CPU contract (no CUDA): GGUF `nomic-embed-text-v1.5.Q8_0.gguf`
+(768-d), llama.cpp `llama-server --embeddings`. Long articles HTTP 400 unless
+context is 8192 with YaRN (400 is not retried; leftover `failed` jobs make the
+worker unhealthy).
+
+```text
+llama-server \
+  -m /path/to/nomic-embed-text-v1.5.Q8_0.gguf \
+  --embeddings --alias nomic-embed-text \
+  --host 172.17.0.1 --port 8741 \
+  -ngl 0 -t 4 \
+  -c 8192 -b 8192 -ub 8192 -np 1 \
+  --pooling mean \
+  --rope-scaling yarn --yarn-orig-ctx 2048 --rope-scale 4
+```
+
+Prefer a systemd `--user` unit with linger. Flags and smoke request:
+[`HYBRID-RETRIEVAL-ACTIVATION.md`](HYBRID-RETRIEVAL-ACTIVATION.md) appendix.
+
+Host smoke must return `model` = `nomic-embed-text` and 768 finite floats:
+
+```bash
+curl -fsS http://172.17.0.1:8741/v1/embeddings \
+  -H 'content-type: application/json' \
+  -d '{"model":"nomic-embed-text","input":"ping","encoding_format":"float"}'
+```
+
+Then from the compose network (app/worker already have
+`extra_hosts: host.docker.internal:host-gateway`):
+
+```bash
+docker compose --project-directory "${NOOSPHERE_HOME:-$HOME/.noosphere}" run --rm --no-deps --entrypoint curl app \
+  -fsS http://host.docker.internal:8741/v1/embeddings \
+  -H 'content-type: application/json' \
+  -d '{"model":"nomic-embed-text","input":"ping","encoding_format":"float"}'
+```
+
+If the image has no `curl`, run the same URL from any throwaway container on
+the project network with `--add-host host.docker.internal:host-gateway`.
+
+---
+
+## Phase 4 — Hybrid on the installer stack
+
+Compose commands in this phase always use:
+
+```bash
+export NOOSPHERE_HOME="${NOOSPHERE_HOME:-$HOME/.noosphere}"
+compose=(docker compose --project-directory "$NOOSPHERE_HOME")
+```
+
+Never `docker compose` from a git clone. Never re-run `init`.
+
+### 4.1 Scripts checkout (not the runtime)
+
+```bash
+git clone --branch v1.13.2 --depth 1 https://github.com/SweetSophia/noosphere.git ~/src/noosphere-scripts
+cd ~/src/noosphere-scripts
+npm ci
+```
+
+Pin the branch to the same release as the installer. `npm ci` is for
+activators only.
+
+### 4.2 Snapshot
+
+```bash
+umask 077
+stamp=$(date +%Y%m%d-%H%M%S)
+dest="$HOME/.noosphere/backups/pre-hybrid-A-${stamp}"
+mkdir -p "$dest"
+chmod 700 "$dest"
+cp -a "$NOOSPHERE_HOME/.env" "$dest/.env.bak"
+chmod 600 "$dest/.env.bak"
+"${compose[@]}" exec -T db pg_dump -U noosphere -d noosphere -Fc >"$dest/pre-hybrid-A.dump"
+chmod 600 "$dest/pre-hybrid-A.dump"
+pg_restore -l "$dest/pre-hybrid-A.dump" >/dev/null
+```
+
+Confirm the writer-authorization marker (must match the digest in
+`docker-compose.noosphere.yml`):
+
+```bash
+"${compose[@]}" exec -T db cat /run/noosphere-pgvector/writer-authorized
+```
+
+### 4.3 Role URLs on the compose network
+
+Postgres is not on the host. Activators must talk to hostname `db`. Load
+`~/.noosphere/.env` without printing it, percent-encode passwords, export the
+five URLs as `postgresql://role:encoded@db:5432/noosphere`.
+
+Roles:
+
+- `noosphere` → `NOOSPHERE_BOOTSTRAP_DATABASE_URL` (`POSTGRES_PASSWORD`)
+- `noosphere_migrator` → `DATABASE_URL` (`POSTGRES_MIGRATION_PASSWORD`)
+- `noosphere_app` → `NOOSPHERE_APP_DATABASE_URL` (`POSTGRES_APP_PASSWORD`)
+- `noosphere_hybrid_admin_login` → `NOOSPHERE_HYBRID_ADMIN_DATABASE_URL`
+- `noosphere_hybrid_worker_login` → `NOOSPHERE_HYBRID_WORKER_DATABASE_URL`
+
+Do not paste those URLs into the shell history. A small Python helper that
+reads os.environ and prints `export …` lines is enough; inspect with
+`echo ${#POSTGRES_PASSWORD}` (length only).
+
+Discover the project network once:
+
+```bash
+db_id=$("${compose[@]}" ps -q db)
+network=$(docker inspect -f '{{range $k, $v := .NetworkSettings.Networks}}{{$k}}{{end}}' "$db_id")
+```
+
+### 4.4 A/B/C + profile, from a sidecar
+
+Host `npm run hybrid-*` cannot resolve `db`. Run the clone on that network.
+The sidecar needs Node 22 and `psql` (activators call both). Build the five
+URLs in a wrapper that never prints them, then pass them as `-e`:
+
+```bash
+docker run --rm --network "$network" \
+  --add-host host.docker.internal:host-gateway \
+  -v "$HOME/src/noosphere-scripts:/src" -w /src \
+  -e NOOSPHERE_BOOTSTRAP_DATABASE_URL \
+  -e DATABASE_URL \
+  -e NOOSPHERE_APP_DATABASE_URL \
+  -e NOOSPHERE_HYBRID_ADMIN_DATABASE_URL \
+  -e NOOSPHERE_HYBRID_WORKER_DATABASE_URL \
+  node:22-bookworm bash -ceu '
+    apt-get update -qq && apt-get install -y -qq postgresql-client >/dev/null
+    npm run hybrid-storage:activate
+    npm run hybrid-worker:activate
+    npm run hybrid-retrieval:activate
+    node scripts/hybrid-profile.mjs create \
+      --locality local \
+      --endpoint http://host.docker.internal:8741/v1/embeddings \
+      --model nomic-embed-text \
+      --revision Q8_0-b10783 \
+      --dimensions 768
+  '
+```
+
+Repeat activation is validate-only — do not repair A/B/C by hand.
+
+`hybrid:profile create` prints a `profileId`. Keep it. Prepare and backfill
+with that id (`node scripts/hybrid-profile.mjs prepare|status` and
+`node scripts/hybrid-backfill.mjs`). Coverage must be ≥ 0.95 before serving.
+
+Persist **only** `NOOSPHERE_HYBRID_PROVIDER_CONFIG_B64` in
+`~/.noosphere/.env` (canonical base64 of compact JSON; empty `apiKey` is
+valid for local). Do not leave `NOOSPHERE_HYBRID_PROVIDER_CONFIG_JSON` set at
+the same time. Encode portably:
+
+```bash
+printf '%s' "$json" | base64 | tr -d '\n'
+```
+
+### 4.5 Worker, then two app recreates
+
+```bash
+"${compose[@]}" --profile hybrid up -d --no-deps --force-recreate hybrid-worker
+```
+
+`--no-deps` keeps `init` from running again. `--force-recreate` picks up the
+new B64 (a live worker can keep `W10=` otherwise).
+
+Wait until the worker is **healthy** (compose healthcheck). Any
+`embedding_job` in `failed` fails that check — cancel over-context rows;
+they stay keyword-only.
+
+When coverage ≥ 0.95: `hybrid:profile serve`. Write HMAC keyring +
+`NOOSPHERE_HYBRID_QUERY_PROFILE_ID` into `~/.noosphere/.env` with the flag
+still `false`. Then:
+
+```bash
+"${compose[@]}" up -d --no-deps --force-recreate app
+"${compose[@]}" exec -T app wget -qO- http://127.0.0.1:3000/api/health
+```
+
+`docker compose restart` does **not** reload env. Set
+`NOOSPHERE_HYBRID_RETRIEVAL_ENABLED` to the exact string `true`, recreate
+app again, health-check again.
+
+### 4.6 Prove hybrid
+
+`POST /api/memory/recall` (not `/api/recall`) returns hits, and app logs
+contain **zero** `[hybrid-retrieval] lexical fallback` lines for that
+request.
+
+---
+
+## Rollback
+
+```bash
+"${compose[@]}" --profile hybrid stop app hybrid-worker
+```
+
+Restore the dump from 4.2, set `NOOSPHERE_HYBRID_RETRIEVAL_ENABLED=false`,
+recreate app with `--no-deps --force-recreate`. llama.cpp can stay installed.
+
+---
+
+## Pitfalls (installer-specific)
+
+- **Wrong Compose project.** Commands without
+  `--project-directory ~/.noosphere` target a different stack or nothing.
+- **Wrong DB container / port.** Installer db is `noosphere-openclaw-db`.
+  There is no host `:5433`.
+- **Re-running `init`.** `up -d` without `--no-deps` on worker/app can
+  double-bootstrap.
+- **llama.cpp on `127.0.0.1` only.** Containers use `host.docker.internal` →
+  docker0 (`172.17.0.1`).
+- **llama.cpp on `0.0.0.0`.** Puts embeddings on LAN/Tailscale without a key.
+- **HTTP 400 from llama.cpp.** Terminal for that job. Raise ctx/ubatch; do
+  not retry.
+- **Draft-only corpus.** Agent saves are drafts by default. Unscoped recall
+  sees published articles only; admin/`['*']` sees drafts too.
+
+---
+
+## Related
+
+- Guided installer: [`INSTALLATION.md`](INSTALLATION.md)
+- Source-compose hybrid how-to: [`HYBRID-RETRIEVAL-ACTIVATION.md`](HYBRID-RETRIEVAL-ACTIVATION.md)
+- Hermes plugin: [`../hermes-noosphere-memory/README.md`](../hermes-noosphere-memory/README.md)
+- Why hybrid is fail-closed: [`HYBRID-RETRIEVAL-ADR.md`](HYBRID-RETRIEVAL-ADR.md)

--- a/docs/HERMES-INSTALLER-HYBRID.md
+++ b/docs/HERMES-INSTALLER-HYBRID.md
@@ -154,6 +154,24 @@ Verified CPU contract (no CUDA): GGUF `nomic-embed-text-v1.5.Q8_0.gguf`
 context is 8192 with YaRN (400 is not retried; leftover `failed` jobs make the
 worker unhealthy).
 
+**Getting the pieces** (the appendix covers flags, not acquisition): build or
+download a `llama-server` binary with embeddings support from the llama.cpp
+releases for your arch, and fetch the GGUF from
+`nomic-ai/nomic-embed-text-v1.5-GGUF` on Hugging Face. Record the SHA-256
+before first start and keep it with the model:
+
+```bash
+sha256sum nomic-embed-text-v1.5.Q8_0.gguf
+# expected: 3e24342164b3d94991ba9692fdc0dd08e3fd7362e0aacc396a9a5c54a544c3b7
+```
+
+**Firewall**: `172.17.0.1` is Docker's default bridge address — if the daemon
+uses a custom `bip`, adjust the bind and the provider endpoint to match
+(`ip -4 addr show docker0`). On a ufw-enabled VM, container traffic to
+`172.17.0.1:8741` can be dropped by INPUT rules — if the in-network smoke
+(Phase 3, second block) fails while host smoke passes, check
+`sudo ufw status` / `journalctl -k` before touching anything else.
+
 ```text
 llama-server \
   -m /path/to/nomic-embed-text-v1.5.Q8_0.gguf \

--- a/docs/HERMES-INSTALLER-HYBRID.md
+++ b/docs/HERMES-INSTALLER-HYBRID.md
@@ -194,7 +194,7 @@ Compose commands in this phase always use:
 
 ```bash
 export NOOSPHERE_HOME="${NOOSPHERE_HOME:-$HOME/.noosphere}"
-compose=(docker compose --project-directory "$NOOSPHERE_HOME")
+compose=(docker compose --project-directory "$NOOSPHERE_HOME" -f "$NOOSPHERE_HOME/docker-compose.yml")
 ```
 
 Never `docker compose` from a git clone. Never re-run `init`.
@@ -326,6 +326,7 @@ magic — build it from the printed id (empty `apiKey` is valid for local):
 
 ```bash
 profile_id='00000000-0000-4000-8000-000000000000'  # paste the printed id
+test "$profile_id" != '00000000-0000-4000-8000-000000000000'
 json=$(python3 -c 'import json,sys; print(json.dumps([{"profileId":sys.argv[1],"locality":"local","endpoint":"http://host.docker.internal:8741/v1/embeddings","apiKey":""}],separators=(",",":")))' "$profile_id")
 b64=$(printf '%s' "$json" | base64 | tr -d '\n')
 test -n "$b64"
@@ -353,12 +354,13 @@ printed id (host `$profile_id` is unset):
 
 ```bash
 export NOOSPHERE_HOME="${NOOSPHERE_HOME:-$HOME/.noosphere}"
-compose=(docker compose --project-directory "$NOOSPHERE_HOME")
+compose=(docker compose --project-directory "$NOOSPHERE_HOME" -f "$NOOSPHERE_HOME/docker-compose.yml")
 db_id=$("${compose[@]}" ps -q db)
 network=$(docker inspect -f '{{range $k, $v := .NetworkSettings.Networks}}{{$k}}{{end}}' "$db_id")
 test -n "$network"
 test -n "${NOOSPHERE_HYBRID_ADMIN_DATABASE_URL:-}"
 profile_id='00000000-0000-4000-8000-000000000000'  # paste the printed id
+test "$profile_id" != '00000000-0000-4000-8000-000000000000'
 docker run --rm --network "$network" \
   -v "$HOME/src/noosphere-scripts:/src" -w /src \
   -e NOOSPHERE_HYBRID_ADMIN_DATABASE_URL \
@@ -394,7 +396,7 @@ request.
 
 ```bash
 export NOOSPHERE_HOME="${NOOSPHERE_HOME:-$HOME/.noosphere}"
-compose=(docker compose --project-directory "$NOOSPHERE_HOME")
+compose=(docker compose --project-directory "$NOOSPHERE_HOME" -f "$NOOSPHERE_HOME/docker-compose.yml")
 "${compose[@]}" --profile hybrid stop app hybrid-worker
 ```
 

--- a/docs/HERMES-INSTALLER-HYBRID.md
+++ b/docs/HERMES-INSTALLER-HYBRID.md
@@ -231,11 +231,15 @@ Compose file (`$NOOSPHERE_HOME/docker-compose.yml`), not the source-checkout
 filename `docker-compose.noosphere.yml`:
 
 ```bash
+set -euo pipefail
 marker=$("${compose[@]}" exec -T db cat /run/noosphere-pgvector/writer-authorized)
-grep -F "$marker" "$NOOSPHERE_HOME/docker-compose.yml"
+marker=$(printf '%s' "$marker" | tr -d '\r\n')
+test -n "$marker"
+grep -Fq -- "$marker" "$NOOSPHERE_HOME/docker-compose.yml"
 ```
 
-`grep` must exit 0. A mismatch means the wrong image or an incomplete
+All three must succeed. An empty marker makes `grep -F ""` match anything —
+do not skip the `test -n`. A mismatch means the wrong image or an incomplete
 new-install guard — stop.
 
 ### 4.3 Role URLs on the compose network
@@ -291,7 +295,7 @@ docker run --rm --network "$network" \
   -e NOOSPHERE_HYBRID_ADMIN_DATABASE_URL \
   -e NOOSPHERE_HYBRID_WORKER_DATABASE_URL \
   node:22-bookworm bash -ceu '
-    apt-get update -qq && apt-get install -y -qq postgresql-client >/dev/null
+    apt-get update -qq && apt-get install -y -qq postgresql-client jq >/dev/null
     npm run hybrid-storage:activate
     npm run hybrid-worker:activate
     npm run hybrid-retrieval:activate
@@ -301,7 +305,7 @@ docker run --rm --network "$network" \
       --model nomic-embed-text \
       --revision Q8_0-b10783 \
       --dimensions 768)
-    profile_id=$(printf "%s" "$profile_json" | node -e "let s=\"\";process.stdin.on(\"data\",d=>s+=d);process.stdin.on(\"end\",()=>console.log(JSON.parse(s).profileId))")
+    profile_id=$(printf "%s" "$profile_json" | jq -er .profileId)
     printf "profile_id=%s\n" "$profile_id"
     node scripts/hybrid-profile.mjs prepare --profile "$profile_id"
     node scripts/hybrid-backfill.mjs --profile "$profile_id" --chunk 100
@@ -313,17 +317,12 @@ Prefer a digest-pinned `node:22-bookworm` if your policy requires it (`docker
 image inspect --format '{{.RepoDigests}}'`). Repeat activation is
 validate-only — do not repair A/B/C by hand.
 
-Keep the printed `profile_id`. Coverage must be ≥ 0.95 before serving. Serve
-from the **same** sidecar (still on the compose network):
-
-```bash
-node scripts/hybrid-profile.mjs serve --profile "$profile_id"
-```
-
-Persist **only** `NOOSPHERE_HYBRID_PROVIDER_CONFIG_B64` in
-`~/.noosphere/.env` (canonical base64 of compact JSON; empty `apiKey` is
-valid for local). Do not leave `NOOSPHERE_HYBRID_PROVIDER_CONFIG_JSON` set at
-the same time. Encode portably:
+Copy the printed `profile_id`. Do not expect `$profile_id` to exist in the
+host shell — the sidecar is `--rm`. Persist **only**
+`NOOSPHERE_HYBRID_PROVIDER_CONFIG_B64` in `$NOOSPHERE_HOME/.env` (canonical
+base64 of compact JSON; empty `apiKey` is valid for local). Do not leave
+`NOOSPHERE_HYBRID_PROVIDER_CONFIG_JSON` set at the same time. Encode
+portably:
 
 ```bash
 printf '%s' "$json" | base64 | tr -d '\n'
@@ -342,9 +341,26 @@ Wait until the worker is **healthy** (compose healthcheck). Any
 `embedding_job` in `failed` fails that check — cancel over-context rows;
 they stay keyword-only.
 
-When coverage ≥ 0.95: serve the profile (sidecar command above). Write HMAC
-keyring + `NOOSPHERE_HYBRID_QUERY_PROFILE_ID` into `$NOOSPHERE_HOME/.env` with
-the flag still `false`. Then:
+Backfill only *queues* jobs. Do **not** `serve` in the create sidecar —
+coverage is still ~0 until the worker runs. When `status` shows coverage
+≥ 0.95, serve from a **second** sidecar on the same network, substituting the
+printed id (host `$profile_id` is unset):
+
+```bash
+profile_id='00000000-0000-4000-8000-000000000000'  # paste the printed id
+docker run --rm --network "$network" \
+  -v "$HOME/src/noosphere-scripts:/src" -w /src \
+  -e NOOSPHERE_HYBRID_ADMIN_DATABASE_URL \
+  -e PROFILE_ID="$profile_id" \
+  node:22-bookworm bash -ceu '
+    apt-get update -qq && apt-get install -y -qq postgresql-client >/dev/null
+    node scripts/hybrid-profile.mjs status --profile "$PROFILE_ID"
+    node scripts/hybrid-profile.mjs serve --profile "$PROFILE_ID"
+  '
+```
+
+Write HMAC keyring + `NOOSPHERE_HYBRID_QUERY_PROFILE_ID` into
+`$NOOSPHERE_HOME/.env` with the flag still `false`. Then:
 
 ```bash
 "${compose[@]}" up -d --no-deps --force-recreate app

--- a/docs/HERMES-INSTALLER-HYBRID.md
+++ b/docs/HERMES-INSTALLER-HYBRID.md
@@ -181,7 +181,7 @@ Then from the compose network. The published app image is `node:22-alpine`
 (BusyBox `wget`, no `curl`):
 
 ```bash
-docker compose --project-directory "$NOOSPHERE_HOME" -f "$NOOSPHERE_HOME/docker-compose.yml" exec -T app \
+docker compose --project-directory "${NOOSPHERE_HOME:-$HOME/.noosphere}" -f "${NOOSPHERE_HOME:-$HOME/.noosphere}/docker-compose.yml" exec -T app \
   wget -qO- --header='content-type: application/json' \
   --post-data='{"model":"nomic-embed-text","input":"ping","encoding_format":"float"}' \
   http://host.docker.internal:8741/v1/embeddings
@@ -333,8 +333,32 @@ test "$profile_id" != '00000000-0000-4000-8000-000000000000'
 json=$(python3 -c 'import json,sys; print(json.dumps([{"profileId":sys.argv[1],"locality":"local","endpoint":"http://host.docker.internal:8741/v1/embeddings","apiKey":""}],separators=(",",":")))' "$profile_id")
 b64=$(printf '%s' "$json" | base64 | tr -d '\n')
 test -n "$b64"
-# write NOOSPHERE_HYBRID_PROVIDER_CONFIG_B64=$b64 into $NOOSPHERE_HOME/.env
-# (atomic replace; never echo $b64)
+python3 - "$b64" <<'PY'
+import os, sys, tempfile
+env_path = os.path.join(os.environ["NOOSPHERE_HOME"], ".env")
+b64 = sys.argv[1]
+sets = {"NOOSPHERE_HYBRID_PROVIDER_CONFIG_B64": b64}
+out, seen = [], set()
+with open(env_path) as f:
+    for line in f:
+        key = line.split("=", 1)[0] if "=" in line else None
+        if key == "NOOSPHERE_HYBRID_PROVIDER_CONFIG_JSON":
+            continue  # strip stale JSON form
+        if key in sets:
+            out.append(key + "=" + sets[key] + "\n")
+            seen.add(key)
+        else:
+            out.append(line)
+for key, value in sets.items():
+    if key not in seen:
+        out.append(key + "=" + value + "\n")
+fd, tmp = tempfile.mkstemp(dir=os.path.dirname(env_path))
+with os.fdopen(fd, "w") as f:
+    f.writelines(out)
+    f.flush()
+    os.fsync(f.fileno())
+os.replace(tmp, env_path)
+PY
 ```
 
 ### 4.5 Worker, then two app recreates
@@ -384,11 +408,34 @@ not a lexical fallback:
 # profile_id pasted from step 4.4; mint a 32-byte v1 key, never print it
 key_b64=$(openssl rand -base64 32)
 hmac_b64=$(printf '{"v1":"%s"}' "$key_b64" | base64 | tr -d '\n')
-# atomic write into $NOOSPHERE_HOME/.env:
-#   NOOSPHERE_HYBRID_QUERY_PROFILE_ID=<profile_id>
-#   NOOSPHERE_HYBRID_CACHE_HMAC_ACTIVE_VERSION=v1
-#   NOOSPHERE_HYBRID_CACHE_HMAC_KEYS_B64=$hmac_b64
-#   NOOSPHERE_HYBRID_RETRIEVAL_ENABLED=false
+python3 - "$profile_id" "$hmac_b64" <<'PY'
+import os, sys, tempfile
+env_path = os.path.join(os.environ["NOOSPHERE_HOME"], ".env")
+sets = {
+    "NOOSPHERE_HYBRID_QUERY_PROFILE_ID": sys.argv[1],
+    "NOOSPHERE_HYBRID_CACHE_HMAC_ACTIVE_VERSION": "v1",
+    "NOOSPHERE_HYBRID_CACHE_HMAC_KEYS_B64": sys.argv[2],
+    "NOOSPHERE_HYBRID_RETRIEVAL_ENABLED": "false",
+}
+out, seen = [], set()
+with open(env_path) as f:
+    for line in f:
+        key = line.split("=", 1)[0] if "=" in line else None
+        if key in sets:
+            out.append(key + "=" + sets[key] + "\n")
+            seen.add(key)
+        else:
+            out.append(line)
+for key, value in sets.items():
+    if key not in seen:
+        out.append(key + "=" + value + "\n")
+fd, tmp = tempfile.mkstemp(dir=os.path.dirname(env_path))
+with os.fdopen(fd, "w") as f:
+    f.writelines(out)
+    f.flush()
+    os.fsync(f.fileno())
+os.replace(tmp, env_path)
+PY
 ```
 
 Then:

--- a/docs/HERMES-INSTALLER-HYBRID.md
+++ b/docs/HERMES-INSTALLER-HYBRID.md
@@ -328,6 +328,8 @@ host shell — the sidecar is `--rm`. Construct and persist **only**
 magic — build it from the printed id (empty `apiKey` is valid for local):
 
 ```bash
+set -euo pipefail
+export NOOSPHERE_HOME="${NOOSPHERE_HOME:-$HOME/.noosphere}"
 profile_id='00000000-0000-4000-8000-000000000000'  # paste the printed id
 uuid_re='^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$'
 { [[ "$profile_id" =~ $uuid_re ]] && test "$profile_id" != '00000000-0000-4000-8000-000000000000'; } \
@@ -409,6 +411,8 @@ still `false` — without these the flag flip fail-closes with
 not a lexical fallback:
 
 ```bash
+set -euo pipefail
+export NOOSPHERE_HOME="${NOOSPHERE_HOME:-$HOME/.noosphere}"
 # profile_id pasted from step 4.4; mint a 32-byte v1 key, never print it
 uuid_re='^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$'
 { test -n "$profile_id" && [[ "$profile_id" =~ $uuid_re ]] && test "$profile_id" != '00000000-0000-4000-8000-000000000000'; } \
@@ -464,10 +468,11 @@ clean until the first recall. After the recreate, run one throwaway recall
 (any Hermes key, `mode: "auto"`), then check for the fail-closed errors:
 
 ```bash
-"${compose[@]}" logs app 2>&1 | grep -E 'HybridCorrectnessError|query_profile_invalid|query_profile_missing|cache_keyring_invalid' || true
+! "${compose[@]}" logs app 2>&1 | grep -qE 'HybridCorrectnessError|query_profile_invalid|query_profile_missing|cache_keyring_invalid'
 ```
 
-Empty output **after that recall** = config valid; any hit = fix `.env`
+The fence itself must exit 0 — any fail-closed hit and the pipeline above
+exits non-zero. Empty output after that recall = config valid; any hit = fix `.env`
 before trusting Phase 4.6. Without the recall, empty output proves nothing.
 
 ### 4.6 Prove hybrid

--- a/docs/HYBRID-RETRIEVAL-ACTIVATION.md
+++ b/docs/HYBRID-RETRIEVAL-ACTIVATION.md
@@ -9,8 +9,14 @@ exact string `true`.
 
 Privilege, SQL, and repeat-validation contracts live in
 [`docker/hybrid-storage/README.md`](../docker/hybrid-storage/README.md).
-This document is the operator how-to. The ADR
+This document is the operator how-to **for a source Compose checkout** (host
+Postgres on `127.0.0.1:5433`, db container `noosphere-db`). The ADR
 ([`HYBRID-RETRIEVAL-ADR.md`](HYBRID-RETRIEVAL-ADR.md)) is why, not how.
+
+If Noosphere was installed with the guided installer (`~/.noosphere`,
+containers `noosphere-openclaw-*`, Postgres only on the compose network), do
+not follow the host `:5433` steps below. Use
+[`HERMES-INSTALLER-HYBRID.md`](HERMES-INSTALLER-HYBRID.md).
 
 ## Local embeddings: llama.cpp only
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -51,6 +51,10 @@ http://127.0.0.1:6578/wiki
 
 The installer reports the actual URL if you selected a different bind address.
 
+A work VM that already has Hermes, and later wants llama.cpp hybrid retrieval
+against this installer runtime (Postgres is **not** on host `:5433`), follow
+[Work VM: Hermes + installer + llama.cpp hybrid](HERMES-INSTALLER-HYBRID.md).
+
 ### Credentials
 
 Generated administrator credentials are written to:
@@ -227,5 +231,7 @@ remain in the repository [README](../README.md#local-development).
 
 Optional pgvector hybrid storage remains a separate activation step. Operator
 how-to (llama.cpp local embeddings):
-[HYBRID-RETRIEVAL-ACTIVATION.md](HYBRID-RETRIEVAL-ACTIVATION.md). SQL/privilege
-contract: [docker/hybrid-storage/README.md](../docker/hybrid-storage/README.md).
+[HYBRID-RETRIEVAL-ACTIVATION.md](HYBRID-RETRIEVAL-ACTIVATION.md) for source
+Compose, or [HERMES-INSTALLER-HYBRID.md](HERMES-INSTALLER-HYBRID.md) for the
+guided-installer runtime. SQL/privilege contract:
+[docker/hybrid-storage/README.md](../docker/hybrid-storage/README.md).

--- a/hermes-noosphere-memory/README.md
+++ b/hermes-noosphere-memory/README.md
@@ -57,7 +57,9 @@ environment file, and configures the provider. Keeping the launcher command in
 the release-owned installation guide avoids a circular bundle-to-launcher pin.
 
 Work VM that already has Hermes and later wants llama.cpp hybrid retrieval on
-the installer runtime: [docs/HERMES-INSTALLER-HYBRID.md](../docs/HERMES-INSTALLER-HYBRID.md).
+the installer runtime:
+https://github.com/SweetSophia/noosphere/blob/master/docs/HERMES-INSTALLER-HYBRID.md
+(the standalone Hermes tarball does not include `docs/`).
 
 ## Install the 1.13.2 Release Bundle
 

--- a/hermes-noosphere-memory/README.md
+++ b/hermes-noosphere-memory/README.md
@@ -56,6 +56,9 @@ and Hermes bundle, writes the scoped WRITE key to the mode-`0600` Hermes
 environment file, and configures the provider. Keeping the launcher command in
 the release-owned installation guide avoids a circular bundle-to-launcher pin.
 
+Work VM that already has Hermes and later wants llama.cpp hybrid retrieval on
+the installer runtime: [docs/HERMES-INSTALLER-HYBRID.md](../docs/HERMES-INSTALLER-HYBRID.md).
+
 ## Install the 1.13.2 Release Bundle
 
 The coordinated Noosphere release attaches a deterministic Hermes provider


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary

This pull request introduces a production runbook for enabling llama.cpp hybrid retrieval on Noosphere installations deployed via the guided installer (with Hermes memory), filling a documentation gap between the source-development Compose workflow and the installer-based deployment model.

## What's new

- **New runbook `docs/HERMES-INSTALLER-HYBRID.md`** — Authoritative operational guide for installations under `~/.noosphere` with `noosphere-openclaw-*` containers. It walks through four sequential phases:
  1. **Install Noosphere with Hermes** — Interactive and non-interactive launcher invocation, including SHA-256 checksum verification, scoped Hermes credentials, mode-0600 `.env`, and confirmation of auto-recall configuration.
  2. **Disambiguate capture layers** — Differentiates auto-recall, Hermes turn capture (drafts, gated by `topic_id`), and server-side `NOOSPHERE_AUTO_MEMORY_CAPTURE_ENABLED`.
  3. **Configure llama.cpp embeddings** — `nomic-embed-text-v1.5.Q8_0.gguf` bound to the Docker bridge (`172.17.0.1:8741`) with 8192-token YaRN context to avoid HTTP 400 over-context failures.
  4. **Activate hybrid SQL A/B/C** — From a Docker socket-enabled sidecar on the compose network, create a local embedding profile, backfill embeddings, serve it, then set `NOOSPHERE_HYBRID_RETRIEVAL_ENABLED` to the exact string `true`.

## Why this was needed

The installer stack and source checkout have divergent Compose projects, container names, network topology, and activation paths. The existing `scripts/activate-hybrid-retrieval-stack.sh` targets the source-compose layout (db container `noosphere-db`, host Postgres on `127.0.0.1:5433`); it is not reusable for installer installations where Postgres is only reachable on the compose network at `db:5432`.

## Key safeguards documented

- **Pinned scripts checkout at `v1.13.2`** — Because the published app image does not include the A/B/C activator scripts (SQL DDL is shipped, activators are not).
- **Docker socket + CLI sidecar** — Mounted on the compose network since bundled activators inspect `noosphere-openclaw-db` via `docker inspect`.
- **Role URLs target `db:5432`** — Five roles loaded from `~/.noosphere/.env` with percent-encoded passwords; never pasted into shell history.
- **Single-source `NOOSPHERE_HYBRID_PROVIDER_CONFIG_B64`** — Strips any stale `NOOSPHERE_HYBRID_PROVIDER_CONFIG_JSON` to prevent dual-form configuration.
- **Writer-authorization marker verification** — Compares against `services.db.image` in the installer Compose file, not the source-checkout filename.
- **`--no-deps --force-recreate`** — Used for worker and app recreations to prevent re-running `init` and to pick up new env values.
- **Pre-activation `.env` backup + `pg_dump` snapshot** — Mode-0600/0700 permissions enforced.
- **`docker compose restart` does not reload env** — Explicitly documented as a common pitfall.
- **HMAC keyring + `NOOSPHERE_HYBRID_QUERY_PROFILE_ID`** — Must be written before flipping the flag, otherwise activation fail-closes with `HybridCorrectnessError` (not lexical fallback).
- **Verification via `POST /api/memory/recall`** — Confirmed by zero `[hybrid-retrieval] lexical fallback` log entries.
- **Rollback procedure** — Snapshot restore, profile stop, flag flip to `false`, app recreate.

## Installer-specific pitfalls documented

- Running Compose from the wrong directory or without `--project-directory ~/.noosphere`.
- Looking for an installer database on host `:5433`.
- Omitting Docker socket/CLI from the activation sidecar (activators exit before SQL).
- Accidentally re-running `init` by omitting `--no-deps`.
- Binding llama.cpp only to loopback (unreachable from containers) or to `0.0.0.0` (exposes unauthenticated embeddings endpoint on LAN/Tailscale).
- Treating llama.cpp HTTP 400 as a terminal failed job rather than addressing context settings.
- Expecting unscoped recall to default to published-only — `metadata.status` is unset on the recall path, so drafts surface unless the API key is scoped.

## Documentation navigation updates

- **`README.md`** — Branches the hybrid retrieval guide link into source-Compose vs. guided-installer paths and adds the new runbook to the Documentation table.
- **`docs/INSTALLATION.md`** — Points work VMs that already have Hermes and later enable hybrid retrieval to the new runbook; splits the hybrid link by deployment type.
- **`docs/HYBRID-RETRIEVAL-ACTIVATION.md`** — Explicitly limits scope to source Compose deployments and redirects installer users to the new runbook.
- **`hermes-noosphere-memory/README.md`** — Adds the upstream URL to the runbook for standalone Hermes bundle users (the tarball does not include `docs/`).

## Functional impact

Documentation-only. No installer or runtime behavior changes. The functional effect is to make the guided-installer hybrid deployment path explicit and operational while preventing source-Compose instructions — particularly the host `:5433` database URL and `noosphere-db` container name — from being incorrectly applied to `noosphere-openclaw-*` containers. Hybrid retrieval remains opt-in and fail-closed, with each activation and restart step tied to the installer's actual network, container, and environment-loading behavior.

---

docs: tighten Hermes installer + llama.cpp hybrid runbook

- Add `openssl` to the prerequisites list (required for the new HMAC key minting step).
- Replace the placeholder UUID check (`profile_id != 0000…`) with a proper regex match against a UUID v1–v5 pattern in both the seed script and the `vectorize.py` run, so a pasted but malformed id fails fast instead of silently triggering the "id‑missing" branch.
- Add the same UUID guard before minting the 32‑byte retrieval key, and clarify that the two writers are intentionally self‑contained/copy‑pasteable (sharing the `os.replace` core by design, not as a duplication accident).
- Expand the Phase 4.5 retrieval‑gate verification: config is parsed per search request, not at boot, so the runbook now instructs operators to run a throwaway `mode: "auto"` recall after the `compose up --create` and watch for `HybridCorrectnessError`, `query_profile_invalid`, `query_profile_missing`, or `cache_keyring_invalid` — empty logs before any recall prove nothing.

Net effect: fewer ways to ship a wrong profile id or a half‑wired hybrid env, and a verifiable signal that the gate actually opened before trusting the downstream hybrid checks.

---

## Summary

This documentation update refines the Hermes installer + llama.cpp hybrid runbook in three ways:

1. **Adds `openssl` to the prerequisites list** alongside the existing tools (`curl`, `jq`, `sha256sum`, `tar`), since it is required for HMAC key generation.

2. **Strengthens the profile-id validation in three places** (steps 4.4, 4.5, and the HMAC key minting step) by adding a UUID regex check in addition to the placeholder check. Each guard now prints a clear error message identifying the bad value if the operator forgot to paste the real id.

3. **Clarifies the config-validation step after enabling the hybrid retrieval gate** by documenting that the gate config is parsed per search request rather than at boot — so an operator must run a throwaway recall and then check the logs for the fail-closed error patterns (`HybridCorrectnessError`, `query_profile_invalid`, `query_profile_missing`, `cache_keyring_invalid`). The previous wording could give a false sense of safety, since an empty log scan before any recall proves nothing.

A comment was also added noting that the two `.env` writer blocks are intentionally self-contained and copy-pasteable in isolation, even though they share the same `os.replace` core.

---

## Summary

This PR refines the work-VM Hermes installer + llama.cpp hybrid runbook with stricter input validation and clearer operational guidance.

### Key changes

1. **Prerequisites list**: added `openssl` to the required CLI tools, needed in Phase 4.5 for `openssl rand -base64 32` when minting the v1 key.

2. **Stricter `profile_id` validation** (Phases 4.4, 4.5, 4.6): replaced the placeholder-only check with a regex that enforces a real RFC-4122 UUID shape (and rejects the literal `00000000-...` placeholder). On failure, the block now exits with a clear stderr message rather than silently proceeding. This catches copy-paste mistakes before they corrupt the keyring.

3. **Comment on duplicated UUID-validation blocks**: explains that both Phase 4.5 blocks are deliberately self-contained and copy-pasteable in isolation, so an operator mid-procedure does not need to have read the other block first.

4. **Phase 4.5 verification clarified**: the hybrid config is parsed per **search request**, not at boot, so app logs stay clean until the first recall. The runbook now instructs operators to fire one throwaway recall (`mode: "auto"`, any Hermes key) **after** the recreate and **then** grep for fail-closed errors. Without that recall, empty grep output proves nothing.

5. **Phase 4.6 clarified**: notes that `/api/recall` is an alias of the same handler as `/api/memory/recall`, and that the Hermes plugin uses `/api/memory/recall` — removing the misleading "not `/api/recall`" framing.

---

### Summary

This PR hardens the Hermes installer + llama.cpp hybrid runbook for the work-VM with several defensive fixes:

- **Prerequisites**: adds `openssl` to the required host tools (needed for HMAC key generation).
- **Profile ID validation**: every block that mints the Noosphere profile id now regex-checks it against the v4 UUID shape and rejects the placeholder id with a clear stderr message, instead of only comparing against the placeholder string. Blocks also enable `set -euo pipefail` and export `NOOSPHERE_HOME` so they remain correct when run in isolation.
- **Keyring flip verification**: clarifies that the hybrid config is parsed per search request, not at boot, and instructs operators to run a throwaway recall (`mode: "auto"`) *before* checking logs for fail-closed errors (`HybridCorrectnessError`, `query_profile_invalid`, `query_profile_missing`, `cache_keyring_invalid`). The check is expressed as a fence that must exit 0, making the gate explicit. A note explains that without the recall, empty logs prove nothing.
- **Recall endpoint**: notes that `/api/recall` is an alias of `/api/memory/recall` and that the Hermes plugin uses `/api/memory/recall`; removes an incorrect parenthetical that singled out one endpoint.

A comment was added explaining that the two keyring blocks intentionally duplicate the same `os.replace` write logic so each block is independently copy-pasteable mid-procedure.

---

docs: work-VM Hermes installer + llama.cpp hybrid runbook

This PR refines the Hermes installer + llama.cpp hybrid runbook with operational hardening and clearer expectations:

- **Prerequisites**: adds `openssl` to the required tool list.
- **Acquisition guidance**: clarifies that the llama.cpp binary and the `nomic-embed-text-v1.5.Q8_0.gguf` model must be built/downloaded separately, with a documented SHA-256 for integrity verification.
- **Networking pitfalls**: documents that `172.17.0.1` is Docker's default bridge and may need adjustment with custom `bip`, and warns that ufw INPUT rules can drop in-network traffic to the host endpoint (`172.17.0.1:8741`) — pointing operators at `ufw status` / `journalctl -k` before debugging elsewhere.
- **Profile-id validation**: replaces the trivial placeholder check with a proper UUID regex match in three places (profile insertion, embedding backfill, and keyring mint), with clear error messages. All three blocks now enable `set -euo pipefail` and export `NOOSPHERE_HOME` so they are individually copy-pasteable.
- **Flag-flip verification**: explains that the hybrid config is parsed per search request, not at boot, so a throwaway `mode: "auto"` recall must be issued before checking logs. The verification command now uses a failing `grep -q` fence and includes `query_profile_missing` in the error pattern.
- **Recall endpoint clarification**: notes that `/api/recall` is an alias of the `/api/memory/recall` handler (the Hermes plugin uses the latter).
<!-- kody-pr-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a comprehensive guide for enabling hybrid retrieval in guided-installer Hermes environments, including setup, verification, activation, rollback, and troubleshooting.
  - Clarified the differences between source Compose and guided-installer workflows.
  - Updated installation and project documentation with links to the appropriate hybrid-retrieval guides.
  - Added guidance for existing Hermes workstations that later adopt llama.cpp-based hybrid retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->