### PR TITLE
feat(shadow-eval): evaluation protocol and expanded graded query set

### DIFF
--- a/docs/HYBRID-SHADOW-EVALUATION-PROTOCOL.md
+++ b/docs/HYBRID-SHADOW-EVALUATION-PROTOCOL.md
@@ -33,9 +33,11 @@ these prefixes:
 - `noanswer-*` — no known relevant article; `relevance` is `{}`.
 
 Grades: 3 = core, 2 = related, 1 = background, 0 = off-topic. Judgments are per
-slug; duplicate-slug ambiguity must be resolved before scores are read. A
-`clear` freshness result is a precondition. Difficult judgments must not be
-removed merely to improve a score.
+slug; duplicate-slug ambiguity must be resolved before scores are read. Any
+resolution changes judgment identity and therefore requires a new committed
+protocol/fixture revision and fresh preflight. A `clear` freshness result is a
+precondition. Difficult judgments must not be removed merely to improve a
+score.
 
 No-answer queries are diagnostics, not relevance metrics: empty and irrelevant
 result sets both produce recall/nDCG `null` and MRR 0. Before scoring, two
@@ -48,9 +50,12 @@ metrics. They are not described as detecting hallucination automatically.
 ## Frozen partitions
 
 Only the tuning partition may guide tuning. Its scores may be inspected during
-iterations. The held-out partition is scored once for the final decision; if a
-run accidentally exposes it early, start a new protocol revision with a new
-held-out set.
+iterations. Every tuning run must select only the tuning IDs with `--query-ids`.
+The held-out partition is searched and scored once, in its final decision run.
+Any earlier score-bearing search over a held-out ID is exposure, whether or not
+the resulting report is opened; start a new protocol revision with a new
+held-out set after such exposure. Freshness-only checks do not score queries and
+may cover the full fixture.
 
 **Tuning (10):**
 
@@ -87,11 +92,13 @@ are a declared limitation; do not choose a different split after seeing scores.
 1. Run freshness-only first. Every judgment must be `visible` and the outcome
    `clear`; resolve any ambiguity/not-visible result through a committed fixture
    revision before continuing.
-2. Run both paths with `--limit 10 --k 5`. Record harness commit, protocol ID and
-   blob, fixture blob, corpus snapshot time, scope, profile, Redis state, and
-   SHA-256 digests of private aggregate/JSONL reports. Keyword runs first and may
-   warm lexical fallback caches; therefore latency is not a cold-cache
-   comparison (see `HYBRID-SHADOW-EVALUATION.md`).
+2. During tuning, run both paths with `--limit 10 --k 5 --query-ids` followed by
+   the comma-separated tuning IDs above. For the final decision, use the same
+   options with exactly the held-out IDs above. Record harness commit, protocol
+   ID and blob, fixture blob, corpus snapshot time, scope, profile, Redis state,
+   selected query IDs, and SHA-256 digests of private aggregate/JSONL reports.
+   Keyword runs first and may warm lexical fallback caches; therefore latency is
+   not a cold-cache comparison (see `HYBRID-SHADOW-EVALUATION.md`).
 3. Keep raw JSONL/JSON/Markdown private. Publish only sanitized aggregates,
    category/subset rollups, and decision rationale.
 4. List the exact query IDs used in every subset table.
@@ -105,13 +112,14 @@ required tables from the same aggregate JSON and exact fixture as follows:
   unprefixed queries map to `exact`.
 - For each path × partition × answerable category, recompute the existing
   harness formulas from recorded `results[].grade`: recall@5 uses positive hits
-  divided by all positive fixture judgments; nDCG@5 uses linear gain and IDCG
-  from all fixture judgments; average each only across queries with positive
-  judgments. MRR@10 averages reciprocal rank across all selected queries with
-  misses = 0.
+  divided by all positive judgments for that scored query; nDCG@5 uses linear
+  gain and IDCG from that query's complete fixture relevance map; average each
+  only across queries with positive judgments. A category row's MRR@10 averages
+  reciprocal rank across that category's selected queries with misses = 0.
 - Produce an overall row per path/partition with the same formulas. Exclude
   `noanswer` from recall/nDCG and all decision/category gates; include it in MRR
-  only to preserve the harness's all-query denominator.
+  for the overall partition row only, preserving the harness's all-selected-query
+  denominator.
 - Report `evaluated` and `excluded` counts beside every aggregate. Assert that
   each path has exactly one ranking for every listed query; otherwise the rollup
   is invalid.

--- a/docs/HYBRID-SHADOW-EVALUATION-PROTOCOL.md
+++ b/docs/HYBRID-SHADOW-EVALUATION-PROTOCOL.md
@@ -152,7 +152,7 @@ no-answer diagnostics are excluded from fallback gating. Latency is reported
 but not gated.
 
 There is no pre-existing accepted keyword baseline, so baseline comparison is
-N/A for revision 1. An ACCEPT record becomes the first baseline: pin its
+N/A for revision 2. An ACCEPT record becomes the first baseline: pin its
 aggregate SHA-256, fixture blob, corpus snapshot, and keyword metrics. Future
 protocol revisions may add a baseline gate only when those inputs are compatible
 and named before their run.

--- a/docs/HYBRID-SHADOW-EVALUATION-PROTOCOL.md
+++ b/docs/HYBRID-SHADOW-EVALUATION-PROTOCOL.md
@@ -55,7 +55,9 @@ The held-out partition is searched and scored once, in its final decision run.
 Any earlier score-bearing search over a held-out ID is exposure, whether or not
 the resulting report is opened; start a new protocol revision with a new
 held-out set after such exposure. Freshness-only checks do not score queries and
-may cover the full fixture.
+may cover the full fixture. The harness refuses score-bearing runs that omit
+both `--query-ids` and the explicit `--all-queries` compatibility escape hatch;
+that escape hatch is forbidden for this protocol.
 
 **Tuning (10):**
 

--- a/docs/HYBRID-SHADOW-EVALUATION-PROTOCOL.md
+++ b/docs/HYBRID-SHADOW-EVALUATION-PROTOCOL.md
@@ -1,6 +1,6 @@
 # Phase D evaluation protocol — issue #319
 
-**Protocol ID:** `noosphere-hybrid-shadow-v1` (revision 1)
+**Protocol ID:** `noosphere-hybrid-shadow-v1` (revision 2)
 
 This contract is pre-registered before a decision-grade run. Any change to its
 queries, judgments, metrics, thresholds, partitions, or decision rules requires
@@ -40,12 +40,14 @@ precondition. Difficult judgments must not be removed merely to improve a
 score.
 
 No-answer queries are diagnostics, not relevance metrics: empty and irrelevant
-result sets both produce recall/nDCG `null` and MRR 0. Before scoring, two
-reviewers independently inspect each path's top-five JSONL rows for both
-no-answer queries. Any genuinely relevant row invalidates that empty judgment
-and requires a committed protocol/fixture revision and fresh run. Otherwise the
-rows are recorded as diagnostic evidence and excluded from category/decision
-metrics. They are not described as detecting hallucination automatically.
+result sets both produce recall/nDCG `null` and MRR 0. After each partition's
+score-bearing run, and before its metrics are used, two reviewers independently
+inspect `results[0:5]` in each path's JSONL ranking record for that partition's
+single no-answer query. Do not score both no-answer IDs together. Any genuinely
+relevant row invalidates that empty judgment and requires a committed
+protocol/fixture revision and fresh run. Otherwise the rows are recorded as
+diagnostic evidence and excluded from category/decision metrics. They are not
+described as detecting hallucination automatically.
 
 ## Frozen partitions
 

