### PR TITLE
fix(shadow-eval): expose denominators and preflight fixture freshness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,11 @@ jobs:
       - name: Run hybrid shadow harness tests (no services required)
         run: npm run test:hybrid-shadow
 
+      - name: Run shadow freshness tests against isolated temporary corpus
+        run: npm run test:hybrid-shadow-db
+        env:
+          SHADOW_TEST_DATABASE_URL: ${{ env.DATABASE_URL }}
+
       - name: Run memory tests
         run: npm run test:memory
 

--- a/docs/HYBRID-SHADOW-EVALUATION.md
+++ b/docs/HYBRID-SHADOW-EVALUATION.md
@@ -51,9 +51,18 @@ Judgments include grade-zero entries and are reported per query/slug:
 - `ambiguous`: more than one match in the authorized evidence, since article
   slugs are unique only within a topic. No article is silently selected.
 
-Soft-deleted articles are outside the corpus. Draft, reviewed and published
-statuses are all included, matching the provider; this is not published-only
-mode. Hidden duplicates cannot be detected by unscoped evidence: `visible` and
+The corpus here is recall-eligible: soft-deleted and recall-quarantined articles
+are excluded before aggregation, as are articles whose every provenance source
+group contains a revoked lineage or a generation/snapshot mismatch. This matches
+the final eligibility checks in both recall paths: no provenance is eligible,
+and one entirely valid source group is sufficient. A blocked duplicate cannot
+create ambiguity. `corpus-absent` means absent from this eligible corpus, not
+physical absence; no quarantine or lineage metadata/reasons are reported.
+Unscoped evidence keeps missing, restricted and privacy-ineligible rows
+indistinguishable. The single SQL statement observes a snapshot, without recall's
+serialization locks; a later revocation can invalidate this preflight.
+Draft, reviewed and published statuses are all included, matching the provider;
+this is not published-only mode. Hidden duplicates cannot be detected by unscoped evidence: `visible` and
 `clear` describe only the inspected scope. The lookup projects only fixture
 slugs and aggregate counts, not titles, tags, topic names or article IDs.
 
