### PR TITLE
Wiki: publish drafts and one Admin menu door

### DIFF
--- a/src/__tests__/api/bootstrap-topics.test.ts
+++ b/src/__tests__/api/bootstrap-topics.test.ts
@@ -88,6 +88,28 @@ test("wiki home labels topic admin as Manage Topics, not New Topic", () => {
   assert.match(topicPage, />\s*Manage Topics\s*</);
 });
 
+test("wiki header exposes one Admin menu door into the admin console", () => {
+  const layout = readRepoFile("src/app/wiki/layout.tsx");
+  const home = readRepoFile("src/app/wiki/page.tsx");
+  assert.match(layout, /href="\/wiki\/admin\/keys"/);
+  assert.match(layout, />\s*Admin menu\s*</);
+  assert.doesNotMatch(layout, />\s*API Keys\s*</);
+  assert.doesNotMatch(layout, />\s*Recall Settings\s*</);
+  assert.match(home, />\s*Admin menu\s*</);
+  assert.doesNotMatch(home, />\s*API Keys\s*</);
+});
+
+test("wiki article pages expose Publish and an edit-form status field", () => {
+  const articlePage = readRepoFile("src/app/wiki/[topicSlug]/[articleSlug]/page.tsx");
+  const editPage = readRepoFile("src/app/wiki/[topicSlug]/[articleSlug]/edit/page.tsx");
+  const actions = readRepoFile("src/app/wiki/[topicSlug]/[articleSlug]/edit/actions.ts");
+  assert.match(articlePage, /publishArticle/);
+  assert.match(articlePage, />\s*Publish\s*</);
+  assert.match(editPage, /name="status"/);
+  assert.match(actions, /export async function publishArticle/);
+  assert.match(actions, /status must be draft, reviewed, or published/i);
+});
+
 test("bootstrap stores generated secrets out of logs", () => {
   const bootstrapSource = readRepoFile("docker/bootstrap.mjs");
   const composeSource = readRepoFile("docker-compose.noosphere.yml");

--- a/src/app/wiki/[topicSlug]/[articleSlug]/edit/actions.ts
+++ b/src/app/wiki/[topicSlug]/[articleSlug]/edit/actions.ts
@@ -13,6 +13,7 @@ import {
   sanitizeArticleExcerpt,
 } from "@/lib/api/article-content";
 import { detectSecretInInputs } from "@/lib/memory/api/save";
+import { isValidStatus } from "@/lib/validation";
 
 async function requireEditorSession() {
   const session = await getServerSession(authOptions);
@@ -48,10 +49,14 @@ export async function saveArticle(
   const content = String(formData.get("content") ?? "");
   const title = String(formData.get("title") ?? "");
   const excerpt = String(formData.get("excerpt") ?? "");
+  const status = String(formData.get("status") ?? "").trim();
   const tags = parseTagInput(String(formData.get("tags") ?? ""));
 
   if (!content.trim()) {
     throw new Error("Content cannot be empty.");
+  }
+  if (!isValidStatus(status)) {
+    throw new Error("Status must be draft, reviewed, or published.");
   }
   const contentSanitization = sanitizeArticleContent(content.trim());
   if (!contentSanitization.ok) {
@@ -123,6 +128,7 @@ export async function saveArticle(
         content: nextContent,
         title: nextTitle,
         excerpt: nextExcerpt,
+        status,
         restrictedTags,
         updatedAt: new Date(),
       },
@@ -203,4 +209,36 @@ export async function deleteArticle(
   revalidatePath("/wiki");
   revalidatePath("/wiki/search");
   redirect(`/wiki/${topicSlug}`);
+}
+
+export async function publishArticle(
+  topicSlug: string,
+  articleSlug: string,
+  _formData: FormData,
+): Promise<void> {
+  void _formData;
+  await requireEditorSession();
+
+  const topic = await prisma.topic.findUnique({ where: { slug: topicSlug } });
+  if (!topic) throw new Error("Topic not found.");
+
+  const article = await prisma.article.findFirst({
+    where: { topicId: topic.id, slug: articleSlug, deletedAt: null },
+  });
+
+  if (!article) throw new Error("Article not found.");
+
+  if (article.status !== "published") {
+    await prisma.article.update({
+      where: { id: article.id },
+      data: { status: "published", updatedAt: new Date() },
+    });
+    await invalidateSearchCache();
+  }
+
+  revalidatePath(`/wiki/${topicSlug}`);
+  revalidatePath(`/wiki/${topicSlug}/${articleSlug}`);
+  revalidatePath("/wiki");
+  revalidatePath("/wiki/search");
+  redirect(`/wiki/${topicSlug}/${articleSlug}`);
 }

--- a/src/app/wiki/[topicSlug]/[articleSlug]/edit/page.tsx
+++ b/src/app/wiki/[topicSlug]/[articleSlug]/edit/page.tsx
@@ -126,6 +126,21 @@ export default async function EditArticlePage({ params }: Props) {
           <p className="form-hint">Comma-separated tags. Existing tags are reused automatically.</p>
         </div>
 
+        <div className="form-group">
+          <label className="form-label" htmlFor="status">Status</label>
+          <select
+            id="status"
+            name="status"
+            className="form-select"
+            defaultValue={article.status || "published"}
+          >
+            <option value="draft">Draft</option>
+            <option value="reviewed">Reviewed</option>
+            <option value="published">Published</option>
+          </select>
+          <p className="form-hint">Drafts stay visible. Publish when the article should leave the draft signal.</p>
+        </div>
+
         <RestrictedTagPicker
           scopes={scopes}
           selected={article.restrictedTags ?? []}

--- a/src/app/wiki/[topicSlug]/[articleSlug]/page.tsx
+++ b/src/app/wiki/[topicSlug]/[articleSlug]/page.tsx
@@ -9,7 +9,7 @@ import { filterVisibleRelatedArticleRows } from "@/lib/articles/relations";
 import { DeleteArticleForm } from "@/components/wiki/DeleteArticleForm";
 import { PageHeader } from "@/components/wiki/PageHeader";
 import { WikiMarkdown } from "@/components/wiki/WikiMarkdown";
-import { deleteArticle } from "./edit/actions";
+import { deleteArticle, publishArticle } from "./edit/actions";
 
 interface Props {
   params: Promise<{ topicSlug: string; articleSlug: string }>;
@@ -96,6 +96,13 @@ export default async function ArticlePage({ params }: Props) {
                   Sign In to Edit
                 </Link>
               )}
+              {canEdit && article.status !== "published" ? (
+                <form action={publishArticle.bind(null, topic.slug, article.slug)}>
+                  <button type="submit" className="btn btn-secondary btn-sm">
+                    Publish
+                  </button>
+                </form>
+              ) : null}
               {canDelete ? (
                 <DeleteArticleForm action={deleteArticle.bind(null, topic.slug, article.slug)} articleId={article.id} />
               ) : null}

--- a/src/app/wiki/layout.tsx
+++ b/src/app/wiki/layout.tsx
@@ -66,12 +66,7 @@ export default async function WikiLayout({
                 </Link>
                 {role === "ADMIN" && (
                   <Link href="/wiki/admin/keys" className="nav-link">
-                    API Keys
-                  </Link>
-                )}
-                {role === "ADMIN" && (
-                  <Link href="/wiki/admin/settings" className="nav-link">
-                    Recall Settings
+                    Admin menu
                   </Link>
                 )}
                 {role === "ADMIN" && (

--- a/src/app/wiki/page.tsx
+++ b/src/app/wiki/page.tsx
@@ -169,7 +169,7 @@ export default async function WikiHomePage() {
                 Manage Topics
               </Link>
               <Link href="/wiki/admin/keys" className="btn btn-secondary btn-sm">
-                API Keys
+                Admin menu
               </Link>
             </div>
           ) : null


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Description

This change closes two gaps in the wiki's publishing and admin navigation flows:

### Article publishing controls

- **Inline Publish button** on the article page for editors/admins when the article's status is anything other than `published`. The new `publishArticle` server action looks up the article, sets `status = "published"`, invalidates the search cache, and revalidates the affected routes. It also enforces an editor session and refuses to act on deleted or missing articles.
- **Status select on the Edit Article form** (`draft` / `reviewed` / `published`), with the current article status pre-selected. The `saveArticle` server action now reads the `status` field, validates it through `isValidStatus`, and persists it in the same Prisma update that already handles title, content, excerpt, tags, and restricted tags. Articles stored as drafts remain visible but are clearly marked until they are published.

### Single Admin menu entry

- The wiki header (`src/app/wiki/layout.tsx`) previously exposed two separate admin links — **API Keys** (`/wiki/admin/keys`) and **Recall Settings** (`/wiki/admin/settings`). These are now consolidated into a single **Admin menu** link pointing to `/wiki/admin/keys`. Other admin tabs (Topics, Recall Settings, etc.) remain reachable from inside the admin console.
- The wiki home page (`src/app/wiki/page.tsx`) mirrors this: the secondary action is labeled **Admin menu** and routes to the admin console.

### Test coverage

Two new source-scan tests in `bootstrap-topics.test.ts` lock in the contract:

- The wiki header and home expose exactly one **Admin menu** link to `/wiki/admin/keys` and no longer contain the old **API Keys** / **Recall Settings** labels.
- Article pages import and use `publishArticle` with a **Publish** button, the edit form has a `name="status"` field, and the actions module exports `publishArticle` and validates the status with the expected error message.

### Files touched

- `src/app/wiki/layout.tsx` — collapsed two admin links into one "Admin menu" link.
- `src/app/wiki/page.tsx` — relabeled the home-page admin button to "Admin menu".
- `src/app/wiki/[topicSlug]/[articleSlug]/page.tsx` — added the Publish form for editors on non-published articles.
- `src/app/wiki/[topicSlug]/[articleSlug]/edit/page.tsx` — added the status select to the edit form.
- `src/app/wiki/[topicSlug]/[articleSlug]/edit/actions.ts` — added `publishArticle`, made `saveArticle` read/validate/persist `status`.
- `src/__tests__/api/bootstrap-topics.test.ts` — new source-scan tests for the Admin menu label and the publish/status controls.

No installer, Docker, or runtime image changes are included.
<!-- kody-pr-summary:end -->