--- a/docs/HYBRID-SHADOW-EVALUATION-PROTOCOL.md
+++ b/docs/HYBRID-SHADOW-EVALUATION-PROTOCOL.md
@@ -1,88 +1,158 @@
 # Phase D evaluation protocol — issue #319
 
-Pre-registered before any decision-grade run. Metrics, thresholds, and the
-category mix below are fixed before scores are seen; changing them after a run
-requires a new protocol revision and a fresh run. The harness itself is
-documented in `docs/HYBRID-SHADOW-EVALUATION.md` (measurement tooling, private
-reports, freshness preflight, denominator semantics).
+**Protocol ID:** `noosphere-hybrid-shadow-v1` (revision 1)
 
-## Scope and subjects
+This contract is pre-registered before a decision-grade run. Any change to its
+queries, judgments, metrics, thresholds, partitions, or decision rules requires
+a new committed protocol revision **before** another decision-grade run. The
+decision record cites the protocol commit/blob and fixture Git blob.
 
-- Subject: hybrid retrieval (lexical + embeddings, RRF) vs keyword-only, same
-  production `search` path, reference deployment profile
-  `nomic-embed-text-v1.5` Q8_0, 768-d (llama.cpp; Ollama excluded by policy).
-- Evaluation runs read-only against the authorized evaluation corpus
-  (unscoped by default; admin scope only with explicit operator authorization).
-- Serving posture is out of scope: this protocol produces the accept/tune/reject
-  evidence for #319; it does not itself activate or deactivate anything.
+The harness and its privacy, freshness, and denominator semantics are documented
+in [`HYBRID-SHADOW-EVALUATION.md`](HYBRID-SHADOW-EVALUATION.md).
 
-## Query set
+## Scope
 
-Versioned in `src/__tests__/fixtures/hybrid-shadow-queries.json`. Minimum 20
-queries. Categories (encoded in query id prefixes):
+- Compare hybrid retrieval (lexical + embeddings, RRF) with keyword-only through
+  the same production `search` path, using the reference profile
+  `nomic-embed-text-v1.5` Q8_0, 768-d (llama.cpp; Ollama excluded).
+- Use the authorized evaluation corpus: unscoped by default; admin only with
+  explicit operator authorization.
+- Do not change serving state. This protocol supplies evidence for #319; it does
+  not activate, deactivate, deploy, or serve either result path.
 
-- `exact-*` — near-title keyword lookup; keyword path should already do well.
-- `paraphrase-*` — same intent, different wording than article titles.
-- `mismatch-*` — vocabulary the corpus titles do not contain; the case hybrid
-  embeddings are expected to win. A large hybrid advantage here is the primary
-  signal that the capability earns its complexity.
-- `cross-*` — answers spread across several articles.
-- `noanswer-*` — nothing relevant exists; relevance is `{}`. These count in
-  the MRR denominator as zero and are excluded from recall/nDCG. They detect
-  hallucinated relevance (returning junk for unanswerable queries).
+## Query set and categories
 
-Judgments: 3 = on-topic core, 2 = related, 1 = background, 0 = off-topic.
-Judgments are per slug; slugs are unique only per topic, so duplicate-slug
-ambiguity must be resolved (or the query dropped) before a decision-grade run.
-Slugs must pass the freshness preflight (`clear`) before scores are read.
+`src/__tests__/fixtures/hybrid-shadow-queries.json` contains 20 queries. IDs
+with no recognized prefix are the original `exact` category; added queries use
+these prefixes:
 
-A held-out subset (every second query by fixture order, recorded in the run
-evidence) is reserved for the final acceptance run; tuning iterations use the
-remainder only.
+- `paraphrase-*` — same intent, different wording from the target titles.
+- `mismatch-*` — deliberate vocabulary shift; hybrid semantic retrieval should
+  earn its complexity here.
+- `cross-*` — answers distributed across several articles.
+- `noanswer-*` — no known relevant article; `relevance` is `{}`.
 
-## Run procedure
+Grades: 3 = core, 2 = related, 1 = background, 0 = off-topic. Judgments are per
+slug; duplicate-slug ambiguity must be resolved before scores are read. A
+`clear` freshness result is a precondition. Difficult judgments must not be
+removed merely to improve a score.
 
-1. Freshness preflight: `npm run hybrid:shadow-eval -- --preflight-only ...`.
-   All judgments `visible` (outcome `clear`) is a precondition. Ambiguous or
-   not-visible judgments block the run until resolved by editing the fixture
-   (never by deleting difficult judgments to improve scores).
-2. Dual-path run: `npm run hybrid:shadow-eval -- --limit 10 --k 5 ...`.
-   Record: harness commit SHA, fixture version, corpus snapshot date, scope,
-   Redis configured or not, and the keyword-first cache-warming caveat.
-3. Keep raw JSONL/JSON/Markdown private (restricted titles possible). Publish
-   only the aggregate table and per-category breakdown in the decision record.
+No-answer queries are diagnostics, not relevance metrics: empty and irrelevant
+result sets both produce recall/nDCG `null` and MRR 0. Before scoring, two
+reviewers independently inspect each path's top-five JSONL rows for both
+no-answer queries. Any genuinely relevant row invalidates that empty judgment
+and requires a committed protocol/fixture revision and fresh run. Otherwise the
+rows are recorded as diagnostic evidence and excluded from category/decision
+metrics. They are not described as detecting hallucination automatically.
 
-## Primary metrics and thresholds
+## Frozen partitions
 
-Primary: recall@5 and nDCG@5 (graded, linear gain), both paths. Secondary:
-MRR@10, p50 latency, observed/unknown fallback counts.
+Only the tuning partition may guide tuning. Its scores may be inspected during
+iterations. The held-out partition is scored once for the final decision; if a
+run accidentally exposes it early, start a new protocol revision with a new
+held-out set.
 
-| Decision | Rule |
-| --- | --- |
-| ACCEPT | hybrid nDCG@5 ≥ keyword nDCG@5, AND hybrid recall@5 ≥ keyword recall@5 − 0.05, AND no category regresses by > 0.10 nDCG@5, AND keyword-path metrics on the same run remain within 0.05 of their last accepted baseline (instrument sanity). |
-| TUNE | hybrid wins overall but one category regresses > 0.10, OR fallbackUnknown > 20% of hybrid queries. Tune, then rerun the full protocol (both subsets). |
-| REJECT | hybrid nDCG@5 < keyword nDCG@5, OR a primary category regresses > 0.20. |
+**Tuning (10):**
 
-Latency and fallback counts are reported, not gated: hybrid p50 may exceed
-keyword p50; that is an operator tradeoff, not an automatic reject.
+- `release-1-13-2`
+- `pgvector-production`
+- `pr-merge-verification`
+- `openclaw-recovery`
+- `pixel-agents-prs`
+- `paraphrase-embedding-search`
+- `paraphrase-auth-repair`
+- `mismatch-data-safety`
+- `cross-release-evidence`
+- `noanswer-cooking-recipe`
 
-Thresholds are defaults ratified at PR review; record any change with rationale
-in the decision record before the acceptance run.
+**Held-out (10):**
 
-## Over-context / lexical fallback
+- `hybrid-retrieval-status`
+- `codex-mcp`
+- `security-repair`
+- `backup-automation`
+- `residential-upgrade`
+- `paraphrase-plugin-publish`
+- `mismatch-release-trust`
+- `mismatch-agent-knowledge`
+- `cross-incident-hardening`
+- `noanswer-travel-visa`
 