@@ -82,7 +91,8 @@ npm run test:hybrid-shadow
 SHADOW_TEST_DATABASE_URL=<disposable-app-role-url> npm run test:hybrid-shadow-db
 ```
 
-The database test creates a connection-local temporary Article table, includes
-restricted/deleted/duplicate fixtures, and never modifies the application corpus.
+The database tests create connection-local temporary Article and provenance tables,
+include restricted/deleted/quarantined/duplicate and lineage-revocation fixtures,
+and never modify the application corpus.
 CI runs it against its disposable database. Production retrieval quality and
 serving acceptance remain outside these tests.

--- a/docs/HYBRID-SHADOW-EVALUATION.md
+++ b/docs/HYBRID-SHADOW-EVALUATION.md
@@ -1,0 +1,88 @@
+# Shadow evaluation: denominators and fixture freshness
+
+The local operator CLI `npm run hybrid:shadow-eval` runs keyword then hybrid
+search without serving results. This is measurement tooling, not a serving
+acceptance gate. Reports remain private; admin runs can include restricted
+rankings. Search may write caches, authorize dispatch, and call embeddings.
+
+## Freshness before evaluation
+
+Every dual-path run performs an exact article lookup **before searching** and
+persists `freshness-<uuid>.json`, even if subsequent retrieval fails. It also
+includes freshness scope, timestamps, outcome and counts in aggregate JSON and
+Markdown. A database lookup failure aborts the run; it is not evidence of absence.
+To inspect only freshness, without search or embedding configuration:
+
+```sh
+npm run hybrid:shadow-eval -- --preflight-only --scopes unscoped --out <private-dir>
+```
+
+Supply `DATABASE_URL` for the authorized evaluation corpus (the extension-less
+application identity). Do not use production access without separate approval.
+The standalone preflight emits only private JSON, not an empty metric report.
+Files are created exclusively with owner-only permissions; directories created
+by the harness use mode 0700. Do not publish these files.
+
+Scope is a trusted local-operator choice, **not authentication**. Like the
+existing `--scopes admin`, the following option asserts that the operator is
+already authorized to inspect all scopes. Never expose these flags through an
+untrusted API or hand an unauthorized user an all-corpus database credential.
+
+```sh
+# Only an authorized administrator may request broader freshness evidence.
+# Retrieval remains unscoped; the preflight may distinguish hidden from missing.
+npm run hybrid:shadow-eval -- --preflight-only --scopes unscoped --freshness-admin --out <private-dir>
+```
+
+Without `--freshness-admin`, preflight evidence is limited to the evaluation
+scope. `--scopes admin` already explicitly selects all scopes for both phases.
+There is no automatic privilege escalation after a lookup/search miss.
+The exported freshness helper likewise supports only unscoped (`undefined` or
+`[]`) and admin (`["*"]`) scopes; named or mixed scopes are rejected.
+
+Judgments include grade-zero entries and are reported per query/slug:
+
+- `visible`: exactly one match in the authorized evidence, visible to evaluation.
+- `excluded-by-scope`: one active match, outside evaluation scope; only emitted
+  with explicit admin evidence.
+- `corpus-absent`: no active match; only emitted with admin evidence.
+- `unknown/not-visible`: no authorized visible match. Missing and restricted
+  slugs are indistinguishable; this is **not** a claim of global absence.
+- `ambiguous`: more than one match in the authorized evidence, since article
+  slugs are unique only within a topic. No article is silently selected.
+
+Soft-deleted articles are outside the corpus. Draft, reviewed and published
+statuses are all included, matching the provider; this is not published-only
+mode. Hidden duplicates cannot be detected by unscoped evidence: `visible` and
+`clear` describe only the inspected scope. The lookup projects only fixture
+slugs and aggregate counts, not titles, tags, topic names or article IDs.
+
+`needs-review` warns about any non-visible judgment but does not stop exploratory
+measurement or alter the fixture. Before using a report for a decision, review
+these outcomes explicitly. A `clear` preflight alone is not decision-grade
+retrieval evidence. It checks presence/ambiguity, not semantic relevance, and is
+a point-in-time observation: corpus or permission changes after it can invalidate
+it. Search misses never establish stale judgments. No scores, judgments or
+metric denominators are automatically changed; fixture revisions require review.
+
+## Metric denominators
+
+For each path, `metrics.<path>.denominators` records `evaluated` and `excluded`
+query counts separately for `recall`, `ndcg`, and `mrr`. Markdown prints the same
+counts. Recall@k and nDCG@k exclude queries with no positive judgments; if every
+query is excluded, their values are null (`n/a`). MRR@limit includes every query,
+including no-positive queries and misses as zero, so its excluded count is zero.
+The MRR cutoff remains the returned limit, not k. Existing metric formulas and
+single-credit duplicate-slug ranking semantics are unchanged.
+
+## Isolated verification
+
+```sh
+npm run test:hybrid-shadow
+SHADOW_TEST_DATABASE_URL=<disposable-app-role-url> npm run test:hybrid-shadow-db
+```
+
+The database test creates a connection-local temporary Article table, includes
+restricted/deleted/duplicate fixtures, and never modifies the application corpus.
+CI runs it against its disposable database. Production retrieval quality and
+serving acceptance remain outside these tests.

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test:hybrid-provider": "node --test scripts/hybrid-provider.test.mjs",
     "test:hybrid-stack": "bash scripts/activate-hybrid-retrieval-stack.test.sh",
     "hybrid:shadow-eval": "tsx scripts/hybrid-shadow-eval.ts",
+    "test:hybrid-shadow-db": "node --import tsx --test scripts/hybrid-shadow-freshness.test.ts",
     "test:hybrid-shadow": "node --import tsx --test scripts/hybrid-shadow-eval.test.ts",
     "test:memory": "node --env-file=.env.test --import tsx --test 'src/__tests__/memory/**/*.test.ts'",
     "test:wiki": "node --import tsx --test 'src/__tests__/wiki/**/*.test.ts'",

--- a/scripts/hybrid-shadow-eval.test.ts
+++ b/scripts/hybrid-shadow-eval.test.ts
@@ -191,6 +191,43 @@ test("rapid report writes preserve aggregate JSON, JSONL and honest secret-free 
   } finally { await rm(dir, { recursive: true, force: true }); }
 });
 
+test("explicit per-path denominators cover mixed, all-excluded and normal judgments", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "denominator-test-"));
+  try {
+    for (const positives of [0, 1, 3]) {
+      const set: QuerySet = { version: 1, queries: Array.from({ length: 3 }, (_, i): QuerySet["queries"][number] => ({
+        id: `query-${i}`, query: "test query", relevance: i < positives ? { relevant: 3 } : i === 1 ? {} : { relevant: 0 },
+      })) };
+      const keyword = await rankings(set, [[row("relevant")], [], [row("zero"), row("relevant")]], "keyword");
+      const hybrid = await rankings(set, [[], [], []]);
+      const report = buildReport(set, keyword, hybrid, parseArgs(["--k", "1"]), {});
+      for (const p of ["keyword", "hybrid"]) assert.deepEqual(report.metrics[p].denominators, {
+        recall: { evaluated: positives, excluded: 3 - positives },
+        ndcg: { evaluated: positives, excluded: 3 - positives },
+        mrr: { evaluated: 3, excluded: 0 },
+      });
+      assert.equal(report.metrics.keyword.recall, positives ? 1 / positives : null);
+      assert.equal(report.metrics.keyword.ndcg, positives ? 1 / positives : null);
+      assert.equal(report.metrics.keyword.mrr, positives === 3 ? 0.5 : positives ? 1 / 3 : 0);
+      assert.equal(report.metrics.hybrid.recall, positives ? 0 : null);
+      assert.equal(report.metrics.hybrid.mrr, 0);
+      const files = await writeReport(report, dir);
+      assert.deepEqual(JSON.parse(await readFile(files.aggregatePath, "utf8")).metrics, report.metrics);
+      const md = await readFile(files.summaryPath, "utf8");
+      for (const p of ["keyword", "hybrid"]) assert.ok(md.includes(`| ${p} | ${positives} | ${3 - positives} | ${positives} | ${3 - positives} | 3 | 0 |`));
+      assert.match(md, /MRR all-query denominator/);
+      assert.match(md, /Not checked; not decision-grade/);
+    }
+  } finally { await rm(dir, { recursive: true, force: true }); }
+});
+
+test("preflight flags require explicit admin evidence opt-in", () => {
+  assert.equal(parseArgs([]).freshnessAdmin, undefined);
+  assert.equal(parseArgs(["--preflight-only"]).preflightOnly, true);
+  assert.equal(parseArgs(["--freshness-admin"]).freshnessAdmin, true);
+  assert.equal(parseArgs(["--freshness-admin"]).scopes, undefined);
+});
+
 test("pure import has no provider/Prisma initialization; CLI rejects arguments before runtime setup", () => {
   const script = path.resolve(import.meta.dirname, "hybrid-shadow-eval.ts");
   const env = { ...process.env, DATABASE_URL: "", NOOSPHERE_HYBRID_QUERY_PROFILE_ID: "" };

--- a/scripts/hybrid-shadow-eval.ts
+++ b/scripts/hybrid-shadow-eval.ts
@@ -14,8 +14,10 @@
  * No article edits or corpus-vector writes are requested by this harness.
  * Reports can contain restricted article titles; keep them private.
  *
- * Usage (always dual-path; unreachable hybrid services may cause fallback):
+ * Usage (dual-path evaluation by default; --preflight-only performs only the
+ * freshness lookup and writes no metric reports — see docs/HYBRID-SHADOW-EVALUATION.md):
  *   npm run hybrid:shadow-eval -- --limit 5 --k 5 --out <dir>
+ *   npm run hybrid:shadow-eval -- --preflight-only --out <dir>
  *
  * Full dual-path run: must execute inside the compose network so the pinned
  * provider endpoint (host.docker.internal:8741) resolves, with the app-role

--- a/scripts/hybrid-shadow-eval.ts
+++ b/scripts/hybrid-shadow-eval.ts
@@ -46,6 +46,7 @@ import { pathToFileURL } from "node:url";
 import type { MemoryProvider } from "@/lib/memory/provider";
 import type { MemoryResult } from "@/lib/memory/types";
 import { HYBRID_MAX_WINDOW } from "@/lib/memory/hybrid-ranking";
+import { checkFixtureFreshness, type FixtureFreshness } from "./hybrid-shadow-freshness";
 
 interface GradedQuery {
   id: string;
@@ -76,9 +77,11 @@ function requireEnv(name: string): string {
   return value;
 }
 
-export function parseArgs(argv: string[]): { limit: number; k: number; outDir: string; scopes: string[] | undefined } {
-  const opts = { limit: 10, k: 5, outDir: "hybrid-shadow-reports", scopes: undefined as string[] | undefined };
+export function parseArgs(argv: string[]): { limit: number; k: number; outDir: string; scopes: string[] | undefined; preflightOnly?: boolean; freshnessAdmin?: boolean } {
+  const opts: ReturnType<typeof parseArgs> = { limit: 10, k: 5, outDir: "hybrid-shadow-reports", scopes: undefined as string[] | undefined };
   for (let i = 0; i < argv.length; i += 1) {
+    if (argv[i] === "--preflight-only") { opts.preflightOnly = true; continue; }
+    if (argv[i] === "--freshness-admin") { opts.freshnessAdmin = true; continue; }
     if (!["--limit", "--k", "--out", "--scopes"].includes(argv[i])) throw new Error(`unknown argument: ${argv[i]}`);
     if (!argv[i + 1]?.trim() || argv[i + 1].startsWith("--")) throw new Error(`missing value for ${argv[i]}`);
     if (argv[i] === "--limit") opts.limit = Number(argv[++i]);
@@ -207,8 +210,9 @@ export function buildReport(
   hybridRankings: Ranking[],
   opts: ReturnType<typeof parseArgs>,
   environment: Readonly<Record<string, string | undefined>>,
+  freshness: FixtureFreshness | null = null,
 ) {
-  const metrics: Record<string, { path: string; recall: number | null; ndcg: number | null; mrr: number | null; latencyP50: number; fallbacks: number; fallbackUnknown: number }> = {};
+  const metrics: Record<string, { path: string; recall: number | null; ndcg: number | null; mrr: number | null; latencyP50: number; fallbacks: number; fallbackUnknown: number; denominators: { recall: { evaluated: number; excluded: number }; ndcg: { evaluated: number; excluded: number }; mrr: { evaluated: number; excluded: number } } }> = {};
   for (const [path, rankings] of [["keyword", keywordRankings], ["hybrid", hybridRankings]] as const) {
     let recallSum = 0, recallN = 0, ndcgSum = 0, ndcgN = 0, mrrSum = 0, fallbacks = 0, fallbackUnknown = 0;
     const latencies: number[] = [];
@@ -235,6 +239,11 @@ export function buildReport(
       latencyP50: latencies[Math.floor(latencies.length / 2)] ?? 0,
       fallbacks,
       fallbackUnknown,
+      denominators: {
+        recall: { evaluated: recallN, excluded: rankings.length - recallN },
+        ndcg: { evaluated: ndcgN, excluded: rankings.length - ndcgN },
+        mrr: { evaluated: rankings.length, excluded: 0 },
+      },
     };
   }
 
@@ -245,6 +254,7 @@ export function buildReport(
     limit: opts.limit,
     k: opts.k,
     relevanceTiers: RELEVANCE_TIERS,
+    freshness,
     observation: {
       scope: opts.scopes?.includes("*") ? "admin (all scopes, all statuses)" : "unscoped (unrestricted articles, all statuses)",
       redis: environment.REDIS_URL ? "configured" : "not configured",
@@ -282,6 +292,20 @@ export async function writeReport(report: ReturnType<typeof buildReport>, outDir
     const m = report.metrics[p];
     md.push(`| ${p} | ${m.recall?.toFixed(3) ?? "n/a"} | ${m.ndcg?.toFixed(3) ?? "n/a"} | ${m.mrr?.toFixed(3) ?? "n/a"} | ${m.latencyP50} | ${m.fallbacks} | ${m.fallbackUnknown} |`);
   }
+  md.push("", "| path | recall evaluated | recall excluded | nDCG evaluated | nDCG excluded | MRR all-query denominator | MRR excluded |",
+    "| --- | --- | --- | --- | --- | --- | --- |");
+  for (const p of ["keyword", "hybrid"]) {
+    const d = report.metrics[p].denominators;
+    md.push(`| ${p} | ${d.recall.evaluated} | ${d.recall.excluded} | ${d.ndcg.evaluated} | ${d.ndcg.excluded} | ${d.mrr.evaluated} | ${d.mrr.excluded} |`);
+  }
+  md.push("", "## Fixture freshness");
+  if (report.freshness) {
+    const f = report.freshness;
+    md.push("", `Evaluation scope: ${f.evaluationScope}; evidence scope: ${f.evidenceScope}.`,
+      `Started: ${f.startedAt}; checked: ${f.checkedAt}; outcome: ${f.outcome}.`, "", f.limitation,
+      "", ...Object.entries(f.counts).map(([status, count]) => `- ${status}: ${count}`),
+      "", "Per-judgment outcomes are in the private aggregate JSON.");
+  } else md.push("", "Not checked; not decision-grade evidence.");
   md.push(``, `Full per-query rankings: \`${path.basename(jsonl)}\``);
   md.push(`Aggregate report: \`${path.basename(aggregatePath)}\``);
   await writeFile(summaryPath, md.join("\n") + "\n", { flag: "wx", mode: 0o600 });
