### PR TITLE
fix: generic bootstrap topics and discoverable topic delete

### DIFF
--- a/docker/bootstrap-topics.json
+++ b/docker/bootstrap-topics.json
@@ -40,16 +40,6 @@
         "name": "Noosphere",
         "slug": "noosphere",
         "description": "This wiki system"
-      },
-      {
-        "name": "PK-PRO",
-        "slug": "pk-pro",
-        "description": "Product knowledge database"
-      },
-      {
-        "name": "IHK Study Trainer",
-        "slug": "ihk-study-trainer",
-        "description": "Study and practice platform"
       }
     ]
   },

--- a/src/__tests__/api/bootstrap-topics.test.ts
+++ b/src/__tests__/api/bootstrap-topics.test.ts
@@ -84,7 +84,7 @@ test("wiki home labels topic admin as Manage Topics, not New Topic", () => {
   const topicPage = readRepoFile("src/app/wiki/[topicSlug]/page.tsx");
   assert.match(home, />\s*Manage Topics\s*</);
   assert.doesNotMatch(home, />\s*New Topic\s*</);
-  assert.match(topicPage, /DeleteTopicButton/);
+  assert.match(topicPage, /<DeleteTopicButton\b/);
   assert.match(topicPage, />\s*Manage Topics\s*</);
 });
 