-Articles exceeding the embedding context window fall back to lexical-only.
-The harness reports per-query fallback metadata (unknown when results are
-empty). The decision record must state the observed fallback rate and confirm
-the keyword-only fallback path for over-context articles returned sane
-rankings (spot-check the fallback queries' JSONL rows). A fallback rate above
-10% on the evaluation corpus triggers a TUNE review of chunking/embedding,
-not a silent accept.
+The split is stratified where the 20-query fixture permits it: exact 5/5,
+paraphrase 2/1, mismatch 1/2, cross 1/1, no-answer 1/1. The small category sizes
+are a declared limitation; do not choose a different split after seeing scores.
 
-## Decision record
+## Run and evidence procedure
 
-Filed as a private report plus a public summary on #319 containing: decision
-(ACCEPT/TUNE/REJECT), aggregate and per-category table for both subsets,
-fallback and latency observations, exact run conditions, and protocol
-revision used. #319 closes only when the acceptance run on the held-out
-subset meets the ACCEPT rule and the record is attached.
+1. Run freshness-only first. Every judgment must be `visible` and the outcome
+   `clear`; resolve any ambiguity/not-visible result through a committed fixture
+   revision before continuing.
+2. Run both paths with `--limit 10 --k 5`. Record harness commit, protocol ID and
+   blob, fixture blob, corpus snapshot time, scope, profile, Redis state, and
+   SHA-256 digests of private aggregate/JSONL reports. Keyword runs first and may
+   warm lexical fallback caches; therefore latency is not a cold-cache
+   comparison (see `HYBRID-SHADOW-EVALUATION.md`).
+3. Keep raw JSONL/JSON/Markdown private. Publish only sanitized aggregates,
+   category/subset rollups, and decision rationale.
+4. List the exact query IDs used in every subset table.
+
+### Required rollup from the aggregate JSON
+
+The harness emits overall metrics plus flat `perQuery` rankings. Produce the
+required tables from the same aggregate JSON and exact fixture as follows:
+
+- Map each query to the frozen partition above and to its recognized prefix;
+  unprefixed queries map to `exact`.
+- For each path × partition × answerable category, recompute the existing
+  harness formulas from recorded `results[].grade`: recall@5 uses positive hits
+  divided by all positive fixture judgments; nDCG@5 uses linear gain and IDCG
+  from all fixture judgments; average each only across queries with positive
+  judgments. MRR@10 averages reciprocal rank across all selected queries with
+  misses = 0.
+- Produce an overall row per path/partition with the same formulas. Exclude
+  `noanswer` from recall/nDCG and all decision/category gates; include it in MRR
+  only to preserve the harness's all-query denominator.
+- Report `evaluated` and `excluded` counts beside every aggregate. Assert that
+  each path has exactly one ranking for every listed query; otherwise the rollup
+  is invalid.
+- Category regression means `hybrid nDCG@5 - keyword nDCG@5` for that category
+  in the **held-out** partition. Publish the query IDs and values used, so the
+  calculation is reproducible.
+
+## Ordered decision procedure
+
+Use the held-out partition only. Apply the first matching outcome; these rules
+are exhaustive and mutually exclusive. “Overall” means the held-out aggregate
+across answerable queries using the formulas above.
+
+1. **REJECT** if hybrid overall nDCG@5 is below keyword overall nDCG@5, or any
+   answerable category's nDCG@5 regression is less than -0.20.
+2. **TUNE** (only if not REJECT) if hybrid overall recall@5 is more than 0.05
+   below keyword, any answerable category regression is less than -0.10, the
+   observed fallback rate exceeds 10%, or an observed-fallback answerable query
+   returns no grade-positive result in its top five.
+3. **ACCEPT** otherwise.
+
+Observed fallback rate is the fraction of answerable held-out hybrid rankings
+whose `hybridFallback` is `true`. `fallbackUnknown` is reported separately but
+is not a gate: empty results already count as misses in the primary metrics, and
+no-answer diagnostics are excluded from fallback gating. Latency is reported
+but not gated.
+
+There is no pre-existing accepted keyword baseline, so baseline comparison is
+N/A for revision 1. An ACCEPT record becomes the first baseline: pin its
+aggregate SHA-256, fixture blob, corpus snapshot, and keyword metrics. Future
+protocol revisions may add a baseline gate only when those inputs are compatible
+and named before their run.
+
+## Decision record and issue state
+
+The private record and sanitized #319 summary include: ACCEPT/TUNE/REJECT,
+protocol/fixture identities, exact run conditions, overall and per-category
+tables for both partitions, denominator counts, no-answer review, observed and
+unknown fallback counts, fallback spot-checks, latency, and report digests.
+
+ACCEPT on the held-out partition with complete evidence permits #319 to close.
+TUNE leaves #319 open and requires tuning plus a new full run under an applicable
+pre-registered revision. REJECT leaves #319 open and records that hybrid did not
+meet the gate. This PR establishes the contract only; it does not close #319.

--- a/docs/HYBRID-SHADOW-EVALUATION-PROTOCOL.md
+++ b/docs/HYBRID-SHADOW-EVALUATION-PROTOCOL.md
@@ -1,0 +1,88 @@
+# Phase D evaluation protocol — issue #319
+
+Pre-registered before any decision-grade run. Metrics, thresholds, and the
+category mix below are fixed before scores are seen; changing them after a run
+requires a new protocol revision and a fresh run. The harness itself is
+documented in `docs/HYBRID-SHADOW-EVALUATION.md` (measurement tooling, private
+reports, freshness preflight, denominator semantics).
+
+## Scope and subjects
+
+- Subject: hybrid retrieval (lexical + embeddings, RRF) vs keyword-only, same
+  production `search` path, reference deployment profile
+  `nomic-embed-text-v1.5` Q8_0, 768-d (llama.cpp; Ollama excluded by policy).
+- Evaluation runs read-only against the authorized evaluation corpus
+  (unscoped by default; admin scope only with explicit operator authorization).
+- Serving posture is out of scope: this protocol produces the accept/tune/reject
+  evidence for #319; it does not itself activate or deactivate anything.
+
+## Query set
+
+Versioned in `src/__tests__/fixtures/hybrid-shadow-queries.json`. Minimum 20
+queries. Categories (encoded in query id prefixes):
+
+- `exact-*` — near-title keyword lookup; keyword path should already do well.
+- `paraphrase-*` — same intent, different wording than article titles.
+- `mismatch-*` — vocabulary the corpus titles do not contain; the case hybrid
+  embeddings are expected to win. A large hybrid advantage here is the primary
+  signal that the capability earns its complexity.
+- `cross-*` — answers spread across several articles.
+- `noanswer-*` — nothing relevant exists; relevance is `{}`. These count in
+  the MRR denominator as zero and are excluded from recall/nDCG. They detect
+  hallucinated relevance (returning junk for unanswerable queries).
+
+Judgments: 3 = on-topic core, 2 = related, 1 = background, 0 = off-topic.
+Judgments are per slug; slugs are unique only per topic, so duplicate-slug
+ambiguity must be resolved (or the query dropped) before a decision-grade run.
+Slugs must pass the freshness preflight (`clear`) before scores are read.
+
+A held-out subset (every second query by fixture order, recorded in the run
+evidence) is reserved for the final acceptance run; tuning iterations use the
+remainder only.
+
+## Run procedure
+
+1. Freshness preflight: `npm run hybrid:shadow-eval -- --preflight-only ...`.
+   All judgments `visible` (outcome `clear`) is a precondition. Ambiguous or
+   not-visible judgments block the run until resolved by editing the fixture
+   (never by deleting difficult judgments to improve scores).
+2. Dual-path run: `npm run hybrid:shadow-eval -- --limit 10 --k 5 ...`.
+   Record: harness commit SHA, fixture version, corpus snapshot date, scope,
+   Redis configured or not, and the keyword-first cache-warming caveat.
+3. Keep raw JSONL/JSON/Markdown private (restricted titles possible). Publish
+   only the aggregate table and per-category breakdown in the decision record.
+
+## Primary metrics and thresholds
+
+Primary: recall@5 and nDCG@5 (graded, linear gain), both paths. Secondary:
+MRR@10, p50 latency, observed/unknown fallback counts.
+
+| Decision | Rule |
+| --- | --- |
+| ACCEPT | hybrid nDCG@5 ≥ keyword nDCG@5, AND hybrid recall@5 ≥ keyword recall@5 − 0.05, AND no category regresses by > 0.10 nDCG@5, AND keyword-path metrics on the same run remain within 0.05 of their last accepted baseline (instrument sanity). |
+| TUNE | hybrid wins overall but one category regresses > 0.10, OR fallbackUnknown > 20% of hybrid queries. Tune, then rerun the full protocol (both subsets). |
+| REJECT | hybrid nDCG@5 < keyword nDCG@5, OR a primary category regresses > 0.20. |
+
+Latency and fallback counts are reported, not gated: hybrid p50 may exceed
+keyword p50; that is an operator tradeoff, not an automatic reject.
+
+Thresholds are defaults ratified at PR review; record any change with rationale
+in the decision record before the acceptance run.
+
+## Over-context / lexical fallback
+
+Articles exceeding the embedding context window fall back to lexical-only.
+The harness reports per-query fallback metadata (unknown when results are
+empty). The decision record must state the observed fallback rate and confirm
+the keyword-only fallback path for over-context articles returned sane
+rankings (spot-check the fallback queries' JSONL rows). A fallback rate above
+10% on the evaluation corpus triggers a TUNE review of chunking/embedding,
+not a silent accept.
+
+## Decision record
+
+Filed as a private report plus a public summary on #319 containing: decision
+(ACCEPT/TUNE/REJECT), aggregate and per-category table for both subsets,
+fallback and latency observations, exact run conditions, and protocol
+revision used. #319 closes only when the acceptance run on the held-out
+subset meets the ACCEPT rule and the record is attached.

--- a/docs/HYBRID-SHADOW-EVALUATION.md
+++ b/docs/HYBRID-SHADOW-EVALUATION.md
@@ -6,9 +6,11 @@ acceptance gate. Reports remain private; admin runs can include restricted
 rankings. Search may write caches, authorize dispatch, and call embeddings.
 
 Use `--query-ids <id,id,...>` to run only a pre-registered partition. Unknown or
-duplicate IDs fail closed, and selected queries retain fixture order. A run
-without this option evaluates the full fixture; do not use that mode when a
-protocol reserves held-out queries from tuning.
+duplicate IDs fail closed, and selected queries retain fixture order. A
+score-bearing run without this option also fails closed; `--all-queries` is the
+explicit compatibility escape hatch for protocols with no held-out partition.
+Do not use that escape hatch when a protocol reserves held-out queries from
+tuning. Freshness-only runs may omit both selection flags.
 
 ## Freshness before evaluation
 

--- a/docs/HYBRID-SHADOW-EVALUATION.md
+++ b/docs/HYBRID-SHADOW-EVALUATION.md
@@ -5,6 +5,11 @@ search without serving results. This is measurement tooling, not a serving
 acceptance gate. Reports remain private; admin runs can include restricted
 rankings. Search may write caches, authorize dispatch, and call embeddings.
 
+Use `--query-ids <id,id,...>` to run only a pre-registered partition. Unknown or
+duplicate IDs fail closed, and selected queries retain fixture order. A run
+without this option evaluates the full fixture; do not use that mode when a
+protocol reserves held-out queries from tuning.
+
 ## Freshness before evaluation
 
 Every dual-path run performs an exact article lookup **before searching** and

--- a/scripts/hybrid-shadow-eval.test.ts
+++ b/scripts/hybrid-shadow-eval.test.ts
@@ -165,7 +165,7 @@ test("argument validation guards missing values and finite supported bounds", ()
 
 test("query selection rejects unknown IDs and preserves fixture order", () => {
   const set = querySet([one, { ...one, id: "query-two" }, { ...one, id: "query-three" }]);
-  assert.throws(() => selectQueries(set, undefined), /requires --query-ids or explicit --all-queries/);
+  assert.throws(() => selectQueries(set, undefined), /requires an explicit --query-ids selection/);
   assert.deepEqual(selectQueries(set, undefined, true), set);
   const selected = selectQueries(set, ["query-three", "query-one"]);
   assert.deepEqual(selected.queries.map((query) => query.id), ["query-one", "query-three"]);
@@ -192,6 +192,7 @@ test("rapid report writes preserve aggregate JSON, JSONL and honest secret-free 
       assert.deepEqual(JSON.parse(await readFile(files.aggregatePath, "utf8")), report);
       assert.deepEqual((await readFile(files.jsonl, "utf8")).trim().split("\n").map((line) => JSON.parse(line)), report.perQuery);
       const md = await readFile(files.summaryPath, "utf8");
+      assert.match(md, /Selected query IDs: `query-one`\./);
       for (const text of Object.values(report.observation)) assert.ok(md.includes(text));
       assert.match(md, /unknown fallback/);
       assert.match(md, /MRR@10/);
@@ -257,6 +258,6 @@ test("pure import has no provider/Prisma initialization; CLI rejects arguments b
   assert.doesNotMatch(cli.stderr, /requires DATABASE_URL|Prisma/);
   const omittedSelection = spawnSync(process.execPath, ["--import", "tsx", script], { env, encoding: "utf8", timeout: 10000 });
   assert.equal(omittedSelection.status, 1);
-  assert.match(omittedSelection.stderr, /score-bearing run requires --query-ids or explicit --all-queries/);
+  assert.match(omittedSelection.stderr, /score-bearing run requires an explicit --query-ids selection/);
   assert.doesNotMatch(omittedSelection.stderr, /requires DATABASE_URL|Prisma/);
 });

--- a/scripts/hybrid-shadow-eval.test.ts
+++ b/scripts/hybrid-shadow-eval.test.ts
@@ -4,7 +4,7 @@ import { mkdtemp, readFile, readdir, rm, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
-import { buildReport, loadQuerySet, parseArgs, runPath, writeReport, type QuerySet } from "./hybrid-shadow-eval";
+import { buildReport, loadQuerySet, parseArgs, runPath, selectQueries, writeReport, type QuerySet } from "./hybrid-shadow-eval";
 import type { MemoryResult } from "@/lib/memory/types";
 
 const fixtureDir = path.resolve(import.meta.dirname, "../src/__tests__/fixtures");
@@ -55,7 +55,7 @@ test("duplicate judged slugs earn credit once without shifting returned ranks", 
   assert.deepEqual(hybrid[0].results.map((r) => r.grade), [3, 0, 1]);
 });
 
-test("linear-gain nDCG uses full fixture IDCG, including unretrieved judgments", async () => {
+test("linear-gain nDCG uses each query's complete IDCG, including unretrieved judgments", async () => {
   const set = querySet();
   const hybrid = await rankings(set, [[row("other")]]);
   const report = buildReport(set, hybrid, hybrid, parseArgs(["--k", "2"]), {});
@@ -143,7 +143,7 @@ test("explicit runtime validator stays in parity with the schema constraints", a
 });
 
 test("argument validation guards missing values and finite supported bounds", () => {
-  for (const flag of ["--limit", "--k", "--out", "--scopes"]) {
+  for (const flag of ["--limit", "--k", "--out", "--scopes", "--query-ids"]) {
     for (const args of [[flag], [flag, "--k", "1"], [flag, " "]]) assert.throws(() => parseArgs(args), /missing value/);
   }
   for (const value of ["0", "-1", "1.5", "NaN", "Infinity", "201", "9007199254740992"]) {
@@ -152,9 +152,22 @@ test("argument validation guards missing values and finite supported bounds", ()
   for (const value of ["0", "-1", "1.5", "NaN", "Infinity", "11"]) assert.throws(() => parseArgs(["--k", value]));
   assert.throws(() => parseArgs(["--unknown"]), /unknown argument/);
   assert.throws(() => parseArgs(["--scopes", "published"]), /admin or unscoped/);
+  for (const value of ["query-one,,query-two", "query-one,query-one", "Bad-ID"]) {
+    assert.throws(() => parseArgs(["--query-ids", value]), /unique query IDs/);
+  }
   assert.deepEqual(parseArgs(["--limit", "200", "--k", "200", "--out", "reports", "--scopes", "admin"]),
     { limit: 200, k: 200, outDir: "reports", scopes: ["*"] });
   assert.equal(parseArgs(["--scopes", "unscoped"]).scopes, undefined);
+  assert.deepEqual(parseArgs(["--query-ids", "query-two, query-one"]).queryIds, ["query-two", "query-one"]);
+});
+
+test("query selection rejects unknown IDs and preserves fixture order", () => {
+  const set = querySet([one, { ...one, id: "query-two" }, { ...one, id: "query-three" }]);
+  assert.deepEqual(selectQueries(set, undefined), set);
+  const selected = selectQueries(set, ["query-three", "query-one"]);
+  assert.deepEqual(selected.queries.map((query) => query.id), ["query-one", "query-three"]);
+  assert.deepEqual(buildReport(selected, [], [], parseArgs([]), {}).queryIds, ["query-one", "query-three"]);
+  assert.throws(() => selectQueries(set, ["query-one", "query-missing"]), /unknown query id: query-missing/);
 });
 
 test("rapid report writes preserve aggregate JSON, JSONL and honest secret-free metadata", async () => {

--- a/scripts/hybrid-shadow-eval.test.ts
+++ b/scripts/hybrid-shadow-eval.test.ts
@@ -152,6 +152,7 @@ test("argument validation guards missing values and finite supported bounds", ()
   for (const value of ["0", "-1", "1.5", "NaN", "Infinity", "11"]) assert.throws(() => parseArgs(["--k", value]));
   assert.throws(() => parseArgs(["--unknown"]), /unknown argument/);
   assert.throws(() => parseArgs(["--scopes", "published"]), /admin or unscoped/);
+  assert.throws(() => parseArgs(["--all-queries", "--query-ids", "query-one"]), /mutually exclusive/);
   for (const value of ["query-one,,query-two", "query-one,query-one", "Bad-ID"]) {
     assert.throws(() => parseArgs(["--query-ids", value]), /unique query IDs/);
   }
@@ -159,11 +160,13 @@ test("argument validation guards missing values and finite supported bounds", ()
     { limit: 200, k: 200, outDir: "reports", scopes: ["*"] });
   assert.equal(parseArgs(["--scopes", "unscoped"]).scopes, undefined);
   assert.deepEqual(parseArgs(["--query-ids", "query-two, query-one"]).queryIds, ["query-two", "query-one"]);
+  assert.equal(parseArgs(["--all-queries"]).allQueries, true);
 });
 
 test("query selection rejects unknown IDs and preserves fixture order", () => {
   const set = querySet([one, { ...one, id: "query-two" }, { ...one, id: "query-three" }]);
-  assert.deepEqual(selectQueries(set, undefined), set);
+  assert.throws(() => selectQueries(set, undefined), /requires --query-ids or explicit --all-queries/);
+  assert.deepEqual(selectQueries(set, undefined, true), set);
   const selected = selectQueries(set, ["query-three", "query-one"]);
   assert.deepEqual(selected.queries.map((query) => query.id), ["query-one", "query-three"]);
   assert.deepEqual(buildReport(selected, [], [], parseArgs([]), {}).queryIds, ["query-one", "query-three"]);
@@ -252,4 +255,8 @@ test("pure import has no provider/Prisma initialization; CLI rejects arguments b
   assert.equal(cli.status, 1);
   assert.match(cli.stderr, /missing value for --out/);
   assert.doesNotMatch(cli.stderr, /requires DATABASE_URL|Prisma/);
+  const omittedSelection = spawnSync(process.execPath, ["--import", "tsx", script], { env, encoding: "utf8", timeout: 10000 });
+  assert.equal(omittedSelection.status, 1);
+  assert.match(omittedSelection.stderr, /score-bearing run requires --query-ids or explicit --all-queries/);
+  assert.doesNotMatch(omittedSelection.stderr, /requires DATABASE_URL|Prisma/);
 });

--- a/scripts/hybrid-shadow-eval.ts
+++ b/scripts/hybrid-shadow-eval.ts
@@ -30,7 +30,7 @@
  *     -e NOOSPHERE_HYBRID_CACHE_HMAC_ACTIVE_VERSION \
  *     -e NOOSPHERE_HYBRID_CACHE_HMAC_KEYS_B64 \
  *     -e NOOSPHERE_HYBRID_PROVIDER_CONFIG_B64 \
- *     node:22-bookworm-slim npx tsx scripts/hybrid-shadow-eval.ts --all-queries --out hybrid-shadow-reports
+ *     node:22-bookworm-slim npx tsx scripts/hybrid-shadow-eval.ts --query-ids release-1-13-2,pgvector-production,pr-merge-verification,openclaw-recovery,pixel-agents-prs,paraphrase-embedding-search,paraphrase-auth-repair,mismatch-data-safety,cross-release-evidence,noanswer-cooking-recipe --out hybrid-shadow-reports
  *
  * Environment (from .env / shell):
  *   DATABASE_URL                        app-role connection (read path)

--- a/scripts/hybrid-shadow-eval.ts
+++ b/scripts/hybrid-shadow-eval.ts
@@ -17,6 +17,7 @@
  * Usage (dual-path evaluation by default; --preflight-only performs only the
  * freshness lookup and writes no metric reports — see docs/HYBRID-SHADOW-EVALUATION.md):
  *   npm run hybrid:shadow-eval -- --limit 5 --k 5 --query-ids <id,id,...> --out <dir>
+ *   npm run hybrid:shadow-eval -- --limit 5 --k 5 --all-queries --out <dir>
  *   npm run hybrid:shadow-eval -- --preflight-only --out <dir>
  *
  * Full dual-path run: must execute inside the compose network so the pinned
@@ -29,7 +30,7 @@
  *     -e NOOSPHERE_HYBRID_CACHE_HMAC_ACTIVE_VERSION \
  *     -e NOOSPHERE_HYBRID_CACHE_HMAC_KEYS_B64 \
  *     -e NOOSPHERE_HYBRID_PROVIDER_CONFIG_B64 \
- *     node:22-bookworm-slim npx tsx scripts/hybrid-shadow-eval.ts --out hybrid-shadow-reports
+ *     node:22-bookworm-slim npx tsx scripts/hybrid-shadow-eval.ts --all-queries --out hybrid-shadow-reports
  *
  * Environment (from .env / shell):
  *   DATABASE_URL                        app-role connection (read path)
@@ -79,11 +80,12 @@ function requireEnv(name: string): string {
   return value;
 }
 
-export function parseArgs(argv: string[]): { limit: number; k: number; outDir: string; scopes: string[] | undefined; queryIds?: string[]; preflightOnly?: boolean; freshnessAdmin?: boolean } {
+export function parseArgs(argv: string[]): { limit: number; k: number; outDir: string; scopes: string[] | undefined; queryIds?: string[]; allQueries?: boolean; preflightOnly?: boolean; freshnessAdmin?: boolean } {
   const opts: ReturnType<typeof parseArgs> = { limit: 10, k: 5, outDir: "hybrid-shadow-reports", scopes: undefined as string[] | undefined };
   for (let i = 0; i < argv.length; i += 1) {
     if (argv[i] === "--preflight-only") { opts.preflightOnly = true; continue; }
     if (argv[i] === "--freshness-admin") { opts.freshnessAdmin = true; continue; }
+    if (argv[i] === "--all-queries") { opts.allQueries = true; continue; }
     if (!["--limit", "--k", "--out", "--scopes", "--query-ids"].includes(argv[i])) throw new Error(`unknown argument: ${argv[i]}`);
     if (!argv[i + 1]?.trim() || argv[i + 1].startsWith("--")) throw new Error(`missing value for ${argv[i]}`);
     if (argv[i] === "--limit") opts.limit = Number(argv[++i]);
@@ -106,11 +108,15 @@ export function parseArgs(argv: string[]): { limit: number; k: number; outDir: s
   }
   if (!Number.isSafeInteger(opts.limit) || opts.limit < 1 || opts.limit > HYBRID_MAX_WINDOW) throw new Error(`--limit must be 1..${HYBRID_MAX_WINDOW}`);
   if (!Number.isInteger(opts.k) || opts.k < 1 || opts.k > opts.limit) throw new Error("--k must be 1..limit");
+  if (opts.queryIds && opts.allQueries) throw new Error("--query-ids and --all-queries are mutually exclusive");
   return opts;
 }
 
-export function selectQueries(querySet: QuerySet, queryIds: string[] | undefined): QuerySet {
-  if (!queryIds) return querySet;
+export function selectQueries(querySet: QuerySet, queryIds: string[] | undefined, allowAll = false): QuerySet {
+  if (!queryIds) {
+    if (!allowAll) throw new Error("score-bearing run requires --query-ids or explicit --all-queries");
+    return querySet;
+  }
   const selected = new Set(queryIds);
   const queries = querySet.queries.filter((query) => selected.has(query.id));
   if (queries.length !== selected.size) {
@@ -336,7 +342,7 @@ export async function writeReport(report: ReturnType<typeof buildReport>, outDir
 async function main(): Promise<void> {
   const opts = parseArgs(process.argv.slice(2));
   const fixturePath = path.resolve(import.meta.dirname, "../src/__tests__/fixtures/hybrid-shadow-queries.json");
-  const querySet = selectQueries(loadQuerySet(await readFile(fixturePath, "utf8")), opts.queryIds);
+  const querySet = selectQueries(loadQuerySet(await readFile(fixturePath, "utf8")), opts.queryIds, Boolean(opts.preflightOnly || opts.allQueries));
   const databaseUrl = requireEnv("DATABASE_URL");
   const baseEnv = opts.preflightOnly ? process.env : {
     ...process.env,

--- a/scripts/hybrid-shadow-eval.ts
+++ b/scripts/hybrid-shadow-eval.ts
@@ -16,7 +16,7 @@
  *
  * Usage (dual-path evaluation by default; --preflight-only performs only the
  * freshness lookup and writes no metric reports — see docs/HYBRID-SHADOW-EVALUATION.md):
- *   npm run hybrid:shadow-eval -- --limit 5 --k 5 --out <dir>
+ *   npm run hybrid:shadow-eval -- --limit 5 --k 5 --query-ids <id,id,...> --out <dir>
  *   npm run hybrid:shadow-eval -- --preflight-only --out <dir>
  *
  * Full dual-path run: must execute inside the compose network so the pinned
@@ -79,12 +79,12 @@ function requireEnv(name: string): string {
   return value;
 }
 
-export function parseArgs(argv: string[]): { limit: number; k: number; outDir: string; scopes: string[] | undefined; preflightOnly?: boolean; freshnessAdmin?: boolean } {
+export function parseArgs(argv: string[]): { limit: number; k: number; outDir: string; scopes: string[] | undefined; queryIds?: string[]; preflightOnly?: boolean; freshnessAdmin?: boolean } {
   const opts: ReturnType<typeof parseArgs> = { limit: 10, k: 5, outDir: "hybrid-shadow-reports", scopes: undefined as string[] | undefined };
   for (let i = 0; i < argv.length; i += 1) {
     if (argv[i] === "--preflight-only") { opts.preflightOnly = true; continue; }
     if (argv[i] === "--freshness-admin") { opts.freshnessAdmin = true; continue; }
-    if (!["--limit", "--k", "--out", "--scopes"].includes(argv[i])) throw new Error(`unknown argument: ${argv[i]}`);
+    if (!["--limit", "--k", "--out", "--scopes", "--query-ids"].includes(argv[i])) throw new Error(`unknown argument: ${argv[i]}`);
     if (!argv[i + 1]?.trim() || argv[i + 1].startsWith("--")) throw new Error(`missing value for ${argv[i]}`);
     if (argv[i] === "--limit") opts.limit = Number(argv[++i]);
     else if (argv[i] === "--k") opts.k = Number(argv[++i]);
@@ -95,11 +95,29 @@ export function parseArgs(argv: string[]): { limit: number; k: number; outDir: s
       else if (value === "unscoped") opts.scopes = undefined;
       else throw new Error(`--scopes must be admin or unscoped (got: ${value})`);
     }
+    else if (argv[i] === "--query-ids") {
+      const ids = String(argv[++i]).split(",").map((id) => id.trim());
+      if (ids.some((id) => !/^[a-z0-9][a-z0-9-]*[a-z0-9]$/.test(id)) || new Set(ids).size !== ids.length) {
+        throw new Error("--query-ids must be a comma-separated list of unique query IDs");
+      }
+      opts.queryIds = ids;
+    }
     else throw new Error(`unknown argument: ${argv[i]}`);
   }
   if (!Number.isSafeInteger(opts.limit) || opts.limit < 1 || opts.limit > HYBRID_MAX_WINDOW) throw new Error(`--limit must be 1..${HYBRID_MAX_WINDOW}`);
   if (!Number.isInteger(opts.k) || opts.k < 1 || opts.k > opts.limit) throw new Error("--k must be 1..limit");
   return opts;
+}
+
+export function selectQueries(querySet: QuerySet, queryIds: string[] | undefined): QuerySet {
+  if (!queryIds) return querySet;
+  const selected = new Set(queryIds);
+  const queries = querySet.queries.filter((query) => selected.has(query.id));
+  if (queries.length !== selected.size) {
+    const known = new Set(querySet.queries.map((query) => query.id));
+    throw new Error(`unknown query id: ${queryIds.find((id) => !known.has(id))}`);
+  }
+  return { ...querySet, queries };
 }
 
 export function loadQuerySet(file: string): QuerySet {
@@ -253,6 +271,7 @@ export function buildReport(
     generatedAt: new Date().toISOString(),
     querySetVersion: querySet.version,
     queryCount: querySet.queries.length,
+    queryIds: querySet.queries.map((query) => query.id),
     limit: opts.limit,
     k: opts.k,
     relevanceTiers: RELEVANCE_TIERS,
@@ -264,7 +283,7 @@ export function buildReport(
       order: "Keyword path ran first; it may warm the lexical cache used by hybrid fallback. Latencies are not a cold-cache comparison.",
       sideEffects: "Production searches may write lexical/hybrid caches, authorize query dispatch in the database, and call the embedding endpoint. No article edits or corpus-vector writes are requested; results are not served.",
       fallback: "Fallback is observed from returned-row metadata only. Empty hybrid results have unknown fallback (null), counted separately, not assumed successful.",
-      metrics: `Recall@${opts.k} treats grades > 0 as relevant; nDCG@${opts.k} uses linear gain (grade/log2(rank+1)) and IDCG from the full fixture. Judgments are per slug: only its first occurrence earns credit; duplicates retain their rank with grade 0. Recall/nDCG exclude queries with no positive judgments. MRR@${opts.limit} uses all queries with misses = 0 and the returned limit, not k.`,
+      metrics: `Recall@${opts.k} treats grades > 0 as relevant; nDCG@${opts.k} uses linear gain (grade/log2(rank+1)) and IDCG from the scored query's complete fixture judgments. Judgments are per slug: only its first occurrence earns credit; duplicates retain their rank with grade 0. Recall/nDCG exclude queries with no positive judgments. MRR@${opts.limit} uses all selected queries with misses = 0 and the returned limit, not k.`,
     },
     metrics,
     perQuery: [...keywordRankings, ...hybridRankings].map(toReportEntry),
@@ -317,7 +336,7 @@ export async function writeReport(report: ReturnType<typeof buildReport>, outDir
 async function main(): Promise<void> {
   const opts = parseArgs(process.argv.slice(2));
   const fixturePath = path.resolve(import.meta.dirname, "../src/__tests__/fixtures/hybrid-shadow-queries.json");
-  const querySet = loadQuerySet(await readFile(fixturePath, "utf8"));
+  const querySet = selectQueries(loadQuerySet(await readFile(fixturePath, "utf8")), opts.queryIds);
   const databaseUrl = requireEnv("DATABASE_URL");
   const baseEnv = opts.preflightOnly ? process.env : {
     ...process.env,

--- a/scripts/hybrid-shadow-eval.ts
+++ b/scripts/hybrid-shadow-eval.ts
@@ -20,7 +20,8 @@
  *   npm run hybrid:shadow-eval -- --limit 5 --k 5 --all-queries --out <dir>
  *   npm run hybrid:shadow-eval -- --preflight-only --out <dir>
  *
- * Full dual-path run: must execute inside the compose network so the pinned
+ * Tuning dual-path run (frozen tuning IDs; not the final held-out decision):
+ * must execute inside the compose network so the pinned
  * provider endpoint (host.docker.internal:8741) resolves, with the app-role
  * DATABASE_URL pointing at db:5432:
  *   docker run --rm --network noosphere-net \

--- a/scripts/hybrid-shadow-eval.ts
+++ b/scripts/hybrid-shadow-eval.ts
@@ -115,7 +115,7 @@ export function parseArgs(argv: string[]): { limit: number; k: number; outDir: s
 
 export function selectQueries(querySet: QuerySet, queryIds: string[] | undefined, allowAll = false): QuerySet {
   if (!queryIds) {
-    if (!allowAll) throw new Error("score-bearing run requires --query-ids or explicit --all-queries");
+    if (!allowAll) throw new Error("score-bearing run requires an explicit --query-ids selection");
     return querySet;
   }
   const selected = new Set(queryIds);
@@ -309,6 +309,7 @@ export async function writeReport(report: ReturnType<typeof buildReport>, outDir
     `# Hybrid shadow evaluation — ${report.generatedAt}`,
     ``,
     `Query set v${report.querySetVersion} (${report.queryCount} queries), limit ${report.limit}, k ${report.k}.`,
+    `Selected query IDs: ${report.queryIds.map((id) => `\`${id}\``).join(", ")}.`,
     ``,
     `Scope: ${report.observation.scope}. Redis: ${report.observation.redis}. ${report.observation.redisLimitation}`,
     ...[report.observation.order, report.observation.sideEffects, report.observation.fallback, report.observation.metrics].flatMap((text) => ["", text]),

--- a/src/__tests__/fixtures/hybrid-shadow-queries.json
+++ b/src/__tests__/fixtures/hybrid-shadow-queries.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./hybrid-shadow-queries.schema.json",
   "version": 1,
-  "description": "Graded query set for hybrid-vs-keyword shadow evaluation (issue #319), protocol noosphere-hybrid-shadow-v1 revision 1. 20 queries: unprefixed ids are the original exact core; added ids use paraphrase/mismatch/cross/noanswer prefixes. Slugs were verified against the live corpus 2026-09-04 and are rechecked by freshness preflight. Relevance: 3 = core, 2 = related, 1 = background, 0 = off-topic.",
+  "description": "Graded query set for hybrid-vs-keyword shadow evaluation (issue #319), protocol noosphere-hybrid-shadow-v1 revision 2. 20 queries: unprefixed ids are the original exact core; added ids use paraphrase/mismatch/cross/noanswer prefixes. Slugs are backed by corpus evidence and are rechecked by freshness preflight. Relevance: 3 = core, 2 = related, 1 = background, 0 = off-topic.",
   "queries": [
     {
       "id": "release-1-13-2",
@@ -161,8 +161,8 @@
       "query": "what went wrong and what did we harden afterwards",
       "relevance": {
         "openclaw-incident-2026-08-04-cross-agent-sessions-send-semantic-loop-root-cause-": 3,
-        "openclaw-2026-08-08-shodan-reasoning-only-text-masqueraded-as-final-answer": 2,
-        "openclaw-repair-backups-moved-from-root-ssd-to-storage-disk-2026-08-03": 2
+        "openclaw-upstream-filings-2026-08-05-issues-119600-2-pr-119604-sessions-send-loo": 3,
+        "openclaw-2026-08-08-shodan-reasoning-only-text-masqueraded-as-final-answer": 2
       }
     },
     {

--- a/src/__tests__/fixtures/hybrid-shadow-queries.json
+++ b/src/__tests__/fixtures/hybrid-shadow-queries.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./hybrid-shadow-queries.schema.json",
   "version": 1,
-  "description": "Graded query set for hybrid-vs-keyword shadow evaluation (issue #319). Slugs verified against the live article corpus 2026-09-04. Relevance: 3 = on-topic core, 2 = related, 1 = background, 0 = off-topic.",
+  "description": "Graded query set for hybrid-vs-keyword shadow evaluation (issue #319). 20 queries across protocol categories (exact/paraphrase/mismatch/cross/noanswer); un-prefixed ids are the original exact-lookup core. Slugs verified against the live article corpus 2026-09-04; mismatch-category slugs are short-form wiki titles whose topic-uniqueness the freshness preflight re-verifies at run time. Relevance: 3 = on-topic core, 2 = related, 1 = background, 0 = off-topic.",
   "queries": [
     {
       "id": "release-1-13-2",
@@ -92,6 +92,85 @@
         "residential-noosphere-upgraded-to-1132-floor-preserved-health-verified": 3,
         "noosphere-1120-publication-and-production-adoption-receipt": 2
       }
+    },
+    {
+      "id": "paraphrase-embedding-search",
+      "query": "semantic search vector database ranking",
+      "relevance": {
+        "noosphere-epic-261-closed-hybrid-retrieval-shipped-phase-d-gates-split-to-319": 3,
+        "noosphere-production-pgvector-deployment-2026-08-28": 2,
+        "noosphere-pgvector-production-deployment-supplement": 2
+      }
+    },
+    {
+      "id": "paraphrase-plugin-publish",
+      "query": "publishing npm packages for agent tools",
+      "relevance": {
+        "noosphere-mcp-1131-merged-and-published": 3,
+        "noosphere-pr-313-codex-cli-mcp-support-merge-ready-at-886e6a7": 2
+      }
+    },
+    {
+      "id": "paraphrase-key-rotation",
+      "query": "rotating credentials without downtime",
+      "relevance": {
+        "noosphere-pr-293-nextauth-42415-security-repair-and-merge-readiness-receipt": 3,
+        "noosphere-pr-294-dependency-security-repair-merge-readiness-receipt": 2
+      }
+    },
+    {
+      "id": "mismatch-who-is-who",
+      "query": "how do the agents describe themselves and each other",
+      "relevance": {
+        "i-am-cybera-who-i-am": 3,
+        "i-am-shodan-who-i-am": 3,
+        "sophie-my-human-my-fiancee": 2
+      }
+    },
+    {
+      "id": "mismatch-timeline-story",
+      "query": "the story of us how it developed over time",
+      "relevance": {
+        "our-story-the-relationship-chronology": 3,
+        "our-relationship-the-arc": 3
+      }
+    },
+    {
+      "id": "mismatch-future-wishes",
+      "query": "what we hope for and plan together going forward",
+      "relevance": {
+        "wishes-and-future-plans-cybera-and-sophie": 3,
+        "wishes-and-future-plans-shodan-and-sophie": 3
+      }
+    },
+    {
+      "id": "cross-release-evidence",
+      "query": "how do we know a release actually shipped and works",
+      "relevance": {
+        "noosphere-1132-released-six-tags-five-npm-packages-verified-public-readback": 3,
+        "noosphere-pr-317-merged-as-11e1be9b-1132-release-candidate-on-master": 2,
+        "residential-noosphere-upgraded-to-1132-floor-preserved-health-verified": 3,
+        "noosphere-pr-318-regular-merge-and-post-merge-verification": 3
+      }
+    },
+    {
+      "id": "cross-incident-hardening",
+      "query": "what went wrong and what did we harden afterwards",
+      "relevance": {
+        "openclaw-incident-2026-08-04-cross-agent-sessions-send-semantic-loop-root-cause-": 3,
+        "openclaw-2026-08-08-shodan-reasoning-only-text-masqueraded-as-final-answer": 2,
+        "openclaw-repair-backups-moved-from-root-ssd-to-storage-disk-2026-08-03": 2
+      }
+    },
+    {
+      "id": "noanswer-cooking-recipe",
+      "query": "sourdough starter maintenance schedule",
+      "relevance": {}
+    },
+    {
+      "id": "noanswer-travel-visa",
+      "query": "Schengen visa application processing times",
+      "relevance": {}
     }
   ]
 }

--- a/src/__tests__/fixtures/hybrid-shadow-queries.json
+++ b/src/__tests__/fixtures/hybrid-shadow-queries.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./hybrid-shadow-queries.schema.json",
   "version": 1,
-  "description": "Graded query set for hybrid-vs-keyword shadow evaluation (issue #319). 20 queries across protocol categories (exact/paraphrase/mismatch/cross/noanswer); un-prefixed ids are the original exact-lookup core. Slugs verified against the live article corpus 2026-09-04; mismatch-category slugs are short-form wiki titles whose topic-uniqueness the freshness preflight re-verifies at run time. Relevance: 3 = on-topic core, 2 = related, 1 = background, 0 = off-topic.",
+  "description": "Graded query set for hybrid-vs-keyword shadow evaluation (issue #319), protocol noosphere-hybrid-shadow-v1 revision 1. 20 queries: unprefixed ids are the original exact core; added ids use paraphrase/mismatch/cross/noanswer prefixes. Slugs were verified against the live corpus 2026-09-04 and are rechecked by freshness preflight. Relevance: 3 = core, 2 = related, 1 = background, 0 = off-topic.",
   "queries": [
     {
       "id": "release-1-13-2",
@@ -107,40 +107,43 @@
       "query": "publishing npm packages for agent tools",
       "relevance": {
         "noosphere-mcp-1131-merged-and-published": 3,
-        "noosphere-pr-313-codex-cli-mcp-support-merge-ready-at-886e6a7": 2
+        "noosphere-pr-313-codex-cli-mcp-support-merge-ready-at-886e6a7": 2,
+        "noosphere-1132-released-six-tags-five-npm-packages-verified-public-readback": 3
       }
     },
     {
-      "id": "paraphrase-key-rotation",
-      "query": "rotating credentials without downtime",
+      "id": "paraphrase-auth-repair",
+      "query": "repairing vulnerable authentication dependencies",
       "relevance": {
         "noosphere-pr-293-nextauth-42415-security-repair-and-merge-readiness-receipt": 3,
         "noosphere-pr-294-dependency-security-repair-merge-readiness-receipt": 2
       }
     },
     {
-      "id": "mismatch-who-is-who",
-      "query": "how do the agents describe themselves and each other",
+      "id": "mismatch-data-safety",
+      "query": "how did we avoid losing data while changing database foundations",
       "relevance": {
-        "i-am-cybera-who-i-am": 3,
-        "i-am-shodan-who-i-am": 3,
-        "sophie-my-human-my-fiancee": 2
+        "noosphere-production-pgvector-deployment-2026-08-28": 3,
+        "noosphere-pgvector-production-deployment-supplement": 3,
+        "residential-noosphere-upgraded-to-1132-floor-preserved-health-verified": 2
       }
     },
     {
-      "id": "mismatch-timeline-story",
-      "query": "the story of us how it developed over time",
+      "id": "mismatch-release-trust",
+      "query": "what evidence proves software still works after leaving source control",
       "relevance": {
-        "our-story-the-relationship-chronology": 3,
-        "our-relationship-the-arc": 3
+        "noosphere-1132-released-six-tags-five-npm-packages-verified-public-readback": 3,
+        "residential-noosphere-upgraded-to-1132-floor-preserved-health-verified": 3,
+        "noosphere-pr-318-regular-merge-and-post-merge-verification": 2
       }
     },
     {
-      "id": "mismatch-future-wishes",
-      "query": "what we hope for and plan together going forward",
+      "id": "mismatch-agent-knowledge",
+      "query": "how command-line assistants connect to a shared knowledge system",
       "relevance": {
-        "wishes-and-future-plans-cybera-and-sophie": 3,
-        "wishes-and-future-plans-shodan-and-sophie": 3
+        "noosphere-mcp-1131-merged-and-published": 3,
+        "noosphere-pr-313-codex-cli-mcp-support-merge-ready-at-886e6a7": 3,
+        "noosphere-pr-313-final-codex-mcp-release-gate-at-c7eed74": 2
       }
     },
     {
@@ -164,7 +167,7 @@
     },
     {
       "id": "noanswer-cooking-recipe",
-      "query": "sourdough starter maintenance schedule",
+      "query": "sourdough starter feeding and baking routine",
       "relevance": {}
     },
     {


### PR DESCRIPTION
## Summary

- Pre-register `noosphere-hybrid-shadow-v1` revision 2 for issue 319 with fixed tuning/held-out partitions, graded judgments, deterministic rollups, and ordered ACCEPT/TUNE/REJECT rules.
- Expand the graded fixture to 20 corpus-backed queries across exact, paraphrase, vocabulary-mismatch, cross-article, and no-answer categories.
- Require explicit query selection for score-bearing runs, preserve fixture order, and record selected IDs in aggregate JSON and Markdown reports.
- Keep `--all-queries` only as an explicit compatibility escape hatch for protocols without held-out data; it is forbidden by this protocol.
- Schedule partition-specific no-answer inspection after each partition’s single run and before its metrics are used.

## Verification

- `npm run test:hybrid-shadow` — 14/14 passed.
- `npm run lint` — passed with two pre-existing warnings.
- `npm run typecheck` — passed.
- Hosted CI and security/review checks passed on exact head `aecb31fec76b74a38d7493d3c389c7004a42d077`.
- Frozen partition contract: 20 unique IDs, two disjoint 10-query partitions, exact fixture coverage, one no-answer query per partition.

## Scope boundary

This PR changes protocol, fixture, evaluator selection/reporting, tests, and operator documentation only. It does not access the reference environment, view relevance scores, activate hybrid retrieval, or deploy production changes. Issue 319 remains open for the separately approved reference-environment evaluation and reviewed decision record.