@@ -293,19 +317,28 @@ async function main(): Promise<void> {
   const fixturePath = path.resolve(import.meta.dirname, "../src/__tests__/fixtures/hybrid-shadow-queries.json");
   const querySet = loadQuerySet(await readFile(fixturePath, "utf8"));
   const databaseUrl = requireEnv("DATABASE_URL");
-  const baseEnv = {
+  const baseEnv = opts.preflightOnly ? process.env : {
     ...process.env,
     NOOSPHERE_HYBRID_QUERY_PROFILE_ID: requireEnv("NOOSPHERE_HYBRID_QUERY_PROFILE_ID"),
     NOOSPHERE_HYBRID_CACHE_HMAC_ACTIVE_VERSION: requireEnv("NOOSPHERE_HYBRID_CACHE_HMAC_ACTIVE_VERSION"),
     NOOSPHERE_HYBRID_CACHE_HMAC_KEYS_B64: requireEnv("NOOSPHERE_HYBRID_CACHE_HMAC_KEYS_B64"),
   };
-  // Pure imports above never initialize Prisma, Redis, or a provider.
-  const [{ PrismaClient }, { PrismaPg }, { Pool }, { createNoosphereProvider }, { closeRedisClient }] = await Promise.all([
-    import("@prisma/client"), import("@prisma/adapter-pg"), import("pg"),
-    import("@/lib/memory/noosphere"), import("@/lib/cache/redis"),
-  ]);
+  // Preflight-only never imports Prisma, Redis, or the search provider.
+  const { Pool } = await import("pg");
   const pool = new Pool({ connectionString: databaseUrl, max: 2 });
   try {
+    const freshness = await checkFixtureFreshness(pool, querySet, opts.scopes, opts.freshnessAdmin);
+    // Persist preflight even if later retrieval fails. No search/cache/embedding
+    // work is requested by preflight-only. Do not treat it as a metric report.
+    await mkdir(opts.outDir, { recursive: true, mode: 0o700 });
+    const freshnessPath = path.join(opts.outDir, `freshness-${randomUUID()}.json`);
+    await writeFile(freshnessPath, JSON.stringify({ querySetVersion: querySet.version, freshness }, null, 2) + "\n", { flag: "wx", mode: 0o600 });
+    process.stdout.write(`freshness: ${freshness.outcome}; evidence: ${freshnessPath}\n`);
+    if (opts.preflightOnly) return;
+    const [{ PrismaClient }, { PrismaPg }, { createNoosphereProvider }, { closeRedisClient }] = await Promise.all([
+      import("@prisma/client"), import("@prisma/adapter-pg"),
+      import("@/lib/memory/noosphere"), import("@/lib/cache/redis"),
+    ]);
     const prisma = new PrismaClient({ adapter: new PrismaPg(pool) });
     try {
       const keywordProvider = createNoosphereProvider({ prisma, allowedScopes: opts.scopes,
@@ -315,13 +348,13 @@ async function main(): Promise<void> {
       process.stdout.write(`shadow eval: ${querySet.queries.length} queries, limit ${opts.limit}, k ${opts.k}, scopes ${opts.scopes ? "admin (all scopes, all statuses)" : "unscoped (unrestricted articles, all statuses)"}\n`);
       const keywordRankings = await runPath("keyword", keywordProvider, querySet, opts.limit);
       const hybridRankings = await runPath("hybrid", hybridProvider, querySet, opts.limit);
-      const files = await writeReport(buildReport(querySet, keywordRankings, hybridRankings, opts, baseEnv), opts.outDir);
+      const files = await writeReport(buildReport(querySet, keywordRankings, hybridRankings, opts, baseEnv, freshness), opts.outDir);
       process.stdout.write(`\nreport: ${files.jsonl}\naggregate: ${files.aggregatePath}\nsummary: ${files.summaryPath}\n`);
     } finally {
-      await prisma.$disconnect();
+      try { await prisma.$disconnect(); } finally { await closeRedisClient(); }
     }
   } finally {
-    try { await pool.end(); } finally { await closeRedisClient(); }
+    await pool.end();
   }
 }
 

--- a/scripts/hybrid-shadow-freshness.test.ts
+++ b/scripts/hybrid-shadow-freshness.test.ts
@@ -29,6 +29,10 @@ test("freshness exact lookup enforces scope, deletion and ambiguity without meta
       ('mixed', '{secret-tag}', NULL, 'secret-title', 'DRAFT'),
       ('hidden-duplicate', '{secret-tag}', NULL, 'secret-title', 'DRAFT'),
       ('hidden-duplicate', '{secret-tag}', NULL, 'secret-title', 'DRAFT')`);
+    await pool.query(`ALTER TABLE "Article" ADD COLUMN id text;
+      ALTER TABLE "Article" ADD COLUMN "recallQuarantinedAt" timestamp;
+      CREATE TEMP TABLE "MemoryLineageState" (id text, generation int, "revokedAt" timestamp);
+      CREATE TEMP TABLE "MemoryProvenanceEdge" ("articleId" text, "sourceGroupId" text, "lineageStateId" text, "generationSnapshot" int)`);
     const set: QuerySet = { version: 1, queries: [{ id: "query-one", query: "search misses everything", relevance: {
       visible: 3, hidden: 3, missing: 3, deleted: 3, "deleted-hidden": 3, duplicate: 3, mixed: 3, "hidden-duplicate": 0,
     } }] };
@@ -69,6 +73,62 @@ test("freshness exact lookup enforces scope, deletion and ambiguity without meta
     await pool.end();
     await rm(dir, { recursive: true, force: true });
   }
+});
+
+test("freshness excludes quarantine and invalid provenance before duplicate aggregation", async () => {
+  assert.ok(process.env.SHADOW_TEST_DATABASE_URL, "isolated fixture database required");
+  const pool = new Pool({ connectionString: process.env.SHADOW_TEST_DATABASE_URL, max: 1 });
+  try {
+    await pool.query(`
+      CREATE TEMP TABLE "Article" (id text, slug text, "restrictedTags" text[], "deletedAt" timestamp, "recallQuarantinedAt" timestamp);
+      CREATE TEMP TABLE "MemoryLineageState" (id text, generation int, "revokedAt" timestamp);
+      CREATE TEMP TABLE "MemoryProvenanceEdge" ("articleId" text, "sourceGroupId" text, "lineageStateId" text, "generationSnapshot" int);
+      INSERT INTO "Article" VALUES
+        ('private-q', 'quarantined', '{}', NULL, now()),
+        ('private-a', 'quarantine-duplicate', '{}', NULL, NULL),
+        ('private-b', 'quarantine-duplicate', '{private-tag}', NULL, now()),
+        ('private-r', 'revoked', '{}', NULL, NULL),
+        ('private-s', 'stale', '{}', NULL, NULL),
+        ('private-g', 'valid-group', '{}', NULL, NULL),
+        ('private-m', 'mixed-group', '{}', NULL, NULL),
+        ('private-d', 'lineage-duplicate', '{}', NULL, NULL),
+        ('private-e', 'lineage-duplicate', '{}', NULL, NULL),
+        ('private-h', 'hidden-revoked', '{private-tag}', NULL, NULL),
+        ('private-n', 'no-provenance', '{}', NULL, NULL);
+      INSERT INTO "MemoryLineageState" VALUES
+        ('private-valid', 2, NULL), ('private-revoked', 2, now()), ('private-stale', 3, NULL);
+      INSERT INTO "MemoryProvenanceEdge" VALUES
+        ('private-r', 'private-group', 'private-revoked', 2),
+        ('private-s', 'private-group', 'private-stale', 2),
+        ('private-g', 'private-group', 'private-revoked', 2),
+        ('private-g', 'private-other', 'private-valid', 2),
+        ('private-m', 'private-group', 'private-valid', 2),
+        ('private-m', 'private-group', 'private-revoked', 2),
+        ('private-m', 'private-other', 'private-stale', 2),
+        ('private-e', 'private-group', 'private-revoked', 2),
+        ('private-h', 'private-group', 'private-revoked', 2);
+    `);
+    const statuses = {
+      quarantined: false, "quarantine-duplicate": true, revoked: false, stale: false,
+      "valid-group": true, "mixed-group": false, "lineage-duplicate": true,
+      "hidden-revoked": false, "no-provenance": true,
+    };
+    for (const [slug, eligible] of Object.entries(statuses)) {
+      const set: QuerySet = { version: 1, queries: [{ id: "fixture", query: "miss", relevance: { [slug]: 3 } }] };
+      const original = JSON.stringify(set);
+      for (const [scopes, adminEvidence] of [[undefined, false], [undefined, true], [["*"], false]] as const) {
+        const report = await checkFixtureFreshness(pool, set, scopes ? [...scopes] : undefined, adminEvidence);
+        assert.equal(report.judgments[0].status, eligible ? "visible" : scopes || adminEvidence ? "corpus-absent" : "unknown/not-visible", slug);
+        assert.equal(report.outcome, eligible ? "clear" : "needs-review", slug);
+        assert.doesNotMatch(JSON.stringify(report), /private-/);
+        assert.equal(JSON.stringify(set), original);
+      }
+    }
+    // Make the quarantined duplicate unrestricted too: neither scope may count it.
+    await pool.query(`UPDATE "Article" SET "restrictedTags" = '{}' WHERE id = 'private-b'`);
+    const duplicate: QuerySet = { version: 1, queries: [{ id: "fixture", query: "miss", relevance: { "quarantine-duplicate": 3 } }] };
+    assert.equal((await checkFixtureFreshness(pool, duplicate, undefined)).outcome, "clear");
+  } finally { await pool.end(); }
 });
 
 test("real CLI preflight needs no hybrid or Redis config and persists no metric report", async () => {

--- a/scripts/hybrid-shadow-freshness.test.ts
+++ b/scripts/hybrid-shadow-freshness.test.ts
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { Pool } from "pg";
+import { checkFixtureFreshness } from "./hybrid-shadow-freshness";
+import { buildReport, parseArgs, runPath, writeReport, type QuerySet } from "./hybrid-shadow-eval";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { execFile } from "node:child_process";
+import { readdir, stat } from "node:fs/promises";
+
+// Explicit opt-in test URL only. This suite creates a connection-local temporary
+// Article table, never writes the application corpus, and does not use Redis.
+test("freshness exact lookup enforces scope, deletion and ambiguity without metadata leaks", async () => {
+  assert.ok(process.env.SHADOW_TEST_DATABASE_URL, "set SHADOW_TEST_DATABASE_URL to an isolated fixture database");
+  const pool = new Pool({ connectionString: process.env.SHADOW_TEST_DATABASE_URL, max: 1 });
+  const dir = await mkdtemp(path.join(tmpdir(), "freshness-test-"));
+  try {
+    await pool.query(`CREATE TEMP TABLE "Article" (slug text, "restrictedTags" text[], "deletedAt" timestamp, title text, status text)`);
+    await pool.query(`INSERT INTO "Article" VALUES
+      ('visible', '{}', NULL, 'public-title', 'DRAFT'),
+      ('hidden', '{secret-tag}', NULL, 'secret-title', 'PUBLISHED'),
+      ('deleted', '{}', now(), 'deleted-title', 'PUBLISHED'),
+      ('deleted-hidden', '{secret-tag}', now(), 'secret-title', 'DRAFT'),
+      ('duplicate', '{}', NULL, 'first-topic', 'DRAFT'),
+      ('duplicate', '{}', NULL, 'second-topic', 'PUBLISHED'),
+      ('mixed', '{}', NULL, 'public-title', 'DRAFT'),
+      ('mixed', '{secret-tag}', NULL, 'secret-title', 'DRAFT'),
+      ('hidden-duplicate', '{secret-tag}', NULL, 'secret-title', 'DRAFT'),
+      ('hidden-duplicate', '{secret-tag}', NULL, 'secret-title', 'DRAFT')`);
+    const set: QuerySet = { version: 1, queries: [{ id: "query-one", query: "search misses everything", relevance: {
+      visible: 3, hidden: 3, missing: 3, deleted: 3, "deleted-hidden": 3, duplicate: 3, mixed: 3, "hidden-duplicate": 0,
+    } }] };
+    for (const scopes of [["secret-tag"], ["*", "secret-tag"]]) {
+      await assert.rejects(checkFixtureFreshness(pool, set, scopes), /supports only unscoped or admin/);
+    }
+    const original = JSON.stringify(set);
+    const unscoped = await checkFixtureFreshness(pool, set, undefined);
+    assert.deepEqual(unscoped.judgments.map((j) => j.status), ["visible", "unknown/not-visible", "unknown/not-visible", "unknown/not-visible", "unknown/not-visible", "ambiguous", "visible", "unknown/not-visible"]);
+    const authorized = await checkFixtureFreshness(pool, set, undefined, true);
+    assert.deepEqual(authorized.judgments.map((j) => j.status), ["visible", "excluded-by-scope", "corpus-absent", "corpus-absent", "corpus-absent", "ambiguous", "ambiguous", "ambiguous"]);
+    const admin = await checkFixtureFreshness(pool, set, ["*"]);
+    assert.equal(admin.judgments[1].status, "visible");
+    assert.deepEqual(admin.counts, { visible: 2, "excluded-by-scope": 0, "corpus-absent": 3, "unknown/not-visible": 0, ambiguous: 3 });
+    assert.equal(unscoped.evidenceScope, "unscoped");
+    assert.equal(authorized.evidenceScope, "admin");
+    assert.equal(authorized.evaluationScope, "unscoped");
+    assert.equal(authorized.outcome, "needs-review");
+    assert.ok(Date.parse(authorized.startedAt) <= Date.parse(authorized.checkedAt));
+    assert.equal((await checkFixtureFreshness(pool, { version: 1, queries: [{ ...set.queries[0], relevance: { visible: 3 } }] }, undefined)).outcome, "clear");
+    const ranks = await runPath("keyword", { search: async () => [] }, set, 10);
+    const report = buildReport(set, ranks, ranks, parseArgs([]), {}, authorized);
+    const unchecked = buildReport(set, ranks, ranks, parseArgs([]), {});
+    assert.deepEqual(report.metrics, unchecked.metrics, "freshness must not change scores or denominators");
+    assert.equal(report.metrics.keyword.recall, 0, "visible judgment can be a search miss, not absent");
+    assert.equal(JSON.stringify(set), original);
+    const files = await writeReport(report, dir);
+    const persisted = JSON.parse(await readFile(files.aggregatePath, "utf8"));
+    assert.deepEqual(persisted.freshness, authorized);
+    const md = await readFile(files.summaryPath, "utf8");
+    for (const text of [authorized.checkedAt, "evidence scope: admin", "needs-review", "corpus-absent: 3"]) assert.ok(md.includes(text));
+    for (const evidence of [JSON.stringify(unscoped), JSON.stringify(authorized), JSON.stringify(admin), md]) {
+      assert.doesNotMatch(evidence, /secret-tag|secret-title|deleted-title|first-topic|second-topic|public-title/);
+    }
+    await pool.query('ALTER TABLE "Article" DROP COLUMN "deletedAt"');
+    await assert.rejects(checkFixtureFreshness(pool, set, undefined), /deletedAt/);
+  } finally {
+    await pool.end();
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("real CLI preflight needs no hybrid or Redis config and persists no metric report", async () => {
+  assert.ok(process.env.SHADOW_TEST_DATABASE_URL, "isolated fixture database required");
+  const dir = await mkdtemp(path.join(tmpdir(), "freshness-cli-"));
+  try {
+    const env = { ...process.env, DATABASE_URL: process.env.SHADOW_TEST_DATABASE_URL,
+      REDIS_URL: "redis://127.0.0.1:1", NOOSPHERE_HYBRID_QUERY_PROFILE_ID: "",
+      NOOSPHERE_HYBRID_CACHE_HMAC_ACTIVE_VERSION: "", NOOSPHERE_HYBRID_CACHE_HMAC_KEYS_B64: "" };
+    const cli = path.resolve(import.meta.dirname, "hybrid-shadow-eval.ts");
+    const result = await promisify(execFile)(process.execPath, ["--import", "tsx", cli, "--preflight-only", "--out", dir], { env, timeout: 20000 });
+    assert.doesNotMatch(result.stdout, /\[keyword\]|\[hybrid\]|aggregate:/);
+    assert.equal(result.stderr, "");
+    const names = await readdir(dir);
+    assert.equal(names.length, 1);
+    assert.match(names[0], /^freshness-.*\.json$/);
+    const file = path.join(dir, names[0]);
+    const report = JSON.parse(await readFile(file, "utf8"));
+    assert.equal(report.freshness.evidenceScope, "unscoped");
+    assert.equal(report.metrics, undefined);
+    assert.equal(report.freshness.counts["corpus-absent"], 0);
+    assert.equal(report.freshness.counts["excluded-by-scope"], 0);
+    if (process.platform !== "win32") assert.equal((await stat(file)).mode & 0o077, 0);
+  } finally { await rm(dir, { recursive: true, force: true }); }
+});

--- a/scripts/hybrid-shadow-freshness.ts
+++ b/scripts/hybrid-shadow-freshness.ts
@@ -1,0 +1,59 @@
+import type { Pool } from "pg";
+import type { QuerySet } from "./hybrid-shadow-eval";
+
+export type FreshnessStatus = "visible" | "excluded-by-scope" | "corpus-absent" | "unknown/not-visible" | "ambiguous";
+
+/** Exact corpus lookup, never retrieval results. Only an explicitly authorized
+ * admin inspection may distinguish hidden rows from absent rows. SQL filters
+ * unauthorized rows before aggregation; no titles, tags, IDs or topics leave SQL.
+ */
+export async function checkFixtureFreshness(
+  db: Pick<Pool, "query">,
+  querySet: QuerySet,
+  scopes: string[] | undefined,
+  adminEvidence = false,
+) {
+  // Match the CLI's deliberately limited scope contract; do not silently
+  // reinterpret named provider scopes as unrestricted-only visibility.
+  if (scopes?.length && !(scopes.length === 1 && scopes[0] === "*")) {
+    throw new Error("freshness supports only unscoped or admin ([\"*\"]) evaluation scopes");
+  }
+  const startedAt = new Date().toISOString();
+  const evaluationAdmin = scopes?.includes("*") ?? false;
+  const inspectAll = evaluationAdmin || adminEvidence;
+  const slugs = [...new Set(querySet.queries.flatMap((q) => Object.keys(q.relevance)))];
+  const { rows } = await db.query<{ slug: string; total: number; visible: number }>(`
+    SELECT slug, count(*)::int AS total,
+      count(*) FILTER (WHERE $2::boolean OR cardinality("restrictedTags") = 0)::int AS visible
+    FROM "Article"
+    WHERE slug = ANY($1::text[]) AND "deletedAt" IS NULL
+      AND ($3::boolean OR cardinality("restrictedTags") = 0)
+    GROUP BY slug
+  `, [slugs, evaluationAdmin, inspectAll]);
+  const bySlug = new Map(rows.map((row) => [row.slug, row]));
+  const judgments = querySet.queries.flatMap((q) => Object.keys(q.relevance).map((slug) => {
+    const row = bySlug.get(slug);
+    const total = row?.total ?? 0;
+    const visible = row?.visible ?? 0;
+    const status: FreshnessStatus = total > 1 ? "ambiguous" : visible > 0 ? "visible"
+      : !inspectAll ? "unknown/not-visible" : total > 0 ? "excluded-by-scope" : "corpus-absent";
+    // Slug and queryId come from the fixture, not restricted corpus metadata.
+    return { queryId: q.id, slug, status };
+  }));
+  const counts: Record<FreshnessStatus, number> = {
+    visible: 0, "excluded-by-scope": 0, "corpus-absent": 0, "unknown/not-visible": 0, ambiguous: 0,
+  };
+  for (const judgment of judgments) counts[judgment.status] += 1;
+  return {
+    startedAt,
+    checkedAt: new Date().toISOString(),
+    evaluationScope: evaluationAdmin ? "admin" : "unscoped",
+    evidenceScope: inspectAll ? "admin" : "unscoped",
+    outcome: judgments.every((j) => j.status === "visible") ? "clear" : "needs-review",
+    limitation: "Point-in-time check, not a serving acceptance decision. Soft-deleted rows are outside the corpus; all lifecycle statuses are included. Slug-only judgments can be ambiguous across topics. Unscoped evidence cannot detect hidden duplicates or distinguish absent from restricted rows. No judgments or metric denominators are changed.",
+    counts,
+    judgments,
+  };
+}
+
+export type FixtureFreshness = Awaited<ReturnType<typeof checkFixtureFreshness>>;

--- a/scripts/hybrid-shadow-freshness.ts
+++ b/scripts/hybrid-shadow-freshness.ts
@@ -25,9 +25,25 @@ export async function checkFixtureFreshness(
   const { rows } = await db.query<{ slug: string; total: number; visible: number }>(`
     SELECT slug, count(*)::int AS total,
       count(*) FILTER (WHERE $2::boolean OR cardinality("restrictedTags") = 0)::int AS visible
-    FROM "Article"
+    FROM "Article" article
     WHERE slug = ANY($1::text[]) AND "deletedAt" IS NULL
+      AND "recallQuarantinedAt" IS NULL
       AND ($3::boolean OR cardinality("restrictedTags") = 0)
+      -- Match final recall hydration: an article is blocked only when every
+      -- provenance source group has at least one revoked or stale lineage.
+      -- No provenance is eligible; one entirely valid group is sufficient.
+      AND NOT EXISTS (
+        SELECT 1 FROM (
+          SELECT edge."sourceGroupId",
+            bool_or(lineage."revokedAt" IS NOT NULL
+              OR lineage.generation <> edge."generationSnapshot") AS invalid
+          FROM "MemoryProvenanceEdge" edge
+          JOIN "MemoryLineageState" lineage ON lineage.id = edge."lineageStateId"
+          WHERE edge."articleId" = article.id
+          GROUP BY edge."sourceGroupId"
+        ) provenance_groups
+        HAVING bool_and(invalid)
+      )
     GROUP BY slug
   `, [slugs, evaluationAdmin, inspectAll]);
   const bySlug = new Map(rows.map((row) => [row.slug, row]));
@@ -50,7 +66,7 @@ export async function checkFixtureFreshness(
     evaluationScope: evaluationAdmin ? "admin" : "unscoped",
     evidenceScope: inspectAll ? "admin" : "unscoped",
     outcome: judgments.every((j) => j.status === "visible") ? "clear" : "needs-review",
-    limitation: "Point-in-time check, not a serving acceptance decision. Soft-deleted rows are outside the corpus; all lifecycle statuses are included. Slug-only judgments can be ambiguous across topics. Unscoped evidence cannot detect hidden duplicates or distinguish absent from restricted rows. No judgments or metric denominators are changed.",
+    limitation: "Point-in-time check, not a serving acceptance decision. Soft-deleted, recall-quarantined and fully invalid provenance rows are outside the recall-eligible corpus; all lifecycle statuses are included. Lineage eligibility uses the query snapshot, not recall's serialization locks; later revocations can invalidate it. Slug-only judgments can be ambiguous across topics. Unscoped evidence cannot detect hidden duplicates or distinguish absent from restricted rows. No judgments or metric denominators are changed.",
     counts,
     judgments,
   };


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Pull Request Summary

This PR restores transparency in shadow evaluation measurement by ensuring retrieval misses are not conflated with stale, deleted, or scope-inaccessible fixture data, while introducing a fixture-freshness preflight that runs before search.

### Key Changes

**1. Explicit Metric Denominators**

Each path's report now exposes per-metric `evaluated` and `excluded` query counts separately for `recall`, `ndcg`, and `mrr`, in both JSON and Markdown output. The MRR denominator is reported explicitly as the all-query count, while recall/nDCG exclude queries with no positive judgments. Metric values and single-credit duplicate-slug ranking semantics remain unchanged.

**2. Fixture Freshness Preflight**

A new `checkFixtureFreshness` module performs an exact article lookup in SQL before any retrieval runs:
- Excludes soft-deleted, recall-quarantined, and fully-lineage-invalid articles (matching the final recall hydration).
- Rejects unsupported named/mixed scopes (`["secret-tag"]`, `["*", "secret-tag"]`, etc.) instead of silently misinterpreting them.
- Distinguishes `visible`, `excluded-by-scope`, `corpus-absent`, `unknown/not-visible`, and `ambiguous` outcomes.
- Emits only slug-level judgments — no titles, tags, IDs, or topic names leave SQL.
- Reports a `needs-review` outcome whenever any non-visible judgment exists.

**3. Standalone Preflight CLI Path**

`--preflight-only` runs only the freshness check without importing Prisma, Redis, the search provider, or hybrid configuration. It emits a private `freshness-<uuid>.json` file (mode 0600) and never produces an empty metric report. `--freshness-admin` enables broader evidence collection while retrieval remains scoped.

**4. Evidence Privacy and Documented Limitations**

- Reports persist private data; admin runs may include restricted rankings.
- Files are written with owner-only permissions; directories use mode 0700.
- Documentation makes clear that freshness checks are visibility-presence, not semantic relevance or serving readiness.

**5. CI Integration and Test Coverage**

- New CI step `test:hybrid-shadow-db` runs against the disposable database with `SHADOW_TEST_DATABASE_URL`.
- Tests cover: scope handling, deletion, quarantine, provenance lineage revocation, duplicate aggregation, ambiguity, privacy boundaries, file permissions, and the real CLI preflight-only path (verifying it fails closed without hybrid/Redis config).

### Functional Impact

Previously, a search miss against a fixture slug could be misinterpreted as a retrieval quality problem when the underlying cause was a stale or scope-inaccessible judgment. The preflight now distinguishes these cases, reports denominators so silent exclusion is no longer invisible, and persists evidence for review. The changes are explicitly scoped to measurement tooling — no serving defaults, deployment, or production evaluation are affected.
<!-- kody-pr-summary:end -->