--- a/src/__tests__/api/bootstrap-topics.test.ts
+++ b/src/__tests__/api/bootstrap-topics.test.ts
@@ -64,8 +64,9 @@ test("bootstrap topic tree is valid and shared by seed/bootstrap scripts", () =>
   assert.ok(topics.length > 0, "bootstrap topics should not be empty");
   for (const topic of topics) visit(topic);
   assert.ok(slugs.has("noosphere"));
-  assert.ok(slugs.has("pk-pro"));
-  assert.ok(slugs.has("ihk-study-trainer"));
+  assert.ok(slugs.has("onboarding"));
+  assert.equal(slugs.has("pk-pro"), false, "house project pk-pro must not ship as a default topic");
+  assert.equal(slugs.has("ihk-study-trainer"), false, "house project ihk-study-trainer must not ship as a default topic");
 });
 
 test("bootstrap and seed scripts load the shared topic tree file", () => {
@@ -76,6 +77,15 @@ test("bootstrap and seed scripts load the shared topic tree file", () => {
   assert.match(seedSource, /bootstrap-topics\.json/);
   assert.doesNotMatch(bootstrapSource, /const\s+TOPICS\s*=\s*\[/);
   assert.doesNotMatch(seedSource, /const\s+TOPICS\s*=\s*\[/);
+});
+
+test("wiki home labels topic admin as Manage Topics, not New Topic", () => {
+  const home = readRepoFile("src/app/wiki/page.tsx");
+  const topicPage = readRepoFile("src/app/wiki/[topicSlug]/page.tsx");
+  assert.match(home, />\s*Manage Topics\s*</);
+  assert.doesNotMatch(home, />\s*New Topic\s*</);
+  assert.match(topicPage, /DeleteTopicButton/);
+  assert.match(topicPage, />\s*Manage Topics\s*</);
 });
 
 test("bootstrap stores generated secrets out of logs", () => {

--- a/src/app/wiki/[topicSlug]/page.tsx
+++ b/src/app/wiki/[topicSlug]/page.tsx
@@ -63,8 +63,14 @@ export default async function TopicPage({ params }: Props) {
   });
   const hasSubtopics = topic.children.length > 0;
   const emptyArticlesState = getTopicArticlesEmptyState(hasSubtopics);
-  const articleCount = await prisma.article.count({ where: { topicId: topic.id } });
-  const canDeleteTopic = isAdmin && !hasSubtopics && articleCount === 0;
+  const blockingArticle =
+    isAdmin && !hasSubtopics
+      ? await prisma.article.findFirst({
+          where: { topicId: topic.id },
+          select: { id: true },
+        })
+      : null;
+  const canDeleteTopic = isAdmin && !hasSubtopics && blockingArticle === null;
 
   return (
     <div className="wiki-content topic-page">
@@ -84,13 +90,11 @@ export default async function TopicPage({ params }: Props) {
         description={topic.description ?? "A focused collection of articles and subtopics inside the Noosphere knowledge graph."}
         className="topic-page-hero"
         actions={
-          canCreateArticle || isAdmin ? (
+          canCreateArticle ? (
             <div className="cluster">
-              {canCreateArticle ? (
-                <Link href={`/wiki/${topic.slug}/new`} className="btn btn-primary btn-sm">
-                  New Article
-                </Link>
-              ) : null}
+              <Link href={`/wiki/${topic.slug}/new`} className="btn btn-primary btn-sm">
+                New Article
+              </Link>
               {isAdmin ? (
                 <Link href="/wiki/admin/topics" className="btn btn-secondary btn-sm">
                   Manage Topics

--- a/src/app/wiki/[topicSlug]/page.tsx
+++ b/src/app/wiki/[topicSlug]/page.tsx
@@ -6,6 +6,8 @@ import { Breadcrumbs } from "@/components/wiki/Breadcrumbs";
 import { EmptyState } from "@/components/wiki/EmptyState";
 import { PageHeader } from "@/components/wiki/PageHeader";
 import { RestrictedArticleIcon } from "@/components/wiki/RestrictedArticleIcon";
+import { DeleteTopicButton } from "@/components/wiki/DeleteTopicButton";
+import { deleteTopicAction } from "@/app/wiki/admin/topics/actions";
 import { authOptions } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { buildScopeFilter } from "@/lib/api/auth";
@@ -22,6 +24,7 @@ export default async function TopicPage({ params }: Props) {
   const session = await getServerSession(authOptions);
   const role = session?.user?.role;
   const canCreateArticle = role === "EDITOR" || role === "ADMIN";
+  const isAdmin = role === "ADMIN";
 
   const topic = await prisma.topic.findUnique({
     where: { slug: topicSlug },
@@ -60,6 +63,8 @@ export default async function TopicPage({ params }: Props) {
   });
   const hasSubtopics = topic.children.length > 0;
   const emptyArticlesState = getTopicArticlesEmptyState(hasSubtopics);
+  const articleCount = await prisma.article.count({ where: { topicId: topic.id } });
+  const canDeleteTopic = isAdmin && !hasSubtopics && articleCount === 0;
 
   return (
     <div className="wiki-content topic-page">
@@ -79,10 +84,27 @@ export default async function TopicPage({ params }: Props) {
         description={topic.description ?? "A focused collection of articles and subtopics inside the Noosphere knowledge graph."}
         className="topic-page-hero"
         actions={
-          canCreateArticle ? (
-            <Link href={`/wiki/${topic.slug}/new`} className="btn btn-primary btn-sm">
-              New Article
-            </Link>
+          canCreateArticle || isAdmin ? (
+            <div className="cluster">
+              {canCreateArticle ? (
+                <Link href={`/wiki/${topic.slug}/new`} className="btn btn-primary btn-sm">
+                  New Article
+                </Link>
+              ) : null}
+              {isAdmin ? (
+                <Link href="/wiki/admin/topics" className="btn btn-secondary btn-sm">
+                  Manage Topics
+                </Link>
+              ) : null}
+              {canDeleteTopic ? (
+                <DeleteTopicButton
+                  topicId={topic.id}
+                  topicName={topic.name}
+                  deleteAction={deleteTopicAction}
+                  next="/wiki"
+                />
+              ) : null}
+            </div>
           ) : null
         }
         meta={

--- a/src/app/wiki/admin/topics/actions.ts
+++ b/src/app/wiki/admin/topics/actions.ts
@@ -155,4 +155,9 @@ export async function deleteTopicAction(formData: FormData) {
 
   revalidatePath("/wiki");
   revalidatePath("/wiki/admin/topics");
+
+  const next = String(formData.get("next") ?? "").trim();
+  if (next === "/wiki") {
+    redirect("/wiki");
+  }
 }

--- a/src/app/wiki/page.tsx
+++ b/src/app/wiki/page.tsx
@@ -166,7 +166,7 @@ export default async function WikiHomePage() {
           isAdmin ? (
             <div className="cluster">
               <Link href="/wiki/admin/topics" className="btn btn-secondary btn-sm">
-                New Topic
+                Manage Topics
               </Link>
               <Link href="/wiki/admin/keys" className="btn btn-secondary btn-sm">
                 API Keys

--- a/src/components/wiki/DeleteTopicButton.tsx
+++ b/src/components/wiki/DeleteTopicButton.tsx
@@ -6,12 +6,15 @@ interface DeleteTopicButtonProps {
   topicId: string;
   topicName: string;
   deleteAction: DeleteAction;
+  /** Allowed post-delete path. Only `/wiki` is accepted by the server action. */
+  next?: "/wiki";
 }
 
-export function DeleteTopicButton({ topicId, topicName, deleteAction }: DeleteTopicButtonProps) {
+export function DeleteTopicButton({ topicId, topicName, deleteAction, next }: DeleteTopicButtonProps) {
   return (
     <form action={deleteAction} className="inline-form">
       <input type="hidden" name="id" value={topicId} />
+      {next ? <input type="hidden" name="next" value={next} /> : null}
       <button
         type="submit"
         className="btn btn-danger btn-sm"


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary by Sourcery

Use generic bootstrap topics and make topic administration, including safe deletion, discoverable from the wiki.

New Features:
- Add admin topic management and conditional deletion controls directly to topic pages.
- Support redirecting to the wiki after an admin deletes a topic.

Bug Fixes:
- Replace application-specific bootstrap topics with generic defaults and prevent house-specific topics from being seeded by default.
- Correct the wiki home admin link label from “New Topic” to “Manage Topics”.

Tests:
- Update bootstrap topic coverage for the generic default tree and verify topic administration labels and controls.
<!-- kody-pr-summary:end -->